### PR TITLE
fixed private access from hidden friends

### DIFF
--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -148,12 +148,18 @@ struct with_type_erased_tag_invoke<
     Derived,
     CPO,
     Ret(Args...) noexcept(NoExcept)> {
+private:
+    template <typename T>
+    static void* get_object_address(T&& t) { return static_cast<T&&>(t).get_object_address(); }
+    template <typename T>
+    static auto  get_vtable(T&& t) { return static_cast<T&&>(t).get_vtable(); }
+public:
   friend Ret tag_invoke(
       base_cpo_t<CPO> cpo,
       replace_this_t<Args, Derived>... args) noexcept(NoExcept) {
     auto& t = extract_this<Args...>{}(args...);
-    void* objPtr = t.get_object_address();
-    auto* fnPtr = t.get_vtable()->template get<CPO>();
+    void* objPtr = get_object_address(t);
+    auto* fnPtr = get_vtable(t)->template get<CPO>();
     return fnPtr(
         std::move(cpo),
         replace_this<Args>::get((Args &&) args, objPtr)...);

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -104,6 +104,8 @@ class let_sender {
     struct successor_receiver {
       operation& op_;
 
+      Receiver&  get_receiver() const { return op_.receiver_; }
+
       template <typename... SuccessorValues>
       void value(SuccessorValues&&... values) && noexcept {
         cleanup();
@@ -138,7 +140,7 @@ class let_sender {
       friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(std::as_const(r.op_.receiver_));
+        return std::move(cpo)(std::as_const(r.get_receiver()));
       }
 
       template <typename Func>
@@ -146,12 +148,14 @@ class let_sender {
           tag_t<visit_continuations>,
           const successor_receiver& r,
           Func&& f) {
-        std::invoke(f, r.op_.receiver_);
+        std::invoke(f, r.get_receiver());
       }
     };
 
     struct predecessor_receiver {
       operation& op_;
+
+      Receiver&  get_receiver() const { return op_.receiver_; }
 
       template <typename... Values>
       void value(Values&&... values) && noexcept {
@@ -200,7 +204,7 @@ class let_sender {
       friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(std::as_const(r.op_.receiver_));
+        return std::move(cpo)(std::as_const(r.get_receiver()));
       }
 
       template <typename Func>
@@ -208,7 +212,7 @@ class let_sender {
           tag_t<visit_continuations>,
           const predecessor_receiver& r,
           Func&& f) {
-        std::invoke(f, r.op_.receiver_);
+        std::invoke(f, r.get_receiver());
       }
     };
 

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -99,6 +99,10 @@ struct stop_immediately_stream {
   struct next_receiver {
     stop_immediately_stream& stream_;
 
+    inplace_stop_source& get_stop_source() const {
+      return stream_.stopSource_;
+    }
+
     // Note, parameters passed by value here just in case we are passed
     // references to values owned by the operation object that we will be
     // destroying before passing the values along to the next receiver.
@@ -171,7 +175,7 @@ struct stop_immediately_stream {
 
     friend inplace_stop_token tag_invoke(
         tag_t<get_stop_token>, const next_receiver& r) noexcept {
-      return r.stream_.stopSource_.get_token();
+      return r.get_stop_source().get_token();
     }
 
     template <typename Func>

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -67,13 +67,15 @@ class submitted_operation {
       typed_allocator_traits::deallocate(typedAllocator, op_, 1);
     }
 
+    Receiver& get_receiver() const { return op_->receiver_; }
+
     template <
         typename CPO,
         std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const wrapped_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {
-      return std::move(cpo)(std::as_const(r.op_->receiver_));
+      return std::move(cpo)(std::as_const(r.get_receiver()));
     }
 
     template <typename Func>

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -55,9 +55,13 @@ struct take_until_stream {
       stream.trigger_next_done();
     }
 
+    inplace_stop_source& get_stopSource() const {
+      return stream_.stopSource_;
+    }
+
     friend inplace_stop_token tag_invoke(
         tag_t<get_stop_token>, const trigger_next_receiver& r) noexcept {
-      return r.stream_.stopSource_.get_token();
+      return r.get_stopSource().get_token();
     }
   };
 
@@ -110,9 +114,13 @@ struct take_until_stream {
           cpo::set_error(std::move(op_.receiver_), (Error&&)error);
         }
 
+        inplace_stop_source& get_stopSource() const {
+          return op_.stream_.stopSource_;
+        }
+
         friend inplace_stop_token tag_invoke(
             tag_t<get_stop_token>, const receiver_wrapper& r) noexcept {
-          return r.op_.stream_.stopSource_.get_token();
+          return r.get_stopSource().get_token();
         }
 
         template <typename Func>

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -55,13 +55,13 @@ struct take_until_stream {
       stream.trigger_next_done();
     }
 
-    inplace_stop_source& get_stopSource() const {
+    inplace_stop_source& get_stop_source() const {
       return stream_.stopSource_;
     }
 
     friend inplace_stop_token tag_invoke(
         tag_t<get_stop_token>, const trigger_next_receiver& r) noexcept {
-      return r.get_stopSource().get_token();
+      return r.get_stop_source().get_token();
     }
   };
 
@@ -114,13 +114,13 @@ struct take_until_stream {
           cpo::set_error(std::move(op_.receiver_), (Error&&)error);
         }
 
-        inplace_stop_source& get_stopSource() const {
+        inplace_stop_source& get_stop_source() const {
           return op_.stream_.stopSource_;
         }
 
         friend inplace_stop_token tag_invoke(
             tag_t<get_stop_token>, const receiver_wrapper& r) noexcept {
-          return r.get_stopSource().get_token();
+          return r.get_stop_source().get_token();
         }
 
         template <typename Func>

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -274,13 +274,13 @@ class thread_unsafe_event_loop {
       friend const StopToken& tag_invoke(
           tag_t<get_stop_token>,
           const receiver& r) noexcept {
-        return r.get_stopToken();
+        return r.get_stop_token();
       }
 
      private:
       friend sync_wait_promise;
 
-      StopToken& get_stopToken() const {
+      StopToken& get_stop_token() const {
         return promise_.stopToken_;
       }
 

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -274,11 +274,15 @@ class thread_unsafe_event_loop {
       friend const StopToken& tag_invoke(
           tag_t<get_stop_token>,
           const receiver& r) noexcept {
-        return r.promise_.stopToken_;
+        return r.get_stopToken();
       }
 
      private:
       friend sync_wait_promise;
+
+      StopToken& get_stopToken() const {
+        return promise_.stopToken_;
+      }
 
       explicit receiver(sync_wait_promise& promise) noexcept
           : promise_(promise) {}

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -142,19 +142,25 @@ class when_all_sender {
         op_.element_complete();
       }
 
+      Receiver& get_receiver() const { return op_.receiver_; }
+
       template <
           typename CPO,
           std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const element_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(std::as_const(r.op_.receiver_));
+        return std::move(cpo)(std::as_const(r.get_receiver()));
+      }
+
+      inplace_stop_source& get_stopSource() const {
+          return op_.stopSource_;
       }
 
       friend inplace_stop_token tag_invoke(
           tag_t<get_stop_token>,
           const element_receiver& r) noexcept {
-        return r.op_.stopSource_.get_token();
+        return r.get_stopSource().get_token();
       }
 
       template <typename Func>
@@ -162,7 +168,7 @@ class when_all_sender {
           tag_t<visit_continuations>,
           const element_receiver& r,
           Func&& func) {
-        std::invoke(func, r.op_.receiver_);
+        std::invoke(func, r.get_receiver());
       }
     };
 

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -153,14 +153,14 @@ class when_all_sender {
         return std::move(cpo)(std::as_const(r.get_receiver()));
       }
 
-      inplace_stop_source& get_stopSource() const {
+      inplace_stop_source& get_stop_source() const {
           return op_.stopSource_;
       }
 
       friend inplace_stop_token tag_invoke(
           tag_t<get_stop_token>,
           const element_receiver& r) noexcept {
-        return r.get_stopSource().get_token();
+        return r.get_stop_source().get_token();
       }
 
       template <typename Func>

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -34,8 +34,10 @@ class with_query_value_operation {
         : receiver_((Receiver2 &&) receiver), op_(op) {}
 
   private:
+    Value& get_value() const { return op_->value_; }
+
     friend const Value &tag_invoke(CPO, const receiver_wrapper &r) noexcept {
-      return r.op_->value_;
+      return r.get_value();
     }
 
     template <typename OtherCPO, typename... Args>


### PR DESCRIPTION
The code in `libunifex` uses in multiple places `friend` functions as customization points. In several of these places the `friend` function is declared in a nested class and accesses a `private` member of an outer class.  Using this approach fails to compile with [gcc](http://gcc.gnu.org/), Intel's compiler, and [EDG](http://edg.com/): A `friend` of a `friend` isn't a `friend`. It seems [clang](http://clang.llvm.org/) does not flag an error for the code.

Here is a minimal example showing the problem ([live](https://godbolt.org/z/EWCrCJ)):

    class outer {
        class inner {
            friend int access(inner i) { return i.o->value; }
            outer* o;
        public:
            inner(outer* o): o(o){}
        };
        int value{};

    public:
        inner get() { return inner{this}; }
    };

    int main() { return access(outer().get()); }

A local fix to the problem is to have the `friend` of the nested class delegate to a [`private`] member of the nested class ([live](https://godbolt.org/z/3j-nq_)]:

    class outer {
        class inner {
            int get_value() const { return o->value; }
            friend int access(inner i) { return i.get_value(); }
            outer* o;
        public:
            inner(outer* o): o(o){}
        };
        int value{};

    public:
        inner get() { return inner{this}; }
    };

    int main() {
        return access(outer().get());
    }

This pull request fixes these problems. It may not be the ideal change as the auxilary methods are probably not named quite the right way and placed a bit random. I'd be happy to adjust these issues based on corresponding comments.