### PR TITLE
Change delay() to be an algorithm over a stream

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -31,6 +31,7 @@
   * `take_until()`
   * `single()`
   * `stop_immediately()`
+  * `delay()`
 * Stream Types
   * `range_stream`
   * `type_erased_stream<Ts...>`
@@ -323,6 +324,11 @@ Any `set_value()` produced by an abandoned `next()` call is discarded.
 Any `set_error()` produced by an abandoned `next()` call is reported in
 the `cleanup()` result.
 
+### `delay(Stream stream, TimeScheduler scheduler, Duration d) -> Stream`
+
+Adapts `stream` to produce a new stream that delays the delivery of each
+value, done and error signal by the specified duration.
+
 ## Scheduler Algorithms
 
 ### `schedule(Scheduler schedule) -> SenderOf<void>`
@@ -347,11 +353,6 @@ the body of `set_value()`.
 
 This is like `schedule(scheduler)` above but uses the implicit scheduler
 obtained from the receiver passed to `connect()` by a calling `get_scheduler(receiver)`.
-
-### `delay(TimeScheduler scheduler, Duration d) -> Scheduler`
-
-Adapts `scheduler` to produce a new scheduler that delays completion of all
-`schedule()` operations by the specified duration.
 
 ## Scheduler Types
 

--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -44,8 +44,8 @@ int main() {
     auto start = steady_clock::now();
 
     auto s = take_until(
-        stop_immediately<int>(typed_via_stream(
-            delay(context.get_scheduler(), 50ms), range_stream{0, 100})),
+        stop_immediately<int>(
+            delay(range_stream{0, 100}, context.get_scheduler(), 50ms)),
         single(schedule_after(context.get_scheduler(), 500ms)));
 
     int sum = 0;

--- a/examples/delayed_stream_cancellation.cpp
+++ b/examples/delayed_stream_cancellation.cpp
@@ -47,9 +47,7 @@ int main() {
 
   sync_wait(
       for_each(
-          typed_via_stream(
-              delay(context.get_scheduler(), 100ms), range_stream{0, 100}),
-
+          delay(range_stream{0, 100}, context.get_scheduler(), 100ms),
           [start](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - start);
             std::printf("[%i ms] %i\n", (int)ms.count(), value);

--- a/examples/stop_immediately.cpp
+++ b/examples/stop_immediately.cpp
@@ -39,9 +39,8 @@ int main() {
   [[maybe_unused]] std::optional<unit> result =
       eventLoop.sync_wait(for_each(
           take_until(
-              stop_immediately<int>(typed_via_stream(
-                  delay(eventLoop.get_scheduler(), 50ms),
-                  range_stream{0, 100})),
+              stop_immediately<int>(
+                  delay(range_stream{0, 100}, eventLoop.get_scheduler(), 50ms)),
               single(schedule_after(eventLoop.get_scheduler(), 500ms))),
           [start](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - start);


### PR DESCRIPTION
The `delay()` function now adapts a stream into another stream that delays delivery of value/done/error signals by the specified duration rather than being an algorithm that adapts a scheduler.