### PR TITLE
Add new_thread_context scheduler type

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -48,6 +48,7 @@
   * `trampoline_scheduler`
   * `timed_single_thread_context`
   * `thread_unsafe_event_loop`
+  * `new_thread_context`
   * `linux::io_uring_context`
 * StopToken Types
   * `unstoppable_token`
@@ -561,6 +562,18 @@ the base `schedule()` operation.
 
 Obtain a TimeScheduler to schedule work onto this context by calling the
 `.get_scheduler()` method.
+
+### `new_thread_context`
+
+An execution context that implements the `schedule()` operation by spawning
+a new thread to schedule the call to `set_value()`.
+
+If thread creation fails then the `schedule()` operation can fail and `set_error()`
+will be called on the receiver inline with the call to `start()`.
+
+The `new_thread_context` keeps track of the threads that have been created
+and the destructor will ensure that all of these threads are joined before
+returning.
 
 ### `linux::io_uring_context`
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -16,6 +16,7 @@
   * `when_all()`
   * `materialize()`
   * `dematerialize()`
+  * `retry_when()`
   * `allocate()`
   * `with_query_value()`
   * `with_allocator()`
@@ -41,6 +42,13 @@
   * `range_stream`
   * `type_erased_stream<Ts...>`
   * `never_stream`
+* Scheduler Types
+  * `inline_scheduler`
+  * `single_thread_context`
+  * `trampoline_scheduler`
+  * `timed_single_thread_context`
+  * `thread_unsafe_event_loop`
+  * `linux::io_uring_context`
 * StopToken Types
   * `unstoppable_token`
   * `inplace_stop_token` / `inplace_stop_source`
@@ -338,6 +346,8 @@ result of `get_allocator()` query on receivers passed to child operations.
 
 Child operations should use this allocator to perform heap allocations.
 
+## Sender Types
+
 ### `async_trace_sender`
 
 A sender that will produce the current async stack-trace containing the
