### PR TITLE
Add a simple static_thread_pool type.

### DIFF
--- a/examples/static_thread_pool_test.cpp
+++ b/examples/static_thread_pool_test.cpp
@@ -14,33 +14,45 @@
  * limitations under the License.
  */
 
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/static_thread_pool.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/when_all.hpp>
 #include <unifex/transform.hpp>
-#include <unifex/scheduler_concepts.hpp>
+#include <unifex/when_all.hpp>
 
 #include <atomic>
 
 using namespace unifex;
 
-template<typename Scheduler, typename F>
+template <typename Scheduler, typename F>
 auto run_on(Scheduler&& s, F&& func) {
-    return transform(cpo::schedule((Scheduler&&)s), (F&&)func);
+  return transform(cpo::schedule((Scheduler &&) s), (F &&) func);
 }
 
 int main() {
-    static_thread_pool tpContext;
-    auto tp = tpContext.get_scheduler();
+  static_thread_pool tpContext;
+  auto tp = tpContext.get_scheduler();
+  std::atomic<int> x = 0;
 
-    std::atomic<int> x = 0;
+  sync_wait(when_all(
+      run_on(
+          tp,
+          [&] {
+            ++x;
+            std::printf("task 1\n");
+          }),
+      run_on(
+          tp,
+          [&] {
+            ++x;
+            std::printf("task 2\n");
+          }),
+      run_on(tp, [&] {
+        ++x;
+        std::printf("task 3\n");
+      })));
 
-    sync_wait(when_all(
-        run_on(tp, [&] { ++x; std::printf("task 1\n"); }),
-        run_on(tp, [&] { ++x; std::printf("task 2\n"); }),
-        run_on(tp, [&] { ++x; std::printf("task 3\n"); })));
+  assert(x == 3);
 
-    assert(x == 3);
-
-    return 0;
+  return 0;
 }

--- a/examples/static_thread_pool_test.cpp
+++ b/examples/static_thread_pool_test.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/static_thread_pool.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/when_all.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/scheduler_concepts.hpp>
+
+#include <atomic>
+
+using namespace unifex;
+
+template<typename Scheduler, typename F>
+auto run_on(Scheduler&& s, F&& func) {
+    return transform(cpo::schedule((Scheduler&&)s), (F&&)func);
+}
+
+int main() {
+    static_thread_pool tpContext;
+    auto tp = tpContext.get_scheduler();
+
+    std::atomic<int> x = 0;
+
+    sync_wait(when_all(
+        run_on(tp, [&] { ++x; std::printf("task 1\n"); }),
+        run_on(tp, [&] { ++x; std::printf("task 2\n"); }),
+        run_on(tp, [&] { ++x; std::printf("task 3\n"); })));
+
+    assert(x == 3);
+
+    return 0;
+}

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -15,104 +15,127 @@
  */
 #pragma once
 
-#include <unifex/detail/intrusive_queue.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
+#include <unifex/detail/intrusive_queue.hpp>
 
 #include <thread>
 #include <type_traits>
 #include <vector>
+#include <atomic>
 
