### PR TITLE
Add sequence() algorithm and refactor on() to be in terms of this

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -107,14 +107,25 @@ The semantics of `typed_via()` is the same as that of `via()` above but
 avoids the need for heap allocation by pre-allocating storage for the
 predecessor's result.
 
-### `on(Sender predecessor, Sender successor) -> Sender`
+### `on(Sender sender, Scheduler scheduler) -> Sender`
 
-Returns a sender that ensures that `successor` is started on the
-execution context that `predecessor` completes on.
+Returns a sender that ensures that `sender` is started on the
+execution context associated with the specified `scheduler`.
 
-Discards any value produced by predecessor and sends the result of
-`successor`. If `predecessor` completes with `set_done()` or `set_error()` then
-sends that signal and never starts executing successor.
+The `sender` is executed with a receiver that customises the
+`get_scheduler` query to return the specified `scheduler`.
+
+The default implementation schedules the call to `connect()`
+and subsequent `start()` onto an execution context associated
+with `scheduler` using the `schedule(scheduler)` operation.
+
+If `schedule(scheduler)` completes with `set_done()` or
+`set_error()` then the `on()` operation completes with
+that signal and never starts executing `sender`.
+
+The `on()` algorithm may be customised by particular schedulers
+and/or scheduler+sender combinations to provide an alternative
+impllementation.
 
 ### `let(Sender pred, Invocable func) -> Sender`
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -10,6 +10,7 @@
   * `typed_via()`
   * `on()`
   * `let()`
+  * `sequence()`
   * `sync_wait()`
   * `when_all()`
   * `with_query_value()`
@@ -147,6 +148,27 @@ whole will complete with the result of the successor.
 
 If the predecessor completes with done/error then `func` is not invoked
 and the operation as a whole completes with that done/error signal.
+
+### `sequence(Sender... predecessors, Sender last) -> Sender`
+
+The `sequence()` algorithm takes a variadic pack of senders and executes
+them sequentially, only starting the next sender if/when the previous sender
+completed successfully (ie. with `set_value`).
+
+All but the `last` sender must produce a `void` value result
+i.e. call `set_value(receiver)` with no additional value args.
+
+If any of the input senders complete with `set_done` or `set_error`
+then the operation as a whole completes with that signal and
+any subsequent operations in the sequence are not started.
+
+This algorithm may be customised by defining a custom `tag_invoke(tag_t<sequence>, ...)`
+overload for your particular sender types. You can either provide a customisation
+for a variadic pack of senders or for a pair of senders.
+
+If you provide a customisation for a pair of senders then this customisation
+will be applied to the first two arguments and then reinvoke `sequence()`
+with the first two arguments replaced with the result of `sequence(first, second)`.
 
 ### `sync_wait(Sender sender, StopToken st = {}) -> std::optional<Result>`
 

--- a/examples/async_trace.cpp
+++ b/examples/async_trace.cpp
@@ -15,7 +15,7 @@
  */
 #include <unifex/async_trace.hpp>
 
-#include <unifex/on.hpp>
+#include <unifex/sequence.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
 