@@ -353,6 +363,8 @@ struct async_trace_entry {
   continuation_info continuation; // description of this continuation
 };
 ```
+
+## Sender Queries
 
 ### `blocking(const Sender&) -> blocking_kind`
 
@@ -373,7 +385,7 @@ Senders can customise this algorithm by providing an overload of
 `tag_invoke(tag_t<blocking>, const your_sender_type&)`.
 
 ## Stream Algorithms
------------------
+
 ### `adapt_stream(Stream stream, Func adaptor) -> Stream`
 
 Applies `adaptor()` to `next(stream)` and `cleanup(stream)` senders.
@@ -463,6 +475,26 @@ the `cleanup()` result.
 
 Adapts `stream` to produce a new stream that delays the delivery of each
 value, done and error signal by the specified duration.
+
+## Stream Types
+
+### `range_stream`
+
+Produces a sequence of `int` values within a given range.
+Mainly used for testing purposes.
+
+### `type_erased_stream<Ts...>`
+
+A type-erased stream that produces a sequence of value packs of type `(Ts, ...)`.
+ie. calls to `set_value()` will be passed arguments of type `Ts&&...`
+
+### `never_stream`
+
+A stream whose `next()` completes with `set_done()` once when stop is requested.
+
+Note that using this stream with a stop-token where `stop_possible()` returns
+`false` will result in a memory-leak. The `next()` operation will never
+complete.
 
 ## Scheduler Algorithms
 
@@ -557,26 +589,6 @@ These CPOs both return a `SenderOf<ssize_t>` that produces the number of bytes w
 
 For files associated with the `io_uring_context`, these operations will always complete
 on the associated on the thread that is calling `run()` on the associated context.
-
-## Stream Types
-
-### `range_stream`
-
-Produces a sequence of `int` values within a given range.
-Mainly used for testing purposes.
-
-### `type_erased_stream<Ts...>`
-
-A type-erased stream that produces a sequence of value packs of type `(Ts, ...)`.
-ie. calls to `set_value()` will be passed arguments of type `Ts&&...`
-
-### `never_stream`
-
-A stream whose `next()` completes with `set_done()` once when stop is requested.
-
-Note that using this stream with a stop-token where `stop_possible()` returns
-`false` will result in a memory-leak. The `next()` operation will never
-complete.
 
 ## StopToken Types
 

--- a/examples/new_thread_context.cpp
+++ b/examples/new_thread_context.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/new_thread_context.hpp>
+
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/when_all.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+struct trace_construction_destruction {
+    static std::atomic<int> instanceCount; 
+
+    trace_construction_destruction() {
+        ++instanceCount;
+        std::stringstream s;
+        s << "thread_local at address " << (void*)this
+          << " constructing on thread " << std::this_thread::get_id() << "\n";
+        std::cout << s.str();
+    }
+    ~trace_construction_destruction() {
+        --instanceCount;
+        std::stringstream s;
+        s << "thread_local at address " << (void*)this
+          << " destructing on thread " << std::this_thread::get_id() << "\n";
+        std::cout << s.str();
+    }
+};
+
+std::atomic<int> trace_construction_destruction::instanceCount = 0;
+
+int main() {
+  {
+    unifex::new_thread_context ctx;
+
+    auto makeThreadTask = [&](int i) {
+        return unifex::transform(
+            unifex::schedule(ctx.get_scheduler()),
+            [i] {
+                std::stringstream s;
+                s << "Task " << i << " running on thread " << std::this_thread::get_id() << "\n";
+                std::cout << s.str();
+
+                thread_local trace_construction_destruction t;
+            });
+    };
+
+    unifex::sync_wait(
+        unifex::when_all(
+            makeThreadTask(1),
+            makeThreadTask(2),
+            makeThreadTask(3),
+            makeThreadTask(4)));
+
+    std::cout << "shutting down new_thread_context\n";
+  }
+
+  std::cout << "new_thread_contxt finished shutting down\n";
+
+  // new_thread_context destructor should have waited for all threads to finish
+  // destroying thread-locals.
+
+  assert(trace_construction_destruction::instanceCount.load() == 0);
+}

--- a/include/unifex/new_thread_context.hpp
+++ b/include/unifex/new_thread_context.hpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/get_stop_token.hpp>
+#include <unifex/receiver_concepts.hpp>
+
+#include <cassert>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace unifex {
+
+
+class new_thread_context {
+private:
+  template<typename Receiver>
+  class schedule_op {
+  public:
+    template<typename Receiver2>
+    explicit schedule_op(new_thread_context* ctx, Receiver2&& r)
+    : ctx_(ctx), receiver_((Receiver2&&)r)
+    {
+    }
+
+    ~schedule_op() {
+        assert(!thread_.joinable());
+    }
+
+    void start() & noexcept {
+      {
+        std::unique_lock lk{ctx_->mut_};
+        ++ctx_->activeThreadCount_;
+      }
+
+      try {
+        std::lock_guard opLock{mut_};
+        thread_ = std::thread([this]() noexcept { this->run(); });
+      } catch (...) {
+        {
+          std::lock_guard ctxLock{ctx_->mut_};
+          --ctx_->activeThreadCount_;
+          // Don't need to signal the condition_variable here as the
+          // operation has not yet completed (we haven't called set_error)
+          // and so the caller shouldn't be calling the destructor of the
+          // new_thread_context yet.
+        }
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
+    }
+
+  private:
+    void run() noexcept {
+      std::thread thisThread;
+      {
+        std::lock_guard opLock{mut_};
+        thisThread = std::move(thread_);
+      }
+
+      new_thread_context* ctx = ctx_;
+      if (get_stop_token(receiver_).stop_requested()) {
+        unifex::set_done(std::move(receiver_));
+      } else {
+        try {
+          unifex::set_value(std::move(receiver_));
+        } catch (...) {
+          unifex::set_error(std::move(receiver_), std::current_exception());
+        }
+      }
+
+      ctx->retire_thread(std::move(thisThread));
+    }
+
+    new_thread_context* ctx_;
+    Receiver receiver_;
+
+    std::mutex mut_;
+    std::thread thread_;
+  };
+
+  class schedule_sender {
+  public:
+    template<template<typename...> class Variant,
+             template<typename...> class Tuple>
+    using value_types = Variant<Tuple<>>;
+
+    template<template<typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    explicit schedule_sender(new_thread_context* ctx) noexcept
+    : context_(ctx) {}
+
+    template<typename Receiver>
+    schedule_op<std::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
+        return schedule_op<std::remove_cvref_t<Receiver>>{context_, (Receiver&&)r};
+    }
+
+  private:
+    new_thread_context* context_;
+  };
+
+  class scheduler {
+  public:
+    explicit scheduler(new_thread_context* ctx) noexcept : context_(ctx) {}
+
+    schedule_sender schedule() const noexcept {
+        return schedule_sender{context_};
+    }
+
+  private:
+    new_thread_context* context_;
+  };
+
+public:
+  new_thread_context() = default;
+
+  ~new_thread_context() {
+    std::unique_lock lk{mut_};
+    cv_.wait(lk, [this] { return activeThreadCount_ == 0; });
+    if (threadToJoin_.joinable()) {
+      threadToJoin_.join();
+    }
+  }
+
+  scheduler get_scheduler() noexcept {
+    return scheduler{this};
+  }
+
+private:
+  void retire_thread(std::thread t) noexcept {
+    std::thread prevThread;
+    {
+      std::lock_guard lk{mut_};
+      prevThread = std::exchange(threadToJoin_, std::move(t));
+      if (--activeThreadCount_ == 0) {
+        cv_.notify_one();
+      }
+    }
+
+    if (prevThread.joinable()) {
+      prevThread.join();
+    }
+  }
+
+  std::mutex mut_;
+  std::condition_variable cv_;
+  std::thread threadToJoin_;
+  size_t activeThreadCount_ = 0;
+};
+
+} // namespace unifex


### PR DESCRIPTION
Adds `unifex::new_thread_context` which implements the `schedule()` interface by creating a new `std::thread` for each schedule operation.

When a thread finishes it installs itself as the 'thread-to-be-joined' in the context. If there was a previous thread that had not yet been joined then the newly finished thread takes responsibility for joining that thread before returning. The destructor of the new_thread_contex then only has to wait until all threads have been retired and then just join the last thread in the chain.

This ensures that we are able to join all of the threads and do so in a relatively timely manner without needing to store a collection of threads that could grow without bound.

Thanks to @kirkshoop for the idea for the implementation strategy!