### PR TITLE
Add support for passing the associated scheduler into child operations

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -1,5 +1,7 @@
 # Index
 
+* Receiver Queries
+  * `get_scheduler()`
 * Sender Algorithms
   * `transform()`
   * `via()`
@@ -32,6 +34,19 @@
 * StopToken Types
   * `unstoppable_token`
   * `inplace_stop_token` / `inplace_stop_source`
+
+# Receiver Queries
+
+### `cpo::get_scheduler(receiver)`
+
+A query that can be used to obtain the associated scheduler from the receiver.
+
+This can be used by senders to obtain a scheduler that can be used to schedule
+work if required.
+
+Receivers can customise this CPO to return the current scheduler.
+
+See the `schedule()` algorithm, which schedules onto the current scheduler.
 
 # Sender Algorithms
 
@@ -256,6 +271,29 @@ Any `.error()` produced by an abandoned `.next()` call is reported in
 the `.cleanup()` result.
 
 ## Scheduler Algorithms
+
+### `schedule(Scheduler schedule) -> SenderOf<void>`
+
+This is the basis operation for a scheduler.
+
+The `schedule` operation returns a sender that is a lazy async operation.
+
+A schedule operation logically enqueues an item onto the scheduler's queue when `start()`
+is called and the operation completes when some thread associated with the scheduler's
+execution context dequeues that item.
+
+The operation signals completion by invoking either the `set_value()`,
+`set_done()` or `set_error()` methods on the receiver passed to `connect()`.
+
+As the operation completes on the execution context, the `set_value()` method by definition
+be called on that execution context. Applications can therefore use the `schedule()`
+operation to execute logic on the associated execution context by placing that logic within
+the body of `set_value()`.
+
+### `schedule() -> SenderOf<void>`
+
+This is like `schedule(scheduler)` above but uses the implicit scheduler
+obtained from the receiver passed to `connect()` by a calling `get_scheduler(receiver)`.
 
 ### `delay(TimeScheduler scheduler, Duration d) -> Scheduler`
 

--- a/examples/get_scheduler_test.cpp
+++ b/examples/get_scheduler_test.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/for_each.hpp>
+#include <unifex/range_stream.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/transform_stream.hpp>
+#include <unifex/via_stream.hpp>
+#include <unifex/with_query_value.hpp>
+
+using namespace unifex;
+
+int main() {
+  single_thread_context ctx;
+
+  struct current_scheduler {
+    auto schedule() { return cpo::schedule(); }
+  };
+
+  // Check that the schedule() operation can pick up the current
+  // scheduler from the receiver which we inject by using 'with_query_value()'.
+  sync_wait(with_query_value(cpo::schedule(), cpo::get_scheduler,
+                             ctx.get_scheduler()));
+
+  // Check that this can propagate through multiple levels of
+  // composed operations.
+  sync_wait(with_query_value(
+      transform(
+          cpo::for_each(via_stream(current_scheduler{},
+                                   transform_stream(range_stream{0, 10},
+                                                    [](int value) {
+                                                      return value * value;
+                                                    })),
+                        [](int value) { std::printf("got %i\n", value); }),
+          []() { std::printf("done\n"); }),
+      cpo::get_scheduler, ctx.get_scheduler()));
+
+  return 0;
+}

--- a/include/unifex/detail/intrusive_queue.hpp
+++ b/include/unifex/detail/intrusive_queue.hpp
@@ -33,6 +33,7 @@ class intrusive_queue {
   intrusive_queue& operator=(intrusive_queue other) noexcept {
     std::swap(head_, other.head_);
     std::swap(tail_, other.tail_);
+    return *this;
   }
 
   ~intrusive_queue() {

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -105,7 +105,7 @@ class manual_event_loop {
     explicit scheduler(manual_event_loop* loop) noexcept : loop_(loop) {}
 
    public:
-    schedule_task schedule() noexcept {
+    schedule_task schedule() const noexcept {
       return schedule_task{loop_};
     }
 

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -71,6 +71,19 @@ struct reduce_stream_sender {
         cpo::set_error(static_cast<Receiver&&>(op.receiver_), std::move(ex));
       }
 
+      template <
+          typename CPO,
+          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+      friend auto tag_invoke(CPO cpo, const error_cleanup_receiver& r) noexcept(
+          std::is_nothrow_invocable_v<CPO, const Receiver&>)
+          -> std::invoke_result_t<CPO, const Receiver&> {
+        return std::move(cpo)(std::as_const(r.op_.receiver_));
+      }
+
+      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const error_cleanup_receiver& r) noexcept {
+        return {};
+      }
+
       template <typename Func>
       friend void tag_invoke(
           tag_t<visit_continuations>,
@@ -96,6 +109,19 @@ struct reduce_stream_sender {
         cpo::set_value(
             static_cast<Receiver&&>(op.receiver_),
             std::forward<State>(op.state_));
+      }
+
+      template <
+          typename CPO,
+          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+      friend auto tag_invoke(CPO cpo, const done_cleanup_receiver& r) noexcept(
+          std::is_nothrow_invocable_v<CPO, const Receiver&>)
+          -> std::invoke_result_t<CPO, const Receiver&> {
+        return std::move(cpo)(std::as_const(r.op_.receiver_));
+      }
+
+      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const done_cleanup_receiver& r) noexcept {
+        return {};
       }
 
       template <typename Func>

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -217,16 +217,16 @@ class thread_unsafe_event_loop {
     };
 
    public:
-    auto schedule_at(time_point_t dueTime) noexcept {
+    auto schedule_at(time_point_t dueTime) const noexcept {
       return schedule_at_sender{loop_, dueTime};
     }
 
     template <typename Rep, typename Ratio>
-    auto schedule_after(std::chrono::duration<Rep, Ratio> d) noexcept {
+    auto schedule_after(std::chrono::duration<Rep, Ratio> d) const noexcept {
       return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{loop_, d};
     }
 
-    auto schedule() noexcept {
+    auto schedule() const noexcept {
       return schedule_after(std::chrono::milliseconds(0));
     }
 

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -218,16 +218,16 @@ class timed_single_thread_context {
 
    public:
     template <typename Rep, typename Ratio>
-    auto schedule_after(std::chrono::duration<Rep, Ratio> delay) noexcept {
+    auto schedule_after(std::chrono::duration<Rep, Ratio> delay) const noexcept {
       return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{
           context_, delay};
     }
 
-    auto schedule_at(clock_t::time_point dueTime) noexcept {
+    auto schedule_at(clock_t::time_point dueTime) const noexcept {
       return schedule_at_sender{context_, dueTime};
     }
 
-    auto schedule() noexcept {
+    auto schedule() const noexcept {
       return schedule_after(std::chrono::milliseconds{0});
     }
 

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -120,7 +120,7 @@ private:
   };
 
 public:
-  schedule_sender schedule() noexcept {
+  schedule_sender schedule() const noexcept {
     return schedule_sender{maxRecursionDepth_};
   }
 };


### PR DESCRIPTION
Adds the following:
* `unifex::cpo::get_scheduler(receiver)` - Get the current scheduler.
* `unifex::cpo::schedule()` - Returns a sender that will schedule onto the current scheduler.

Also contains some fixes:
* Adds missing docs for `get_stop_token()`, `get_allocator()`, `with_query_value()` and `with_allocator()`
* Fixes the `reduce_stream` cleanup receivers to forward through query CPOs
* Const-qualify the `schedule()`, `schedule_at()` and `schedule_after()` methods on scheduler implementations.

Addresses #21, #20.