-namespace unifex {
-class static_thread_pool {
-  struct task_base {
-    task_base *next;
-    void (*execute)(task_base *) noexcept;
-  };
-
-public:
-  static_thread_pool();
-  static_thread_pool(std::uint32_t threadCount);
-  ~static_thread_pool();
-
-  class scheduler {
-    class schedule_sender {
-    public:
-        template <template<typename...> class Variant,
-                  template<typename...> class Tuple>
-        using value_types = Variant<Tuple<>>;
-
-        template <template<typename...> class Variant>
-        using error_types = Variant<>;
-    private:
-      template <typename Receiver> class operation : task_base {
-        friend schedule_sender;
-
-        static_thread_pool &pool_;
-        Receiver receiver_;
-
-        explicit operation(static_thread_pool &pool, Receiver &&r)
-            : pool_(pool), receiver_((Receiver &&) r) {
-          this->execute = [](task_base * t) noexcept {
-            auto &op = *static_cast<operation *>(t);
-            if constexpr (!is_stop_never_possible_v<
-                              stop_token_type_t<Receiver>>) {
-              if (get_stop_token(op.receiver_).stop_requested()) {
-                cpo::set_done((Receiver &&) op.receiver_);
-                return;
-              }
-            }
-            cpo::set_value((Receiver &&) op.receiver_);
-          };
-        }
-
-        friend void tag_invoke(tag_t<cpo::start>, operation &op) noexcept {
-          op.pool_.enqueue(&op);
-        }
-      };
-
-      template <typename Receiver>
-      friend operation<std::decay_t<Receiver>>
-      tag_invoke(tag_t<cpo::connect>, schedule_sender s, Receiver &&r) {
-        return operation<std::decay_t<Receiver>>{s.pool_, (Receiver &&) r};
-      }
-
-      friend scheduler;
-
-      explicit schedule_sender(static_thread_pool &pool) noexcept
-          : pool_(pool) {}
-
-      static_thread_pool &pool_;
+namespace unifex
+{
+  class static_thread_pool {
+    struct task_base {
+      task_base* next;
+      void (*execute)(task_base*) noexcept;
     };
 
-    friend schedule_sender tag_invoke(tag_t<cpo::schedule>,
-                                      const scheduler &s) noexcept {
-      return schedule_sender{s.pool_};
-    }
+  public:
+    static_thread_pool();
+    static_thread_pool(std::uint32_t threadCount);
+    ~static_thread_pool();
 
-    friend static_thread_pool;
-    explicit scheduler(static_thread_pool &pool) noexcept : pool_(pool) {}
+    class scheduler {
+      class schedule_sender {
+      public:
+        template <
+            template <typename...>
+            class Variant,
+            template <typename...>
+            class Tuple>
+        using value_types = Variant<Tuple<>>;
 
-    static_thread_pool &pool_;
+        template <template <typename...> class Variant>
+        using error_types = Variant<>;
+
+      private:
+        template <typename Receiver>
+        class operation : task_base {
+          friend schedule_sender;
+
+          static_thread_pool& pool_;
+          Receiver receiver_;
+
+          explicit operation(static_thread_pool& pool, Receiver&& r)
+            : pool_(pool)
+            , receiver_((Receiver &&) r) {
+            this->execute = [](task_base* t) noexcept {
+              auto& op = *static_cast<operation*>(t);
+              if constexpr (!is_stop_never_possible_v<
+                                stop_token_type_t<Receiver>>) {
+                if (get_stop_token(op.receiver_).stop_requested()) {
+                  cpo::set_done((Receiver &&) op.receiver_);
+                  return;
+                }
+              }
+              cpo::set_value((Receiver &&) op.receiver_);
+            };
+          }
+
+          friend void tag_invoke(tag_t<cpo::start>, operation& op) noexcept {
+            op.pool_.enqueue(&op);
+          }
+        };
+
+        template <typename Receiver>
+        friend operation<std::decay_t<Receiver>>
+        tag_invoke(tag_t<cpo::connect>, schedule_sender s, Receiver&& r) {
+          return operation<std::decay_t<Receiver>>{s.pool_, (Receiver &&) r};
+        }
+
+        friend scheduler;
+
+        explicit schedule_sender(static_thread_pool& pool) noexcept
+          : pool_(pool) {}
+
+        static_thread_pool& pool_;
+      };
+
+      friend schedule_sender
+      tag_invoke(tag_t<cpo::schedule>, const scheduler& s) noexcept {
+        return schedule_sender{s.pool_};
+      }
+
+      friend static_thread_pool;
+      explicit scheduler(static_thread_pool& pool) noexcept : pool_(pool) {}
+
+      static_thread_pool& pool_;
+    };
+
+    scheduler get_scheduler() noexcept { return scheduler{*this}; }
+
+    void request_stop() noexcept;
+
+  private:
+    class thread_state {
+    public:
+      task_base* try_pop();
+      task_base* pop();
+      bool try_push(task_base* task);
+      void push(task_base* task);
+      void request_stop();
+
+    private:
+      std::mutex mut_;
+      std::condition_variable cv_;
+      intrusive_queue<task_base, &task_base::next> queue_;
+      bool stopRequested_ = false;
+    };
+
+    void run(std::uint32_t index) noexcept;
+    void join() noexcept;
+
+    void enqueue(task_base* task) noexcept;
+
+    std::uint32_t threadCount_;
+    std::vector<std::thread> threads_;
+    std::vector<thread_state> threadStates_;
+    std::atomic<std::uint32_t> nextThread_;
   };
 
-  scheduler get_scheduler() noexcept { return scheduler{*this}; }
-
-private:
-  void run() noexcept;
-  void close() noexcept;
-
-  void enqueue(task_base *task) noexcept;
-
-  std::vector<std::thread> threads_;
-  std::mutex mut_;
-  std::condition_variable cv_;
-  bool stop_ = false;
-
-  intrusive_queue<task_base, &task_base::next> queue_;
-};
-
-} // namespace unifex
+}  // namespace unifex

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/detail/intrusive_queue.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/stop_token_concepts.hpp>
+
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace unifex {
+class static_thread_pool {
+  struct task_base {
+    task_base *next;
+    void (*execute)(task_base *) noexcept;
+  };
+
+public:
+  static_thread_pool();
+  static_thread_pool(std::uint32_t threadCount);
+  ~static_thread_pool();
+
+  class scheduler {
+    class schedule_sender {
+    public:
+        template <template<typename...> class Variant,
+                  template<typename...> class Tuple>
+        using value_types = Variant<Tuple<>>;
+
+        template <template<typename...> class Variant>
+        using error_types = Variant<>;
+    private:
+      template <typename Receiver> class operation : task_base {
+        friend schedule_sender;
+
+        static_thread_pool &pool_;
+        Receiver receiver_;
+
+        explicit operation(static_thread_pool &pool, Receiver &&r)
+            : pool_(pool), receiver_((Receiver &&) r) {
+          this->execute = [](task_base * t) noexcept {
+            auto &op = *static_cast<operation *>(t);
+            if constexpr (!is_stop_never_possible_v<
+                              stop_token_type_t<Receiver>>) {
+              if (get_stop_token(op.receiver_).stop_requested()) {
+                cpo::set_done((Receiver &&) op.receiver_);
+                return;
+              }
+            }
+            cpo::set_value((Receiver &&) op.receiver_);
+          };
+        }
+
+        friend void tag_invoke(tag_t<cpo::start>, operation &op) noexcept {
+          op.pool_.enqueue(&op);
+        }
+      };
+
+      template <typename Receiver>
+      friend operation<std::decay_t<Receiver>>
+      tag_invoke(tag_t<cpo::connect>, schedule_sender s, Receiver &&r) {
+        return operation<std::decay_t<Receiver>>{s.pool_, (Receiver &&) r};
+      }
+
+      friend scheduler;
+
+      explicit schedule_sender(static_thread_pool &pool) noexcept
+          : pool_(pool) {}
+
+      static_thread_pool &pool_;
+    };
+
+    friend schedule_sender tag_invoke(tag_t<cpo::schedule>,
+                                      const scheduler &s) noexcept {
+      return schedule_sender{s.pool_};
+    }
+
+    friend static_thread_pool;
+    explicit scheduler(static_thread_pool &pool) noexcept : pool_(pool) {}
+
+    static_thread_pool &pool_;
+  };
+
+  scheduler get_scheduler() noexcept { return scheduler{*this}; }
+
+private:
+  void run() noexcept;
+  void close() noexcept;
+
+  void enqueue(task_base *task) noexcept;
+
+  std::vector<std::thread> threads_;
+  std::mutex mut_;
+  std::condition_variable cv_;
+  bool stop_ = false;
+
+  intrusive_queue<task_base, &task_base::next> queue_;
+};
+
+} // namespace unifex

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -9,9 +9,10 @@ target_sources(unifex
   PRIVATE
     inplace_stop_token.cpp
     manual_event_loop.cpp
-    trampoline_scheduler.cpp
+    static_thread_pool.cpp
     thread_unsafe_event_loop.cpp
-    timed_single_thread_context.cpp)
+    timed_single_thread_context.cpp
+    trampoline_scheduler.cpp)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_sources(unifex

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ #include <unifex/static_thread_pool.hpp>
+
+namespace unifex
+{
+
+static_thread_pool::static_thread_pool()
+: static_thread_pool(std::thread::hardware_concurrency())
+{}
+
+static_thread_pool::static_thread_pool(std::uint32_t threadCount) {
+    assert(threadCount > 0);
+
+    threads_.reserve(threadCount);
+    try {
+        threads_.emplace_back([this] { this->run(); });
+    } catch (...) {
+        close();
+    }
+}
+
+static_thread_pool::~static_thread_pool() {
+    close();
+}
+
+void static_thread_pool::run() noexcept {
+    std::unique_lock lk{mut_};
+    while (true) {
+        while (!queue_.empty()) {
+            auto* task = queue_.pop_front();
+            lk.unlock();
+            task->execute(task);
+            lk.lock();
+        }
+
+        if (stop_) {
+            return;
+        }
+
+        cv_.wait(lk);
+    }
+}
+
+void static_thread_pool::close() noexcept {
+    {
+        std::lock_guard lk{mut_};
+        stop_ = true;
+        cv_.notify_all();
+    }
+    for (auto& t : threads_) {
+        t.join();
+    }
+}
+
+void static_thread_pool::enqueue(task_base* task) noexcept {
+    std::lock_guard lk{mut_};
+    queue_.push_back(task);
+    cv_.notify_one();
+}
+
+}

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -13,63 +13,139 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #include <unifex/static_thread_pool.hpp>
+#include <unifex/static_thread_pool.hpp>
 
 namespace unifex
 {
+  static_thread_pool::static_thread_pool()
+    : static_thread_pool(std::thread::hardware_concurrency()) {}
 
-static_thread_pool::static_thread_pool()
-: static_thread_pool(std::thread::hardware_concurrency())
-{}
-
-static_thread_pool::static_thread_pool(std::uint32_t threadCount) {
+  static_thread_pool::static_thread_pool(std::uint32_t threadCount)
+    : threadCount_(threadCount)
+    , threadStates_(threadCount)
+    , nextThread_(0) {
     assert(threadCount > 0);
 
     threads_.reserve(threadCount);
     try {
-        threads_.emplace_back([this] { this->run(); });
+      for (std::uint32_t i = 0; i < threadCount; ++i) {
+        threads_.emplace_back([this, i] { run(i); });
+      }
     } catch (...) {
-        close();
+      request_stop();
+      join();
+      throw;
     }
-}
+  }
 
-static_thread_pool::~static_thread_pool() {
-    close();
-}
+  static_thread_pool::~static_thread_pool() {
+    request_stop();
+    join();
+  }
 
-void static_thread_pool::run() noexcept {
-    std::unique_lock lk{mut_};
+  void static_thread_pool::request_stop() noexcept {
+    for (auto& state : threadStates_) {
+      state.request_stop();
+    }
+  }
+
+  void static_thread_pool::run(std::uint32_t index) noexcept {
     while (true) {
-        while (!queue_.empty()) {
-            auto* task = queue_.pop_front();
-            lk.unlock();
-            task->execute(task);
-            lk.lock();
+      task_base* task = nullptr;
+      for (std::uint32_t i = 0; i < threadCount_; ++i) {
+        auto queueIndex = (index + i) < threadCount_
+            ? (index + i)
+            : (index + i - threadCount_);
+        auto& state = threadStates_[queueIndex];
+        task = state.try_pop();
+        if (task != nullptr) {
+          break;
         }
+      }
 
-        if (stop_) {
-            return;
+      if (task == nullptr) {
+        task = threadStates_[index].pop();
+        if (task == nullptr) {
+          // request_stop() was called.
+          return;
         }
+      }
 
-        cv_.wait(lk);
+      task->execute(task);
     }
-}
+  }
 
-void static_thread_pool::close() noexcept {
-    {
-        std::lock_guard lk{mut_};
-        stop_ = true;
-        cv_.notify_all();
-    }
+  void static_thread_pool::join() noexcept {
     for (auto& t : threads_) {
-        t.join();
+      t.join();
     }
-}
+    threads_.clear();
+  }
 
-void static_thread_pool::enqueue(task_base* task) noexcept {
-    std::lock_guard lk{mut_};
+  void static_thread_pool::enqueue(task_base* task) noexcept {
+    const std::uint32_t threadCount = threads_.size();
+    const std::uint32_t startIndex =
+        nextThread_.fetch_add(1, std::memory_order_relaxed) % threadCount;
+
+    // First try to enqueue to one of the threads without blocking.
+    for (std::uint32_t i = 0; i < threadCount; ++i) {
+      const auto index = (startIndex + i) < threadCount
+          ? (startIndex + i)
+          : (startIndex + i - threadCount);
+      if (threadStates_[index].try_push(task)) {
+        return;
+      }
+    }
+
+    // Otherwise, do a blocking enqueue on the selected thread.
+    threadStates_[startIndex].push(task);
+  }
+
+  static_thread_pool::task_base* static_thread_pool::thread_state::try_pop() {
+    std::unique_lock lk{mut_, std::try_to_lock};
+    if (!lk || queue_.empty()) {
+      return nullptr;
+    }
+    return queue_.pop_front();
+  }
+
+  static_thread_pool::task_base* static_thread_pool::thread_state::pop() {
+    std::unique_lock lk{mut_};
+    while (queue_.empty()) {
+      if (stopRequested_) {
+        return nullptr;
+      }
+      cv_.wait(lk);
+    }
+    return queue_.pop_front();
+  }
+
+  bool static_thread_pool::thread_state::try_push(task_base* task) {
+    std::unique_lock lk{mut_, std::try_to_lock};
+    if (!lk) {
+      return false;
+    }
+    const bool wasEmpty = queue_.empty();
     queue_.push_back(task);
-    cv_.notify_one();
-}
+    if (wasEmpty) {
+      cv_.notify_one();
+    }
+    return true;
+  }
 
-}
+  void static_thread_pool::thread_state::push(task_base* task) {
+    std::lock_guard lk{mut_};
+    const bool wasEmpty = queue_.empty();
+    queue_.push_back(task);
+    if (wasEmpty) {
+      cv_.notify_one();
+    }
+  }
+
+  void static_thread_pool::thread_state::request_stop() {
+    std::lock_guard lk{mut_};
+    stopRequested_ = true;
+    cv_.notify_one();
+  }
+
+}  // namespace unifex


### PR DESCRIPTION
Adds a simple static_thread_pool class.

Its implementation makes use of relatively heavy-weight condition_variable/mutex synchronisation to synchronise access to the single queue that is shared across all threads. More sophisticated data-structures are possible (mostly-lock-free, work-stealing) with various fairness/performance tradeoffs.

Addresses #17.