### PR TITLE
Remove unifex::cpo namespace

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -216,7 +216,7 @@ struct async_trace_entry {
 };
 ```
 
-### `cpo::blocking(const Sender&) -> blocking_kind`
+### `blocking(const Sender&) -> blocking_kind`
 
 Returns `blocking_kind::never` if the receiver will never be called on the
 current thread before `start()` returns.
@@ -232,7 +232,7 @@ called inline on the current thread before `start()` returns.
 Otherwise returns `blocking_kind::maybe`.
 
 Senders can customise this algorithm by providing an overload of
-`tag_invoke(tag_t<cpo::blocking>, const your_sender_type&)`.
+`tag_invoke(tag_t<blocking>, const your_sender_type&)`.
 
 ## Stream Algorithms
 -----------------

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -41,7 +41,7 @@
 
 # Receiver Queries
 
-### `cpo::get_scheduler(receiver)`
+### `get_scheduler(receiver)`
 
 A query that can be used to obtain the associated scheduler from the receiver.
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -255,13 +255,13 @@ The `stream.cleanup()` Sender is passed through unchanged.
 Applies `state = func(state, value)` for each value produced by `stream`.
 Returns a Sender that returns the final value.
 
-### `cpo::for_each(Stream stream, Func func) -> Sender<void>`
+### `for_each(Stream stream, Func func) -> Sender<void>`
 
 Executes func(value) for each value produced by stream.
 Returned sender sends .value() once end of stream is reached.
 
 Stream types can customise this algorithm via ADL by providing an overload
-of `tag_invoke(tag_t<cpo::for_each>, your_stream_type, Func)`.
+of `tag_invoke(tag_t<for_each>, your_stream_type, Func)`.
 
 ### `transform_stream(Stream stream, Func func) -> Stream`
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -238,17 +238,17 @@ Senders can customise this algorithm by providing an overload of
 -----------------
 ### `adapt_stream(Stream stream, Func adaptor) -> Stream`
 
-Applies `adaptor()` to `stream.next()` and `stream.cleanup()` senders.
+Applies `adaptor()` to `next(stream)` and `cleanup(stream)` senders.
 
 ### `adapt_stream(Stream stream, Func nextAdaptor, Func cleanupAdaptor) -> Stream`
 
-Applies `nextAdaptor()` to `stream.next()` and
-applies `cleanupAdaptor()` to `stream.cleanup()`.
+Applies `nextAdaptor()` to `next(stream)` and
+applies `cleanupAdaptor()` to `cleanup(stream)`.
 
 ### `next_adapt_stream(Stream stream, Func adaptor) -> Stream`
 
-Applies `adaptor()` to `stream.next()` only.
-The `stream.cleanup()` Sender is passed through unchanged.
+Applies `adaptor()` to `next(stream)` only.
+The `cleanup(stream)` Sender is passed through unchanged.
 
 ### `reduce_stream(Stream stream, T initialState, Func reducer) -> Sender<T>`
 
@@ -287,7 +287,7 @@ providing the `value_types`/`error_types` type aliases.
 
 ### `on_stream(Scheduler scheduler, Stream stream) -> Stream`
 
-Returns a stream that ensures `stream.next()` is started on the specified
+Returns a stream that ensures `next(stream)` is started on the specified
 scheduler's execution context.
 
 ### `type_erase<Ts...>(Stream stream) -> type_erased_stream<Ts...>`
@@ -308,18 +308,18 @@ produce `done()` as the second element of the stream.
 
 ### `stop_immediately<Ts...>(Stream stream) -> Stream`
 
-Returns a stream that will immediately send `.done()` from a pending `.next()`
+Returns a stream that will immediately send `set_done()` from a pending `next()`
 when stop is requested on the provided stop-token.
 
-The request to stop will be passed on to the upstream `.next()` call but
+The request to stop will be passed on to the upstream `next()` call but
 it will not wait for that stream to respond to cancellation before sending
-`.done()`.
+`set_done()`.
 
-The abandoned `.next()` call will be waited-for by the `.cleanup()`.
+The abandoned `next(stream)` call will be waited-for by the `cleanup(stream)`.
 
-Any `.value()` produced by an abandoned `.next()` call is discarded.
-Any `.error()` produced by an abandoned `.next()` call is reported in
-the `.cleanup()` result.
+Any `.value()` produced by an abandoned `next()` call is discarded.
+Any `.error()` produced by an abandoned `next()` call is reported in
+the `cleanup()` result.
 
 ## Scheduler Algorithms
 
@@ -434,10 +434,10 @@ ie. calls to `.value()` will be passed arguments of type `Ts&&...`
 
 ### `never_stream`
 
-A stream whose `.next()` completes with `.done()` once when stop is requested.
+A stream whose `next()` completes with `set_done()` once when stop is requested.
 
 Note that using this stream with a stop-token where `stop_possible()` returns
-`false` will result in a memory-leak. The `.next()` operation will never
+`false` will result in a memory-leak. The `next()` operation will never
 complete.
 
 ## StopToken Types

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -374,8 +374,8 @@ work to run once the call-stack has unwound back to the first call.
 ### `timed_single_thread_context`
 
 A single-threaded execution context that suppors scheduling work at a
-particular time via either `cpo::schedule_at()` with a time-point or
-`cpo::schedule_after()` with a delay in addition to the regular `cpo::schedule()`
+particular time via either `schedule_at()` with a time-point or
+`schedule_after()` with a delay in addition to the regular `schedule()`
 operation which is equivalent to calling `schedule_at()` with the current
 time.
 
@@ -386,8 +386,8 @@ Obtain a TimeScheduler by calling the `.get_scheduler()` method.
 An execution context that assumes all accesses to the scheduler are from the same
 thread. It does not do any thread-synchronisation internally.
 
-Supports `.schedule_at()` and `.schedule_after()` operations in addition to
-the base `.schedule()` operation.
+Supports `schedule_at()` and `schedule_after()` operations in addition to
+the base `schedule()` operation.
 
 Obtain a TimeScheduler to schedule work onto this context by calling the
 `.get_scheduler()` method.

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -87,15 +87,15 @@ execution context that `successor` completes on.
 Any value produced by `successor` is discarded.
 QUESTION: Should we require that `successor` is a `void`-sender?
 
-If `successor` completes with `.done()` then `.done()` is sent.
-If `successor` completes with `.error()` then its error is sent.
+If `successor` completes with `set_done()` then `set_done()` is sent.
+If `successor` completes with `set_error()` then its error is sent.
 Otherwise sends the result of `predecessor`.
 
 ### `typed_via(Sender successor, Sender predecessor) -> Sender`
 
 Returns a sender that produces the result from `predecessor`, which must
 declare the nested `value_types`/`error_types` type aliases which describe which
-overloads of `.value()`/`.error()` they will call, on the execution context that
+overloads of `set_value()`/`set_error()` they will call, on the execution context that
 `successor` completes on.
 
 Any value produced by `successor` is discarded.
@@ -110,7 +110,7 @@ Returns a sender that ensures that `successor` is started on the
 execution context that `predecessor` completes on.
 
 Discards any value produced by predecessor and sends the result of
-`successor`. If `predecessor` completes with `.done()` or `.error()` then
+`successor`. If `predecessor` completes with `set_done()` or `set_error()` then
 sends that signal and never starts executing successor.
 
 ### `let(Sender pred, Invocable func) -> Sender`
@@ -150,9 +150,9 @@ and the operation as a whole completes with that done/error signal.
 
 Blocks the current thread waiting for the specified sender to complete.
 
-Returns a non-empty optional if it completed with `.value()`.
-Or `std::nullopt` if it completed with `.done()`
-Or throws an exception if it completed with `.error()`
+Returns a non-empty optional if it completed with `set_value()`.
+Or `std::nullopt` if it completed with `set_done()`
+Or throws an exception if it completed with `set_error()`
 
 ### `when_all(Senders...) -> Sender`
 
@@ -257,8 +257,8 @@ Returns a Sender that returns the final value.
 
 ### `for_each(Stream stream, Func func) -> Sender<void>`
 
-Executes func(value) for each value produced by stream.
-Returned sender sends .value() once end of stream is reached.
+Executes `func(value)` for each value produced by stream.
+Returned sender completes with `set_value()` once end of stream is reached.
 
 Stream types can customise this algorithm via ADL by providing an overload
 of `tag_invoke(tag_t<for_each>, your_stream_type, Func)`.
@@ -282,7 +282,7 @@ Returns a stream that calls the receiver methods on the specified
 scheduler's execution context.
 
 This differs from `via_stream()` in that it requires that the stream
-declares what overloads of `.value()` and `.error()` it will call by
+declares what overloads of `set_value()` and `set_error()` it will call by
 providing the `value_types`/`error_types` type aliases.
 
 ### `on_stream(Scheduler scheduler, Stream stream) -> Stream`
@@ -317,8 +317,8 @@ it will not wait for that stream to respond to cancellation before sending
 
 The abandoned `next(stream)` call will be waited-for by the `cleanup(stream)`.
 
-Any `.value()` produced by an abandoned `next()` call is discarded.
-Any `.error()` produced by an abandoned `next()` call is reported in
+Any `set_value()` produced by an abandoned `next()` call is discarded.
+Any `set_error()` produced by an abandoned `next()` call is reported in
 the `cleanup()` result.
 
 ## Scheduler Algorithms
@@ -430,7 +430,7 @@ Mainly used for testing purposes.
 ### `type_erased_stream<Ts...>`
 
 A type-erased stream that produces a sequence of value packs of type `(Ts, ...)`.
-ie. calls to `.value()` will be passed arguments of type `Ts&&...`
+ie. calls to `set_value()` will be passed arguments of type `Ts&&...`
 
 ### `never_stream`
 

--- a/doc/cancellation.md
+++ b/doc/cancellation.md
@@ -87,8 +87,8 @@ For example, a consumer might be processing elements from a stream one
 at a time until it sees an element that matches a certain predicate.
 When it receives the next element it matches it against the predicate
 and then based on the result can either ask for the next element,
-by calling the `.next()` method on the stream. Or it can cancel the
-stream by calling the `.cleanup()` method on the stream.
+by calling the `next()` operation on the stream. Or it can cancel the
+stream by calling the `cleanup()` operation on the stream.
 
 As the stream has not yet been asked to produce the next element there
 is no need to cancel an already-running operation and so we can cancel

--- a/doc/concepts.md
+++ b/doc/concepts.md
@@ -671,7 +671,7 @@ namespace unifex
     requires(const T scheduler) {
       now(scheduler);
       schedule_at(scheduler, now(scheduler));
-      schedule_after(scheduelr, now(scheduler) - now(scheduler));
+      schedule_after(scheduler, now(scheduler) - now(scheduler));
     };
 }
 ```

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -22,9 +22,9 @@ template<typename Receiver>
 struct my_receiver {
   Receiver wrappedReceiver_;
 
-  void value() && noexcept;
-  void error(std::exception_ptr) && noexcept;
-  void done() && noexcept;
+  void set_value() && noexcept;
+  void set_error(std::exception_ptr) && noexcept;
+  void set_done() && noexcept;
 
   template <typename Func>
   friend void tag_invoke(

--- a/examples/async_trace.cpp
+++ b/examples/async_trace.cpp
@@ -78,7 +78,7 @@ int main() {
       when_all(
           transform(
               dump_async_trace_on_start(
-                  cpo::schedule_after(context.get_scheduler(), 100ms), "part1"),
+                  schedule_after(context.get_scheduler(), 100ms), "part1"),
               [=]() {
                 auto time = steady_clock::now() - start;
                 auto timeMs = duration_cast<milliseconds>(time).count();
@@ -87,7 +87,7 @@ int main() {
               }),
           transform(
               dump_async_trace_on_completion(
-                  cpo::schedule_after(context.get_scheduler(), 200ms), "part2"),
+                  schedule_after(context.get_scheduler(), 200ms), "part2"),
               [=]() {
                 auto time = steady_clock::now() - start;
                 auto timeMs = duration_cast<milliseconds>(time).count();

--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -49,7 +49,7 @@ int main() {
         single(cpo::schedule_after(context.get_scheduler(), 500ms)));
 
     int sum = 0;
-    while (auto value = co_await s.next()) {
+    while (auto value = co_await next(s)) {
       auto ms = duration_cast<milliseconds>(steady_clock::now() - start);
       std::printf("[%i ms] %i\n", (int)ms.count(), *value);
       std::fflush(stdout);
@@ -57,7 +57,7 @@ int main() {
       sum += *value;
     }
 
-    co_await s.cleanup();
+    co_await cleanup(s);
 
     auto ms = duration_cast<milliseconds>(steady_clock::now() - start);
     std::printf("[%i ms] sum = %i\n", (int)ms.count(), sum);

--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -46,7 +46,7 @@ int main() {
     auto s = take_until(
         stop_immediately<int>(typed_via_stream(
             delay(context.get_scheduler(), 50ms), range_stream{0, 100})),
-        single(cpo::schedule_after(context.get_scheduler(), 500ms)));
+        single(schedule_after(context.get_scheduler(), 500ms)));
 
     int sum = 0;
     while (auto value = co_await next(s)) {

--- a/examples/delayed_stream_cancellation.cpp
+++ b/examples/delayed_stream_cancellation.cpp
@@ -46,9 +46,10 @@ int main() {
   auto start = steady_clock::now();
 
   sync_wait(
-      cpo::for_each(
+      for_each(
           typed_via_stream(
               delay(context.get_scheduler(), 100ms), range_stream{0, 100}),
+
           [start](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - start);
             std::printf("[%i ms] %i\n", (int)ms.count(), value);

--- a/examples/for_each_synchronous.cpp
+++ b/examples/for_each_synchronous.cpp
@@ -25,7 +25,7 @@ using namespace unifex;
 
 int main() {
   sync_wait(transform(
-      cpo::for_each(
+      for_each(
           transform_stream(
               range_stream{0, 10}, [](int value) { return value * value; }),
           [](int value) { std::printf("got %i\n", value); }),

--- a/examples/for_each_via_thread_scheduler.cpp
+++ b/examples/for_each_via_thread_scheduler.cpp
@@ -29,7 +29,7 @@ int main() {
   single_thread_context context;
 
   sync_wait(transform(
-      cpo::for_each(
+      for_each(
           via_stream(
               context.get_scheduler(),
               transform_stream(

--- a/examples/for_each_via_trampoline.cpp
+++ b/examples/for_each_via_trampoline.cpp
@@ -27,7 +27,7 @@ using namespace unifex;
 
 int main() {
   sync_wait(transform(
-      cpo::for_each(
+      for_each(
           typed_via_stream(
               trampoline_scheduler{},
               transform_stream(

--- a/examples/get_scheduler.cpp
+++ b/examples/get_scheduler.cpp
@@ -29,12 +29,14 @@ int main() {
   single_thread_context ctx;
 
   struct current_scheduler {
-    auto schedule() { return cpo::schedule(); }
+    auto schedule() const noexcept {
+      return unifex::schedule();
+    }
   };
 
   // Check that the schedule() operation can pick up the current
   // scheduler from the receiver which we inject by using 'with_query_value()'.
-  sync_wait(with_query_value(cpo::schedule(), cpo::get_scheduler,
+  sync_wait(with_query_value(schedule(), get_scheduler,
                              ctx.get_scheduler()));
 
   // Check that this can propagate through multiple levels of
@@ -48,7 +50,7 @@ int main() {
                                                })),
                    [](int value) { std::printf("got %i\n", value); }),
           []() { std::printf("done\n"); }),
-      cpo::get_scheduler, ctx.get_scheduler()));
+      get_scheduler, ctx.get_scheduler()));
 
   return 0;
 }

--- a/examples/get_scheduler.cpp
+++ b/examples/get_scheduler.cpp
@@ -41,12 +41,12 @@ int main() {
   // composed operations.
   sync_wait(with_query_value(
       transform(
-          cpo::for_each(via_stream(current_scheduler{},
-                                   transform_stream(range_stream{0, 10},
-                                                    [](int value) {
-                                                      return value * value;
-                                                    })),
-                        [](int value) { std::printf("got %i\n", value); }),
+          for_each(via_stream(current_scheduler{},
+                              transform_stream(range_stream{0, 10},
+                                               [](int value) {
+                                                 return value * value;
+                                               })),
+                   [](int value) { std::printf("got %i\n", value); }),
           []() { std::printf("done\n"); }),
       cpo::get_scheduler, ctx.get_scheduler()));
 

--- a/examples/let.cpp
+++ b/examples/let.cpp
@@ -35,7 +35,7 @@ int main() {
 
   auto async = [&](auto&& func) {
     return transform(
-        cpo::schedule_after(context.get_scheduler(), 100ms),
+        schedule_after(context.get_scheduler(), 100ms),
         (decltype(func))func);
   };
 

--- a/examples/linux/io_uring_test.cpp
+++ b/examples/linux/io_uring_test.cpp
@@ -119,13 +119,13 @@ int main() {
       sync_wait(
           when_all(
               transform(
-                  cpo::schedule_at(scheduler, cpo::now(scheduler) + 1s),
+                  schedule_at(scheduler, now(scheduler) + 1s),
                   []() { std::printf("timer 1 completed (1s)\n"); }),
               transform(
-                  cpo::schedule_at(scheduler, cpo::now(scheduler) + 2s),
+                  schedule_at(scheduler, now(scheduler) + 2s),
                   []() { std::printf("timer 2 completed (2s)\n"); }),
               transform(
-                  cpo::schedule_at(scheduler, cpo::now(scheduler) + 1500ms),
+                  schedule_at(scheduler, now(scheduler) + 1500ms),
                   [&]() {
                     std::printf("timer 3 completed (1.5s) cancelling\n");
                     timerStopSource.request_stop();
@@ -145,7 +145,7 @@ int main() {
         write_new_file(scheduler, "test.txt"),
         lazy([] { std::printf("write completed, waiting 1s\n"); }),
         transform(
-            cpo::schedule_at(scheduler, cpo::now(scheduler) + 1s),
+            schedule_at(scheduler, now(scheduler) + 1s),
             []() { std::printf("timer 1 completed (1s)\n"); }),
         lazy([] { std::printf("reading file concurrently\n"); }),
         when_all(

--- a/examples/never_stream_cancellation.cpp
+++ b/examples/never_stream_cancellation.cpp
@@ -44,7 +44,7 @@ int main() {
   scope_guard joinThread = [&]() noexcept { t.join(); };
 
   std::optional<unit> result = sync_wait(
-      cpo::for_each(
+      for_each(
           never_stream{},
           [](auto) {
             std::printf("got value");

--- a/examples/produce_on_consume_via.cpp
+++ b/examples/produce_on_consume_via.cpp
@@ -31,7 +31,7 @@ int main() {
   single_thread_context context2;
 
   sync_wait(transform(
-      cpo::for_each(
+      for_each(
           typed_via_stream(
               context1.get_scheduler(),
               on_stream(

--- a/examples/schedule_with_subscheduler.cpp
+++ b/examples/schedule_with_subscheduler.cpp
@@ -25,7 +25,7 @@ int main() {
   auto scheduler = context.get_scheduler();
 
   std::optional<bool> result = sync_wait(transform(
-      cpo::schedule_with_subscheduler(scheduler),
+      schedule_with_subscheduler(scheduler),
       [&](auto subScheduler) noexcept { return subScheduler == scheduler; }));
 
   if (result.has_value() && result.value()) {

--- a/examples/static_thread_pool.cpp
+++ b/examples/static_thread_pool.cpp
@@ -26,7 +26,7 @@ using namespace unifex;
 
 template <typename Scheduler, typename F>
 auto run_on(Scheduler&& s, F&& func) {
-  return transform(cpo::schedule((Scheduler &&) s), (F &&) func);
+  return transform(schedule((Scheduler &&) s), (F &&) func);
 }
 
 int main() {

--- a/examples/stop_immediately.cpp
+++ b/examples/stop_immediately.cpp
@@ -42,7 +42,7 @@ int main() {
               stop_immediately<int>(typed_via_stream(
                   delay(eventLoop.get_scheduler(), 50ms),
                   range_stream{0, 100})),
-              single(eventLoop.get_scheduler().schedule_after(500ms))),
+              single(schedule_after(eventLoop.get_scheduler(), 500ms))),
           [start](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - start);
             std::printf("[%i ms] %i\n", (int)ms.count(), value);

--- a/examples/stop_immediately.cpp
+++ b/examples/stop_immediately.cpp
@@ -37,7 +37,7 @@ int main() {
   auto start = steady_clock::now();
 
   [[maybe_unused]] std::optional<unit> result =
-      eventLoop.sync_wait(cpo::for_each(
+      eventLoop.sync_wait(for_each(
           take_until(
               stop_immediately<int>(typed_via_stream(
                   delay(eventLoop.get_scheduler(), 50ms),

--- a/examples/stream_cancellation.cpp
+++ b/examples/stream_cancellation.cpp
@@ -49,7 +49,7 @@ int main() {
   auto start = steady_clock::now();
 
   sync_wait(
-      on(cpo::schedule(context.get_scheduler()),
+      on(schedule(context.get_scheduler()),
          for_each(
              on_stream(trampoline_scheduler{}, range_stream{0, 20}),
              [](int value) {

--- a/examples/stream_cancellation.cpp
+++ b/examples/stream_cancellation.cpp
@@ -50,7 +50,7 @@ int main() {
 
   sync_wait(
       on(cpo::schedule(context.get_scheduler()),
-         cpo::for_each(
+         for_each(
              on_stream(trampoline_scheduler{}, range_stream{0, 20}),
              [](int value) {
                // Simulate some work

--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -88,7 +88,7 @@ void test(Scheduler scheduler, Allocator allocator) {
   auto addToValue = [&](int x) {
     // The via() is expected to allocate when it calls submit().
     // NOTE: This may start failing if we ever merge via() and typed_via().
-    return transform(via(cpo::schedule(scheduler), just(x)), [&](int x) {
+    return transform(via(schedule(scheduler), just(x)), [&](int x) {
       std::printf("got %i\n", x);
       value += x;
     });

--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -33,17 +33,17 @@ struct increment_receiver {
   int &value_;
   manual_event_loop &loop_;
 
-  void value() && noexcept {
+  void set_value() && noexcept {
     if (++value_ == 3) {
       loop_.stop();
     }
   }
 
-  template <typename E>[[noreturn]] void error(E &&error) && noexcept {
+  template <typename E>[[noreturn]] void set_error(E &&error) && noexcept {
     std::terminate();
   }
 
-  [[noreturn]] void done() && noexcept { std::terminate(); }
+  [[noreturn]] void set_done() && noexcept { std::terminate(); }
 };
 
 #if !UNIFEX_NO_MEMORY_RESOURCE

--- a/examples/via.cpp
+++ b/examples/via.cpp
@@ -26,7 +26,7 @@ using namespace unifex;
 int main() {
   inline_scheduler scheduler;
   sync_wait_r<void>(
-      via(cpo::schedule(scheduler), transform(cpo::schedule(scheduler), []() {
+      via(schedule(scheduler), transform(schedule(scheduler), []() {
             std::printf("Hello from inline_scheduler");
           })));
   return 0;

--- a/examples/when_all.cpp
+++ b/examples/when_all.cpp
@@ -36,7 +36,7 @@ int main() {
   sync_wait(transform(
       when_all(
           transform(
-              cpo::schedule_after(scheduler, 100ms),
+              schedule_after(scheduler, 100ms),
               [=]() {
                 auto time = steady_clock::now() - start;
                 auto timeMs = duration_cast<milliseconds>(time).count();
@@ -44,7 +44,7 @@ int main() {
                 return time;
               }),
           transform(
-              cpo::schedule_after(scheduler, 200ms),
+              schedule_after(scheduler, 200ms),
               [=]() {
                 auto time = steady_clock::now() - start;
                 auto timeMs = duration_cast<milliseconds>(time).count();

--- a/examples/when_all_2.cpp
+++ b/examples/when_all_2.cpp
@@ -44,7 +44,7 @@ int main() {
     sync_wait(transform(
         when_all(
             transform(
-                cpo::schedule_after(scheduler, 100ms),
+                schedule_after(scheduler, 100ms),
                 [&]() -> steady_clock::time_point::duration {
                   ranPart1Callback = true;
                   auto time = steady_clock::now() - start;
@@ -54,7 +54,7 @@ int main() {
                   throw my_error{};
                 }),
             transform(
-                cpo::schedule_after(scheduler, 200ms),
+                schedule_after(scheduler, 200ms),
                 [&]() {
                   ranPart2Callback = true;
                   auto time = steady_clock::now() - start;

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -186,7 +186,7 @@ class async_trace_sender {
   }
 
   friend blocking_kind tag_invoke(
-      tag_t<cpo::blocking>,
+      tag_t<blocking>,
       const async_trace_sender&) noexcept {
     return blocking_kind::always_inline;
   }

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -172,9 +172,9 @@ class async_trace_sender {
     void start() noexcept {
       try {
         auto trace = async_trace(receiver_);
-        cpo::set_value(std::move(receiver_), std::move(trace));
+        unifex::set_value(std::move(receiver_), std::move(trace));
       } catch (...) {
-        cpo::set_error(std::move(receiver_), std::current_exception());
+        unifex::set_error(std::move(receiver_), std::current_exception());
       }
     }
   };

--- a/include/unifex/awaitable_sender.hpp
+++ b/include/unifex/awaitable_sender.hpp
@@ -129,7 +129,7 @@ struct awaitable_sender {
             if constexpr (std::is_void_v<result_type>) {
               co_await(Awaitable &&) awaitable;
               co_yield[&] {
-                cpo::set_value(std::move(receiver));
+                unifex::set_value(std::move(receiver));
               };
             } else {
               // This is a bit mind bending control-flow wise.
@@ -143,7 +143,7 @@ struct awaitable_sender {
               co_yield std::invoke(
                   [&](result_type&& result) {
                     return [&] {
-                      cpo::set_value(
+                      unifex::set_value(
                           std::move(receiver), (result_type &&) result);
                     };
                   },
@@ -153,7 +153,7 @@ struct awaitable_sender {
             ex = std::current_exception();
           }
           co_yield[&] {
-            cpo::set_error(std::move(receiver), std::move(ex));
+            unifex::set_error(std::move(receiver), std::move(ex));
           };
         },
         (Awaitable &&) awaitable_,

--- a/include/unifex/blocking.hpp
+++ b/include/unifex/blocking.hpp
@@ -41,8 +41,6 @@ enum class blocking_kind {
   always_inline
 };
 
-namespace cpo {
-
 inline constexpr struct blocking_cpo {
   template <typename Sender>
   friend constexpr blocking_kind tag_invoke(
@@ -59,5 +57,4 @@ inline constexpr struct blocking_cpo {
   }
 } blocking;
 
-} // namespace cpo
 } // namespace unifex

--- a/include/unifex/delay.hpp
+++ b/include/unifex/delay.hpp
@@ -28,7 +28,7 @@ struct delayed_scheduler {
   Duration duration_;
 
   auto schedule() {
-    return cpo::schedule_after(scheduler_, duration_);
+    return unifex::schedule_after(scheduler_, duration_);
   }
 };
 

--- a/include/unifex/execute.hpp
+++ b/include/unifex/execute.hpp
@@ -45,7 +45,7 @@ namespace unifex
             } else {
                 // Default implementation.
                 return submit(
-                    transform(cpo::schedule((Scheduler&&)s), (Func&&)func),
+                    transform(schedule((Scheduler&&)s), (Func&&)func),
                     detail::default_execute_receiver{});
             }
         }

--- a/include/unifex/execute.hpp
+++ b/include/unifex/execute.hpp
@@ -28,12 +28,12 @@ namespace unifex
     namespace detail
     {
         struct default_execute_receiver {
-            void done() && noexcept {}
+            void set_done() && noexcept {}
             template<typename Error>
-            [[noreturn]] void error(Error&&) && noexcept {
+            [[noreturn]] void set_error(Error&&) && noexcept {
                 std::terminate();
             }
-            void value() && noexcept {}
+            void set_value() && noexcept {}
         };
     }
 

--- a/include/unifex/for_each.hpp
+++ b/include/unifex/for_each.hpp
@@ -20,7 +20,6 @@
 #include <unifex/type_traits.hpp>
 
 namespace unifex {
-namespace cpo {
 
 inline constexpr struct for_each_cpo {
   template <typename Stream, typename Func>
@@ -44,5 +43,4 @@ inline constexpr struct for_each_cpo {
   }
 } for_each;
 
-} // namespace cpo
 } // namespace unifex

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -55,12 +55,12 @@ struct inline_scheduler {
 
       void start() noexcept {
         if constexpr (is_stop_never_possible_v<stop_token_type>) {
-          cpo::set_value((Receiver &&) receiver_);
+          unifex::set_value((Receiver &&) receiver_);
         } else {
           if (get_stop_token(receiver_).stop_requested()) {
-            cpo::set_done((Receiver &&) receiver_);
+            unifex::set_done((Receiver &&) receiver_);
           } else {
-            cpo::set_value((Receiver &&) receiver_);
+            unifex::set_value((Receiver &&) receiver_);
           }
         }
       }

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -38,7 +38,7 @@ struct inline_scheduler {
     using error_types = Variant<>;
 
     friend constexpr blocking_kind tag_invoke(
-        tag_t<cpo::blocking>,
+        tag_t<blocking>,
         const schedule_task&) noexcept {
       return blocking_kind::always_inline;
     }

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -72,7 +72,7 @@ struct inline_scheduler {
     }
   };
 
-  schedule_task schedule() {
+  constexpr schedule_task schedule() const noexcept {
     return {};
   }
 };

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -69,7 +69,7 @@ class just_sender {
     return {std::move(values_), (Receiver &&) r};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<cpo::blocking>, const just_sender&) noexcept {
+  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const just_sender&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -54,11 +54,11 @@ class just_sender {
       try {
         std::apply(
             [&](Values&&... values) {
-              cpo::set_value((Receiver &&) receiver_, (Values &&) values...);
+              unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
             },
             std::move(values_));
       } catch (...) {
-        cpo::set_error((Receiver &&) receiver_, std::current_exception());
+        unifex::set_error((Receiver &&) receiver_, std::current_exception());
       }
     }
   };

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -110,22 +110,22 @@ class let_sender {
       void value(SuccessorValues&&... values) && noexcept {
         cleanup();
         try {
-          cpo::set_value(
+          unifex::set_value(
               std::move(op_.receiver_), (SuccessorValues &&) values...);
         } catch (...) {
-          cpo::set_error(std::move(op_.receiver_), std::current_exception());
+          unifex::set_error(std::move(op_.receiver_), std::current_exception());
         }
       }
 
       void done() && noexcept {
         cleanup();
-        cpo::set_done(std::move(op_.receiver_));
+        unifex::set_done(std::move(op_.receiver_));
       }
 
       template <typename Error>
       void error(Error&& error) && noexcept {
         cleanup();
-        cpo::set_error(std::move(op_.receiver_), (Error &&) error);
+        unifex::set_error(std::move(op_.receiver_), (Error &&) error);
       }
 
      private:
@@ -136,7 +136,7 @@ class let_sender {
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -183,24 +183,24 @@ class let_sender {
           if (!destroyedPredOp) {
             op_.predOp_.destruct();
           }
-          cpo::set_error(std::move(op_.receiver_), std::current_exception());
+          unifex::set_error(std::move(op_.receiver_), std::current_exception());
         }
       }
 
       void done() && noexcept {
         op_.predOp_.destruct();
-        cpo::set_done(std::move(op_.receiver_));
+        unifex::set_done(std::move(op_.receiver_));
       }
 
       template <typename Error>
       void error(Error&& error) && noexcept {
         op_.predOp_.destruct();
-        cpo::set_error(std::move(op_.receiver_), (Error &&) error);
+        unifex::set_error(std::move(op_.receiver_), (Error &&) error);
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -170,11 +170,11 @@ class let_sender {
             auto& succOp =
                 op_.succOp_.template get<successor_operation<Values...>>()
                     .construct_from([&] {
-                      return cpo::connect(
+                      return unifex::connect(
                           std::apply(std::move(op_.func_), valueTuple.get()),
                           successor_receiver<Values...>{op_});
                     });
-            cpo::start(succOp);
+            unifex::start(succOp);
           } catch (...) {
             valueTuple.destruct();
             throw;
@@ -225,7 +225,7 @@ class let_sender {
         : func_((SuccessorFactory &&) func),
           receiver_((Receiver2 &&) receiver) {
       predOp_.construct_from([&] {
-        return cpo::connect((Predecessor &&) pred, predecessor_receiver{*this});
+        return unifex::connect((Predecessor &&) pred, predecessor_receiver{*this});
       });
     }
 
@@ -237,7 +237,7 @@ class let_sender {
 
     void start() noexcept {
       started_ = true;
-      cpo::start(predOp_.get());
+      unifex::start(predOp_.get());
     }
 
    private:

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -107,7 +107,7 @@ class let_sender {
       Receiver&  get_receiver() const { return op_.receiver_; }
 
       template <typename... SuccessorValues>
-      void value(SuccessorValues&&... values) && noexcept {
+      void set_value(SuccessorValues&&... values) && noexcept {
         cleanup();
         try {
           unifex::set_value(
@@ -117,13 +117,13 @@ class let_sender {
         }
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         cleanup();
         unifex::set_done(std::move(op_.receiver_));
       }
 
       template <typename Error>
-      void error(Error&& error) && noexcept {
+      void set_error(Error&& error) && noexcept {
         cleanup();
         unifex::set_error(std::move(op_.receiver_), (Error &&) error);
       }
@@ -158,7 +158,7 @@ class let_sender {
       Receiver&  get_receiver() const { return op_.receiver_; }
 
       template <typename... Values>
-      void value(Values&&... values) && noexcept {
+      void set_value(Values&&... values) && noexcept {
         bool destroyedPredOp = false;
         try {
           auto& valueTuple =
@@ -187,13 +187,13 @@ class let_sender {
         }
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         op_.predOp_.destruct();
         unifex::set_done(std::move(op_.receiver_));
       }
 
       template <typename Error>
-      void error(Error&& error) && noexcept {
+      void set_error(Error&& error) && noexcept {
         op_.predOp_.destruct();
         unifex::set_error(std::move(op_.receiver_), (Error &&) error);
       }

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -324,7 +324,7 @@ class io_uring_context::schedule_sender {
       try {
         context_.schedule_impl(this);
       } catch (...) {
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }
@@ -342,12 +342,12 @@ class io_uring_context::schedule_sender {
       operation& op = *static_cast<operation*>(p);
       if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
         if (get_stop_token(op.receiver_).stop_requested()) {
-          cpo::set_done(static_cast<Receiver&&>(op.receiver_));
+          unifex::set_done(static_cast<Receiver&&>(op.receiver_));
           return;
         }
       }
 
-      cpo::set_value(static_cast<Receiver&&>(op.receiver_));
+      unifex::set_value(static_cast<Receiver&&>(op.receiver_));
     }
 
     io_uring_context& context_;
@@ -440,11 +440,11 @@ class io_uring_context::read_sender {
     static void on_read_complete(operation_base* op) noexcept {
       auto& self = *static_cast<operation*>(op);
       if (self.result_ >= 0) {
-        cpo::set_value(std::move(self.receiver_), ssize_t(self.result_));
+        unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
       } else if (self.result_ == -ECANCELED) {
-        cpo::set_done(std::move(self.receiver_));
+        unifex::set_done(std::move(self.receiver_));
       } else {
-        cpo::set_error(
+        unifex::set_error(
             std::move(self.receiver_),
             std::error_code{-self.result_, std::system_category()});
       }
@@ -548,11 +548,11 @@ class io_uring_context::write_sender {
     static void on_write_complete(operation_base* op) noexcept {
       auto& self = *static_cast<operation*>(op);
       if (self.result_ >= 0) {
-        cpo::set_value(std::move(self.receiver_), ssize_t(self.result_));
+        unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
       } else if (self.result_ == -ECANCELED) {
-        cpo::set_done(std::move(self.receiver_));
+        unifex::set_done(std::move(self.receiver_));
       } else {
-        cpo::set_error(
+        unifex::set_error(
             std::move(self.receiver_),
             std::error_code{-self.result_, std::system_category()});
       }
@@ -708,7 +708,7 @@ class io_uring_context::schedule_at_sender {
       // Avoid instantiating set_done() if we're not going to call it.
       if constexpr (is_stop_ever_possible) {
         auto& timerOp = *static_cast<operation*>(op);
-        cpo::set_done(std::move(timerOp).receiver_);
+        unifex::set_done(std::move(timerOp).receiver_);
       } else {
         // This should never be called if stop is not possible.
         assert(false);
@@ -727,7 +727,7 @@ class io_uring_context::schedule_at_sender {
         }
       }
 
-      cpo::set_value(std::move(timerOp).receiver_);
+      unifex::set_value(std::move(timerOp).receiver_);
     }
 
     static void remove_timer_from_queue_and_complete_with_done(
@@ -745,7 +745,7 @@ class io_uring_context::schedule_at_sender {
           timerOp.context_.remove_timer(&timerOp);
         }
 
-        cpo::set_done(std::move(timerOp).receiver_);
+        unifex::set_done(std::move(timerOp).receiver_);
       } else {
         // Should never be called if stop is not possible.
         assert(false);

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -46,7 +46,7 @@ class manual_event_loop {
 
     private:
       friend constexpr blocking_kind tag_invoke(
-          tag_t<cpo::blocking>,
+          tag_t<blocking>,
           const schedule_task&) noexcept {
         return blocking_kind::never;
       }

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -69,12 +69,12 @@ class manual_event_loop {
 
         void execute() noexcept override {
           if constexpr (is_stop_never_possible_v<stop_token_type>) {
-            cpo::set_value(std::move(receiver_));
+            unifex::set_value(std::move(receiver_));
           } else {
             if (get_stop_token(receiver_).stop_requested()) {
-              cpo::set_done(std::move(receiver_));
+              unifex::set_done(std::move(receiver_));
             } else {
-              cpo::set_value(std::move(receiver_));
+              unifex::set_value(std::move(receiver_));
             }
           }
         }

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -43,7 +43,7 @@ struct never_sender {
       operation& op_;
       void operator()() noexcept {
         op_.stopCallback_.destruct();
-        cpo::set_done(static_cast<Receiver&&>(op_.receiver_));
+        unifex::set_done(static_cast<Receiver&&>(op_.receiver_));
       }
     };
 

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -22,6 +22,7 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
 #include <unifex/get_stop_token.hpp>
+#include <unifex/stream_concepts.hpp>
 
 #include <type_traits>
 
@@ -76,10 +77,10 @@ struct never_sender {
 };
 
 struct never_stream {
-  never_sender next() noexcept {
+  friend constexpr never_sender tag_invoke(tag_t<next>, never_stream&) noexcept {
     return {};
   }
-  ready_done_sender cleanup() noexcept {
+  friend constexpr ready_done_sender tag_invoke(tag_t<cleanup>, never_stream&) noexcept {
     return {};
   }
 };

--- a/include/unifex/next_adapt_stream.hpp
+++ b/include/unifex/next_adapt_stream.hpp
@@ -21,25 +21,27 @@
 
 namespace unifex {
 
-template <typename StreamSender, typename AdaptFunc>
+template <typename Stream, typename AdaptFunc>
 struct next_adapted_stream {
-  StreamSender innerStream_;
+  Stream innerStream_;
   AdaptFunc adapter_;
 
-  auto next() {
-    return std::invoke(adapter_, cpo::next(innerStream_));
+  friend auto tag_invoke(tag_t<next>, next_adapted_stream& s)
+    -> std::invoke_result_t<AdaptFunc&, next_sender_t<Stream>> {
+    return std::invoke(s.adapter_, next(s.innerStream_));
   }
 
-  auto cleanup() {
-    return cpo::cleanup(innerStream_);
+  friend auto tag_invoke(tag_t<cleanup>, next_adapted_stream& s)
+    -> cleanup_sender_t<Stream> {
+    return cleanup(s.innerStream_);
   }
 };
 
-template <typename StreamSender, typename AdapterFunc>
-auto next_adapt_stream(StreamSender&& stream, AdapterFunc&& adapt) {
+template <typename Stream, typename AdapterFunc>
+auto next_adapt_stream(Stream&& stream, AdapterFunc&& adapt) {
   return next_adapted_stream<
-      std::remove_cvref_t<StreamSender>,
-      std::remove_cvref_t<AdapterFunc>>{(StreamSender &&) stream,
+      std::remove_cvref_t<Stream>,
+      std::remove_cvref_t<AdapterFunc>>{(Stream &&) stream,
                                         (AdapterFunc &&) adapt};
 }
 

--- a/include/unifex/null_receiver.hpp
+++ b/include/unifex/null_receiver.hpp
@@ -20,12 +20,12 @@
 namespace unifex {
 
 struct null_receiver {
-  void value() noexcept {}
-  [[noreturn]] void done() noexcept {
+  void set_value() noexcept {}
+  [[noreturn]] void set_done() noexcept {
     std::terminate();
   }
   template <typename Error>
-  [[noreturn]] void error(Error&&) noexcept {
+  [[noreturn]] void set_error(Error&&) noexcept {
     std::terminate();
   }
 };

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -74,7 +74,7 @@ struct on_sender {
       operation& op_;
 
       template <typename... Values>
-      void value(Values... values) && noexcept {
+      void set_value(Values... values) && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
         unifex::set_value(
@@ -82,14 +82,14 @@ struct on_sender {
       }
 
       template <typename Error>
-      void error(Error error) && noexcept {
+      void set_error(Error error) && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
         unifex::set_error(
             static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
         unifex::set_done(static_cast<Receiver&&>(op.receiver_));
@@ -117,7 +117,7 @@ struct on_sender {
       operation& op_;
 
       template <typename... Values>
-      void value(Values&&...) noexcept {
+      void set_value(Values&&...) noexcept {
         auto& op = op_;
         op.predOp_.destruct();
         try {
@@ -135,14 +135,14 @@ struct on_sender {
       }
 
       template <typename Error>
-      void error(Error error) noexcept {
+      void set_error(Error error) noexcept {
         auto& op = op_;
         op.predOp_.destruct();
         unifex::set_error(
             static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         auto& op = op_;
         op.predOp_.destruct();
         unifex::set_done(static_cast<Receiver&&>(op.receiver_));

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -122,11 +122,11 @@ struct on_sender {
         op.predOp_.destruct();
         try {
           op.succOp_.construct_from([&]() {
-            return cpo::connect(
+            return unifex::connect(
                 static_cast<Successor&&>(op.succ_),
                 successor_receiver{op});
           });
-          cpo::start(op.succOp_.get());
+          unifex::start(op.succOp_.get());
         } catch (...) {
           cpo::set_error(
               static_cast<Receiver&&>(op.receiver_),
@@ -174,7 +174,7 @@ struct on_sender {
         : succ_((Successor &&) succ)
         , receiver_((Receiver2&&)receiver) {
       predOp_.construct_from([&] {
-        return cpo::connect(
+        return unifex::connect(
             static_cast<Predecessor&&>(pred),
             predecessor_receiver{*this});
       });
@@ -197,7 +197,7 @@ struct on_sender {
 
     void start() noexcept {
       started_ = true;
-      cpo::start(predOp_.get());
+      unifex::start(predOp_.get());
     }
   };
 

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -47,10 +47,10 @@ struct on_sender {
       typename Successor::template error_types<Variant>>;
 
   friend blocking_kind tag_invoke(
-      tag_t<cpo::blocking>,
+      tag_t<blocking>,
       const on_sender<Predecessor, Successor>& sender) {
-    const auto predBlocking = cpo::blocking(sender.pred_);
-    const auto succBlocking = cpo::blocking(sender.succ_);
+    const auto predBlocking = blocking(sender.pred_);
+    const auto succBlocking = blocking(sender.succ_);
     if (predBlocking == blocking_kind::never) {
       return blocking_kind::never;
     } else if (

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -77,7 +77,7 @@ struct on_sender {
       void value(Values... values) && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
-        cpo::set_value(
+        unifex::set_value(
             static_cast<Receiver&&>(op.receiver_), (Values &&) values...);
       }
 
@@ -85,19 +85,19 @@ struct on_sender {
       void error(Error error) && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
       void done() && noexcept {
         auto& op = op_;
         op.succOp_.destruct();
-        cpo::set_done(static_cast<Receiver&&>(op.receiver_));
+        unifex::set_done(static_cast<Receiver&&>(op.receiver_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -128,7 +128,7 @@ struct on_sender {
           });
           unifex::start(op.succOp_.get());
         } catch (...) {
-          cpo::set_error(
+          unifex::set_error(
               static_cast<Receiver&&>(op.receiver_),
               std::current_exception());
         }
@@ -138,19 +138,19 @@ struct on_sender {
       void error(Error error) noexcept {
         auto& op = op_;
         op.predOp_.destruct();
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
       void done() noexcept {
         auto& op = op_;
         op.predOp_.destruct();
-        cpo::set_done(static_cast<Receiver&&>(op.receiver_));
+        unifex::set_done(static_cast<Receiver&&>(op.receiver_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {

--- a/include/unifex/on_stream.hpp
+++ b/include/unifex/on_stream.hpp
@@ -26,7 +26,7 @@ auto on_stream(Scheduler&& scheduler, StreamSender&& stream) {
   return adapt_stream(
       (StreamSender &&) stream,
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return on(cpo::schedule(s), (decltype(sender))sender);
+        return on(schedule(s), (decltype(sender))sender);
       });
 }
 

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -18,6 +18,7 @@
 #include <unifex/blocking.hpp>
 #include <unifex/ready_done_sender.hpp>
 #include <unifex/receiver_concepts.hpp>
+#include <unifex/stream_concepts.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -69,11 +70,11 @@ struct range_stream {
     }
   };
 
-  next_sender next() & {
-    return next_sender{*this};
+  friend next_sender tag_invoke(tag_t<next>, range_stream& s) noexcept {
+    return next_sender{s};
   }
 
-  ready_done_sender cleanup() & {
+  friend ready_done_sender tag_invoke(tag_t<cleanup>, range_stream&) noexcept {
     return {};
   }
 };

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -43,7 +43,7 @@ struct range_stream {
     using error_types = Variant<>;
 
     friend constexpr blocking_kind tag_invoke(
-        tag_t<cpo::blocking>,
+        tag_t<blocking>,
         const range_stream&) noexcept {
       return blocking_kind::always_inline;
     }

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -56,9 +56,9 @@ struct range_stream {
 
       void start() noexcept {
         if (stream_.next_ < stream_.max_) {
-          cpo::set_value(std::move(receiver_), stream_.next_++);
+          unifex::set_value(std::move(receiver_), stream_.next_++);
         } else {
-          cpo::set_done(std::move(receiver_));
+          unifex::set_done(std::move(receiver_));
         }
       }
     };

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -33,7 +33,7 @@ struct ready_done_sender {
   using error_types = Variant<>;
 
   friend constexpr blocking_kind tag_invoke(
-      tag_t<cpo::blocking>,
+      tag_t<blocking>,
       const ready_done_sender&) {
     return blocking_kind::always_inline;
   }

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -43,7 +43,7 @@ struct ready_done_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     void start() noexcept {
-      cpo::set_done(static_cast<Receiver&&>(receiver_));
+      unifex::set_done(static_cast<Receiver&&>(receiver_));
     }
   };
 

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -26,9 +26,9 @@ inline constexpr struct set_value_cpo {
   template <typename Receiver, typename... Values>
   friend auto
   tag_invoke(set_value_cpo, Receiver&& r, Values&&... values) noexcept(
-      noexcept(static_cast<Receiver&&>(r).value((Values &&) values...)))
-      -> decltype(static_cast<Receiver&&>(r).value((Values &&) values...)) {
-    return static_cast<Receiver&&>(r).value((Values &&) values...);
+      noexcept(static_cast<Receiver&&>(r).set_value((Values &&) values...)))
+      -> decltype(static_cast<Receiver&&>(r).set_value((Values &&) values...)) {
+    return static_cast<Receiver&&>(r).set_value((Values &&) values...);
   }
 
   template <typename Receiver, typename... Values>
@@ -44,11 +44,11 @@ inline constexpr struct set_value_cpo {
 inline constexpr struct set_error_cpo {
   template <typename Receiver, typename Error>
   friend auto tag_invoke(set_error_cpo, Receiver&& r, Error&& e) noexcept
-      -> decltype(static_cast<Receiver&&>(r).error((Error &&) e)) {
+      -> decltype(static_cast<Receiver&&>(r).set_error((Error &&) e)) {
     static_assert(
-        noexcept(static_cast<Receiver&&>(r).error((Error &&) e)),
-        "receiver.error() method must be nothrow invocable");
-    return static_cast<Receiver&&>(r).error((Error &&) e);
+        noexcept(static_cast<Receiver&&>(r).set_error((Error &&) e)),
+        "receiver.set_error() method must be nothrow invocable");
+    return static_cast<Receiver&&>(r).set_error((Error &&) e);
   }
 
   template <typename Receiver, typename Error>
@@ -67,11 +67,11 @@ inline constexpr struct set_error_cpo {
 inline constexpr struct set_done_cpo {
   template <typename Receiver>
   friend auto tag_invoke(set_done_cpo, Receiver&& r) noexcept
-      -> decltype(static_cast<Receiver&&>(r).done()) {
+      -> decltype(static_cast<Receiver&&>(r).set_done()) {
     static_assert(
-        noexcept(static_cast<Receiver&&>(r).done()),
-        "receiver.done() method must be nothrow invocable");
-    return static_cast<Receiver&&>(r).done();
+        noexcept(static_cast<Receiver&&>(r).set_done()),
+        "receiver.set_done() method must be nothrow invocable");
+    return static_cast<Receiver&&>(r).set_done();
   }
 
   template <typename Receiver>

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -22,8 +22,6 @@
 
 namespace unifex {
 
-namespace cpo {
-
 inline constexpr struct set_value_cpo {
   template <typename Receiver, typename... Values>
   friend auto
@@ -94,5 +92,4 @@ constexpr bool is_receiver_cpo_v = is_one_of_v<
     set_error_cpo,
     set_done_cpo>;
 
-} // namespace cpo
 } // namespace unifex

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -163,16 +163,16 @@ struct reduce_stream_sender {
               std::forward<State>(op.state_),
               (Values &&) values...);
           op.next_.construct_from([&]() {
-            return cpo::connect(next(op.stream_), next_receiver{op});
+            return unifex::connect(next(op.stream_), next_receiver{op});
           });
-          cpo::start(op.next_.get());
+          unifex::start(op.next_.get());
         } catch (...) {
           op.errorCleanup_.construct_from([&] {
-            return cpo::connect(
+            return unifex::connect(
                 cleanup(op.stream_),
                 error_cleanup_receiver{op, std::current_exception()});
           });
-          cpo::start(op.errorCleanup_.get());
+          unifex::start(op.errorCleanup_.get());
         }
       }
 
@@ -180,21 +180,21 @@ struct reduce_stream_sender {
         auto& op = op_;
         op.next_.destruct();
         op.doneCleanup_.construct_from([&]() {
-          return cpo::connect(
+          return unifex::connect(
               cleanup(op.stream_), done_cleanup_receiver{op});
         });
-        cpo::start(op.doneCleanup_.get());
+        unifex::start(op.doneCleanup_.get());
       }
 
       void error(std::exception_ptr ex) && noexcept {
         auto& op = op_;
         op.next_.destruct();
         op.errorCleanup_.construct_from([&]() {
-          return cpo::connect(
+          return unifex::connect(
               cleanup(op.stream_),
               error_cleanup_receiver{op, std::move(ex)});
         });
-        cpo::start(op.errorCleanup_.get());
+        unifex::start(op.errorCleanup_.get());
       }
 
       template <typename Error>
@@ -231,9 +231,9 @@ struct reduce_stream_sender {
     void start() noexcept {
       try {
         next_.construct_from([&]() {
-          return cpo::connect(next(stream_), next_receiver{*this});
+          return unifex::connect(next(stream_), next_receiver{*this});
         });
-        cpo::start(next_.get());
+        unifex::start(next_.get());
       } catch (...) {
         cpo::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -163,13 +163,13 @@ struct reduce_stream_sender {
               std::forward<State>(op.state_),
               (Values &&) values...);
           op.next_.construct_from([&]() {
-            return cpo::connect(cpo::next(op.stream_), next_receiver{op});
+            return cpo::connect(next(op.stream_), next_receiver{op});
           });
           cpo::start(op.next_.get());
         } catch (...) {
           op.errorCleanup_.construct_from([&] {
             return cpo::connect(
-                cpo::cleanup(op.stream_),
+                cleanup(op.stream_),
                 error_cleanup_receiver{op, std::current_exception()});
           });
           cpo::start(op.errorCleanup_.get());
@@ -181,7 +181,7 @@ struct reduce_stream_sender {
         op.next_.destruct();
         op.doneCleanup_.construct_from([&]() {
           return cpo::connect(
-              cpo::cleanup(op.stream_), done_cleanup_receiver{op});
+              cleanup(op.stream_), done_cleanup_receiver{op});
         });
         cpo::start(op.doneCleanup_.get());
       }
@@ -191,7 +191,7 @@ struct reduce_stream_sender {
         op.next_.destruct();
         op.errorCleanup_.construct_from([&]() {
           return cpo::connect(
-              cpo::cleanup(op.stream_),
+              cleanup(op.stream_),
               error_cleanup_receiver{op, std::move(ex)});
         });
         cpo::start(op.errorCleanup_.get());
@@ -231,7 +231,7 @@ struct reduce_stream_sender {
     void start() noexcept {
       try {
         next_.construct_from([&]() {
-          return cpo::connect(cpo::next(stream_), next_receiver{*this});
+          return cpo::connect(next(stream_), next_receiver{*this});
         });
         cpo::start(next_.get());
       } catch (...) {

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -61,19 +61,19 @@ struct reduce_stream_sender {
       void error(Error error) noexcept {
         auto& op = op_;
         op.errorCleanup_.destruct();
-        cpo::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+        unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
       void done() noexcept {
         auto& op = op_;
         auto ex = std::move(ex_);
         op.errorCleanup_.destruct();
-        cpo::set_error(static_cast<Receiver&&>(op.receiver_), std::move(ex));
+        unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::move(ex));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const error_cleanup_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -100,20 +100,20 @@ struct reduce_stream_sender {
       void error(Error error) && noexcept {
         auto& op = op_;
         op.doneCleanup_.destruct();
-        cpo::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+        unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
       void done() && noexcept {
         auto& op = op_;
         op.doneCleanup_.destruct();
-        cpo::set_value(
+        unifex::set_value(
             static_cast<Receiver&&>(op.receiver_),
             std::forward<State>(op.state_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const done_cleanup_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -138,7 +138,7 @@ struct reduce_stream_sender {
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const next_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -235,7 +235,7 @@ struct reduce_stream_sender {
         });
         unifex::start(next_.get());
       } catch (...) {
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -58,13 +58,13 @@ struct reduce_stream_sender {
       // No value() in cleanup receiver
 
       template <typename Error>
-      void error(Error error) noexcept {
+      void set_error(Error error) noexcept {
         auto& op = op_;
         op.errorCleanup_.destruct();
         unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         auto& op = op_;
         auto ex = std::move(ex_);
         op.errorCleanup_.destruct();
@@ -97,13 +97,13 @@ struct reduce_stream_sender {
       operation& op_;
 
       template <typename Error>
-      void error(Error error) && noexcept {
+      void set_error(Error error) && noexcept {
         auto& op = op_;
         op.doneCleanup_.destruct();
         unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         auto& op = op_;
         op.doneCleanup_.destruct();
         unifex::set_value(
@@ -154,7 +154,7 @@ struct reduce_stream_sender {
       }
 
       template <typename... Values>
-      void value(Values... values) && noexcept {
+      void set_value(Values... values) && noexcept {
         auto& op = op_;
         op.next_.destruct();
         try {
@@ -176,7 +176,7 @@ struct reduce_stream_sender {
         }
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         auto& op = op_;
         op.next_.destruct();
         op.doneCleanup_.construct_from([&]() {
@@ -186,7 +186,7 @@ struct reduce_stream_sender {
         unifex::start(op.doneCleanup_.get());
       }
 
-      void error(std::exception_ptr ex) && noexcept {
+      void set_error(std::exception_ptr ex) && noexcept {
         auto& op = op_;
         op.next_.destruct();
         op.errorCleanup_.construct_from([&]() {
@@ -198,8 +198,8 @@ struct reduce_stream_sender {
       }
 
       template <typename Error>
-      void error(Error&& e) && noexcept {
-        std::move(*this).error(std::make_exception_ptr((Error &&) e));
+      void set_error(Error&& e) && noexcept {
+        std::move(*this).set_error(std::make_exception_ptr((Error &&) e));
       }
     };
 

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -20,7 +20,6 @@
 #include <unifex/transform.hpp>
 
 namespace unifex {
-namespace cpo {
 
 inline constexpr struct schedule_with_subscheduler_cpo {
  private:
@@ -44,7 +43,7 @@ inline constexpr struct schedule_with_subscheduler_cpo {
   template <typename Scheduler>
   friend auto tag_invoke(schedule_with_subscheduler_cpo, Scheduler&& scheduler)
       -> decltype(transform(
-          std::declval<std::invoke_result_t<decltype(schedule), Scheduler&>>(),
+          std::declval<std::invoke_result_t<decltype(cpo::schedule), Scheduler&>>(),
           std::declval<return_value<std::decay_t<Scheduler>>>())) {
     auto&& scheduleOp = cpo::schedule(scheduler);
     return transform(
@@ -61,5 +60,4 @@ inline constexpr struct schedule_with_subscheduler_cpo {
   }
 } schedule_with_subscheduler;
 
-} // namespace cpo
 } // namespace unifex

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -43,9 +43,9 @@ inline constexpr struct schedule_with_subscheduler_cpo {
   template <typename Scheduler>
   friend auto tag_invoke(schedule_with_subscheduler_cpo, Scheduler&& scheduler)
       -> decltype(transform(
-          std::declval<std::invoke_result_t<decltype(cpo::schedule), Scheduler&>>(),
+          std::declval<std::invoke_result_t<decltype(schedule), Scheduler&>>(),
           std::declval<return_value<std::decay_t<Scheduler>>>())) {
-    auto&& scheduleOp = cpo::schedule(scheduler);
+    auto&& scheduleOp = schedule(scheduler);
     return transform(
         static_cast<decltype(scheduleOp)>(scheduleOp),
         return_value<std::decay_t<Scheduler>>{(Scheduler &&) scheduler});

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -22,7 +22,6 @@
 #include <exception>
 
 namespace unifex {
-namespace cpo {
 
 inline constexpr struct schedule_cpo {
   template <typename Scheduler>
@@ -41,7 +40,7 @@ inline constexpr struct schedule_cpo {
 
   struct schedule_sender;
 
-  schedule_sender operator()() const noexcept;
+  constexpr schedule_sender operator()() const noexcept;
 } schedule;
 
 inline constexpr struct get_scheduler_cpo {
@@ -65,19 +64,19 @@ struct schedule_cpo::schedule_sender {
   using error_types = Variant<std::exception_ptr>;
 
   template <typename Receiver>
-  friend auto tag_invoke(tag_t<connect>, schedule_sender, Receiver &&r)
+  friend auto tag_invoke(tag_t<cpo::connect>, schedule_sender, Receiver &&r)
       -> std::invoke_result_t<
-          decltype(connect),
+          decltype(cpo::connect),
           std::invoke_result_t<
               decltype(schedule),
               std::invoke_result_t<decltype(get_scheduler), const Receiver &>>,
           Receiver> {
     auto scheduler = get_scheduler(std::as_const(r));
-    return connect(schedule(scheduler), (Receiver &&) r);
+    return cpo::connect(schedule(scheduler), (Receiver &&) r);
   }
 };
 
-inline schedule_cpo::schedule_sender schedule_cpo::operator()() const noexcept {
+inline constexpr schedule_cpo::schedule_sender schedule_cpo::operator()() const noexcept {
   return {};
 }
 
@@ -133,5 +132,4 @@ inline constexpr struct now_cpo {
   }
 } now;
 
-} // namespace cpo
 } // namespace unifex

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -64,15 +64,15 @@ struct schedule_cpo::schedule_sender {
   using error_types = Variant<std::exception_ptr>;
 
   template <typename Receiver>
-  friend auto tag_invoke(tag_t<cpo::connect>, schedule_sender, Receiver &&r)
+  friend auto tag_invoke(tag_t<connect>, schedule_sender, Receiver &&r)
       -> std::invoke_result_t<
-          decltype(cpo::connect),
+          decltype(connect),
           std::invoke_result_t<
               decltype(schedule),
               std::invoke_result_t<decltype(get_scheduler), const Receiver &>>,
           Receiver> {
     auto scheduler = get_scheduler(std::as_const(r));
-    return cpo::connect(schedule(scheduler), (Receiver &&) r);
+    return connect(schedule(scheduler), (Receiver &&) r);
   }
 };
 

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -39,7 +39,7 @@ struct sender_awaiter {
     sender_awaiter& awaiter_;
 
     template<typename... Values>
-    void value(Values&&... values) && noexcept {
+    void set_value(Values&&... values) && noexcept {
       if constexpr (std::is_nothrow_constructible_v<Value, Values...>) {
         awaiter_.value_.construct((Values&&)values...);
         awaiter_.state_ = state::value;
@@ -56,17 +56,17 @@ struct sender_awaiter {
     }
 
     template<typename Error>
-    void error(Error&& error) && noexcept {
-      std::move(*this).error(std::make_exception_ptr((Error&&)error));
+    void set_error(Error&& error) && noexcept {
+      std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
     }
 
-    void error(std::exception_ptr ex) && noexcept {
+    void set_error(std::exception_ptr ex) && noexcept {
       awaiter_.ex_.construct(std::move(ex));
       awaiter_.state_ = state::error;
       awaiter_.continuation_.resume();
     }
 
-    void done() && noexcept {
+    void set_done() && noexcept {
       awaiter_.state_ = state::done;
       awaiter_.continuation_.resume();
     }

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -83,7 +83,7 @@ struct sender_awaiter {
   };
 
   explicit sender_awaiter(Sender&& sender)
-  : op_(cpo::connect(
+  : op_(connect(
       static_cast<Sender&&>(sender),
       coroutine_receiver{*this}))
   {}
@@ -104,7 +104,7 @@ struct sender_awaiter {
     if constexpr (!std::is_void_v<Promise>) {
       info_.emplace(continuation_info::from_continuation(h.promise()));
     }
-    cpo::start(op_);
+    start(op_);
   }
 
   auto await_resume()

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -22,7 +22,6 @@
 #include <type_traits>
 
 namespace unifex {
-namespace cpo {
 
 inline constexpr struct start_cpo {
   template <typename Operation>
@@ -59,10 +58,8 @@ inline constexpr struct connect_cpo {
   }
 } connect{};
 
-} // namespace cpo
-
 template <typename Sender, typename Receiver>
-using operation_t = decltype(cpo::connect(
+using operation_t = decltype(connect(
     std::declval<Sender>(),
     std::declval<Receiver>()));
 

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -74,7 +74,7 @@ struct single_stream {
 
       void start() noexcept {
         if (done_) {
-          cpo::set_done(std::move(receiver_));
+          unifex::set_done(std::move(receiver_));
         } else {
           unifex::start(innerOp_.get());
         }

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -17,6 +17,7 @@
 
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/stream_concepts.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/ready_done_sender.hpp>
 #include <unifex/scope_guard.hpp>
@@ -90,12 +91,12 @@ struct single_stream {
     }
   };
 
-  next_sender next() {
-    scope_guard g{[&]() noexcept { sender_.reset(); }};
-    return next_sender{std::move(sender_)};
+  friend next_sender tag_invoke(tag_t<next>, single_stream& s) {
+    scope_guard g{[&]() noexcept { s.sender_.reset(); }};
+    return next_sender{std::move(s.sender_)};
   }
 
-  ready_done_sender cleanup() noexcept {
+  friend ready_done_sender tag_invoke(tag_t<cleanup>, single_stream&) noexcept {
     return {};
   }
 

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -59,7 +59,7 @@ struct single_stream {
       : done_(false)
       {
         innerOp_.construct_from([&] {
-          return cpo::connect(
+          return unifex::connect(
               static_cast<Sender&&>(sender), (Receiver&&)receiver);
         });
       }
@@ -76,7 +76,7 @@ struct single_stream {
         if (done_) {
           cpo::set_done(std::move(receiver_));
         } else {
-          cpo::start(innerOp_.get());
+          unifex::start(innerOp_.get());
         }
       }
     };

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -77,14 +77,14 @@ namespace unifex
             };
           }
 
-          friend void tag_invoke(tag_t<cpo::start>, operation& op) noexcept {
+          friend void tag_invoke(tag_t<start>, operation& op) noexcept {
             op.pool_.enqueue(&op);
           }
         };
 
         template <typename Receiver>
         friend operation<std::decay_t<Receiver>>
-        tag_invoke(tag_t<cpo::connect>, schedule_sender s, Receiver&& r) {
+        tag_invoke(tag_t<connect>, schedule_sender s, Receiver&& r) {
           return operation<std::decay_t<Receiver>>{s.pool_, (Receiver &&) r};
         }
 

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -97,7 +97,7 @@ namespace unifex
       };
 
       friend schedule_sender
-      tag_invoke(tag_t<cpo::schedule>, const scheduler& s) noexcept {
+      tag_invoke(tag_t<schedule>, const scheduler& s) noexcept {
         return schedule_sender{s.pool_};
       }
 

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -69,11 +69,11 @@ namespace unifex
               if constexpr (!is_stop_never_possible_v<
                                 stop_token_type_t<Receiver>>) {
                 if (get_stop_token(op.receiver_).stop_requested()) {
-                  cpo::set_done((Receiver &&) op.receiver_);
+                  unifex::set_done((Receiver &&) op.receiver_);
                   return;
                 }
               }
-              cpo::set_value((Receiver &&) op.receiver_);
+              unifex::set_value((Receiver &&) op.receiver_);
             };
           }
 

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -211,17 +211,17 @@ struct stop_immediately_stream {
 
         void value(Values&&... values) && noexcept final {
           op_.stopCallback_.destruct();
-          cpo::set_value(std::move(op_.receiver_), (Values&&)values...);
+          unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
         }
 
         void done() && noexcept final {
           op_.stopCallback_.destruct();
-          cpo::set_done(std::move(op_.receiver_));
+          unifex::set_done(std::move(op_.receiver_));
         }
 
         void error(std::exception_ptr ex) && noexcept final {
           op_.stopCallback_.destruct();
-          cpo::set_error(std::move(op_.receiver_), std::move(ex));
+          unifex::set_error(std::move(op_.receiver_), std::move(ex));
         }
       };
 
@@ -246,7 +246,7 @@ struct stop_immediately_stream {
       void start() noexcept {
         auto stopToken = get_stop_token(receiver_);
         if (stopToken.stop_requested()) {
-            cpo::set_done(std::move(receiver_));
+            unifex::set_done(std::move(receiver_));
             return;
         }
 
@@ -272,12 +272,12 @@ struct stop_immediately_stream {
             stream_.nextOp_.destruct();
             stream_.state_.store(
               state::source_next_completed, std::memory_order_relaxed);
-            cpo::set_error(std::move(receiver_), std::current_exception());
+            unifex::set_error(std::move(receiver_), std::current_exception());
           }
         } catch (...) {
           stream_.state_.store(
             state::source_next_completed, std::memory_order_relaxed);
-          cpo::set_error(std::move(receiver_), std::current_exception());
+          unifex::set_error(std::move(receiver_), std::current_exception());
         }
       }
     };
@@ -313,10 +313,10 @@ struct stop_immediately_stream {
           op.cleanupOp_.destruct();
 
           if (op.stream_.nextError_) {
-            cpo::set_error(
+            unifex::set_error(
                 std::move(op.receiver_), std::move(op.stream_.nextError_));
           } else {
-            cpo::set_done(std::move(op.receiver_));
+            unifex::set_done(std::move(op.receiver_));
           }
         }
 
@@ -328,10 +328,10 @@ struct stop_immediately_stream {
           // Prefer sending the error from the next(source_) rather than
           // the error from cleanup(source_).
           if (op.stream_.nextError_) {
-            cpo::set_error(
+            unifex::set_error(
               std::move(op.receiver_), std::move(op.stream_.nextError_));
           } else {
-            cpo::set_error(std::move(op.receiver_), (Error&&)error);
+            unifex::set_error(std::move(op.receiver_), (Error&&)error);
           }
         }
       };
@@ -376,7 +376,7 @@ struct stop_immediately_stream {
         // No prior next() call has been made. Nothing to do for cleanup.
         // Send done() immediately.
         assert(oldState == state::not_started);
-        cpo::set_done(std::move(receiver_));
+        unifex::set_done(std::move(receiver_));
       }
 
       void start_cleanup() noexcept final {
@@ -391,9 +391,9 @@ struct stop_immediately_stream {
           // Prefer to send the error from next(source_) over the error
           // from cleanup(source_) if there was one.
           if (stream_.nextError_) {
-            cpo::set_error(std::move(receiver_), std::move(stream_.nextError_));
+            unifex::set_error(std::move(receiver_), std::move(stream_.nextError_));
           } else {
-            cpo::set_error(std::move(receiver_), std::current_exception());
+            unifex::set_error(std::move(receiver_), std::current_exception());
           }
         }
       }

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -255,7 +255,7 @@ struct stop_immediately_stream {
 
         try {
           stream_.nextOp_.construct_from([&] {
-            return cpo::connect(
+            return unifex::connect(
               next(stream_.source_),
               next_receiver{stream_});
           });
@@ -266,7 +266,7 @@ struct stop_immediately_stream {
             stopCallback_.construct(
               std::move(stopToken),
               cancel_next_callback{stream_});
-            cpo::start(stream_.nextOp_.get());
+            unifex::start(stream_.nextOp_.get());
           } catch (...) {
             stream_.nextReceiver_ = nullptr;
             stream_.nextOp_.destruct();
@@ -382,11 +382,11 @@ struct stop_immediately_stream {
       void start_cleanup() noexcept final {
         try {
           cleanupOp_.construct_from([&] {
-            return cpo::connect(
+            return unifex::connect(
               cleanup(stream_.source_),
               receiver_wrapper{*this});
           });
-          cpo::start(cleanupOp_.get());
+          unifex::start(cleanupOp_.get());
         } catch (...) {
           // Prefer to send the error from next(source_) over the error
           // from cleanup(source_) if there was one.

--- a/include/unifex/stream_concepts.hpp
+++ b/include/unifex/stream_concepts.hpp
@@ -19,7 +19,6 @@
 #include <unifex/sender_concepts.hpp>
 
 namespace unifex {
-namespace cpo {
 
 inline constexpr struct next_cpo {
   template <typename Stream>
@@ -51,13 +50,11 @@ inline constexpr struct cleanup_cpo {
   }
 } cleanup{};
 
-} // namespace cpo
+template <typename Stream>
+using next_sender_t = decltype(next(std::declval<Stream&>()));
 
 template <typename Stream>
-using next_sender_t = decltype(cpo::next(std::declval<Stream&>()));
-
-template <typename Stream>
-using cleanup_sender_t = decltype(cpo::cleanup(std::declval<Stream&>()));
+using cleanup_sender_t = decltype(cleanup(std::declval<Stream&>()));
 
 template <typename Stream, typename Receiver>
 using next_operation_t = operation_t<next_sender_t<Stream>, Receiver>;

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -38,20 +38,20 @@ class submitted_operation {
     template <typename... Values>
     void value(Values&&... values) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
-      cpo::set_value(std::move(op_->receiver_), (Values &&) values...);
+      unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
       destroy(std::move(allocator));
     }
 
     template <typename Error>
     void error(Error&& error) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
-      cpo::set_error(std::move(op_->receiver_), (Error &&) error);
+      unifex::set_error(std::move(op_->receiver_), (Error &&) error);
       destroy(std::move(allocator));
     }
 
     void done() && noexcept {
       auto allocator = get_allocator(op_->receiver_);
-      cpo::set_done(std::move(op_->receiver_));
+      unifex::set_done(std::move(op_->receiver_));
       destroy(std::move(allocator));
     }
 
@@ -71,7 +71,7 @@ class submitted_operation {
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const wrapped_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -113,7 +113,7 @@ inline constexpr struct submit_cpo {
       unifex::tag_invoke(*this, (Sender&&)sender, (Receiver&&)receiver);
     } else {
       // Default implementation in terms of connect/start
-      switch (cpo::blocking(sender)) {
+      switch (blocking(sender)) {
         case blocking_kind::always:
         case blocking_kind::always_inline:
         {

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -91,11 +91,11 @@ public:
   template <typename Receiver2>
   explicit submitted_operation(Sender&& sender, Receiver2&& receiver)
       : receiver_((Receiver2 &&) receiver),
-        inner_(cpo::connect((Sender &&) sender, wrapped_receiver{this}))
+        inner_(unifex::connect((Sender &&) sender, wrapped_receiver{this}))
       {}
 
   void start() & noexcept {
-    cpo::start(inner_);
+    unifex::start(inner_);
   }
 
 private:
@@ -119,8 +119,8 @@ inline constexpr struct submit_cpo {
         {
           // The sender will complete synchronously so we can avoid allocating the
           // state on the heap.
-          auto op = cpo::connect((Sender &&) sender, (Receiver &&) receiver);
-          cpo::start(op);
+          auto op = unifex::connect((Sender &&) sender, (Receiver &&) receiver);
+          unifex::start(op);
         }
         default:
         {

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -36,20 +36,20 @@ class submitted_operation {
     explicit wrapped_receiver(submitted_operation* op) noexcept : op_(op) {}
 
     template <typename... Values>
-    void value(Values&&... values) && noexcept {
+    void set_value(Values&&... values) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
       unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
       destroy(std::move(allocator));
     }
 
     template <typename Error>
-    void error(Error&& error) && noexcept {
+    void set_error(Error&& error) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
       unifex::set_error(std::move(op_->receiver_), (Error &&) error);
       destroy(std::move(allocator));
     }
 
-    void done() && noexcept {
+    void set_done() && noexcept {
       auto allocator = get_allocator(op_->receiver_);
       unifex::set_done(std::move(op_->receiver_));
       destroy(std::move(allocator));

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -61,7 +61,7 @@ struct sync_wait_receiver {
   StopToken stopToken_;
 
   template <typename... Values>
-      void value(Values&&... values) && noexcept {
+      void set_value(Values&&... values) && noexcept {
     std::lock_guard lock{promise_.mutex_};
     try {
       promise_.value_.construct((Values &&) values...);
@@ -73,7 +73,7 @@ struct sync_wait_receiver {
     promise_.cv_.notify_one();
   }
 
-  void error(std::exception_ptr err) && noexcept {
+  void set_error(std::exception_ptr err) && noexcept {
     std::lock_guard lock{promise_.mutex_};
     promise_.exception_.construct(std::move(err));
     promise_.state_ = sync_wait_promise<T>::state::error;
@@ -81,11 +81,11 @@ struct sync_wait_receiver {
   }
 
   template <typename Error>
-      void error(Error&& e) && noexcept {
-    std::move(*this).error(std::make_exception_ptr((Error &&) e));
+      void set_error(Error&& e) && noexcept {
+    std::move(*this).set_error(std::make_exception_ptr((Error &&) e));
   }
 
-  void done() && noexcept {
+  void set_done() && noexcept {
     std::lock_guard lock{promise_.mutex_};
     promise_.state_ = sync_wait_promise<T>::state::done;
     promise_.cv_.notify_one();
@@ -124,7 +124,7 @@ struct thread_unsafe_sync_wait_receiver {
   StopToken stopToken_;
 
   template <typename... Values>
-  void value(Values&&... values) && noexcept {
+  void set_value(Values&&... values) && noexcept {
     try {
       promise_.value_.construct((Values &&) values...);
       promise_.state_ = thread_unsafe_sync_wait_promise<T>::state::value;
@@ -134,17 +134,17 @@ struct thread_unsafe_sync_wait_receiver {
     }
   }
 
-  void error(std::exception_ptr err) && noexcept {
+  void set_error(std::exception_ptr err) && noexcept {
     promise_.exception_.construct(std::move(err));
     promise_.state_ = thread_unsafe_sync_wait_promise<T>::state::error;
   }
 
   template <typename Error>
-  void error(Error&& e) && noexcept {
-    std::move(*this).error(std::make_exception_ptr((Error &&) e));
+  void set_error(Error&& e) && noexcept {
+    std::move(*this).set_error(std::make_exception_ptr((Error &&) e));
   }
 
-  void done() && noexcept {
+  void set_done() && noexcept {
     promise_.state_ = thread_unsafe_sync_wait_promise<T>::state::done;
   }
 

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -162,7 +162,7 @@ template <
     typename Result = single_value_result_t<std::remove_cvref_t<Sender>>>
 auto sync_wait(Sender&& sender, StopToken&& stopToken = {})
     -> std::optional<Result> {
-  auto blockingResult = cpo::blocking(sender);
+  auto blockingResult = blocking(sender);
   if (blockingResult == blocking_kind::always ||
       blockingResult == blocking_kind::always_inline) {
     using promise_t = detail::thread_unsafe_sync_wait_promise<Result>;

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -168,12 +168,12 @@ auto sync_wait(Sender&& sender, StopToken&& stopToken = {})
     using promise_t = detail::thread_unsafe_sync_wait_promise<Result>;
     promise_t promise;
 
-    auto operation = cpo::connect(
+    auto operation = connect(
       (Sender&&)sender,
       detail::thread_unsafe_sync_wait_receiver<Result, StopToken&&>{
         promise, (StopToken&&)stopToken});
 
-    cpo::start(operation);
+    start(operation);
 
     assert(promise.state_ != promise_t::state::incomplete);
 
@@ -192,12 +192,12 @@ auto sync_wait(Sender&& sender, StopToken&& stopToken = {})
     promise_t promise;
 
     // Store state for the operation on the stack.
-    auto operation = cpo::connect(
+    auto operation = connect(
         ((Sender &&) sender),
         detail::sync_wait_receiver<Result, StopToken&&>{
           promise, (StopToken&&)stopToken});
 
-    cpo::start(operation);
+    start(operation);
 
     std::unique_lock lock{promise.mutex_};
     promise.cv_.wait(

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -98,20 +98,20 @@ struct take_until_stream {
         template<typename... Values>
         void value(Values&&... values) && noexcept {
           op_.stopCallback_.destruct();
-          cpo::set_value(std::move(op_.receiver_), (Values&&)values...);
+          unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
         }
 
         void done() && noexcept {
           op_.stopCallback_.destruct();
           op_.stream_.stopSource_.request_stop();
-          cpo::set_done(std::move(op_.receiver_));
+          unifex::set_done(std::move(op_.receiver_));
         }
 
         template<typename Error>
         void error(Error&& error) && noexcept {
           op_.stopCallback_.destruct();
           op_.stream_.stopSource_.request_stop();
-          cpo::set_error(std::move(op_.receiver_), (Error&&)error);
+          unifex::set_error(std::move(op_.receiver_), (Error&&)error);
         }
 
         inplace_stop_source& get_stop_source() const {
@@ -319,9 +319,9 @@ struct take_until_stream {
 
         // The other operation finished first.
         if (triggerError_) {
-          cpo::set_error(std::move(receiver_), std::move(triggerError_));
+          unifex::set_error(std::move(receiver_), std::move(triggerError_));
         } else {
-          cpo::set_done(std::move(receiver_));
+          unifex::set_done(std::move(receiver_));
         }
       }
 
@@ -339,7 +339,7 @@ struct take_until_stream {
         // Trigger cleanup finished first
         // Prefer to propagate the source cleanup error over the trigger
         // cleanup error if there was one.
-        cpo::set_error(std::move(receiver_), std::move(sourceError_));
+        unifex::set_error(std::move(receiver_), std::move(sourceError_));
       }
 
       void trigger_cleanup_done() noexcept {
@@ -353,9 +353,9 @@ struct take_until_stream {
 
         // The other operation finished first.
         if (sourceError_) {
-          cpo::set_error(std::move(receiver_), std::move(sourceError_));
+          unifex::set_error(std::move(receiver_), std::move(sourceError_));
         } else {
-          cpo::set_done(std::move(receiver_));
+          unifex::set_done(std::move(receiver_));
         }
       }
 
@@ -374,9 +374,9 @@ struct take_until_stream {
         // Prefer to propagate the source cleanup error over the trigger
         // cleanup error if there was one.
         if (sourceError_) {
-          cpo::set_error(std::move(receiver_), std::move(sourceError_));
+          unifex::set_error(std::move(receiver_), std::move(sourceError_));
         } else {
-          cpo::set_error(std::move(receiver_), std::move(triggerError_));
+          unifex::set_error(std::move(receiver_), std::move(triggerError_));
         }
       }
     };

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -40,16 +40,16 @@ struct take_until_stream {
     take_until_stream& stream_;
 
     template<typename... Values>
-    void value(Values&&...) && noexcept {
-      std::move(*this).done();
+    void set_value(Values&&...) && noexcept {
+      std::move(*this).set_done();
     }
 
     template<typename Error>
-    void error(Error&&) && noexcept {
-      std::move(*this).done();
+    void set_error(Error&&) && noexcept {
+      std::move(*this).set_done();
     }
 
-    void done() && noexcept {
+    void set_done() && noexcept {
       auto& stream = stream_;
       stream.triggerNextOp_.destruct();
       stream.trigger_next_done();
@@ -96,19 +96,19 @@ struct take_until_stream {
         operation& op_;
 
         template<typename... Values>
-        void value(Values&&... values) && noexcept {
+        void set_value(Values&&... values) && noexcept {
           op_.stopCallback_.destruct();
           unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
         }
 
-        void done() && noexcept {
+        void set_done() && noexcept {
           op_.stopCallback_.destruct();
           op_.stream_.stopSource_.request_stop();
           unifex::set_done(std::move(op_.receiver_));
         }
 
         template<typename Error>
-        void error(Error&& error) && noexcept {
+        void set_error(Error&& error) && noexcept {
           op_.stopCallback_.destruct();
           op_.stream_.stopSource_.request_stop();
           unifex::set_error(std::move(op_.receiver_), (Error&&)error);
@@ -196,18 +196,18 @@ struct take_until_stream {
       struct source_receiver {
         operation& op_;
 
-        void done() && noexcept {
+        void set_done() && noexcept {
           auto& op = op_;
           op.sourceOp_.destruct();
           op.source_cleanup_done();
         }
 
         template<typename Error>
-        void error(Error&& error) && noexcept {
-          std::move(*this).error(std::make_exception_ptr((Error&&)error));
+        void set_error(Error&& error) && noexcept {
+          std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
         }
 
-        void error(std::exception_ptr error) && noexcept {
+        void set_error(std::exception_ptr error) && noexcept {
           auto& op = op_;
           op.sourceOp_.destruct();
           op.source_cleanup_error(std::move(error));
@@ -225,18 +225,18 @@ struct take_until_stream {
       struct trigger_receiver {
         operation& op_;
 
-        void done() && noexcept {
+        void set_done() && noexcept {
           auto& op = op_;
           op.sourceOp_.destruct();
           op.trigger_cleanup_done();
         }
 
         template<typename Error>
-        void error(Error&& error) && noexcept {
-          std::move(*this).error(std::make_exception_ptr((Error&&)error));
+        void set_error(Error&& error) && noexcept {
+          std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
         }
 
-        void error(std::exception_ptr error) && noexcept {
+        void set_error(std::exception_ptr error) && noexcept {
           auto& op = op_;
           op.triggerOp_.destruct();
           op.trigger_cleanup_error(std::move(error));

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -143,7 +143,7 @@ struct take_until_stream {
       explicit operation(take_until_stream& stream, Receiver2&& receiver)
       : stream_(stream)
       , receiver_((Receiver2&&)receiver)
-      , innerOp_(cpo::connect(
+      , innerOp_(unifex::connect(
           next(stream.source_),
           receiver_wrapper{*this}))
       {}
@@ -153,11 +153,11 @@ struct take_until_stream {
           stream_.triggerNextStarted_ = true;
           try {
             stream_.triggerNextOp_.construct_from([&] {
-              return cpo::connect(
+              return unifex::connect(
                 next(stream_.trigger_),
                 trigger_next_receiver{stream_});
             });
-            cpo::start(stream_.triggerNextOp_.get());
+            unifex::start(stream_.triggerNextOp_.get());
           } catch (...) {
             stream_.trigger_next_done();
           }
@@ -166,7 +166,7 @@ struct take_until_stream {
         stopCallback_.construct(
           get_stop_token(receiver_),
           cancel_callback{stream_.stopSource_});
-        cpo::start(innerOp_);
+        unifex::start(innerOp_);
       }
     };
 
@@ -271,11 +271,11 @@ struct take_until_stream {
       void start() noexcept {
         try {
           sourceOp_.construct_from([&] {
-            return cpo::connect(
+            return unifex::connect(
               cleanup(stream_.source_),
               source_receiver{*this});
           });
-          cpo::start(sourceOp_.get());
+          unifex::start(sourceOp_.get());
         } catch (...) {
           source_cleanup_error(std::current_exception());
         }
@@ -297,11 +297,11 @@ struct take_until_stream {
       void start_trigger_cleanup() noexcept final {
         try {
           triggerOp_.construct_from([&] {
-            return cpo::connect(
+            return unifex::connect(
               cleanup(stream_.trigger_),
               trigger_receiver{*this});
           });
-          cpo::start(triggerOp_.get());
+          unifex::start(triggerOp_.get());
         } catch (...) {
           trigger_cleanup_error(std::current_exception());
           return;

--- a/include/unifex/then_execute.hpp
+++ b/include/unifex/then_execute.hpp
@@ -24,7 +24,7 @@ namespace unifex {
 template <typename Scheduler, typename Predecessor, typename Func>
 auto then_execute(Scheduler&& s, Predecessor&& p, Func&& f) {
   return transform(
-      typed_via(cpo::schedule((Scheduler &&) s), (Predecessor &&) p),
+      typed_via(schedule((Scheduler &&) s), (Predecessor &&) p),
       (Func &&) f);
 }
 

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -252,7 +252,7 @@ class thread_unsafe_event_loop {
     class receiver {
      public:
       template <typename... Values>
-          void value(Values&&... values) && noexcept {
+          void set_value(Values&&... values) && noexcept {
         try {
           promise_.value_.construct((Values &&) values...);
           promise_.state_ = state::value;
@@ -262,12 +262,12 @@ class thread_unsafe_event_loop {
         }
       }
 
-      void error(std::exception_ptr ex) && noexcept {
+      void set_error(std::exception_ptr ex) && noexcept {
         promise_.exception_.construct(std::move(ex));
         promise_.state_ = state::error;
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         promise_.state_ = state::done;
       }
 

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -339,8 +339,8 @@ class thread_unsafe_event_loop {
     using promise_t = sync_wait_promise<Result, StopToken&&>;
     promise_t promise{(StopToken &&) st};
 
-    auto op = cpo::connect((Sender &&) sender, promise.get_receiver());
-    cpo::start(op);
+    auto op = connect((Sender &&) sender, promise.get_receiver());
+    start(op);
 
     run_until_empty();
 

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -110,12 +110,12 @@ class thread_unsafe_event_loop {
           callback_.destruct();
           if constexpr (is_stop_never_possible_v<
                             stop_token_type_t<Receiver&>>) {
-            cpo::set_value(std::move(receiver_));
+            unifex::set_value(std::move(receiver_));
           } else {
             if (get_stop_token(receiver_).stop_requested()) {
-              cpo::set_done(std::move(receiver_));
+              unifex::set_done(std::move(receiver_));
             } else {
-              cpo::set_value(std::move(receiver_));
+              unifex::set_value(std::move(receiver_));
             }
           }
         }
@@ -181,12 +181,12 @@ class thread_unsafe_event_loop {
           callback_.destruct();
           if constexpr (is_stop_never_possible_v<
                             stop_token_type_t<Receiver&>>) {
-            cpo::set_value(std::move(receiver_));
+            unifex::set_value(std::move(receiver_));
           } else {
             if (get_stop_token(receiver_).stop_requested()) {
-              cpo::set_done(std::move(receiver_));
+              unifex::set_done(std::move(receiver_));
             } else {
-              cpo::set_value(std::move(receiver_));
+              unifex::set_value(std::move(receiver_));
             }
           }
         }

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -103,12 +103,12 @@ class timed_single_thread_context {
           cancelCallback_.destruct();
           if constexpr (is_stop_never_possible_v<
                             stop_token_type_t<Receiver&>>) {
-            cpo::set_value(static_cast<Receiver&&>(receiver_));
+            unifex::set_value(static_cast<Receiver&&>(receiver_));
           } else {
             if (get_stop_token(receiver_).stop_requested()) {
-              cpo::set_done(static_cast<Receiver&&>(receiver_));
+              unifex::set_done(static_cast<Receiver&&>(receiver_));
             } else {
-              cpo::set_value(static_cast<Receiver&&>(receiver_));
+              unifex::set_value(static_cast<Receiver&&>(receiver_));
             }
           }
         }
@@ -173,13 +173,13 @@ class timed_single_thread_context {
           cancelCallback_.destruct();
           if constexpr (is_stop_never_possible_v<
                             stop_token_type_t<Receiver&>>) {
-            cpo::set_value(
+            unifex::set_value(
                 static_cast<Receiver&&>(receiver_), scheduler{this->context_});
           } else {
             if (get_stop_token(receiver_).stop_requested()) {
-              cpo::set_done(static_cast<Receiver&&>(receiver_));
+              unifex::set_done(static_cast<Receiver&&>(receiver_));
             } else {
-              cpo::set_value(static_cast<Receiver&&>(receiver_));
+              unifex::set_value(static_cast<Receiver&&>(receiver_));
             }
           }
         }

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -73,12 +73,12 @@ private:
 
     void execute() noexcept final {
       if (is_stop_never_possible_v<stop_token_type_t<Receiver&>>) {
-        cpo::set_value(static_cast<Receiver&&>(receiver_));
+        unifex::set_value(static_cast<Receiver&&>(receiver_));
       } else {
         if (get_stop_token(receiver_).stop_requested()) {
-          cpo::set_done(static_cast<Receiver&&>(receiver_));
+          unifex::set_done(static_cast<Receiver&&>(receiver_));
         } else {
-          cpo::set_value(static_cast<Receiver&&>(receiver_));
+          unifex::set_value(static_cast<Receiver&&>(receiver_));
         }
       }
     }

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -150,7 +150,7 @@ struct transform_sender {
 
   template <typename Receiver>
   auto connect(Receiver&& receiver) && {
-    return cpo::connect(
+    return unifex::connect(
         std::forward<Predecessor>(pred_),
         transform_receiver<std::remove_cvref_t<Receiver>>{
             std::forward<Func>(func_), std::forward<Receiver>(receiver)});

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -94,28 +94,28 @@ struct transform_sender {
         if constexpr (noexcept(std::invoke(
                           (Func &&) func_, (Values &&) values...))) {
           std::invoke((Func &&) func_, (Values &&) values...);
-          cpo::set_value((Receiver &&) receiver_);
+          unifex::set_value((Receiver &&) receiver_);
         } else {
           try {
             std::invoke((Func &&) func_, (Values &&) values...);
-            cpo::set_value((Receiver &&) receiver_);
+            unifex::set_value((Receiver &&) receiver_);
           } catch (...) {
-            cpo::set_error((Receiver &&) receiver_, std::current_exception());
+            unifex::set_error((Receiver &&) receiver_, std::current_exception());
           }
         }
       } else {
         if constexpr (noexcept(std::invoke(
                           (Func &&) func_, (Values &&) values...))) {
-          cpo::set_value(
+          unifex::set_value(
               (Receiver &&) receiver_,
               std::invoke((Func &&) func_, (Values &&) values...));
         } else {
           try {
-            cpo::set_value(
+            unifex::set_value(
                 (Receiver &&) receiver_,
                 std::invoke((Func &&) func_, (Values &&) values...));
           } catch (...) {
-            cpo::set_error((Receiver &&) receiver_, std::current_exception());
+            unifex::set_error((Receiver &&) receiver_, std::current_exception());
           }
         }
       }
@@ -123,16 +123,16 @@ struct transform_sender {
 
     template <typename Error>
     void error(Error&& error) && noexcept {
-      cpo::set_error((Receiver &&) receiver_, (Error &&) error);
+      unifex::set_error((Receiver &&) receiver_, (Error &&) error);
     }
 
     void done() && noexcept {
-      cpo::set_done((Receiver &&) receiver_);
+      unifex::set_done((Receiver &&) receiver_);
     }
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const transform_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -88,7 +88,7 @@ struct transform_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     template <typename... Values>
-    void value(Values&&... values) && noexcept {
+    void set_value(Values&&... values) && noexcept {
       using result_type = std::invoke_result_t<Func, Values...>;
       if constexpr (std::is_void_v<result_type>) {
         if constexpr (noexcept(std::invoke(
@@ -122,11 +122,11 @@ struct transform_sender {
     }
 
     template <typename Error>
-    void error(Error&& error) && noexcept {
+    void set_error(Error&& error) && noexcept {
       unifex::set_error((Receiver &&) receiver_, (Error &&) error);
     }
 
-    void done() && noexcept {
+    void set_done() && noexcept {
       unifex::set_done((Receiver &&) receiver_);
     }
 

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -77,9 +77,9 @@ struct transform_sender {
       calculate_errors<Variant>::template apply>;
 
   friend constexpr auto tag_invoke(
-      tag_t<cpo::blocking>,
+      tag_t<blocking>,
       const transform_sender& sender) {
-    return cpo::blocking(sender.pred_);
+    return blocking(sender.pred_);
   }
 
   template <typename Receiver>

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -223,11 +223,11 @@ struct type_erased_stream {
       try {
         next_
             .construct_from([&] {
-              return cpo::connect(
+              return connect(
                   next(stream_),
                   next_receiver_wrapper{receiver, *this, std::move(stopToken)});
             });
-        cpo::start(next_.get());
+        start(next_.get());
       } catch (...) {
         receiver.error(std::current_exception());
       }
@@ -237,11 +237,11 @@ struct type_erased_stream {
       try {
         cleanup_
             .construct_from([&] {
-              return cpo::connect(
+              return connect(
                   cleanup(stream_),
                   cleanup_receiver_wrapper{receiver, *this});
             });
-        cpo::start(cleanup_.get());
+        start(cleanup_.get());
       } catch (...) {
         receiver.error(std::current_exception());
       }

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -81,15 +81,15 @@ struct type_erased_stream {
         : receiver_((Receiver &&) receiver) {}
 
     void value(Values&&... values) noexcept override {
-      cpo::set_value(std::move(receiver_), (Values &&) values...);
+      unifex::set_value(std::move(receiver_), (Values &&) values...);
     }
 
     void done() noexcept override {
-      cpo::set_done(std::move(receiver_));
+      unifex::set_done(std::move(receiver_));
     }
 
     void error(std::exception_ptr ex) noexcept override {
-      cpo::set_error(std::move(receiver_), std::move(ex));
+      unifex::set_error(std::move(receiver_), std::move(ex));
     }
 
    private:
@@ -106,11 +106,11 @@ struct type_erased_stream {
         : receiver_((Receiver &&) receiver) {}
 
     void done() noexcept override {
-      cpo::set_done(std::move(receiver_));
+      unifex::set_done(std::move(receiver_));
     }
 
     void error(std::exception_ptr ex) noexcept override {
-      cpo::set_error(std::move(receiver_), std::move(ex));
+      unifex::set_error(std::move(receiver_), std::move(ex));
     }
 
    private:

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -224,7 +224,7 @@ struct type_erased_stream {
         next_
             .construct_from([&] {
               return cpo::connect(
-                  cpo::next(stream_),
+                  next(stream_),
                   next_receiver_wrapper{receiver, *this, std::move(stopToken)});
             });
         cpo::start(next_.get());
@@ -238,7 +238,7 @@ struct type_erased_stream {
         cleanup_
             .construct_from([&] {
               return cpo::connect(
-                  cpo::cleanup(stream_),
+                  cleanup(stream_),
                   cleanup_receiver_wrapper{receiver, *this});
             });
         cpo::start(cleanup_.get());
@@ -338,12 +338,12 @@ struct type_erased_stream {
                 concrete_stream<std::remove_cvref_t<ConcreteStream>>>(
             (ConcreteStream &&) stream)) {}
 
-  next_sender next() noexcept {
-    return next_sender{*stream_};
+  friend next_sender tag_invoke(tag_t<next>, type_erased_stream& s) noexcept {
+    return next_sender{*s.stream_};
   }
 
-  cleanup_sender cleanup() noexcept {
-    return cleanup_sender{*stream_};
+  friend cleanup_sender tag_invoke(tag_t<cleanup>, type_erased_stream& s) noexcept {
+    return cleanup_sender{*s.stream_};
   }
 };
 

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -243,11 +243,11 @@ struct typed_via_sender {
         op.predOp_.destruct();
 
         try {
-          cpo::start(
+          unifex::start(
               op.succValueOp_
                   .template get<value_operation<std::remove_cvref_t<Values>...>>()
                   .construct_from([&] {
-                    return cpo::connect(
+                    return unifex::connect(
                         static_cast<Successor&&>(op.succ_),
                         value_receiver<std::remove_cvref_t<Values>...>{op});
                   }));
@@ -273,11 +273,11 @@ struct typed_via_sender {
 
         op.predOp_.destruct();
         try {
-          cpo::start(
+          unifex::start(
               op.succErrorOp_
                   .template get<error_operation<std::remove_cvref_t<Error>>>()
                   .construct_from([&] {
-                    return cpo::connect(
+                    return unifex::connect(
                         static_cast<Successor&&>(op.succ_),
                         error_receiver<std::remove_cvref_t<Error>>{op});
                   }));
@@ -292,8 +292,8 @@ struct typed_via_sender {
       void done() && noexcept {
         auto& op = op_;
         try {
-          cpo::start(op.succDoneOp_.construct_from([&] {
-            return cpo::connect(
+          unifex::start(op.succDoneOp_.construct_from([&] {
+            return unifex::connect(
                 static_cast<Successor&&>(op.succ_),
                 done_receiver{op});
           }));
@@ -366,11 +366,11 @@ struct typed_via_sender {
     void start() noexcept {
       try {
         predOp_.construct_from([&] {
-          return cpo::connect(
+          return unifex::connect(
               static_cast<Predecessor&&>(pred_),
               predecessor_receiver{*this});
         });
-        cpo::start(predOp_.get());
+        unifex::start(predOp_.get());
       } catch (...) {
         cpo::set_error(std::move(receiver_), std::current_exception());
       }

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -59,7 +59,7 @@ struct typed_via_sender {
     struct value_receiver {
       operation& op_;
 
-      void value() noexcept {
+      void set_value() noexcept {
         auto& op = op_;
         auto& valueOp =
             op.succValueOp_.template get<value_operation<Values...>>();
@@ -87,7 +87,7 @@ struct typed_via_sender {
       }
 
       template <typename Error>
-      void error(Error&& error) noexcept {
+      void set_error(Error&& error) noexcept {
         auto& op = op_;
         auto& valueOp = op.succValueOp_.template get<value_operation<Values...>>();
         auto& storedValue = op.value_.template get<std::tuple<Values...>>();
@@ -97,7 +97,7 @@ struct typed_via_sender {
             std::forward<Receiver>(op.receiver_), (Error &&) error);
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         auto& op = op_;
         auto& valueOp = op.succValueOp_.template get<value_operation<Values...>>();
         auto& storedValue = op.value_.template get<std::tuple<Values...>>();
@@ -128,7 +128,7 @@ struct typed_via_sender {
     struct error_receiver {
       operation& op_;
 
-      void value() noexcept {
+      void set_value() noexcept {
         auto& op = op_;
         auto& errorOp = op.succErrorOp_.template get<error_operation<Error>>();
         errorOp.destruct();
@@ -142,7 +142,7 @@ struct typed_via_sender {
       }
 
       template <typename OtherError>
-      void error(OtherError&& otherError) noexcept {
+      void set_error(OtherError&& otherError) noexcept {
         auto& op = op_;
 
         auto& errorOp = op.succErrorOp_.template get<error_operation<Error>>();
@@ -155,7 +155,7 @@ struct typed_via_sender {
             std::forward<Receiver>(op.receiver_), (OtherError &&) otherError);
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         auto& op = op_;
         auto& errorOp = op.succErrorOp_.template get<error_operation<Error>>();
         auto& storedError = op.error_.template get<Error>();
@@ -185,21 +185,21 @@ struct typed_via_sender {
     struct done_receiver {
       operation& op_;
 
-      void value() noexcept {
+      void set_value() noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
         unifex::set_done(std::forward<Receiver>(op.receiver_));
       }
 
       template <typename OtherError>
-      void error(OtherError&& otherError) noexcept {
+      void set_error(OtherError&& otherError) noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
         unifex::set_error(
             std::forward<Receiver>(op.receiver_), (OtherError &&) otherError);
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
         unifex::set_done(std::forward<Receiver>(op.receiver_));
@@ -227,7 +227,7 @@ struct typed_via_sender {
       operation& op_;
 
       template <typename... Values>
-      void value(Values&&... values) && noexcept {
+      void set_value(Values&&... values) && noexcept {
         auto& op = op_;
 
         auto& storedValue =
@@ -236,7 +236,7 @@ struct typed_via_sender {
         try {
           storedValue.construct((Values &&) values...);
         } catch (...) {
-          std::move(*this).error(std::current_exception());
+          std::move(*this).set_error(std::current_exception());
           return;
         }
 
@@ -260,7 +260,7 @@ struct typed_via_sender {
       }
 
       template <typename Error>
-      void error(Error&& e) && noexcept {
+      void set_error(Error&& e) && noexcept {
         auto& op = op_;
 
         static_assert(
@@ -289,7 +289,7 @@ struct typed_via_sender {
         }
       }
 
-      void done() && noexcept {
+      void set_done() && noexcept {
         auto& op = op_;
         try {
           unifex::start(op.succDoneOp_.construct_from([&] {

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -74,13 +74,13 @@ struct typed_via_sender {
             });
             std::apply(
               [&](Values&&... values) noexcept {
-                cpo::set_value(
+                unifex::set_value(
                   std::forward<Receiver>(op.receiver_),
                   (Values &&) values...);
               },
               std::move(values));
         } catch (...) {
-          cpo::set_error(
+          unifex::set_error(
               std::forward<Receiver>(op.receiver_),
               std::current_exception());
         }
@@ -93,7 +93,7 @@ struct typed_via_sender {
         auto& storedValue = op.value_.template get<std::tuple<Values...>>();
         valueOp.destruct();
         storedValue.destruct();
-        cpo::set_error(
+        unifex::set_error(
             std::forward<Receiver>(op.receiver_), (Error &&) error);
       }
 
@@ -103,12 +103,12 @@ struct typed_via_sender {
         auto& storedValue = op.value_.template get<std::tuple<Values...>>();
         valueOp.destruct();
         storedValue.destruct();
-        cpo::set_done(std::forward<Receiver>(op.receiver_));
+        unifex::set_done(std::forward<Receiver>(op.receiver_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -137,7 +137,7 @@ struct typed_via_sender {
         auto error = std::move(storedError).get();
         storedError.destruct();
 
-        cpo::set_error(
+        unifex::set_error(
             std::forward<Receiver>(op.receiver_), std::move(error));
       }
 
@@ -151,7 +151,7 @@ struct typed_via_sender {
         auto& storedError = op.error_.template get<Error>();
         storedError.destruct();
 
-        cpo::set_error(
+        unifex::set_error(
             std::forward<Receiver>(op.receiver_), (OtherError &&) otherError);
       }
 
@@ -161,12 +161,12 @@ struct typed_via_sender {
         auto& storedError = op.error_.template get<Error>();
         errorOp.destruct();
         storedError.destruct();
-        cpo::set_done(std::forward<Receiver>(op.receiver_));
+        unifex::set_done(std::forward<Receiver>(op.receiver_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -188,26 +188,26 @@ struct typed_via_sender {
       void value() noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
-        cpo::set_done(std::forward<Receiver>(op.receiver_));
+        unifex::set_done(std::forward<Receiver>(op.receiver_));
       }
 
       template <typename OtherError>
       void error(OtherError&& otherError) noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
-        cpo::set_error(
+        unifex::set_error(
             std::forward<Receiver>(op.receiver_), (OtherError &&) otherError);
       }
 
       void done() noexcept {
         auto& op = op_;
         op.succDoneOp_.destruct();
-        cpo::set_done(std::forward<Receiver>(op.receiver_));
+        unifex::set_done(std::forward<Receiver>(op.receiver_));
       }
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -253,7 +253,7 @@ struct typed_via_sender {
                   }));
         } catch (...) {
           storedValue.destruct();
-          cpo::set_error(
+          unifex::set_error(
               std::forward<Receiver>(op.receiver_),
               std::current_exception());
         }
@@ -283,7 +283,7 @@ struct typed_via_sender {
                   }));
         } catch (...) {
           storedError.destruct();
-          cpo::set_error(
+          unifex::set_error(
               std::forward<Receiver>(op.receiver_),
               std::current_exception());
         }
@@ -298,7 +298,7 @@ struct typed_via_sender {
                 done_receiver{op});
           }));
         } catch (...) {
-          cpo::set_error(
+          unifex::set_error(
               std::forward<Receiver>(op.receiver_),
               std::current_exception());
         }
@@ -306,7 +306,7 @@ struct typed_via_sender {
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -372,7 +372,7 @@ struct typed_via_sender {
         });
         unifex::start(predOp_.get());
       } catch (...) {
-        cpo::set_error(std::move(receiver_), std::current_exception());
+        unifex::set_error(std::move(receiver_), std::current_exception());
       }
     }
   };

--- a/include/unifex/typed_via_stream.hpp
+++ b/include/unifex/typed_via_stream.hpp
@@ -26,10 +26,10 @@ auto typed_via_stream(Scheduler&& scheduler, StreamSender&& stream) {
   return adapt_stream(
       (StreamSender &&) stream,
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return typed_via(cpo::schedule(s), (decltype(sender))sender);
+        return typed_via(schedule(s), (decltype(sender))sender);
       },
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return typed_via(cpo::schedule(s), (decltype(sender))sender);
+        return typed_via(schedule(s), (decltype(sender))sender);
       });
 }
 

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -77,7 +77,7 @@ struct via_sender {
     void value() noexcept {
       std::apply(
           [&](Values && ... values) noexcept {
-            cpo::set_value(
+            unifex::set_value(
                 std::forward<Receiver>(receiver_), (Values &&) values...);
           },
           std::move(values_));
@@ -85,16 +85,16 @@ struct via_sender {
 
     template <typename Error>
     void error(Error&& error) noexcept {
-      cpo::set_error(std::forward<Receiver>(receiver_), (Error &&) error);
+      unifex::set_error(std::forward<Receiver>(receiver_), (Error &&) error);
     }
 
     void done() noexcept {
-      cpo::set_done(std::forward<Receiver>(receiver_));
+      unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {
@@ -116,22 +116,22 @@ struct via_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     void value() noexcept {
-      cpo::set_error(std::forward<Receiver>(receiver_), std::move(error_));
+      unifex::set_error(std::forward<Receiver>(receiver_), std::move(error_));
     }
 
     template <typename OtherError>
     void error(OtherError&& otherError) noexcept {
-      cpo::set_error(
+      unifex::set_error(
           std::forward<Receiver>(receiver_), (OtherError &&) otherError);
     }
 
     void done() noexcept {
-      cpo::set_done(std::forward<Receiver>(receiver_));
+      unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {
@@ -152,22 +152,22 @@ struct via_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     void value() noexcept {
-      cpo::set_done(std::forward<Receiver>(receiver_));
+      unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
     template <typename OtherError>
     void error(OtherError&& otherError) noexcept {
-      cpo::set_error(
+      unifex::set_error(
           std::forward<Receiver>(receiver_), (OtherError &&) otherError);
     }
 
     void done() noexcept {
-      cpo::set_done(std::forward<Receiver>(receiver_));
+      unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {
@@ -196,7 +196,7 @@ struct via_sender {
             value_receiver<Receiver, std::remove_cvref_t<Values>...>{
                 {(Values &&) values...}, (Receiver &&) receiver_});
       } catch (...) {
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }
@@ -209,7 +209,7 @@ struct via_sender {
             error_receiver<Receiver, std::remove_cvref_t<Error>>{
                 (Error &&) error, (Receiver &&) receiver_});
       } catch (...) {
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }
@@ -220,14 +220,14 @@ struct via_sender {
             (Successor &&) successor_,
             done_receiver<Receiver>{(Receiver &&) receiver_});
       } catch (...) {
-        cpo::set_error(
+        unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }
 
     template <
         typename CPO,
-        std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
     friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
         std::is_nothrow_invocable_v<CPO, const Receiver&>)
         -> std::invoke_result_t<CPO, const Receiver&> {

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -47,10 +47,10 @@ struct via_sender {
       typename Successor::template error_types<Variant>>;
 
   friend constexpr blocking_kind tag_invoke(
-      tag_t<cpo::blocking>,
+      tag_t<blocking>,
       const via_sender& sender) {
-    const auto predBlocking = cpo::blocking(sender.pred_);
-    const auto succBlocking = cpo::blocking(sender.succ_);
+    const auto predBlocking = blocking(sender.pred_);
+    const auto succBlocking = blocking(sender.succ_);
     if (predBlocking == blocking_kind::never &&
         succBlocking == blocking_kind::never) {
       return blocking_kind::never;

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -245,7 +245,7 @@ struct via_sender {
 
   template <typename Receiver>
   auto connect(Receiver&& receiver) && {
-    return cpo::connect(
+    return unifex::connect(
         static_cast<Predecessor&&>(pred_),
         predecessor_receiver<
             std::remove_cvref_t<Receiver>>{static_cast<Successor&&>(succ_),

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -74,7 +74,7 @@ struct via_sender {
     UNIFEX_NO_UNIQUE_ADDRESS std::tuple<Values...> values_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-    void value() noexcept {
+    void set_value() noexcept {
       std::apply(
           [&](Values && ... values) noexcept {
             unifex::set_value(
@@ -84,11 +84,11 @@ struct via_sender {
     }
 
     template <typename Error>
-    void error(Error&& error) noexcept {
+    void set_error(Error&& error) noexcept {
       unifex::set_error(std::forward<Receiver>(receiver_), (Error &&) error);
     }
 
-    void done() noexcept {
+    void set_done() noexcept {
       unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
@@ -115,17 +115,17 @@ struct via_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Error error_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-    void value() noexcept {
+    void set_value() noexcept {
       unifex::set_error(std::forward<Receiver>(receiver_), std::move(error_));
     }
 
     template <typename OtherError>
-    void error(OtherError&& otherError) noexcept {
+    void set_error(OtherError&& otherError) noexcept {
       unifex::set_error(
           std::forward<Receiver>(receiver_), (OtherError &&) otherError);
     }
 
-    void done() noexcept {
+    void set_done() noexcept {
       unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
@@ -151,17 +151,17 @@ struct via_sender {
   struct done_receiver {
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-    void value() noexcept {
+    void set_value() noexcept {
       unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
     template <typename OtherError>
-    void error(OtherError&& otherError) noexcept {
+    void set_error(OtherError&& otherError) noexcept {
       unifex::set_error(
           std::forward<Receiver>(receiver_), (OtherError &&) otherError);
     }
 
-    void done() noexcept {
+    void set_done() noexcept {
       unifex::set_done(std::forward<Receiver>(receiver_));
     }
 
@@ -189,7 +189,7 @@ struct via_sender {
     Receiver receiver_;
 
     template <typename... Values>
-    void value(Values&&... values) && noexcept {
+    void set_value(Values&&... values) && noexcept {
       try {
         submit(
             (Successor &&) successor_,
@@ -202,7 +202,7 @@ struct via_sender {
     }
 
     template <typename Error>
-    void error(Error&& error) && noexcept {
+    void set_error(Error&& error) && noexcept {
       try {
         submit(
             (Successor &&) successor_,
@@ -214,7 +214,7 @@ struct via_sender {
       }
     }
 
-    void done() && noexcept {
+    void set_done() && noexcept {
       try {
         submit(
             (Successor &&) successor_,

--- a/include/unifex/via_stream.hpp
+++ b/include/unifex/via_stream.hpp
@@ -27,10 +27,10 @@ auto via_stream(Scheduler&& scheduler, StreamSender&& stream) {
   return adapt_stream(
       (StreamSender &&) stream,
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return via(cpo::schedule(s), (decltype(sender))sender);
+        return via(schedule(s), (decltype(sender))sender);
       },
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return typed_via(cpo::schedule(s), (decltype(sender))sender);
+        return typed_via(schedule(s), (decltype(sender))sender);
       });
 }
 

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -247,7 +247,7 @@ class when_all_sender {
 
   // Customise the 'blocking' CPO to combine the blocking-nature
   // of each of the child operations.
-  friend blocking_kind tag_invoke(tag_t<cpo::blocking>, const when_all_sender& s) noexcept {
+  friend blocking_kind tag_invoke(tag_t<blocking>, const when_all_sender& s) noexcept {
     bool alwaysInline = true;
     bool alwaysBlocking = true;
     bool neverBlocking =  false;
@@ -270,7 +270,7 @@ class when_all_sender {
 
     std::apply([&](const auto&... senders) {
       (void)std::initializer_list<int>{
-        (handleBlockingStatus(cpo::blocking(senders)), 0)... };
+        (handleBlockingStatus(blocking(senders)), 0)... };
     }, s.senders_);
 
     if (neverBlocking) {

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -64,10 +64,10 @@ struct when_all_operation_tuple<Index, Receiver, First, Rest...>
       : when_all_operation_tuple<Index + 1, Receiver, Rest...>{parent,
                                                                (Rest &&)
                                                                    rest...},
-        op_(cpo::connect((First &&) first, Receiver<Index>{parent})) {}
+        op_(connect((First &&) first, Receiver<Index>{parent})) {}
 
   void start() noexcept {
-    cpo::start(op_);
+    unifex::start(op_);
     when_all_operation_tuple<Index + 1, Receiver, Rest...>::start();
   }
 

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -114,7 +114,7 @@ class when_all_sender {
       operation& op_;
 
       template <typename... Values>
-      void value(Values&&... values) noexcept {
+      void set_value(Values&&... values) noexcept {
         try {
           std::get<Index>(op_.values_)
               .emplace(
@@ -122,12 +122,12 @@ class when_all_sender {
                   (Values &&) values...);
           op_.element_complete();
         } catch (...) {
-          error(std::current_exception());
+          this->set_error(std::current_exception());
         }
       }
 
       template <typename Error>
-      void error(Error&& error) noexcept {
+      void set_error(Error&& error) noexcept {
         if (!op_.doneOrError_.exchange(true, std::memory_order_relaxed)) {
           op_.error_.emplace(std::in_place_type<Error>, (Error &&) error);
           op_.stopSource_.request_stop();
@@ -135,7 +135,7 @@ class when_all_sender {
         op_.element_complete();
       }
 
-      void done() noexcept {
+      void set_done() noexcept {
         if (!op_.doneOrError_.exchange(true, std::memory_order_relaxed)) {
           op_.stopSource_.request_stop();
         }

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -146,7 +146,7 @@ class when_all_sender {
 
       template <
           typename CPO,
-          std::enable_if_t<!cpo::is_receiver_cpo_v<CPO>, int> = 0>
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
       friend auto tag_invoke(CPO cpo, const element_receiver& r) noexcept(
           std::is_nothrow_invocable_v<CPO, const Receiver&>)
           -> std::invoke_result_t<CPO, const Receiver&> {
@@ -193,16 +193,16 @@ class when_all_sender {
       stopCallback_.destruct();
 
       if (get_stop_token(receiver_).stop_requested()) {
-        cpo::set_done(std::move(receiver_));
+        unifex::set_done(std::move(receiver_));
       } else if (doneOrError_.load(std::memory_order_relaxed)) {
         if (error_.has_value()) {
           std::visit(
               [this](auto&& error) {
-                cpo::set_error(std::move(receiver_), (decltype(error))error);
+                unifex::set_error(std::move(receiver_), (decltype(error))error);
               },
               std::move(error_.value()));
         } else {
-          cpo::set_done(std::move(receiver_));
+          unifex::set_done(std::move(receiver_));
         }
       } else {
         deliver_value(std::index_sequence_for<Senders...>{});
@@ -212,11 +212,11 @@ class when_all_sender {
     template <std::size_t... Indices>
     void deliver_value(std::index_sequence<Indices...>) noexcept {
       try {
-        cpo::set_value(
+        unifex::set_value(
             std::move(receiver_),
             std::get<Indices>(std::move(values_)).value()...);
       } catch (...) {
-        cpo::set_error(std::move(receiver_), std::current_exception());
+        unifex::set_error(std::move(receiver_), std::current_exception());
       }
     }
 

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -78,10 +78,10 @@ public:
                                       Value2 &&value)
       : value_((Value2 &&) value),
         innerOp_(
-            cpo::connect((Sender &&) sender,
+            connect((Sender &&) sender,
                          receiver_wrapper{(Receiver2 &&) receiver, this})) {}
 
-  void start() & noexcept { cpo::start(innerOp_); }
+  void start() & noexcept { unifex::start(innerOp_); }
 
 private:
   UNIFEX_NO_UNIQUE_ADDRESS Value value_;

--- a/test/static_thread_pool_test.cpp
+++ b/test/static_thread_pool_test.cpp
@@ -28,7 +28,7 @@ using namespace unifex;
 
 template <typename Scheduler, typename F>
 auto run_on(Scheduler&& s, F&& func) {
-  return transform(cpo::schedule((Scheduler &&) s), (F &&) func);
+  return transform(schedule((Scheduler &&) s), (F &&) func);
 }
 
 TEST(StaticThreadPool, Smoke) {

--- a/test/submit_allocator_customisation_test.cpp
+++ b/test/submit_allocator_customisation_test.cpp
@@ -90,7 +90,7 @@ void test(Scheduler scheduler, Allocator allocator) {
   auto addToValue = [&](int x) {
     // The via() is expected to allocate when it calls submit().
     // NOTE: This may start failing if we ever merge via() and typed_via().
-    return transform(via(cpo::schedule(scheduler), just(x)), [&](int x) {
+    return transform(via(schedule(scheduler), just(x)), [&](int x) {
       std::printf("got %i\n", x);
       value += x;
     });

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -46,7 +46,7 @@ TEST(WhenAll2, Smoke) {
     sync_wait(transform(
         when_all(
             transform(
-                cpo::schedule_after(scheduler, 100ms),
+                schedule_after(scheduler, 100ms),
                 [&]() -> steady_clock::time_point::duration {
                   ranPart1Callback = true;
                   auto time = steady_clock::now() - start;
@@ -56,7 +56,7 @@ TEST(WhenAll2, Smoke) {
                   throw my_error{};
                 }),
             transform(
-                cpo::schedule_after(scheduler, 200ms),
+                schedule_after(scheduler, 200ms),
                 [&]() {
                   ranPart2Callback = true;
                   auto time = steady_clock::now() - start;


### PR DESCRIPTION
Move all of the CPOs that were previously defined in the `unifex::cpo` namespace to now be defined in the `unifex` namespace.

Since we want to eventually make most algorithms/functions CPOs it doesn't really make sense to organise them into a namespace based on whether they are CPOs or not. We shouldn't need to update call-sites that invoke algorithms when we convert an algorithm from an ordinary function to be a CPO.

Also, modify the receiver CPOs to look for `.set_value()`/`.set_error()`/`.set_done()` member functions instead of `.value()`/`.error()`/`.done()` so that we are more consistent with the design in [P0443R11](https://wg21.link/P0443R11).