### PR TITLE
Allow compilation without coroutine support

### DIFF
--- a/examples/async_trace_test.cpp
+++ b/examples/async_trace_test.cpp
@@ -26,7 +26,7 @@
 #include <unifex/typed_via.hpp>
 #include <unifex/when_all.hpp>
 
-#if UNIFEX_HAVE_COROUTINES
+#if !UNIFEX_NO_COROUTINES
 #include <unifex/awaitable_sender.hpp>
 #include <unifex/sender_awaitable.hpp>
 #include <unifex/task.hpp>
@@ -94,7 +94,7 @@ int main() {
                 std::cout << "part2 finished - [" << timeMs << "]\n";
                 return time;
               }),
-#if UNIFEX_HAVE_COROUTINES
+#if !UNIFEX_NO_COROUTINES
           awaitable_sender {
             []() -> task<int> {
               co_await dump_async_trace("coroutine");
@@ -103,7 +103,7 @@ int main() {
           }
 #else
           just(42)
-#endif // UNIFEX_HAVE_COROUTINES
+#endif // UNIFEX_NO_COROUTINES
           ),
       [](auto &&a, auto &&b, auto &&c) {
         std::cout

--- a/examples/coroutine_stream_consumer_test.cpp
+++ b/examples/coroutine_stream_consumer_test.cpp
@@ -15,7 +15,7 @@
  */
 #include <unifex/config.hpp>
 
-#if UNIFEX_HAVE_COROUTINES
+#if !UNIFEX_NO_COROUTINES
 
 #include <unifex/awaitable_sender.hpp>
 #include <unifex/delay.hpp>
@@ -71,7 +71,7 @@ int main() {
   return 0;
 }
 
-#else // UNIFEX_HAVE_COROUTINES
+#else // UNIFEX_NO_COROUTINES
 
 #include <cstdio>
 
@@ -81,4 +81,4 @@ int main() {
   return 0;
 }
 
-#endif
+#endif // UNIFEX_NO_COROUTINES

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -21,7 +21,7 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/config.hpp>
 
-#if UNIFEX_HAVE_COROUTINES
+#if !UNIFEX_NO_COROUTINES
 #include <experimental/coroutine>
 #endif
 
@@ -36,7 +36,7 @@ inline constexpr struct visit_continuations_cpo {
   friend void
   tag_invoke(visit_continuations_cpo, const Continuation&, Func&&) noexcept {}
 
-#if UNIFEX_HAVE_COROUTINES
+#if !UNIFEX_NO_COROUTINES
   template <
       typename Promise,
       typename Func,
@@ -47,7 +47,7 @@ inline constexpr struct visit_continuations_cpo {
       Func&& func) {
     cpo(h.promise(), (Func &&) func);
   }
-#endif // UNIFEX_HAVE_COROUTINES
+#endif // UNIFEX_NO_COROUTINES
 
   template <typename Continuation, typename Func>
   void operator()(const Continuation& c, Func&& func) const

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -19,8 +19,12 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
+#include <unifex/config.hpp>
 
+#if UNIFEX_HAVE_COROUTINES
 #include <experimental/coroutine>
+#endif
+
 #include <functional>
 #include <typeindex>
 #include <vector>
@@ -32,6 +36,7 @@ inline constexpr struct visit_continuations_cpo {
   friend void
   tag_invoke(visit_continuations_cpo, const Continuation&, Func&&) noexcept {}
 
+#if UNIFEX_HAVE_COROUTINES
   template <
       typename Promise,
       typename Func,
@@ -42,6 +47,7 @@ inline constexpr struct visit_continuations_cpo {
       Func&& func) {
     cpo(h.promise(), (Func &&) func);
   }
+#endif // UNIFEX_HAVE_COROUTINES
 
   template <typename Continuation, typename Func>
   void operator()(const Continuation& c, Func&& func) const

--- a/include/unifex/awaitable_sender.hpp
+++ b/include/unifex/awaitable_sender.hpp
@@ -19,6 +19,11 @@
 #include <unifex/coroutine_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/receiver_concepts.hpp>
+#include <unifex/config.hpp>
+
+#if !UNIFEX_HAVE_COROUTINES
+# error "C++20 coroutine support is required to use <unifex/awaitable_sender.hpp>"
+#endif
 
 #include <experimental/coroutine>
 #include <optional>

--- a/include/unifex/awaitable_sender.hpp
+++ b/include/unifex/awaitable_sender.hpp
@@ -21,7 +21,7 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/config.hpp>
 
-#if !UNIFEX_HAVE_COROUTINES
+#if UNIFEX_NO_COROUTINES
 # error "C++20 coroutine support is required to use <unifex/awaitable_sender.hpp>"
 #endif
 

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -21,12 +21,12 @@
 #define UNIFEX_NO_UNIQUE_ADDRESS
 #endif
 
-// UNIFEX_HAVE_COROUTINES is defined to 1 if you are
-// compiling with coroutine support enabled.
-#ifndef UNIFEX_HAVE_COROUTINES
+// UNIFEX_NO_COROUTINES is defined to 1 if compiling without coroutine support
+// enabled and is defined to 0 if coroutine support is enabled.
+#ifndef UNIFEX_NO_COROUTINES
 #if __cpp_coroutines >= 201703L && __has_include(<experimental/coroutine>)
-# define UNIFEX_HAVE_COROUTINES 1
+# define UNIFEX_NO_COROUTINES 0
 #else
-# define UNIFEX_HAVE_COROUTINES 0
+# define UNIFEX_NO_COROUTINES 1
 #endif
 #endif

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -21,8 +21,12 @@
 #define UNIFEX_NO_UNIQUE_ADDRESS
 #endif
 
-#if __cpp_coroutines >= 201703L
+// UNIFEX_HAVE_COROUTINES is defined to 1 if you are
+// compiling with coroutine support enabled.
+#ifndef UNIFEX_HAVE_COROUTINES
+#if __cpp_coroutines >= 201703L && __has_include(<experimental/coroutine>)
 # define UNIFEX_HAVE_COROUTINES 1
 #else
 # define UNIFEX_HAVE_COROUTINES 0
+#endif
 #endif

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -15,6 +15,12 @@
  */
 #pragma once
 
+#include <unifex/config.hpp>
+
+#if !UNIFEX_HAVE_COROUTINES
+# error "C++20 coroutine support is required to use <unifex/coroutine_concepts.hpp>"
+#endif
+
 #include <experimental/coroutine>
 #include <type_traits>
 

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -17,7 +17,7 @@
 
 #include <unifex/config.hpp>
 
-#if !UNIFEX_HAVE_COROUTINES
+#if UNIFEX_NO_COROUTINES
 # error "C++20 coroutine support is required to use <unifex/coroutine_concepts.hpp>"
 #endif
 

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -21,7 +21,7 @@
 #include <unifex/async_trace.hpp>
 #include <unifex/config.hpp>
 
-#if !UNIFEX_HAVE_COROUTINES
+#if UNIFEX_NO_COROUTINES
 #error                                                                         \
     "C++20 coroutine support is required to use <unifex/sender_awaitable.hpp>"
 #endif

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -19,6 +19,12 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/unstoppable_token.hpp>
 #include <unifex/async_trace.hpp>
+#include <unifex/config.hpp>
+
+#if !UNIFEX_HAVE_COROUTINES
+#error                                                                         \
+    "C++20 coroutine support is required to use <unifex/sender_awaitable.hpp>"
+#endif
 
 #include <exception>
 #include <experimental/coroutine>

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -17,6 +17,11 @@
 
 #include <unifex/async_trace.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/config.hpp>
+
+#if !UNIFEX_HAVE_COROUTINES
+# error "C++20 coroutine support is required to use this header"
+#endif
 
 #include <exception>
 #include <experimental/coroutine>

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -19,7 +19,7 @@
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/config.hpp>
 
-#if !UNIFEX_HAVE_COROUTINES
+#if UNIFEX_NO_COROUTINES
 # error "C++20 coroutine support is required to use this header"
 #endif
 


### PR DESCRIPTION
Conditionally disable facilities that depend on coroutine support when `UNIFEX_HAVE_COROUTINES` is false.

Also try to give a meaningful error message if you try to include coroutine-specific unifex headers without coroutine support enabled.

This should address #10.