### PR TITLE
indexed_for customisation

### DIFF
--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -127,5 +127,28 @@ int main() {
     std::cout << "\t" << v << "\n";
   }
 
+  // Double indexed_for to show customisation
+  auto first_indexed_for_sender =
+    indexed_for(
+      just(3),
+      execution::seq,
+      ranges::iota_view{3},
+      [](int idx, int& i){
+        i = i + idx;
+      });
+  auto second_indexed_for_sender =
+    indexed_for(
+      std::move(first_indexed_for_sender),
+      execution::seq,
+      ranges::iota_view{3},
+      [](int idx, int& i){
+        i = i + idx;
+      });
+  int chained_result =
+    *sync_wait(std::move(second_indexed_for_sender));
+
+  std::cout << "chained: " << chained_result << "\n";
+
+
   return 0;
 }

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -37,7 +37,11 @@ template <typename Predecessor, typename Policy, typename Range, typename Func>
 struct indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+<<<<<<< HEAD
   UNIFEX_NO_UNIQUE_ADDRESS Range range_;
+=======
+  UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector rangeOrSelector_;
+>>>>>>> Majority of requested changes
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <template <typename...> class Tuple>
@@ -74,7 +78,7 @@ struct indexed_for_sender {
   // sequenced_policy version supports forward range
   template<typename Range, typename... Values>
   static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...>) {
+      noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     for(auto idx : range) {
       std::invoke(func, idx, values...);
     }
@@ -83,7 +87,7 @@ struct indexed_for_sender {
   // parallel_policy version requires random access range
   template<typename Range, typename... Values>
   static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...>) {
+      noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     auto start = range.begin();
     for(auto idx = 0; idx < range.size(); ++idx) {
       std::invoke(func, start[idx], values...);
@@ -100,7 +104,7 @@ struct indexed_for_sender {
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
       using Range = std::invoke_result_t<indexed_for_detail::extract_range, RangeOrRangeSelector&&, Values&...>;
-      auto range = indexed_for_detail::extract_range{}(std::move(range_or_selector_), values...);
+      decltype(auto) range = indexed_for_detail::extract_range{}(std::move(rangeOrSelector_), values...);
       if constexpr (
           std::is_nothrow_invocable_v<
             Func&, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
@@ -151,7 +155,11 @@ struct indexed_for_sender {
         indexed_for_receiver<std::remove_cvref_t<Receiver>>{
             std::forward<Func>(func_),
             std::forward<Policy>(policy_),
+<<<<<<< HEAD
             std::forward<Range>(range_),
+=======
+            std::forward<RangeOrRangeSelector>(rangeOrSelector_),
+>>>>>>> Majority of requested changes
             std::forward<Receiver>(receiver)});
   }
 };
@@ -187,7 +195,7 @@ template <typename Predecessor, typename Policy, typename RangeOrRangeSelector, 
 struct double_indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-  UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector range_or_selector_;
+  UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector rangeOrSelector_;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <template <typename...> class Tuple>
@@ -232,7 +240,7 @@ struct double_indexed_for_sender {
   // sequenced_policy version supports forward range
   template<typename Range, typename... Values>
   static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...>) {
+      noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     for(auto idx : range) {
       std::invoke(func, idx, values...);
     }
@@ -241,7 +249,7 @@ struct double_indexed_for_sender {
   // parallel_policy version requires random access range
   template<typename Range, typename... Values>
   static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...>) {
+      noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     auto start = range.begin();
     for(auto idx = 0; idx < range.size(); ++idx) {
       std::invoke(func, start[idx], values...);
@@ -250,30 +258,30 @@ struct double_indexed_for_sender {
 
   template <typename Receiver>
   struct double_indexed_for_receiver {
-    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::func_) pred_func_;
+    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::func_) predFunc_;
     UNIFEX_NO_UNIQUE_ADDRESS Func func_;
-    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::policy_) pred_policy_;
+    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::policy_) predPolicy_;
     UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::range_or_selector_) pred_range_or_selector_;
-    UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector range_or_selector_;
+    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::rangeOrSelector_) predRangeOrSelector_;
+    UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector rangeOrSelector_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
-      using PredRange = std::invoke_result_t<indexed_for_detail::extract_range, decltype(Predecessor::range_or_selector_)&&, Values&...>;
-      auto pred_range = indexed_for_detail::extract_range{}(std::move(pred_range_or_selector_), values...);
+      using PredRange = std::invoke_result_t<indexed_for_detail::extract_range, decltype(Predecessor::rangeOrSelector_)&&, Values&...>;
+      decltype(auto) pred_range = indexed_for_detail::extract_range{}(std::move(predRangeOrSelector_), values...);
       using Range = std::invoke_result_t<indexed_for_detail::extract_range, RangeOrRangeSelector&&, Values&...>;
-      auto range = indexed_for_detail::extract_range{}(std::move(range_or_selector_), values...);
+      decltype(auto) range = indexed_for_detail::extract_range{}(std::move(rangeOrSelector_), values...);
 
       if constexpr (std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...> &&
                     std::is_nothrow_invocable_v<decltype(Predecessor::func_), typename Range::iterator::value_type, Values...>) {
         // Apply predecessors operation first, then the immediate sender's
-        Predecessor::apply_func_with_policy(pred_policy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) pred_func_, values...);
+        Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) predFunc_, values...);
         apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {
         try {
-          Predecessor::apply_func_with_policy(pred_policy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) pred_func_, values...);
+          Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) predFunc_, values...);
           apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
           unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
         } catch (...) {
@@ -324,13 +332,13 @@ struct double_indexed_for_sender {
             std::forward<Func>(func_),
             std::forward<Predecessor>(pred_).policy_,
             std::forward<Policy>(policy_),
-            std::forward<Predecessor>(pred_).range_or_selector_,
-            std::forward<RangeOrRangeSelector>(range_or_selector_),
+            std::forward<Predecessor>(pred_).rangeOrSelector_,
+            std::forward<RangeOrRangeSelector>(rangeOrSelector_),
             std::forward<Receiver>(receiver)});
   }
 };
 
