### PR TITLE
Add materialize() and dematerialize() sender algorithms

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -13,6 +13,8 @@
   * `sequence()`
   * `sync_wait()`
   * `when_all()`
+  * `materialize()`
+  * `dematerialize()`
   * `with_query_value()`
   * `with_allocator()`
 * Sender Types
@@ -208,6 +210,36 @@ to `value()`.
 If any of the input senders complete with done or error then it will request
 any senders that have not yet completed to stop and the operation as a whole
 will complete with done or error.
+
+### `materialize(Sender sender) -> Sender`
+
+Materializes the completion signal of `sender` into the value-channel by
+invoking prepending the completion arguments with the corresponding
+`set_value`, `set_error` or `set_done` CPO as an additional argument.
+
+ie. Transforms the following LHS completion signals to the RHS completion signals
+* `set_value(r, values...)` -> `set_value(r, set_value, values...)`
+* `set_error(r, e)` -> `set_value(r, set_error, e)`
+* `set_done(r)` -> `set_value(r, set_done)`
+
+This allows you to treat any result as a success and process the result as
+a value.
+
+### `dematerialize(Sender sender) -> Sender`
+
+Converts a sender of materialized signals into a sender of those signals.
+This reverses the transformation of signals performed by `materialize()`.
+
+If `sender` completes with `set_value(r, set_value, values...)` then the
+dematerialized sender will complete with `set_value(r, values...)`.
+
+Similarly if `sender` completes with `set_value(r, set_error, e)` then the
+dematerialized sender will complete with `set_error(r, e)`.
+
+And if `sender` completes with `set_value(r, set_done)` then the dematerialized
+sender will complete with `set_done(r)`.
+
+Any `set_error()` or `set_done()` signals are passed through unchanged.
 
 ### `with_query_value(Sender sender, CPO cpo, T value) -> Sender`
 

