### PR TITLE
Implement blocking() for just() and when_all() senders

### DIFF
--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -17,6 +17,7 @@
 
 #include <unifex/config.hpp>
 #include <unifex/receiver_concepts.hpp>
+#include <unifex/blocking.hpp>
 
 #include <exception>
 #include <tuple>
@@ -66,6 +67,10 @@ class just_sender {
   template <typename Receiver>
   operation<std::remove_cvref_t<Receiver>> connect(Receiver&& r) && {
     return {std::move(values_), (Receiver &&) r};
+  }
+
+  friend constexpr blocking_kind tag_invoke(tag_t<cpo::blocking>, const just_sender&) noexcept {
+    return blocking_kind::always_inline;
   }
 };
 


### PR DESCRIPTION
This should allow more efficient implementations of sync_wait() to be called when operations always complete synchronously.