### PR TITLE
Add an async_mutex synchronisation primitive

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -38,6 +38,8 @@
 * StopToken Types
   * `unstoppable_token`
   * `inplace_stop_token` / `inplace_stop_source`
+* Synchronisation Primitives
+  * `async_mutex`
 
 # Receiver Queries
 
@@ -459,3 +461,42 @@ destroyed before the stop-source is destructed.
 
 This is a less-safe but more efficient version of `std::stop_token`
 proposed in [P0660R10](https://wg21.link/P0660R10).
+
+
+## Synchronisation Primitives
+
+### `async_mutex`
+
+A mutex that allows acquiring the mutex asynchronously.
+
+```c++
+namespace unifex
+{
+  class async_mutex {
+  public:
+    async_mutex() noexcept;
+    async_mutex(async_mutex&&) = delete;
+    async_mutex(const async_mutex&) = delete;
+    ~async_mutex();
+
+    // Attempt to acquire the mutex lock synchronously.
+    // Returns true if successful, false otherwise.
+    // If the lock is acquired then the caller is responsible for releasing
+    // the lock by calling unlock().
+    bool try_lock() noexcept;
+
+    // Acquire the mutex lock asynchronously.
+    // Returns a sender that will complete when the lock has been
+    // acquired. The caller is then responsible for calling unlock()
+    // to release the mutex.
+    sender auto async_lock() noexcept;
+
+    // Unlock the mutex.
+    // Only valid to call if you currently own the mutex lock.
+    //
+    // This will cause the next 'async_lock' operation in the queue to complete
+    // (if any).
+    void unlock() noexcept;
+  };
+};
+```

--- a/examples/async_mutex.cpp
+++ b/examples/async_mutex.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <unifex/async_mutex.hpp>
+#include <unifex/awaitable_sender.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_awaitable.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/when_all.hpp>
+
+#include <cstdio>
+
+using namespace unifex;
+
+int main() {
+  async_mutex mutex;
+
+  int sharedState = 0;
+
+  auto makeTask = [&](manual_event_loop::scheduler scheduler) -> task<int> {
+    for (int i = 0; i < 100'000; ++i) {
+      std::printf("acquiring lock\n");
+      co_await mutex.async_lock();
+      std::printf("scheduling\n");
+      co_await schedule(scheduler);
+      ++sharedState;
+      std::printf("unlocking\n");
+      mutex.unlock();
+    }
+    co_return 0;
+  };
+
+  single_thread_context ctx1;
+  single_thread_context ctx2;
+
+  sync_wait(when_all(awaitable_sender{makeTask(ctx1.get_scheduler())},
+                     awaitable_sender{makeTask(ctx2.get_scheduler())}));
+
+  if (sharedState != 200'000) {
+    std::printf("error: incorrect result %i, expected 2000000\n", sharedState);
+    return 1;
+  }
+
+  return 0;
+}
+
+#else // UNIFEX_NO_COROUTINES
+
+#include <cstdio>
+
+int main() {
+  std::printf("warning: skipping test as coroutines are not available\n");
+  return 0;
+}
+
+#endif // UNIFEX_NO_COROUTINES

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/detail/atomic_intrusive_queue.hpp>
+#include <unifex/detail/intrusive_queue.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+
+namespace unifex {
+
+class async_mutex {
+  class lock_sender;
+
+public:
+  async_mutex() noexcept;
+  async_mutex(const async_mutex &) = delete;
+  async_mutex(async_mutex &&) = delete;
+  ~async_mutex();
+
+  async_mutex &operator=(const async_mutex &) = delete;
+  async_mutex &operator=(async_mutex &&) = delete;
+
+  [[nodiscard]] bool try_lock() noexcept;
+
+  [[nodiscard]] lock_sender async_lock() noexcept;
+
+  void unlock() noexcept;
+
+private:
+  struct waiter_base {
+    void (*resume_)(waiter_base *) noexcept;
+    waiter_base *next_;
+  };
+
+  class lock_sender {
+  public:
+    template <template <typename...> class Variant,
+              template <typename...> class Tuple>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<>;
+
+  private:
+    friend async_mutex;
+
+    explicit lock_sender(async_mutex &mutex) noexcept : mutex_(mutex) {}
+
+    lock_sender(const lock_sender &) = delete;
+    lock_sender(lock_sender &&) = default;
+
+    template <typename Receiver> class operation : waiter_base {
+      friend lock_sender;
+
+      template <typename Receiver2>
+      explicit operation(async_mutex &mutex, Receiver2 &&r) noexcept
+          : mutex_(mutex), receiver_((Receiver2 &&) r) {
+        this->resume_ = [](waiter_base * self) noexcept {
+          operation &op = *static_cast<operation *>(self);
+          unifex::set_value((Receiver &&) op.receiver_);
+        };
+      }
+
+      operation(operation &&) = delete;
+
+      friend void tag_invoke(tag_t<start>, operation &op) noexcept {
+        if (!op.mutex_.try_enqueue(&op)) {
+          // Failed to enqueue because we acquired the lock
+          // synchronously. Invoke the continuation inline
+          // without type-erasure here.
+          set_value((Receiver &&) op.receiver_);
+        }
+      }
+
+      async_mutex &mutex_;
+      Receiver receiver_;
+    };
+
+    template <typename Receiver>
+    friend operation<std::decay_t<Receiver>>
+    tag_invoke(tag_t<connect>, lock_sender &&s, Receiver &&r) noexcept {
+      return operation<std::decay_t<Receiver>>{s.mutex_, (Receiver &&) r};
+    }
+
+    async_mutex &mutex_;
+  };
+
+  // Attempt to enqueue the waiter object to the queue.
+  // Returns true if successfully enqueued, false if it was not enqueued because
+  // the lock was acquired synchronously.
+  bool try_enqueue(waiter_base *waiter) noexcept;
+
+  atomic_intrusive_queue<waiter_base, &waiter_base::next_> atomicQueue_;
+  intrusive_queue<waiter_base, &waiter_base::next_> pendingQueue_;
+};
+
+inline async_mutex::lock_sender async_mutex::async_lock() noexcept {
+  return lock_sender{*this};
+}
+
+inline bool async_mutex::try_lock() noexcept {
+  return atomicQueue_.try_mark_active();
+}
+
+} // namespace unifex

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(unifex "")
 
 target_sources(unifex
   PRIVATE
+    async_mutex.cpp
     inplace_stop_token.cpp
     manual_event_loop.cpp
     static_thread_pool.cpp

--- a/source/async_mutex.cpp
+++ b/source/async_mutex.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/async_mutex.hpp>
+
+#include <cassert>
+
+namespace unifex {
+
+async_mutex::async_mutex() noexcept : atomicQueue_(false) {}
+
+async_mutex::~async_mutex() {}
+
+bool async_mutex::try_enqueue(waiter_base *base) noexcept {
+  return atomicQueue_.enqueue_or_mark_active(base);
+}
+
+void async_mutex::unlock() noexcept {
+  if (pendingQueue_.empty()) {
+    auto newWaiters = atomicQueue_.try_mark_inactive_or_dequeue_all();
+    if (newWaiters.empty()) {
+      return;
+    }
+    pendingQueue_ = std::move(newWaiters);
+  }
+
+  waiter_base *item = pendingQueue_.pop_front();
+  item->resume_(item);
+}
+
+} // namespace unifex

--- a/test/async_mutex_test.cpp
+++ b/test/async_mutex_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#  include <unifex/async_mutex.hpp>
+#  include <unifex/awaitable_sender.hpp>
+#  include <unifex/scheduler_concepts.hpp>
+#  include <unifex/sender_awaitable.hpp>
+#  include <unifex/single_thread_context.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/task.hpp>
+#  include <unifex/when_all.hpp>
+
+#  include <gtest/gtest.h>
+
+using namespace unifex;
+
+TEST(async_mutex, multiple_threads) {
+  async_mutex mutex;
+
+  int sharedState = 0;
+
+  auto makeTask = [&](manual_event_loop::scheduler scheduler) -> task<int> {
+    for (int i = 0; i < 100'000; ++i) {
+      co_await mutex.async_lock();
+      co_await schedule(scheduler);
+      ++sharedState;
+      mutex.unlock();
+    }
+    co_return 0;
+  };
+
+  single_thread_context ctx1;
+  single_thread_context ctx2;
+
+  sync_wait(when_all(
+      awaitable_sender{makeTask(ctx1.get_scheduler())},
+      awaitable_sender{makeTask(ctx2.get_scheduler())}));
+
+  EXPECT_EQ(200'000, sharedState);
+}
+
+#endif  // UNIFEX_NO_COROUTINES


### PR DESCRIPTION
Ports the `cppcoro::async_mutex` synchronisation primitive to libunifex and recasts it in terms of senders instead of using the awaitable concepts.
