### PR TITLE
Fix Linux build partially

### DIFF
--- a/examples/linux/io_uring_test.cpp
+++ b/examples/linux/io_uring_test.cpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 using namespace unifex;
-using namespace unifex::linux;
+using namespace unifex::linuxos;
 using namespace std::chrono_literals;
 
 template <typename F>

--- a/include/unifex/filesystem.hpp
+++ b/include/unifex/filesystem.hpp
@@ -15,8 +15,20 @@
  */
 #pragma once
 
+#if __has_include(<filesystem>)
+
+#include <filesystem>
+
+namespace unifex {
+    namespace filesystem = std::filesystem;
+}
+
+#else
+
 #include <experimental/filesystem>
 
 namespace unifex {
     namespace filesystem = std::experimental::filesystem;
 }
+
+#endif // __has_include(<filesystem>)


### PR DESCRIPTION
Remaining errors:

```
[ 14%] Built target unifex
[ 16%] Built target get_scheduler
[ 19%] Built target static_thread_pool
[ 21%] Built target for_each_via_trampoline
[ 23%] Built target for_each_via_thread_scheduler
[ 26%] Built target heap_allocate_operation
[ 28%] Built target execute
[ 30%] Built target stream_cancellation
[ 33%] Built target delayed_stream_cancellation
[ 35%] Built target async_mutex
[ 38%] Built target any_unique
[ 40%] Built target for_each_synchronous
[ 42%] Built target let
[ 45%] Built target coroutine_stream_consumer
[ 47%] Built target reduce_synchronous
[ 50%] Built target async_trace
[ 52%] Built target materialize
[ 54%] Built target when_all
[ 57%] Built target io_epoll_test
[ 59%] Built target never_stream_cancellation
[ 61%] Built target p1897
[ 64%] Built target produce_on_consume_via
[ 66%] Built target reduce_with_trampoline
[ 69%] Built target stop_immediately
[ 70%] Building CXX object examples/CMakeFiles/io_uring_test.dir/linux/io_uring_test.cpp.o
In file included from /home/carter/libunifex/examples/linux/io_uring_test.cpp:21:
/home/carter/libunifex/source/../include/unifex/let.hpp:113:11: error: no matching function for call to object of type 'const struct set_value_cpo'
          unifex::set_value(
          ^~~~~~~~~~~~~~~~~
/home/carter/libunifex/source/../include/unifex/receiver_concepts.hpp:31:39: note: in instantiation of function template specialization 'unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>::set_value<std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
    return static_cast<Receiver&&>(r).set_value((Values &&) values...);
                                      ^
/home/carter/libunifex/source/../include/unifex/tag_invoke.hpp:32:12: note: in instantiation of function template specialization 'unifex::tag_invoke<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
    return tag_invoke((CPO&&)cpo, (Args &&) args...);
           ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:215:9: note: in instantiation of function template specialization 'unifex::set_value_cpo::operator()<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
        unifex::set_value(
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:208:9: note: in instantiation of function template specialization 'unifex::when_all_sender<unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender>::operation<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file> >::deliver_value<0, 1, 2, 3, 4, 5, 6, 7>' requested here
        deliver_value(std::index_sequence_for<Senders...>{});
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:188:9: note: in instantiation of member function 'unifex::when_all_sender<unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender>::operation<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file> >::deliver_result' requested here
        deliver_result();
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:123:15: note: (skipping 45 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
          op_.element_complete();
              ^
/home/carter/libunifex/source/../include/unifex/sequence.hpp:232:9: note: in instantiation of function template specialization 'unifex::start_cpo::operator()<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > >' requested here
        unifex::start(predOp_.get());
        ^
/home/carter/libunifex/source/../include/unifex/sender_concepts.hpp:30:15: note: in instantiation of member function 'unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> >::start' requested here
    return op.start();
              ^
/home/carter/libunifex/source/../include/unifex/tag_invoke.hpp:32:12: note: in instantiation of function template specialization 'unifex::tag_invoke<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > >' requested here
    return tag_invoke((CPO&&)cpo, (Args &&) args...);
           ^
/home/carter/libunifex/source/../include/unifex/sync_wait.hpp:176:5: note: in instantiation of function template specialization 'unifex::start_cpo::operator()<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > >' requested here
    start(operation);
    ^
/home/carter/libunifex/examples/linux/io_uring_test.cpp:132:5: note: in instantiation of function template specialization 'unifex::sync_wait<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> > >, unifex::unstoppable_token, std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > > >' requested here
    sync_wait(sequence(
    ^
/home/carter/libunifex/source/../include/unifex/receiver_concepts.hpp:35:8: note: candidate template ignored: substitution failure [with Receiver = unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > >, Values = <std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >>]: no type named 'type' in 'std::__1::invoke_result<unifex::tag_invoke_impl::tag_invoke_cpo, unifex::set_value_cpo, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::thread_unsafe_sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >'
  auto operator()(Receiver&& r, Values&&... values) const noexcept(
       ^
In file included from /home/carter/libunifex/examples/linux/io_uring_test.cpp:21:
/home/carter/libunifex/source/../include/unifex/let.hpp:113:11: error: no matching function for call to object of type 'const struct set_value_cpo'
          unifex::set_value(
          ^~~~~~~~~~~~~~~~~
/home/carter/libunifex/source/../include/unifex/receiver_concepts.hpp:31:39: note: in instantiation of function template specialization 'unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>::set_value<std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
    return static_cast<Receiver&&>(r).set_value((Values &&) values...);
                                      ^
/home/carter/libunifex/source/../include/unifex/tag_invoke.hpp:32:12: note: in instantiation of function template specialization 'unifex::tag_invoke<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
    return tag_invoke((CPO&&)cpo, (Args &&) args...);
           ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:215:9: note: in instantiation of function template specialization 'unifex::set_value_cpo::operator()<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file>, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >' requested here
        unifex::set_value(
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:208:9: note: in instantiation of function template specialization 'unifex::when_all_sender<unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender>::operation<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file> >::deliver_value<0, 1, 2, 3, 4, 5, 6, 7>' requested here
        deliver_value(std::index_sequence_for<Senders...>{});
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:188:9: note: in instantiation of member function 'unifex::when_all_sender<unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender, unifex::linuxos::io_uring_context::write_sender>::operation<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>::operation<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > > >::successor_receiver<unifex::linuxos::io_uring_context::async_write_only_file> >::deliver_result' requested here
        deliver_result();
        ^
/home/carter/libunifex/source/../include/unifex/when_all.hpp:123:15: note: (skipping 45 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
          op_.element_complete();
              ^
/home/carter/libunifex/source/../include/unifex/sequence.hpp:232:9: note: in instantiation of function template specialization 'unifex::start_cpo::operator()<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > >' requested here
        unifex::start(predOp_.get());
        ^
/home/carter/libunifex/source/../include/unifex/sender_concepts.hpp:30:15: note: in instantiation of member function 'unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> >::start' requested here
    return op.start();
              ^
/home/carter/libunifex/source/../include/unifex/tag_invoke.hpp:32:12: note: in instantiation of function template specialization 'unifex::tag_invoke<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > >' requested here
    return tag_invoke((CPO&&)cpo, (Args &&) args...);
           ^
/home/carter/libunifex/source/../include/unifex/sync_wait.hpp:200:5: note: in instantiation of function template specialization 'unifex::start_cpo::operator()<unifex::detail::sequence_operation<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > >' requested here
    start(operation);
    ^
/home/carter/libunifex/examples/linux/io_uring_test.cpp:132:5: note: in instantiation of function template specialization 'unifex::sync_wait<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> > >, unifex::unstoppable_token, std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > > >' requested here
    sync_wait(sequence(
    ^
/home/carter/libunifex/source/../include/unifex/receiver_concepts.hpp:35:8: note: candidate template ignored: substitution failure [with Receiver = unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > >, Values = <std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >>]: no type named 'type' in 'std::__1::invoke_result<unifex::tag_invoke_impl::tag_invoke_cpo, unifex::set_value_cpo, unifex::detail::sequence_successor_receiver<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)>, unifex::detail::sequence_predecessor_receiver<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::sequence_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:133:14)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:51:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:57:7)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:135:14)> >, unifex::transform_sender<unifex::linuxos::io_uring_context::schedule_at_sender, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:138:13)> >, unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:139:14)> >, unifex::when_all_sender<unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)>, unifex::let_sender<unifex::transform_sender<unifex::just_sender<>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:76:12)>, (lambda at /home/carter/libunifex/examples/linux/io_uring_test.cpp:77:7)> >, unifex::detail::sync_wait_receiver<std::__1::tuple<std::__1::variant<std::__1::tuple<> >, std::__1::variant<std::__1::tuple<> > >, unifex::unstoppable_token &&> > > > > >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> >, std::__1::variant<std::__1::tuple<long> > >'
  auto operator()(Receiver&& r, Values&&... values) const noexcept(
       ^
2 errors generated.
```