### PR TITLE
Some CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,22 +14,6 @@ include(unifex_options)
 include(unifex_env)
 include(unifex_flags)
 
-configure_file(include/unifex/config.hpp.in unifex/config.hpp)
-
-add_library(unifex-interface INTERFACE)
-
-target_include_directories(unifex-interface
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-    "${PROJECT_BINARY_DIR}") # find the generated config header
-target_compile_features(unifex-interface INTERFACE cxx_std_20)
-if(UNIFEX_CXX_COMPILER_CLANG)
-  target_compile_options(unifex-interface INTERFACE -stdlib=libc++)
-endif()
-if(CXX_COROUTINES_HAVE_COROUTINES)
-  target_link_libraries(unifex-interface INTERFACE std::coroutines)
-endif()
-
 enable_testing()
 
 add_subdirectory(source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the Apache License found in the
 # LICENSE.txt file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 
 project(libunifex CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,8 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(libunifex CXX)
-
-# set the project name and version
-project(libunifex VERSION 0.1)
+project(libunifex LANGUAGES CXX
+                  VERSION 0.1)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,6 +4,7 @@
 # LICENSE.txt file in the root directory of this source tree.
 
 add_library(unifex "")
+
 target_sources(unifex
   PRIVATE
     inplace_stop_token.cpp
@@ -11,11 +12,10 @@ target_sources(unifex
     trampoline_scheduler.cpp
     thread_unsafe_event_loop.cpp
     timed_single_thread_context.cpp)
-target_link_libraries(unifex PUBLIC unifex-interface)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_sources(unifex
-    INTERFACE
+    PRIVATE
       linux/mmap_region.cpp
       linux/monotonic_clock.cpp
       linux/safe_file_descriptor.cpp
@@ -27,6 +27,20 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
       uring)
 endif()
 
+configure_file(
+  ../include/unifex/config.hpp.in
+  unifex/config.hpp)
+
 target_include_directories(unifex
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>)
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
+    "${PROJECT_BINARY_DIR}")
+
+target_compile_features(unifex INTERFACE cxx_std_20)
+
+if(UNIFEX_CXX_COMPILER_CLANG)
+  target_compile_options(unifex INTERFACE -stdlib=libc++)
+endif()
+if(CXX_COROUTINES_HAVE_COROUTINES)
+  target_link_libraries(unifex INTERFACE std::coroutines)
+endif()


### PR DESCRIPTION
- Increase the minimum CMake version to 3.12 (minimum version that supports C++20 language detection)
- Remove the need for both 'unifex-interface' and 'unifex' library targets by using appropriately scoped calls to target_include_directories(), target_sources()
   Note that I may have misunderstood the purpose of the 'unifex-interface' target, but it still seems to build ok for me without it.