--- a/examples/materialize.cpp
+++ b/examples/materialize.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/when_all.hpp>
+#include <unifex/materialize.hpp>
+#include <unifex/dematerialize.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/scheduler_concepts.hpp>
+
+#include <cassert>
+#include <optional>
+
+using namespace unifex;
+
+int main() {
+    single_thread_context ctx;
+
+    std::optional<int> result = sync_wait(
+        dematerialize(
+            materialize(
+                transform(
+                    schedule(ctx.get_scheduler()),
+                    []() { return 42; }))));
+    assert(result.value() == 42);
+
+    return 0;
+}

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/async_trace.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <type_traits>
+
+namespace unifex
+{
+  namespace detail
+  {
+    template <typename Receiver>
+    class dematerialize_receiver {
+    public:
+      template <
+        typename Receiver2,
+        std::enable_if_t<std::is_constructible_v<Receiver, Receiver2>, int> = 0>
+      explicit dematerialize_receiver(Receiver2&& receiver) noexcept(
+          std::is_nothrow_constructible_v<Receiver, Receiver2>)
+        : receiver_(static_cast<Receiver2&&>(receiver)) {}
+
+      template <
+          typename CPO,
+          typename... Values,
+          std::enable_if_t<
+              is_receiver_cpo_v<CPO> &&
+                  std::is_invocable_v<CPO, Receiver, Values...>,
+              int> = 0>
+      void set_value(CPO cpo, Values&&... values) && noexcept(
+          std::is_nothrow_invocable_v<CPO, Receiver, Values...>) {
+        static_cast<CPO&&>(cpo)(
+            static_cast<Receiver&&>(receiver_),
+            static_cast<Values&&>(values)...);
+      }
+
+      template <
+          typename Error,
+          std::enable_if_t<
+              std::is_invocable_v<decltype(unifex::set_error), Receiver, Error>,
+              int> = 0>
+      void set_error(Error&& error) && noexcept {
+        unifex::set_error(
+            static_cast<Receiver&&>(receiver_), static_cast<Error&&>(error));
+      }
+
+      template <
+          typename... DummyPack,
+          std::enable_if_t<
+              sizeof...(DummyPack) == 0 &&
+                  std::is_invocable_v<decltype(unifex::set_done), Receiver>,
+              int> = 0>
+      void set_done(DummyPack...) && noexcept {
+        unifex::set_done(static_cast<Receiver&&>(receiver_));
+      }
+
+      template <
+          typename CPO,
+          typename... Args,
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+      friend auto tag_invoke(
+          CPO cpo,
+          const dematerialize_receiver& r,
+          Args&&... args) noexcept(std::
+                                       is_nothrow_invocable_v<
+                                           CPO,
+                                           const Receiver&,
+                                           Args...>)
+          -> std::invoke_result_t<CPO, const Receiver&, Args...> {
+        return static_cast<CPO&&>(cpo)(
+            std::as_const(r.receiver_), static_cast<Args&&>(args)...);
+      }
+
+      template <typename Func>
+      friend void tag_invoke(
+          tag_t<visit_continuations>,
+          const dematerialize_receiver& r,
+          Func&& func) noexcept(std::
+                                    is_nothrow_invocable_v<
+                                        Func&,
+                                        const Receiver&>) {
+        std::invoke(func, std::as_const(r.receiver_));
+      }
+
+    private:
+      Receiver receiver_;
+    };
+
+    template <typename CPO, template <typename...> class Tuple>
+    struct dematerialize_tuple {
+    private:
+      template <typename... Values>
+      struct apply_impl;
+
+      template <typename First, typename... Rest>
+      struct apply_impl<First, Rest...>
+        : std::conditional<
+              std::is_base_of_v<CPO, std::decay_t<First>>,
+              type_list<Tuple<Rest...>>,
+              type_list<>> {};
+
+    public:
+      template <typename... Values>
+      using apply = typename apply_impl<Values...>::type;
+    };
+
+    template <template <typename...> class Variant>
+    struct dematerialize_variant {
+      template <typename... Lists>
+      using apply =
+          typename concat_type_lists<Lists...>::type::template apply<Variant>;
+    };
+  }  // namespace detail
+
+  template <typename Source>
+  class dematerialize_sender {
+    template <template <typename...> class Variant>
+    struct append_error_types {
+    private:
+      template <typename... Errors>
+      struct impl {
+        // Concatenate and deduplicate errors from value_types, error_types along with
+        // std::exception_ptr.
+        template <typename... OtherErrors>
+        using apply = typename concat_type_lists_unique<
+            type_list<Errors...>,
+            type_list<OtherErrors...>,
+            type_list<std::exception_ptr>>::template apply<Variant>;
+      };
+
+    public:
+      template <typename... Errors>
+      using apply = typename Source::template error_types<
+          impl<Errors...>::template apply>;
+    };
+
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = typename Source::template value_types<
+        detail::dematerialize_variant<Variant>::template apply,
+        detail::dematerialize_tuple<tag_t<set_value>, Tuple>::template apply>;
+
+    template <template <typename...> class Variant>
+    using error_types = typename Source::template value_types<
+        detail::dematerialize_variant<
+            append_error_types<Variant>::template apply>::template apply,
+        detail::dematerialize_tuple<tag_t<set_error>, single_type_t>::
+            template apply>;
+
+    template <typename Source2>
+    explicit dematerialize_sender(Source2&& source) noexcept(
+        std::is_nothrow_constructible_v<Source, Source2>)
+      : source_(static_cast<Source2&&>(source)) {}
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                Source,
+                detail::dematerialize_receiver<std::decay_t<Receiver>>>,
+            int> = 0>
+    friend auto
+    tag_invoke(tag_t<unifex::connect>, dematerialize_sender&& s, Receiver&& r)
+        -> operation_t<
+            Source,
+            detail::dematerialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          static_cast<Source&&>(s.source_),
+          detail::dematerialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                Source&,
+                detail::dematerialize_receiver<std::decay_t<Receiver>>>,
+            int> = 0>
+    friend auto
+    tag_invoke(tag_t<unifex::connect>, dematerialize_sender& s, Receiver&& r)
+        -> operation_t<
+            Source&,
+            detail::dematerialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          s.source_,
+          detail::dematerialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+    template <
+        typename Receiver,
+        std::enable_if_t<
+            is_connectable_v<
+                const Source&,
+                detail::dematerialize_receiver<std::decay_t<Receiver>>>,
+            int> = 0>
+    friend auto tag_invoke(
+        tag_t<unifex::connect>, const dematerialize_sender& s, Receiver&& r)
+        -> operation_t<
+            const Source&,
+            detail::dematerialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          std::as_const(s.source_),
+          detail::dematerialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+  private:
+    Source source_;
+  };
+
+  inline constexpr struct dematerialize_cpo {
+    template <
+        typename Source,
+        std::enable_if_t<is_tag_invocable_v<dematerialize_cpo, Source>, int> =
+            0>
+    auto operator()(Source&& source) const
+        noexcept(is_nothrow_tag_invocable_v<dematerialize_cpo, Source>)
+            -> tag_invoke_result_t<dematerialize_cpo, Source> {
+      return tag_invoke(*this, static_cast<Source&&>(source));
+    }
+
+    template <
+        typename Source,
+        std::enable_if_t<!is_tag_invocable_v<dematerialize_cpo, Source>, int> =
+            0>
+    auto operator()(Source&& source) const
+        noexcept(std::is_nothrow_constructible_v<
+                 dematerialize_sender<std::decay_t<Source>>,
+                 Source>) -> dematerialize_sender<std::decay_t<Source>> {
+      return dematerialize_sender<std::decay_t<Source>>{
+          static_cast<Source&&>(source)};
+    }
+  } dematerialize;
+}  // namespace unifex

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/async_trace.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <type_traits>
+
+namespace unifex
+{
+  namespace detail
+  {
+    template <typename Receiver>
+    class materialize_receiver {
+    public:
+      template <typename Receiver2>
+      explicit materialize_receiver(Receiver2&& receiver) noexcept(
+          std::is_nothrow_constructible_v<Receiver, Receiver2>)
+        : receiver_(static_cast<Receiver2&&>(receiver)) {}
+
+      template <
+          typename... Values,
+          std::enable_if_t<
+              std::is_invocable_v<
+                  decltype(unifex::set_value),
+                  Receiver,
+                  decltype(unifex::set_value),
+                  Values...>,
+              int> = 0>
+      void
+      set_value(Values&&... values) && noexcept(std::is_nothrow_invocable_v<
+                                                decltype(unifex::set_value),
+                                                Receiver,
+                                                decltype(unifex::set_value),
+                                                Values...>) {
+        unifex::set_value(
+            static_cast<Receiver&&>(receiver_),
+            unifex::set_value,
+            static_cast<Values&&>(values)...);
+      }
+
+      template <
+          typename Error,
+          std::enable_if_t<
+              std::is_invocable_v<
+                  decltype(unifex::set_value),
+                  Receiver,
+                  decltype(unifex::set_error),
+                  Error>,
+              int> = 0>
+      void set_error(Error&& error) && noexcept {
+        if constexpr (std::is_nothrow_invocable_v<
+                          decltype(unifex::set_value),
+                          Receiver,
+                          decltype(unifex::set_error),
+                          Error>) {
+          unifex::set_value(
+              static_cast<Receiver&&>(receiver_),
+              unifex::set_error,
+              static_cast<Error&&>(error));
+        } else {
+          try {
+            unifex::set_value(
+                static_cast<Receiver&&>(receiver_),
+                unifex::set_error,
+                static_cast<Error&&>(error));
+          } catch (...) {
+            unifex::set_error(
+                static_cast<Receiver&&>(receiver_), std::current_exception());
+          }
+        }
+      }
+
+      template <
+          typename... DummyPack,
+          std::enable_if_t<
+              sizeof...(DummyPack) == 0 &&
+                  std::is_invocable_v<
+                      decltype(unifex::set_value),
+                      Receiver,
+                      decltype(unifex::set_done)>,
+              int> = 0>
+      void set_done(DummyPack...) && noexcept {
+        if constexpr (std::is_nothrow_invocable_v<
+                          decltype(unifex::set_value),
+                          Receiver,
+                          decltype(unifex::set_done)>) {
+          unifex::set_value(
+              static_cast<Receiver&&>(receiver_), unifex::set_done);
+        } else {
+          try {
+            unifex::set_value(
+                static_cast<Receiver&&>(receiver_), unifex::set_done);
+          } catch (...) {
+            unifex::set_error(
+                static_cast<Receiver&&>(receiver_), std::current_exception());
+          }
+        }
+      }
+
+      template <
+          typename CPO,
+          typename... Args,
+          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+      friend auto tag_invoke(
+          CPO cpo,
+          const materialize_receiver& r,
+          Args&&... args) noexcept(std::
+                                       is_nothrow_invocable_v<
+                                           CPO,
+                                           const Receiver&,
+                                           Args...>)
+          -> std::invoke_result_t<CPO, const Receiver&, Args...> {
+        return static_cast<CPO&&>(cpo)(
+            std::as_const(r.receiver_), static_cast<Args&&>(args)...);
+      }
+
+      template <typename Func>
+      friend void tag_invoke(
+          tag_t<visit_continuations>,
+          const materialize_receiver& r,
+          Func&& func) noexcept(std::
+                                    is_nothrow_invocable_v<
+                                        Func&,
+                                        const Receiver&>) {
+        std::invoke(func, std::as_const(r.receiver_));
+      }
+
+    private:
+      Receiver receiver_;
+    };
+
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple,
+        typename... ValueTuples>
+    struct materialize_error_variant {
+      template <typename... Errors>
+      using apply = Variant<
+          ValueTuples...,
+          Tuple<decltype(set_error), Errors>...,
+          Tuple<decltype(set_done)>>;
+    };
+
+    template <
+        typename Source,
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    struct materialize_value_types {
+      template <typename... Values>
+      using value_tuple = Tuple<decltype(set_value), Values...>;
+
+      template <typename... ValueTuples>
+      using value_variant = typename Source::template error_types<
+          materialize_error_variant<Variant, Tuple, ValueTuples...>::
+              template apply>;
+
+      using type =
+          typename Source::template value_types<value_variant, value_tuple>;
+    };
+  }  // namespace detail
+
+  template <typename Source>
+  class materialize_sender {
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types =
+        typename detail::materialize_value_types<Source, Variant, Tuple>::type;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    template <
+        typename Source2,
+        std::enable_if_t<std::is_constructible_v<Source, Source2>, int> = 0>
+    explicit materialize_sender(Source2&& source) noexcept(
+        std::is_nothrow_constructible_v<Source, Source2>)
+      : source_(static_cast<Source2&&>(source)) {}
+
+    template <typename Receiver>
+    friend auto
+    tag_invoke(tag_t<unifex::connect>, materialize_sender&& s, Receiver&& r) noexcept(
+        is_nothrow_connectable_v<
+            Source,
+            detail::materialize_receiver<std::decay_t<Receiver>>>&&
+            std::is_nothrow_constructible_v<
+                detail::materialize_receiver<std::decay_t<Receiver>>,
+                Receiver>)
+        -> operation_t<
+            Source,
+            detail::materialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          static_cast<Source&&>(s.source_),
+          detail::materialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+    template <typename Receiver>
+    friend auto
+    tag_invoke(tag_t<unifex::connect>, materialize_sender& s, Receiver&& r)
+        -> operation_t<
+            Source&,
+            detail::materialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          s.source_,
+          detail::materialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+    template <typename Receiver>
+    friend auto tag_invoke(
+        tag_t<unifex::connect>, const materialize_sender& s, Receiver&& r)
+        -> operation_t<
+            const Source&,
+            detail::materialize_receiver<std::decay_t<Receiver>>> {
+      return unifex::connect(
+          std::as_const(s.source_),
+          detail::materialize_receiver<std::decay_t<Receiver>>{
+              static_cast<Receiver&&>(r)});
+    }
+
+  private:
+    Source source_;
+  };
+
+  inline constexpr struct materialize_cpo {
+    template <
+        typename Source,
+        std::enable_if_t<is_tag_invocable_v<materialize_cpo, Source>, int> = 0>
+    auto operator()(Source&& source) const
+        noexcept(is_nothrow_tag_invocable_v<materialize_cpo, Source>)
+            -> tag_invoke_result_t<materialize_cpo, Source> {
+      return tag_invoke(*this, static_cast<Source&&>(source));
+    }
+
+    template <
+        typename Source,
+        std::enable_if_t<!is_tag_invocable_v<materialize_cpo, Source>, int> = 0>
+    auto operator()(Source&& source) const
+        noexcept(std::is_nothrow_constructible_v<
+                 materialize_sender<std::decay_t<Source>>,
+                 Source>) -> materialize_sender<std::decay_t<Source>> {
+      return materialize_sender<std::decay_t<Source>>{
+          static_cast<Source&&>(source)};
+    }
+  } materialize;
+}  // namespace unifex

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -82,16 +82,6 @@ template <
 using adapt_value_types_t =
     typename Sender::template value_types<Variant, typename Adaptor::apply>;
 
