### PR TITLE
Use factory form of indexed_for to generate a range at async runtime

### DIFF
--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -100,6 +100,17 @@ int main() {
 
   std::cout << "all done " << *result << "\n";
 
+  // Use range factory
+  auto factory_result = sync_wait(indexed_for(
+      just(5),
+      execution::seq,
+      [](int& x){return ranges::iota_view{x};},
+      [](int idx, int& x) {
+        x = x + idx;
+      }));
+
+  std::cout << "factory all done " << *factory_result << "\n";
+
   // indexed_for example from P1897R2:
   auto  just_sender =
     just(std::vector<int>{3, 4, 5}, 10);

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -33,11 +33,26 @@ class parallel_policy;
 
 namespace unifex {
 
-template <typename Predecessor, typename Policy, typename Range, typename Func>
+namespace indexed_for_detail {
+// Return a range from the range factory, if provided, or simply pass through
+// the range.
+struct extract_range {
+  template<typename RangeOrFactory, typename... Values>
+  auto operator()(RangeOrFactory&& rf, Values&... values) {
+    if constexpr(std::is_invocable_v<RangeOrFactory&&, Values&...>) {
+      return std::forward<RangeOrFactory>(rf)(values...);
+    } else {
+      return std::forward<RangeOrFactory>(rf);
+    }
+  }
+};
+} // namespace indexed_for_detail
+
+template <typename Predecessor, typename Policy, typename RangeOrFactory, typename Func>
 struct indexed_for_sender {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-  UNIFEX_NO_UNIQUE_ADDRESS Range range_;
+  UNIFEX_NO_UNIQUE_ADDRESS RangeOrFactory range_;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <template <typename...> class Tuple>
@@ -75,20 +90,21 @@ struct indexed_for_sender {
   struct indexed_for_receiver {
     UNIFEX_NO_UNIQUE_ADDRESS Func func_;
     UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
-    UNIFEX_NO_UNIQUE_ADDRESS Range range_;
+    UNIFEX_NO_UNIQUE_ADDRESS RangeOrFactory range_;
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
     // sequenced_policy version supports forward range
-    template<typename... Values>
+    template<typename Range, typename... Values>
     static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
         noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
+
       for(auto idx : range) {
         std::invoke(func, idx, values...);
       }
     }
 
     // parallel_policy version requires random access range
-    template<typename... Values>
+    template<typename Range, typename... Values>
     static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
         noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
       auto start = range.begin();
@@ -99,12 +115,14 @@ struct indexed_for_sender {
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
+      using Range = std::invoke_result_t<indexed_for_detail::extract_range, RangeOrFactory&&, Values&...>;
+      auto range = indexed_for_detail::extract_range{}(std::move(range_), values...);
       if constexpr (std::is_nothrow_invocable_v<Func&, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
-        apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
+        apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
       } else {
         try {
-          apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
+          apply_func_with_policy(policy_, (Range&&) range, (Func &&) func_, values...);
           unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
         } catch (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
@@ -146,15 +164,16 @@ struct indexed_for_sender {
         indexed_for_receiver<std::remove_cvref_t<Receiver>>{
             std::forward<Func>(func_),
             std::forward<Policy>(policy_),
-            std::forward<Range>(range_),
+            std::forward<RangeOrFactory>(range_),
             std::forward<Receiver>(receiver)});
   }
 };
 
-template <typename Sender, typename Policy, typename Range, typename Func>
-auto indexed_for(Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) {
-  return indexed_for_sender<std::remove_cvref_t<Sender>, std::decay_t<Policy>, std::decay_t<Range>, std::decay_t<Func>>{
-      (Sender &&) predecessor, (Policy&&) policy, (Range&& ) range, (Func &&) func};
+template <typename Sender, typename Policy, typename RangeOrFactory, typename Func>
+auto indexed_for(Sender&& predecessor, Policy&& policy, RangeOrFactory&& range, Func&& func) {
+  return indexed_for_sender<
+      std::remove_cvref_t<Sender>, std::decay_t<Policy>, std::decay_t<RangeOrFactory>, std::decay_t<Func>>{
+      (Sender &&) predecessor, (Policy&&) policy, (RangeOrFactory&& ) range, (Func &&) func};
 }
 
 } // namespace unifex


### PR DESCRIPTION
Implementation of the factory-form of indexed_for where a factory converts the inputs to a range to execute over, allowing adaptation at runtime to the arguments flowing through the pipeline.