@@ -60,7 +60,7 @@ auto dump_async_trace(std::string tag = {}) {
 
 template <typename Sender>
 auto dump_async_trace_on_start(Sender &&sender, std::string tag = {}) {
-  return unifex::on(dump_async_trace(std::move(tag)), (Sender &&) sender);
+  return unifex::sequence(dump_async_trace(std::move(tag)), (Sender &&) sender);
 }
 
 template <typename Sender>

--- a/examples/let.cpp
+++ b/examples/let.cpp
@@ -15,12 +15,10 @@
  */
 #include <unifex/just.hpp>
 #include <unifex/let.hpp>
-#include <unifex/on.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
 #include <unifex/transform.hpp>
-#include <unifex/typed_via.hpp>
 #include <unifex/when_all.hpp>
 
 #include <chrono>

--- a/examples/linux/io_uring_test.cpp
+++ b/examples/linux/io_uring_test.cpp
@@ -17,9 +17,9 @@
 #include <unifex/just.hpp>
 #include <unifex/let.hpp>
 #include <unifex/linux/io_uring_context.hpp>
-#include <unifex/on.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/scope_guard.hpp>
+#include <unifex/sequence.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/transform.hpp>
 #include <unifex/when_all.hpp>
@@ -37,20 +37,6 @@ using namespace std::chrono_literals;
 template <typename F>
 auto lazy(F&& f) {
   return transform(just(), (F &&) f);
-}
-
-auto sequence() {
-  return just();
-}
-
-template <typename S>
-auto sequence(S&& s) {
-  return (S &&) s;
-}
-
-template <typename S1, typename S2, typename... Others>
-auto sequence(S1&& s1, S2&& s2, Others&&... others) {
-  return sequence(on((S1 &&) s1, (S2 &&) s2), (Others &&) others...);
 }
 
 static constexpr unsigned char data[6] = {'h', 'e', 'l', 'l', 'o', '\n'};

--- a/examples/stream_cancellation.cpp
+++ b/examples/stream_cancellation.cpp
@@ -49,14 +49,14 @@ int main() {
   auto start = steady_clock::now();
 
   sync_wait(
-      on(schedule(context.get_scheduler()),
-         for_each(
+      on(for_each(
              on_stream(trampoline_scheduler{}, range_stream{0, 20}),
              [](int value) {
                // Simulate some work
                std::printf("processing %i\n", value);
                std::this_thread::sleep_for(10ms);
-             })),
+             }),
+         context.get_scheduler()),
       stopSource.get_token());
 
   auto end = steady_clock::now();

--- a/include/unifex/execute.hpp
+++ b/include/unifex/execute.hpp
@@ -18,7 +18,6 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/transform.hpp>
-#include <unifex/on.hpp>
 #include <unifex/submit.hpp>
 
 #include <exception>

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -15,205 +15,37 @@
  */
 #pragma once
 
-#include <unifex/config.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/manual_lifetime.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/async_trace.hpp>
-#include <unifex/blocking.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/with_query_value.hpp>
+#include <unifex/sequence.hpp>
 
-#include <exception>
 #include <type_traits>
-#include <utility>
 
-namespace unifex {
-
-template <typename Predecessor, typename Successor>
-struct on_sender {
-  UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
-  UNIFEX_NO_UNIQUE_ADDRESS Successor succ_;
-
-  template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
-  using value_types = typename Successor::template value_types<Variant, Tuple>;
-
-  template <template <typename...> class Variant>
-  using error_types = concat_unique_t<
-      typename Predecessor::template error_types<Variant>,
-      typename Successor::template error_types<Variant>>;
-
-  friend blocking_kind tag_invoke(
-      tag_t<blocking>,
-      const on_sender<Predecessor, Successor>& sender) {
-    const auto predBlocking = blocking(sender.pred_);
-    const auto succBlocking = blocking(sender.succ_);
-    if (predBlocking == blocking_kind::never) {
-      return blocking_kind::never;
-    } else if (
-        predBlocking == blocking_kind::always_inline &&
-        predBlocking == blocking_kind::always_inline) {
-      return blocking_kind::always_inline;
-    } else if (
-        (predBlocking == blocking_kind::always_inline ||
-         predBlocking == blocking_kind::always) &&
-        (succBlocking == blocking_kind::always_inline ||
-         succBlocking == blocking_kind::always)) {
-      return blocking_kind::always;
-    } else {
-      return blocking_kind::maybe;
-    }
-  }
-
-  template <typename Receiver>
-  struct operation {
-    struct successor_receiver {
-      operation& op_;
-
-      template <typename... Values>
-      void set_value(Values... values) && noexcept {
-        auto& op = op_;
-        op.succOp_.destruct();
-        unifex::set_value(
-            static_cast<Receiver&&>(op.receiver_), (Values &&) values...);
-      }
-
-      template <typename Error>
-      void set_error(Error error) && noexcept {
-        auto& op = op_;
-        op.succOp_.destruct();
-        unifex::set_error(
-            static_cast<Receiver&&>(op.receiver_), (Error &&) error);
-      }
-
-      void set_done() && noexcept {
-        auto& op = op_;
-        op.succOp_.destruct();
-        unifex::set_done(static_cast<Receiver&&>(op.receiver_));
-      }
-
-      template <
-          typename CPO,
-          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
-      friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
-          std::is_nothrow_invocable_v<CPO, const Receiver&>)
-          -> std::invoke_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(std::as_const(r.op_.receiver_));
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const successor_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.op_.receiver_);
-      }
-    };
-
-    struct predecessor_receiver {
-      operation& op_;
-
-      template <typename... Values>
-      void set_value(Values&&...) noexcept {
-        auto& op = op_;
-        op.predOp_.destruct();
-        try {
-          op.succOp_.construct_from([&]() {
-            return unifex::connect(
-                static_cast<Successor&&>(op.succ_),
-                successor_receiver{op});
-          });
-          unifex::start(op.succOp_.get());
-        } catch (...) {
-          unifex::set_error(
-              static_cast<Receiver&&>(op.receiver_),
-              std::current_exception());
-        }
-      }
-
-      template <typename Error>
-      void set_error(Error error) noexcept {
-        auto& op = op_;
-        op.predOp_.destruct();
-        unifex::set_error(
-            static_cast<Receiver&&>(op.receiver_), (Error &&) error);
-      }
-
-      void set_done() noexcept {
-        auto& op = op_;
-        op.predOp_.destruct();
-        unifex::set_done(static_cast<Receiver&&>(op.receiver_));
-      }
-
-      template <
-          typename CPO,
-          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
-      friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
-          std::is_nothrow_invocable_v<CPO, const Receiver&>)
-          -> std::invoke_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(std::as_const(r.op_.receiver_));
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const predecessor_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.op_.receiver_);
-      }
-    };
-
-    template <typename Receiver2>
-    explicit operation(
-        Predecessor&& pred,
-        Successor&& succ,
-        Receiver2&& receiver)
-        : succ_((Successor &&) succ)
-        , receiver_((Receiver2&&)receiver) {
-      predOp_.construct_from([&] {
-        return unifex::connect(
-            static_cast<Predecessor&&>(pred),
-            predecessor_receiver{*this});
-      });
+namespace unifex
+{
+  inline constexpr struct on_cpo {
+    template <
+        typename Sender,
+        typename Scheduler,
+        std::enable_if_t<is_tag_invocable_v<on_cpo, Sender, Scheduler>, int> =
+            0>
+    auto operator()(Sender&& sender, Scheduler&& scheduler) const
+        noexcept(is_nothrow_tag_invocable_v<on_cpo, Sender, Scheduler>) {
+      return unifex::tag_invoke(
+          *this, (Sender &&) sender, (Scheduler &&) scheduler);
     }
 
-    ~operation() {
-      if (!started_)
-        predOp_.destruct();
+    template <
+        typename Sender,
+        typename Scheduler,
+        std::enable_if_t<!is_tag_invocable_v<on_cpo, Sender, Scheduler>, int> =
+            0>
+    auto operator()(Sender&& sender, Scheduler&& scheduler) const {
+      return sequence(
+          schedule(scheduler),
+          with_query_value((Sender &&) sender, get_scheduler, scheduler));
     }
+  } on;
 
-    Successor succ_;
-    Receiver receiver_;
-    union {
-      manual_lifetime<operation_t<Predecessor, predecessor_receiver>>
-          predOp_;
-      manual_lifetime<operation_t<Successor, successor_receiver>>
-          succOp_;
-    };
-    bool started_ = false;
-
-    void start() noexcept {
-      started_ = true;
-      unifex::start(predOp_.get());
-    }
-  };
-
-  template <typename Receiver>
-  operation<std::remove_cvref_t<Receiver>> connect(Receiver&& receiver) && {
-    return operation<std::remove_cvref_t<Receiver>>{
-        (Predecessor &&) pred_, (Successor &&) succ_, (Receiver &&) receiver};
-  }
-};
-
-template <typename Predecessor, typename Successor>
-auto on(Predecessor&& predecessor, Successor&& successor) {
-  return on_sender<
-      std::remove_cvref_t<Predecessor>,
-      std::remove_cvref_t<Successor>>{(Predecessor &&) predecessor,
-                                      (Successor &&) successor};
-}
-
-} // namespace unifex
+}  // namespace unifex

