### PR TITLE
Add missing `break` that was causing blocking ops to be started twice

### DIFF
--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -121,6 +121,7 @@ inline constexpr struct submit_cpo {
           // state on the heap.
           auto op = unifex::connect((Sender &&) sender, (Receiver &&) receiver);
           unifex::start(op);
+          break;
         }
         default:
         {


### PR DESCRIPTION
Fixes #52