-// Customisation for when two indexed_for_senders are chained
+// Customisation for when an indexed_for is chained after an indexed_for_sender
 // This simulates how we might customise an arbitrary set of types for
 // optimal interaction
 template <typename InnerPredecessor, typename InnerPolicy, typename InnerRange, typename InnerFunc, typename Policy, typename Range, typename Func>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -33,6 +33,8 @@ class parallel_policy;
 
 namespace unifex {
 
+namespace indexed_for_detail {
+
 template <typename Predecessor, typename Policy, typename Range, typename Func>
 struct indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
@@ -72,7 +74,7 @@ struct indexed_for_sender {
   }
 
   // sequenced_policy version supports forward range
-  template<typename Range, typename... Values>
+  template<typename... Values>
   static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
       noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     for(auto idx : range) {
@@ -81,7 +83,7 @@ struct indexed_for_sender {
   }
 
   // parallel_policy version requires random access range
-  template<typename Range, typename... Values>
+  template<typename... Values>
   static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
       noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     auto start = range.begin();
@@ -99,12 +101,10 @@ struct indexed_for_sender {
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
-      using Range = std::invoke_result_t<indexed_for_detail::extract_range, RangeOrRangeSelector&&, Values&...>;
-      decltype(auto) range = indexed_for_detail::extract_range{}(std::move(rangeOrSelector_), values...);
       if constexpr (
           std::is_nothrow_invocable_v<
             Func&, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
-        apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
+        apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {
         try {
@@ -162,11 +162,11 @@ struct indexed_for_sender {
 // mechanism but directly applies pred_'s function to the data.
 // This simulates how we would specialse on a custom type rather than the one
 // provided by the standard library.
-template <typename Predecessor, typename Policy, typename RangeOrRangeSelector, typename Func>
+template <typename Predecessor, typename Policy, typename Range, typename Func>
 struct double_indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-  UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector rangeOrSelector_;
+  UNIFEX_NO_UNIQUE_ADDRESS Range range_;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <template <typename...> class Tuple>
@@ -209,7 +209,7 @@ struct double_indexed_for_sender {
   }
 
   // sequenced_policy version supports forward range
-  template<typename Range, typename... Values>
+  template<typename... Values>
   static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
       noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     for(auto idx : range) {
@@ -218,7 +218,7 @@ struct double_indexed_for_sender {
   }
 
   // parallel_policy version requires random access range
-  template<typename Range, typename... Values>
+  template<typename... Values>
   static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
       noexcept(std::is_nothrow_invocable_v<Func&, typename Range::iterator::value_type, Values...>) {
     auto start = range.begin();
@@ -233,27 +233,24 @@ struct double_indexed_for_sender {
     UNIFEX_NO_UNIQUE_ADDRESS Func func_;
     UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::policy_) predPolicy_;
     UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::rangeOrSelector_) predRangeOrSelector_;
-    UNIFEX_NO_UNIQUE_ADDRESS RangeOrRangeSelector rangeOrSelector_;
+    UNIFEX_NO_UNIQUE_ADDRESS decltype(Predecessor::range_) predrange_;
+    UNIFEX_NO_UNIQUE_ADDRESS Range range_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
-      using PredRange = std::invoke_result_t<indexed_for_detail::extract_range, decltype(Predecessor::rangeOrSelector_)&&, Values&...>;
-      decltype(auto) pred_range = indexed_for_detail::extract_range{}(std::move(predRangeOrSelector_), values...);
-      using Range = std::invoke_result_t<indexed_for_detail::extract_range, RangeOrRangeSelector&&, Values&...>;
-      decltype(auto) range = indexed_for_detail::extract_range{}(std::move(rangeOrSelector_), values...);
+      using PredRange = decltype(Predecessor::range_);
 
       if constexpr (std::is_nothrow_invocable_v<Func, typename Range::iterator::value_type, Values...> &&
                     std::is_nothrow_invocable_v<decltype(Predecessor::func_), typename Range::iterator::value_type, Values...>) {
         // Apply predecessors operation first, then the immediate sender's
-        Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) predFunc_, values...);
-        apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
+        Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) predrange_, (decltype(Predecessor::func_) &&) predFunc_, values...);
+        apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {
         try {
-          Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) pred_range, (decltype(Predecessor::func_) &&) predFunc_, values...);
-          apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
+          Predecessor::apply_func_with_policy(predPolicy_, (PredRange&&) predrange_, (decltype(Predecessor::func_) &&) predFunc_, values...);
+          apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
           unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
         } catch (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
@@ -303,52 +300,52 @@ struct double_indexed_for_sender {
             std::forward<Func>(func_),
             std::forward<Predecessor>(pred_).policy_,
             std::forward<Policy>(policy_),
-            std::forward<Predecessor>(pred_).rangeOrSelector_,
-            std::forward<RangeOrRangeSelector>(rangeOrSelector_),
+            std::forward<Predecessor>(pred_).range_,
+            std::forward<Range>(range_),
             std::forward<Receiver>(receiver)});
   }
 };
 
 struct indexed_for_cpo {
   // Default version of CPO that returns a sender tied directly together
-  template <typename Sender, typename Policy, typename RangeOrRangeSelector, typename Func>
+  template <typename Sender, typename Policy, typename Range, typename Func>
   friend auto
-  tag_invoke(indexed_for_cpo, Sender&& predecessor, Policy&& policy, RangeOrRangeSelector&& rangeOrSelector, Func&& func) noexcept {
-    return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Policy>, std::decay_t<RangeOrRangeSelector>, std::decay_t<Func>>{
-        (Sender &&) predecessor, (Policy&&) policy, (RangeOrRangeSelector&& ) rangeOrSelector, (Func &&) func};
+  tag_invoke(indexed_for_cpo, Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) noexcept {
+    return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Policy>, std::decay_t<Range>, std::decay_t<Func>>{
+        (Sender &&) predecessor, (Policy&&) policy, (Range&& ) range, (Func &&) func};
   }
 
-  template <typename Sender, typename Policy, typename RangeOrRangeSelector, typename Func>
-  auto operator()( Sender&& predecessor, Policy&& policy, RangeOrRangeSelector&& rangeOrSelector, Func&& func) const
+  template <typename Sender, typename Policy, typename Range, typename Func>
+  auto operator()( Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<
                visit_continuations_cpo,
                Sender&&,
                Policy&&,
-               RangeOrRangeSelector&&,
+               Range&&,
                Func&&>) {
     return tag_invoke(
-      indexed_for_cpo{}, (Sender &&) predecessor, (Policy&&) policy, (RangeOrRangeSelector&& ) rangeOrSelector, (Func &&) func);
+      indexed_for_cpo{}, (Sender &&) predecessor, (Policy&&) policy, (Range&& ) range, (Func &&) func);
   }
 };
 
 // Customisation for when an indexed_for is chained after an indexed_for_sender
 // This simulates how we might customise an arbitrary set of types for
 // optimal interaction
-template <typename InnerPredecessor, typename InnerPolicy, typename InnerRangeOrRangeSelector, typename InnerFunc, typename Policy, typename RangeOrRangeSelector, typename Func>
+template <typename InnerPredecessor, typename InnerPolicy, typename InnerRange, typename InnerFunc, typename Policy, typename Range, typename Func>
 auto
 tag_invoke(
     indexed_for_cpo,
-    indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRangeOrRangeSelector, InnerFunc>&& predecessor,
-    Policy&& policy, RangeOrRangeSelector&& rangeOrSelector, Func&& func) noexcept {
+    indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRange, InnerFunc>&& predecessor,
+    Policy&& policy, Range&& range, Func&& func) noexcept {
 
   // Construct the doubled version of the sender that grabs content from the predecessor directly
   // and does not apply connect/start in between.
   return double_indexed_for_sender<
-        std::remove_cvref_t<indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRangeOrRangeSelector, InnerFunc>>,
-        std::decay_t<Policy>, std::decay_t<RangeOrRangeSelector>, std::decay_t<Func>>{
-      (indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRangeOrRangeSelector, InnerFunc>&& ) predecessor,
+        std::remove_cvref_t<indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRange, InnerFunc>>,
+        std::decay_t<Policy>, std::decay_t<Range>, std::decay_t<Func>>{
+      (indexed_for_sender<InnerPredecessor, InnerPolicy, InnerRange, InnerFunc>&& ) predecessor,
       (Policy&&) policy,
-      (RangeOrRangeSelector&& ) rangeOrSelector,
+      (Range&& ) range,
       (Func &&) func};
 }
 


### PR DESCRIPTION
Builds on https://github.com/facebookexperimental/libunifex/pull/50 by adding a customisation of indexed_for using tag_invoke.

This customisation specialises the indexed_for algorithm when the predecessor was indexed_for, to not use connect/start between the two. This is a simple simulation of how we might customise more specifically, such that an implementation of indexed_for might trigger off of the type returned by applying via to a known executor type, for example. 