### PR TITLE
An implementation of indexed_for as described in P1897R2

### DIFF
--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -53,30 +53,30 @@ struct int_iterator {
     return *this;
   }
 
+  bool operator!=(const int_iterator& rhs) {
+    return base_ != rhs.base_;
+  }
+
   int base_;
 };
 
 struct iota_view {
   int size_;
+
+  int_iterator begin() {
+    return int_iterator{0};
+  }
+
+  int_iterator end() {
+    return int_iterator{size_};
+  }
 };
-
-template<class T>
-int_iterator begin(const iota_view& r) {
-  return int_iterator{0};
-}
-
-template<class T>
-int_iterator end(const iota_view& r) {
-  return int_iterator{r.size_};
-}
-}
+} // namespace ranges
 
 int main() {
-// TODO: This is still acting as transform
-// TODO: This does not use the range yet or iterate
   auto result = sync_wait(indexed_for(
       just(42),
-      ranges::iota_view{3},
+      ranges::iota_view{10},
       execution::seq,
       [](int& x) {
         x = x + 3;

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -52,14 +52,15 @@ struct int_iterator {
     return base_;
   }
 
-  int_iterator& operator++() {
+  int_iterator operator++() {
     ++base_;
     return *this;
   }
 
   int_iterator operator++(int) {
+    auto cur = *this;
     ++base_;
-    return *this;
+    return cur;
   }
 
   bool operator!=(const int_iterator& rhs) const {

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -80,8 +80,8 @@ struct iota_view {
 int main() {
   auto result = sync_wait(indexed_for(
       just(42),
-      ranges::iota_view{10},
       execution::seq,
+      ranges::iota_view{10},
       [](int idx, int& x) {
         x = x + idx;
       }));
@@ -96,8 +96,8 @@ int main() {
   auto indexed_for_sender =
     indexed_for(
       std::move(just_sender),
-      ranges::iota_view{3},
       execution::seq,
+      ranges::iota_view{3},
       [](int idx, std::vector<int>& vec, const int& i){
         vec[idx] = vec[idx] + i + idx;
       });

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/just.hpp>
+#include <unifex/let.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/timed_single_thread_context.hpp>
+#include <unifex/indexed_for.hpp>
+#include <unifex/when_all.hpp>
+
+#include <chrono>
+#include <iostream>
+
+using namespace unifex;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+namespace execution {
+class sequenced_policy {};
+inline constexpr sequenced_policy seq{};
+}
+
+namespace ranges {
+struct int_iterator {
+  const int operator[](size_t offset) const {
+    return base_+offset;
+  }
+
+  const int operator*() const {
+    return base_;
+  }
+
+  int_iterator& operator++() {
+    ++base_;
+    return *this;
+  }
+
+  int_iterator& operator++(int) {
+    ++base_;
+    return *this;
+  }
+
+  int base_;
+};
+
+struct iota_view {
+  int size_;
+};
+
+template<class T>
+int_iterator begin(const iota_view& r) {
+  return int_iterator{0};
+}
+
+template<class T>
+int_iterator end(const iota_view& r) {
+  return int_iterator{r.size_};
+}
+}
+
+int main() {
+// TODO: This is still acting as transform
+// TODO: This does not use the range yet or iterate
+  auto result = sync_wait(indexed_for(
+      just(42),
+      ranges::iota_view{3},
+      execution::seq,
+      [](const int& x) {
+        return x+1;
+      }));
+
+  std::cout << "all done " << *result << "\n";
+
+  return 0;
+}

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -78,8 +78,8 @@ int main() {
       just(42),
       ranges::iota_view{3},
       execution::seq,
-      [](const int& x) {
-        return x+1;
+      [](int& x) {
+        x = x + 3;
       }));
 
   std::cout << "all done " << *result << "\n";

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -39,6 +39,10 @@ inline constexpr parallel_policy par{};
 namespace ranges {
 struct int_iterator {
   using value_type = int;
+  using reference = value_type&;
+  using difference_type = size_t;
+  using pointer = value_type*;
+  using iterator_category = std::random_access_iterator_tag;
 
   const int operator[](size_t offset) const {
     return base_+offset;
@@ -53,12 +57,12 @@ struct int_iterator {
     return *this;
   }
 
-  int_iterator& operator++(int) {
+  int_iterator operator++(int) {
     ++base_;
     return *this;
   }
 
-  bool operator!=(const int_iterator& rhs) {
+  bool operator!=(const int_iterator& rhs) const {
     return base_ != rhs.base_;
   }
 
@@ -77,7 +81,7 @@ struct iota_view {
     return int_iterator{size_};
   }
 
-  size_t size() {
+  size_t size() const {
     return size_;
   }
 };

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -31,7 +31,9 @@ using namespace std::chrono_literals;
 
 namespace execution {
 class sequenced_policy {};
+class parallel_policy{};
 inline constexpr sequenced_policy seq{};
+inline constexpr parallel_policy par{};
 }
 
 namespace ranges {
@@ -74,10 +76,15 @@ struct iota_view {
   int_iterator end() {
     return int_iterator{size_};
   }
+
+  size_t size() {
+    return size_;
+  }
 };
 } // namespace ranges
 
 int main() {
+  // use seq, which supports a forward range
   auto result = sync_wait(indexed_for(
       just(42),
       execution::seq,
@@ -92,11 +99,11 @@ int main() {
   auto  just_sender =
     just(std::vector<int>{3, 4, 5}, 10);
 
-  // TODO: Switch to par
+  // Use par which requires range to be random access
   auto indexed_for_sender =
     indexed_for(
       std::move(just_sender),
-      execution::seq,
+      execution::par,
       ranges::iota_view{3},
       [](int idx, std::vector<int>& vec, const int& i){
         vec[idx] = vec[idx] + i + idx;

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -13,18 +13,156 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #pragma once
+#pragma once
 
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/transform.hpp>
-#include <unifex/typed_via.hpp>
+#include <unifex/config.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/type_traits.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/async_trace.hpp>
+
+#include <functional>
+#include <type_traits>
 
 namespace unifex {
 
 template <typename Predecessor, typename Range, typename Policy, typename Func>
-auto indexed_for(Predecessor&& p, Range&& r, Policy&& p, Func&& f) {
+struct indexed_for_sender {
+  UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
+  UNIFEX_NO_UNIQUE_ADDRESS Range range_;
+  UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+
+  template <template <typename...> class Tuple>
+  struct indexed_for_result {
+   private:
+    template <typename Result, typename = void>
+    struct impl {
+      using type = Tuple<Result>;
+    };
+    template <typename Result>
+    struct impl<Result, std::enable_if_t<std::is_void_v<Result>>> {
+      using type = Tuple<>;
+    };
+
+   public:
+    template <typename... Args>
+    using apply = typename impl<std::invoke_result_t<Func, Args...>>::type;
+  };
+
+  template <typename... Args>
+  using is_overload_noexcept = std::bool_constant<noexcept(
+      std::invoke(std::declval<Func>(), std::declval<Args>()...))>;
+
+  template <template <typename...> class Variant>
+  struct calculate_errors {
+   public:
+    template <typename... Errors>
+    using apply = std::conditional_t<
+        Predecessor::
+            template value_types<std::conjunction, is_overload_noexcept>::value,
+        Variant<Errors...>,
+        deduplicate_t<Variant<Errors..., std::exception_ptr>>>;
+  };
+
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = deduplicate_t<typename Predecessor::template value_types<
+      Variant,
+      indexed_for_result<Tuple>::template apply>>;
+
+  template <template <typename...> class Variant>
+  using error_types = typename Predecessor::template error_types<
+      calculate_errors<Variant>::template apply>;
+
+  friend constexpr auto tag_invoke(
+      tag_t<blocking>,
+      const indexed_for_sender& sender) {
+    return blocking(sender.pred_);
+  }
+
+  template <typename Receiver>
+  struct indexed_for_receiver {
+    UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+
+    template <typename... Values>
+    void set_value(Values&&... values) && noexcept {
+      using result_type = std::invoke_result_t<Func, Values...>;
+      if constexpr (std::is_void_v<result_type>) {
+        if constexpr (noexcept(std::invoke(
+                          (Func &&) func_, (Values &&) values...))) {
+          std::invoke((Func &&) func_, (Values &&) values...);
+          unifex::set_value((Receiver &&) receiver_);
+        } else {
+          try {
+            std::invoke((Func &&) func_, (Values &&) values...);
+            unifex::set_value((Receiver &&) receiver_);
+          } catch (...) {
+            unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          }
+        }
+      } else {
+        if constexpr (noexcept(std::invoke(
+                          (Func &&) func_, (Values &&) values...))) {
+          unifex::set_value(
+              (Receiver &&) receiver_,
+              std::invoke((Func &&) func_, (Values &&) values...));
+        } else {
+          try {
+            unifex::set_value(
+                (Receiver &&) receiver_,
+                std::invoke((Func &&) func_, (Values &&) values...));
+          } catch (...) {
+            unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          }
+        }
+      }
+    }
+
+    template <typename Error>
+    void set_error(Error&& error) && noexcept {
+      unifex::set_error((Receiver &&) receiver_, (Error &&) error);
+    }
+
+    void set_done() && noexcept {
+      unifex::set_done((Receiver &&) receiver_);
+    }
+
+    template <
+        typename CPO,
+        std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+    friend auto tag_invoke(CPO cpo, const indexed_for_receiver& r) noexcept(
+        std::is_nothrow_invocable_v<CPO, const Receiver&>)
+        -> std::invoke_result_t<CPO, const Receiver&> {
+      return std::move(cpo)(std::as_const(r.receiver_));
+    }
+
+    template <typename Visit>
+    friend void tag_invoke(
+        tag_t<visit_continuations>,
+        const indexed_for_receiver& r,
+        Visit&& visit) {
+      std::invoke(visit, r.receiver_);
+    }
+  };
+
+  template <typename Receiver>
+  auto connect(Receiver&& receiver) && {
+    return unifex::connect(
+        std::forward<Predecessor>(pred_),
+        indexed_for_receiver<std::remove_cvref_t<Receiver>>{
+            std::forward<Func>(func_), std::forward<Receiver>(receiver)});
+  }
+};
+
+template <typename Sender, typename Range, typename Policy, typename Func>
+auto indexed_for(Sender&& predecessor, Range&& range, Policy&& policy, Func&& func) {
   return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Range>, std::decay_t<Policy>, std::decay_t<Func>>{
-      (Sender &&) predecessor, (Range&& ) r, (Policy&&) p, (Func &&) func};
+      (Sender &&) predecessor, (Range&& ) range, (Policy&&) policy, (Func &&) func};
 }
 
 } // namespace unifex

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -28,6 +28,7 @@
 
 namespace execution {
 class sequenced_policy;
+class parallel_policy;
 }
 
 namespace unifex {
@@ -85,13 +86,22 @@ struct indexed_for_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Range range_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-
-    // TODO: Par policy overload will depend on random access range
+    // sequenced_policy version supports forward range
     template<typename... Values>
     void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
         noexcept(noexcept(std::invoke((Func &&) func_, std::declval<typename Range::iterator::value_type>(), values...))) {
       for(auto idx : range) {
         std::invoke((Func &&) func, idx, values...);
+      }
+    }
+
+    // parallel_policy version requires random access range
+    template<typename... Values>
+    void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
+        noexcept(noexcept(std::invoke((Func &&) func_, std::declval<typename Range::iterator::value_type>(), values...))) {
+      auto start = range.begin();
+      for(auto idx = 0; idx < range.size(); ++idx) {
+        std::invoke((Func &&) func, start[idx], values...);
       }
     }
 

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -85,18 +85,20 @@ struct indexed_for_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
+
+    // TODO: Par policy overload will depend on random access range
     template<typename... Values>
     void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
-        noexcept(noexcept(std::invoke((Func &&) func_, values...))) {
+        noexcept(noexcept(std::invoke((Func &&) func_, std::declval<typename Range::iterator::value_type>(), values...))) {
       for(auto idx : range) {
-        std::invoke((Func &&) func_, values...);
+        std::invoke((Func &&) func, idx, values...);
       }
     }
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
       if constexpr (noexcept(std::invoke(
-                        (Func &&) func_, values...))) {
+                        (Func &&) func_, std::declval<typename Range::iterator::value_type>(), values...))) {
         apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ #pragma once
+
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/typed_via.hpp>
+
+namespace unifex {
+
+template <typename Predecessor, typename Range, typename Policy, typename Func>
+auto indexed_for(Predecessor&& p, Range&& r, Policy&& p, Func&& f) {
+  return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Range>, std::decay_t<Policy>, std::decay_t<Func>>{
+      (Sender &&) predecessor, (Range&& ) r, (Policy&&) p, (Func &&) func};
+}
+
+} // namespace unifex

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -47,9 +47,6 @@ struct indexed_for_sender {
     using apply = Tuple<Args...>;
   };
 
-  template<typename... Args>
-  using is_overload_noexcept = std::is_nothrow_invocable<Func, Args...>;
-
   template <template <typename...> class Variant>
   struct calculate_errors {
    public:
@@ -102,7 +99,7 @@ struct indexed_for_sender {
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
-      if constexpr (std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
+      if constexpr (std::is_nothrow_invocable_v<Func&, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
         apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -32,11 +32,11 @@ class sequenced_policy;
 
 namespace unifex {
 
-template <typename Predecessor, typename Range, typename Policy, typename Func>
+template <typename Predecessor, typename Policy, typename Range, typename Func>
 struct indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
-  UNIFEX_NO_UNIQUE_ADDRESS Range range_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+  UNIFEX_NO_UNIQUE_ADDRESS Range range_;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <template <typename...> class Tuple>
@@ -81,8 +81,8 @@ struct indexed_for_sender {
   template <typename Receiver>
   struct indexed_for_receiver {
     UNIFEX_NO_UNIQUE_ADDRESS Func func_;
-    UNIFEX_NO_UNIQUE_ADDRESS Range range_;
     UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+    UNIFEX_NO_UNIQUE_ADDRESS Range range_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
 
@@ -144,16 +144,16 @@ struct indexed_for_sender {
         std::forward<Predecessor>(pred_),
         indexed_for_receiver<std::remove_cvref_t<Receiver>>{
             std::forward<Func>(func_),
-            std::forward<Range>(range_),
             std::forward<Policy>(policy_),
+            std::forward<Range>(range_),
             std::forward<Receiver>(receiver)});
   }
 };
 
-template <typename Sender, typename Range, typename Policy, typename Func>
-auto indexed_for(Sender&& predecessor, Range&& range, Policy&& policy, Func&& func) {
-  return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Range>, std::decay_t<Policy>, std::decay_t<Func>>{
-      (Sender &&) predecessor, (Range&& ) range, (Policy&&) policy, (Func &&) func};
+template <typename Sender, typename Policy, typename Range, typename Func>
+auto indexed_for(Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) {
+  return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Policy>, std::decay_t<Range>, std::decay_t<Func>>{
+      (Sender &&) predecessor, (Policy&&) policy, (Range&& ) range, (Func &&) func};
 }
 
 } // namespace unifex


### PR DESCRIPTION
`indexed_for` applies an operation to data accessed by reference, across a provided indexed space and following the rules in a provided policy.