-template <typename... Values>
-struct single_type {
-  // empty so we are SFINAE friendly.
-};
-
-template <typename T>
-struct single_type<T> {
-  using type = T;
-};
-
 template <typename... Types>
 struct single_value_type {
   using type = std::tuple<Types...>;

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/type_traits.hpp>
+
+#include <type_traits>
+
+namespace unifex
+{
+  // A template metaprogramming data-structure used to represent an
+  // ordered list of types.
+  template <typename... Ts>
+  struct type_list {
+    // Invoke the template metafunction with the type-list's elements
+    // as arguments.
+    template <template <typename...> class F>
+    using apply = F<Ts...>;
+  };
+
+  // concat_type_lists<Lists...>
+  //
+  // Concatenates a variadic pack of type_list<Ts...> into a single
+  // type_list that contains the concatenation of the elements of the
+  // input type_lists.
+  //
+  // Result is produced via nested ::type.
+  template <typename... Lists>
+  struct concat_type_lists;
+
+  template <>
+  struct concat_type_lists<> {
+    using type = type_list<>;
+  };
+
+  template <typename List>
+  struct concat_type_lists<List> {
+    using type = List;
+  };
+
+  template <typename... Ts, typename... Us>
+  struct concat_type_lists<type_list<Ts...>, type_list<Us...>> {
+      using type = type_list<Ts..., Us...>;
+  };
+
+  template <typename... Ts, typename... Us, typename... Vs, typename... OtherLists>
+  struct concat_type_lists<type_list<Ts...>, type_list<Us...>, type_list<Vs...>, OtherLists...>
+    : concat_type_lists<type_list<Ts..., Us..., Vs...>, OtherLists...> {};
+
+  // concat_type_lists_unique<UniqueLists...>
+  //
+  // Result is produced via '::type' which will contain a type_list<Ts...> that
+  // contains the unique elements from the input type_list types.
+  // Assumes that the input lists already
+  template <typename... UniqueLists>
+  struct concat_type_lists_unique;
+
+  template <>
+  struct concat_type_lists_unique<> {
+    using type = type_list<>;
+  };
+
+  template <typename UniqueList>
+  struct concat_type_lists_unique<UniqueList> {
+    using type = UniqueList;
+  };
+
+  template <typename... Ts, typename... Us, typename... OtherLists>
+  struct concat_type_lists_unique<type_list<Ts...>, type_list<Us...>, OtherLists...>
+    : concat_type_lists_unique<
+          typename concat_type_lists<
+              type_list<Ts...>,
+              std::conditional_t<
+                is_one_of_v<Us, Ts...>,
+                type_list<>,
+                type_list<Us>>...>::type,
+          OtherLists...> {};
+
+} // namespace unifex

--- a/include/unifex/type_traits.hpp
+++ b/include/unifex/type_traits.hpp
@@ -26,6 +26,17 @@ struct identity {
   using type = T;
 };
 
+template<typename... Ts>
+struct single_type {};
+
+template<typename T>
+struct single_type<T> {
+    using type = T;
+};
+
+template<typename... Ts>
+using single_type_t = typename single_type<Ts...>::type;
+
 template <template <typename T> class Predicate, typename T>
 using requires_t = std::enable_if_t<Predicate<T>::value, T>;
 


### PR DESCRIPTION
The `materialize()` algorithm takes an input sender and returns a new sender that transforms the completion signals (ie. `set_value`, `set_error` and `set_done`) into the value channel (ie. calls to `set_value`) by prepending the respective completion CPO as an additional argument to `set_value`.
ie.

* `set_value(r, values...)` -> `set_value(r, set_value, values...)`
* `set_error(r, error)` -> `set_value(r, set_error, error)`
* `set_done(r)` -> `set_value(r, set_done)`

The `dematerialize()` algorithm reverses the transformation of `materialize()`, turning calls:
* `set_value(r, set_value, values...)` -> `set_value(r, values...)`
* `set_value(r, set_error, error)` -> `set_error(r, error)`
* `set_value(r, set_done)` -> `set_done(r)`
* `set_error(r, e)` and `set_done(r)` pass through unchanged

Also adds a `type_list<Ts...>` helper for manipulating lists of types and a `concat_type_lists_unique<UniqueLists...>` metafunction that operates on `type_list` instances and can be used to deduplicate entries of a type-list more reliably compared with doing this with using whatever type the user passes in for `Variant` parameter of `value_types`/`error_types`.