--- a/include/unifex/on_stream.hpp
+++ b/include/unifex/on_stream.hpp
@@ -26,7 +26,7 @@ auto on_stream(Scheduler&& scheduler, StreamSender&& stream) {
   return adapt_stream(
       (StreamSender &&) stream,
       [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-        return on(schedule(s), (decltype(sender))sender);
+        return on((decltype(sender))sender, s);
       });
 }
 

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -63,6 +63,14 @@ using operation_t = decltype(connect(
     std::declval<Sender>(),
     std::declval<Receiver>()));
 
+template <typename Sender, typename Receiver>
+inline constexpr bool is_connectable_v =
+  std::is_invocable_v<decltype(connect), Sender, Receiver>;
+
+template <typename Sender, typename Receiver>
+inline constexpr bool is_nothrow_connectable_v =
+  std::is_nothrow_invocable_v<decltype(connect), Sender, Receiver>;
+
 template <typename Sender, typename Adaptor>
 using adapt_error_types_t =
     typename Sender::template error_types<Adaptor::template apply>;

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace unifex
+{
+  namespace detail
+  {
+    template <typename Predecessor, typename Successor, typename Receiver>
+    class sequence_operation;
+
+    template <typename Predecessor, typename Successor, typename Receiver>
+    class sequence_successor_receiver {
+      using operation_type =
+          sequence_operation<Predecessor, Successor, Receiver>;
+
+    public:
+      explicit sequence_successor_receiver(operation_type* op) noexcept
+        : op_(op) {}
+
+      sequence_successor_receiver(sequence_successor_receiver&& other) noexcept
+        : op_(std::exchange(other.op_, nullptr)) {}
+
+    private:
+      template <typename CPO, typename... Args>
+      friend auto tag_invoke(
+          CPO cpo,
+          sequence_successor_receiver&& r,
+          Args&&... args) noexcept(std::
+                                       is_nothrow_invocable_v<
+                                           CPO,
+                                           Receiver,
+                                           Args...>)
+          -> std::invoke_result_t<CPO, Receiver, Args...> {
+        return static_cast<CPO&&>(cpo)(
+            r.get_receiver_rvalue(), static_cast<Args&&>(args)...);
+      }
+
+      template <typename CPO, typename... Args>
+      friend auto tag_invoke(
+          CPO cpo,
+          const sequence_successor_receiver& r,
+          Args&&... args) noexcept(std::
+                                       is_nothrow_invocable_v<
+                                           CPO,
+                                           const Receiver&,
+                                           Args...>)
+          -> std::invoke_result_t<CPO, const Receiver&, Args...> {
+        return static_cast<CPO&&>(cpo)(
+            r.get_const_receiver(), static_cast<Args&&>(args)...);
+      }
+
+      template <typename Func>
+      friend void tag_invoke(
+          tag_t<visit_continuations>,
+          const sequence_successor_receiver& r,
+          Func&& func) {
+        std::invoke(func, r.get_const_receiver());
+      }
+
+      Receiver&& get_receiver_rvalue() noexcept {
+        return static_cast<Receiver&&>(op_->receiver_);
+      }
+
+      const Receiver& get_const_receiver() const noexcept {
+        return op_->receiver_;
+      }
+
+      operation_type* op_;
+    };
+
+    template <typename Predecessor, typename Successor, typename Receiver>
+    class sequence_predecessor_receiver {
+      using operation_type =
+          sequence_operation<Predecessor, Successor, Receiver>;
+
+    public:
+      explicit sequence_predecessor_receiver(operation_type* op) noexcept
+        : op_(op) {}
+
+      sequence_predecessor_receiver(
+          sequence_predecessor_receiver&& other) noexcept
+        : op_(std::exchange(other.op_, nullptr)) {}
+
+      void set_value() && noexcept {
+        // Take a copy of op_ before destroying predOp_ as this may end up
+        // destroying *this.
+        using successor_receiver =
+            sequence_successor_receiver<Predecessor, Successor, Receiver>;
+
+        auto* op = op_;
+        op->status_ = operation_type::status::empty;
+        op->predOp_.destruct();
+        if constexpr (is_nothrow_connectable_v<Successor, successor_receiver>) {
+          op->succOp_.construct_from([&]() noexcept {
+            return unifex::connect(
+                static_cast<Successor&&>(op->successor_), successor_receiver{op});
+          });
+          op->status_ = operation_type::status::successor_operation_constructed;
+          unifex::start(op->succOp_.get());
+        } else {
+          try {
+            op->succOp_.construct_from([&]() {
+              return unifex::connect(
+                  static_cast<Successor&&>(op->successor_), successor_receiver{op});
+            });
+            op->status_ = operation_type::status::successor_operation_constructed;
+            unifex::start(op->succOp_.get());
+          } catch (...) {
+            unifex::set_error(
+                static_cast<Receiver&&>(op->receiver_),
+                std::current_exception());
+          }
+        }
+      }
+
+      template <
+          typename Error,
+          std::enable_if_t<
+              std::is_invocable_v<decltype(unifex::set_error), Receiver, Error>,
+              int> = 0>
+      void set_error(Error&& error) && noexcept {
+        unifex::set_error(
+            static_cast<Receiver&&>(op_->receiver_),
+            static_cast<Error&&>(error));
+      }
+
+      template <
+          typename... Args,
+          std::enable_if_t<
+              std::
+                  is_invocable_v<decltype(unifex::set_done), Receiver, Args...>,
+              int> = 0>
+      void set_done(Args...) && noexcept {
+        unifex::set_done(static_cast<Receiver&&>(op_->receiver_));
+      }
+
+    private:
+      template <
+          typename CPO,
+          typename... Args,
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+      friend auto tag_invoke(
+          CPO cpo,
+          const sequence_predecessor_receiver& r,
+          Args&&... args) noexcept(std::
+                                       is_nothrow_invocable_v<
+                                           CPO,
+                                           const Receiver&,
+                                           Args...>)
+          -> std::invoke_result_t<CPO, const Receiver&, Args...> {
+        return static_cast<CPO&&>(cpo)(
+            r.get_const_receiver(), static_cast<Args&&>(args)...);
+      }
+
+      template <typename Func>
+      friend void tag_invoke(
+          tag_t<visit_continuations>,
+          const sequence_predecessor_receiver& r,
+          Func&& func) {
+        std::invoke(func, r.get_const_receiver());
+      }
+
+      const Receiver& get_const_receiver() const noexcept {
+        return op_->receiver_;
+      }
+
+      operation_type* op_;
+    };
+
+    template <typename Predecessor, typename Successor, typename Receiver>
+    class sequence_operation {
+    public:
+      template <typename Successor2, typename Receiver2>
+      explicit sequence_operation(
+          Predecessor&& predecessor,
+          Successor2&& successor,
+          Receiver2&& receiver)
+        : successor_(static_cast<Successor2&&>(successor))
+        , receiver_(static_cast<Receiver&&>(receiver))
+        , status_(status::predecessor_operation_constructed) {
+        predOp_.construct_from([&] {
+          return unifex::connect(
+              static_cast<Predecessor&&>(predecessor),
+              sequence_predecessor_receiver<Predecessor, Successor, Receiver>{
+                  this});
+        });
+      }
+
+      ~sequence_operation() {
+        switch (status_) {
+          case status::predecessor_operation_constructed:
+            predOp_.destruct();
+            break;
+          case status::successor_operation_constructed:
+            succOp_.destruct();
+            break;
+          case status::empty: break;
+        }
+      }
+
+      void start() & noexcept {
+        assert(status_ == status::predecessor_operation_constructed);
+        unifex::start(predOp_.get());
+      }
+
+    private:
+      friend class sequence_predecessor_receiver<
+          Predecessor,
+          Successor,
+          Receiver>;
+      friend class sequence_successor_receiver<
+          Predecessor,
+          Successor,
+          Receiver>;
+
+      Successor successor_;
+      Receiver receiver_;
+      enum class status {
+        empty,
+        predecessor_operation_constructed,
+        successor_operation_constructed
+      };
+      status status_;
+      union {
+        manual_lifetime<operation_t<
+            Predecessor,
+            sequence_predecessor_receiver<Predecessor, Successor, Receiver>>>
+            predOp_;
+        manual_lifetime<operation_t<
+            Successor,
+            sequence_successor_receiver<Predecessor, Successor, Receiver>>>
+            succOp_;
+      };
+    };
+  }  // namespace detail
+
+  template <typename Predecessor, typename Successor>
+  class sequence_sender {
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types =
+        typename Successor::template value_types<Variant, Tuple>;
+
+    template <template <typename...> class Variant>
+    using error_types = concat_unique_t<
+        typename Predecessor::template error_types<Variant>,
+        typename Successor::template error_types<Variant>>;
+
+    template <
+        typename Predecessor2,
+        typename Successor2,
+        std::enable_if_t<
+            std::is_constructible_v<Predecessor, Predecessor2> &&
+                std::is_constructible_v<Successor, Successor2>,
+            int> = 0>
+    explicit sequence_sender(
+        Predecessor2&& predecessor,
+        Successor2&&
+            successor) noexcept(std::
+                                    is_nothrow_constructible_v<
+                                        Predecessor,
+                                        Predecessor2>&&
+                                        std::is_nothrow_constructible_v<
+                                            Successor,
+                                            Successor2>)
+      : predecessor_(static_cast<Predecessor&&>(predecessor))
+      , successor_(static_cast<Successor&&>(successor)) {}
+
+    friend blocking_kind
+    tag_invoke(tag_t<blocking>, const sequence_sender& sender) {
+      const auto predBlocking = blocking(sender.predecessor_);
+      const auto succBlocking = blocking(sender.successor_);
+      if (predBlocking == blocking_kind::never) {
+        return blocking_kind::never;
+      } else if (
+          predBlocking == blocking_kind::always_inline &&
+          succBlocking == blocking_kind::always_inline) {
+        return blocking_kind::always_inline;
+      } else if (
+          (predBlocking == blocking_kind::always_inline ||
+           predBlocking == blocking_kind::always) &&
+          (succBlocking == blocking_kind::always_inline ||
+           succBlocking == blocking_kind::always)) {
+        return blocking_kind::always;
+      } else {
+        return blocking_kind::maybe;
+      }
+    }
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                Predecessor,
+                detail::sequence_predecessor_receiver<
+                    Predecessor,
+                    Successor,
+                    std::remove_cvref_t<Receiver>>> &&
+                is_connectable_v<
+                    Successor,
+                    detail::sequence_successor_receiver<
+                        Predecessor,
+                        Successor,
+                        Receiver>>,
+            int> = 0>
+    auto connect(Receiver&& receiver) && -> detail::sequence_operation<
+        Predecessor,
+        Successor,
+        std::remove_cvref_t<Receiver>> {
+      return detail::sequence_operation<
+          Predecessor,
+          Successor,
+          std::remove_cvref_t<Receiver>>{
+          (Predecessor &&) predecessor_,
+          (Successor &&) successor_,
+          (Receiver &&) receiver};
+    }
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                Predecessor&,
+                detail::sequence_predecessor_receiver<
+                    Predecessor&,
+                    Successor,
+                    std::remove_cvref_t<Receiver>>> &&
+                is_connectable_v<
+                    Successor,
+                    detail::sequence_successor_receiver<
+                        Predecessor&,
+                        Successor,
+                        std::remove_cvref_t<Receiver>>> &&
+                std::is_constructible_v<Successor, Successor&>,
+            int> = 0>
+    auto connect(Receiver&& receiver) & -> detail::sequence_operation<
+        Predecessor&,
+        Successor,
+        std::remove_cvref_t<Receiver>> {
+      return detail::sequence_operation<
+          Predecessor&,
+          Successor,
+          std::remove_cvref_t<Receiver>>{
+          predecessor_, successor_, (Receiver &&) receiver};
+    }
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                const Predecessor&,
+                detail::sequence_predecessor_receiver<
+                    Predecessor,
+                    Successor,
+                    Receiver>> &&
+                is_connectable_v<
+                    Successor,
+                    detail::sequence_successor_receiver<
+                        Predecessor,
+                        Successor,
+                        Receiver>> &&
+                std::is_constructible_v<Successor, const Successor&>,
+            int> = 0>
+    auto connect(Receiver&& receiver) const& -> detail::sequence_operation<
+        const Predecessor&,
+        Successor,
+        std::remove_cvref_t<Receiver>> {
+      return detail::sequence_operation<
+          const Predecessor&,
+          Successor,
+          std::remove_cvref_t<Receiver>>{
+          predecessor_, successor_, (Receiver &&) receiver};
+    }
+
+  private:
+    UNIFEX_NO_UNIQUE_ADDRESS Predecessor predecessor_;
+    UNIFEX_NO_UNIQUE_ADDRESS Successor successor_;
+  };
+
+  inline constexpr struct sequence_cpo {
+    // Sequencing a single sender is just the same as returning the sender
+    // itself.
+    template <typename First>
+    std::decay_t<First> operator()(First&& first) const
+        noexcept(std::is_nothrow_move_constructible_v<First>) {
+      return static_cast<First&&>(first);
+    }
+
+    template <
+        typename First,
+        typename Second,
+        std::enable_if_t<is_tag_invocable_v<sequence_cpo, First, Second>, int> =
+            0>
+    auto operator()(First&& first, Second&& second) const
+        noexcept(is_nothrow_tag_invocable_v<sequence_cpo, First, Second>)
+            -> tag_invoke_result_t<sequence_cpo, First, Second> {
+      return unifex::tag_invoke(
+          *this, static_cast<First&&>(first), static_cast<Second&&>(second));
+    }
+
+    template <
+        typename First,
+        typename Second,
+        std::enable_if_t<
+            !is_tag_invocable_v<sequence_cpo, First, Second>,
+            int> = 0>
+    auto operator()(First&& first, Second&& second) const
+        noexcept(std::is_nothrow_constructible_v<
+                 sequence_sender<
+                     std::remove_cvref_t<First>,
+                     std::remove_cvref_t<Second>>,
+                 First,
+                 Second>)
+            -> sequence_sender<
+                std::remove_cvref_t<First>,
+                std::remove_cvref_t<Second>> {
+      return sequence_sender<
+          std::remove_cvref_t<First>,
+          std::remove_cvref_t<Second>>{
+          static_cast<First&&>(first), static_cast<Second&&>(second)};
+    }
+
+    template <
+        typename First,
+        typename Second,
+        typename... Rest,
+        std::enable_if_t<
+            is_tag_invocable_v<sequence_cpo, First, Second, Rest...>,
+            int> = 0>
+    auto operator()(First&& first, Second&& second, Rest&&... rest) const
+        noexcept(
+            is_nothrow_tag_invocable_v<sequence_cpo, First, Second, Rest...>)
+            -> tag_invoke_result_t<sequence_cpo, First, Second, Rest...> {
+      return unifex::tag_invoke(
+          *this,
+          static_cast<First&&>(first),
+          static_cast<Second&&>(second),
+          static_cast<Rest&&>(rest)...);
+    }
+
+    template <
+        typename First,
+        typename Second,
+        typename... Rest,
+        std::enable_if_t<
+            !is_tag_invocable_v<sequence_cpo, First, Second, Rest...>,
+            int> = 0>
+    auto operator()(First&& first, Second&& second, Rest&&... rest) const
+        noexcept(is_nothrow_tag_invocable_v<First, Second, Rest...>)
+            -> std::invoke_result_t<
+                sequence_cpo,
+                std::invoke_result_t<sequence_cpo, First, Second>,
+                Rest...> {
+      // Fall-back to pair-wise invocation of the sequence() CPO.
+      return operator()(
+          operator()(
+              static_cast<First&&>(first), static_cast<Second&&>(second)),
+          static_cast<Rest&&>(rest)...);
+    }
+  } sequence;
+}  // namespace unifex


### PR DESCRIPTION
- Adds a new `sequence(senders...)` algorithm that supports chaining multiple senders together in sequence.
  This is a variadic version with the semantics of the previous `on()` algorithm.
- Modified `on()` to now take a sender and a scheduler instead of two senders.
  This now also injects the scheduler as the current scheduler into the child operations by
  customising the `get_scheduler` CPO on the receiver.