### PR TITLE
Allow schedule_after(d) to use implicit scheduler.

### DIFF
--- a/examples/get_scheduler.cpp
+++ b/examples/get_scheduler.cpp
@@ -17,16 +17,19 @@
 #include <unifex/for_each.hpp>
 #include <unifex/range_stream.hpp>
 #include <unifex/scheduler_concepts.hpp>
-#include <unifex/single_thread_context.hpp>
 #include <unifex/sync_wait.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/transform_stream.hpp>
 #include <unifex/via_stream.hpp>
 #include <unifex/with_query_value.hpp>
 
+#include <chrono>
+
 using namespace unifex;
+using namespace std::chrono_literals;
 
 int main() {
-  single_thread_context ctx;
+  timed_single_thread_context ctx;
 
   struct current_scheduler {
     auto schedule() const noexcept {
@@ -38,6 +41,11 @@ int main() {
   // scheduler from the receiver which we inject by using 'with_query_value()'.
   sync_wait(with_query_value(schedule(), get_scheduler,
                              ctx.get_scheduler()));
+
+  // Check that the schedule_after(d) operation can pick up the current
+  // scheduler from the receiver.
+  sync_wait(with_query_value(
+      schedule_after(200ms), get_scheduler, ctx.get_scheduler()));
 
   // Check that this can propagate through multiple levels of
   // composed operations.


### PR DESCRIPTION
You can now specify the `schedule_after(d)` CPO without needing to explicitly specify a scheduler.

This will pick up the implicit current scheduler from the receiver that is eventually attached to the `schedule_after()` operation.