### PR TITLE
Change value_types/error_types calculations to use type_lists

### DIFF
--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -22,6 +22,7 @@
 #include <unifex/scope_guard.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 
 #include <cassert>
 #include <exception>
@@ -616,12 +617,12 @@ namespace unifex
     // TODO: In theory we could eliminate exception_ptr in the case that the
     // connect() operation and move/copy of values
     template <template <typename...> class Variant>
-    using error_types = concat_unique_t<
+    using error_types = typename concat_type_lists_unique_t<
         typename SourceSender::template error_types<
-            decayed_tuple<Variant>::template apply>,
-        typename CompletionSender::template error_types<decayed_tuple<
-            append_unique<Variant, std::exception_ptr>::template apply>::
-                                                            template apply>>;
+            decayed_tuple<type_list>::template apply>,
+        typename CompletionSender::template error_types<
+            decayed_tuple<type_list>::template apply>,
+        type_list<std::exception_ptr>>::template apply<Variant>;
 
     template <typename SourceSender2, typename CompletionSender2>
     explicit finally_sender(

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -22,6 +22,7 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 
 #include <exception>
 #include <functional>
@@ -62,18 +63,17 @@ class let_sender {
   struct value_types_impl {
    public:
     template <typename... Senders>
-    using apply = deduplicate_t<concat_lists_t<
-        Variant,
-        typename Senders::template value_types<Variant, Tuple>...>>;
+    using apply = typename concat_type_lists_unique_t<
+        typename Senders::template value_types<type_list, Tuple>...
+        >::template apply<Variant>;
   };
 
   template <template <typename...> class Variant>
   struct error_types_impl {
     template <typename... Senders>
-    using apply = deduplicate_t<concat_lists_t<
-        Variant,
-        Variant<std::exception_ptr>,
-        typename Senders::template error_types<Variant>...>>;
+    using apply = typename concat_type_lists_unique_t<
+        typename Senders::template error_types<type_list>...,
+        type_list<std::exception_ptr>>::template apply<Variant>;
   };
 
  public:

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -21,6 +21,7 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/stream_concepts.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 #include <unifex/unstoppable_token.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/async_trace.hpp>
@@ -44,10 +45,10 @@ struct reduce_stream_sender {
   using value_types = Variant<Tuple<State>>;
 
   template <template <typename...> class Variant>
-  using error_types = concat_unique_t<
-      typename next_sender_t<StreamSender>::template error_types<Variant>,
-      typename cleanup_sender_t<StreamSender>::template error_types<
-          append_unique<Variant, std::exception_ptr>::template apply>>;
+  using error_types = typename concat_type_lists_unique_t<
+      typename next_sender_t<StreamSender>::template error_types<type_list>,
+      typename cleanup_sender_t<StreamSender>::template error_types<type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   template <typename Receiver>
   struct operation {

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -24,6 +24,7 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 
 #include <cassert>
 #include <exception>
@@ -275,9 +276,10 @@ namespace unifex
         typename Successor::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
-    using error_types = concat_unique_t<
-        typename Predecessor::template error_types<Variant>,
-        typename Successor::template error_types<Variant>>;
+    using error_types = typename concat_type_lists_unique_t<
+        typename Predecessor::template error_types<type_list>,
+        typename Successor::template error_types<type_list>,
+        type_list<std::exception_ptr>>::template apply<Variant>;
 
     template <
         typename Predecessor2,

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -20,6 +20,7 @@
 #include <unifex/stream_concepts.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/unstoppable_token.hpp>
 #include <unifex/get_stop_token.hpp>
@@ -298,9 +299,9 @@ struct stop_immediately_stream {
     using value_types = Variant<>;
 
     template<template<typename...> class Variant>
-    using error_types = adapt_error_types_t<
-      cleanup_sender_t<SourceStream>,
-      append_unique<Variant, std::exception_ptr>>;
+    using error_types = typename concat_type_lists_unique_t<
+      typename cleanup_sender_t<SourceStream>::template error_types<type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
     template<typename Receiver>
     struct operation final : cleanup_operation_base {

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -60,6 +60,9 @@ namespace unifex
   struct concat_type_lists<type_list<Ts...>, type_list<Us...>, type_list<Vs...>, OtherLists...>
     : concat_type_lists<type_list<Ts..., Us..., Vs...>, OtherLists...> {};
 
+  template <typename... UniqueLists>
+  using concat_type_lists_t = typename concat_type_lists<UniqueLists...>::type;
+
   // concat_type_lists_unique<UniqueLists...>
   //
   // Result is produced via '::type' which will contain a type_list<Ts...> that
@@ -89,4 +92,24 @@ namespace unifex
                 type_list<Us>>...>::type,
           OtherLists...> {};
 
+  template <typename... UniqueLists>
+  using concat_type_lists_unique_t = typename concat_type_lists_unique<UniqueLists...>::type;
+
+  namespace detail
+  {
+    template<
+      template<typename...> class Outer,
+      template<typename...> class Inner>
+    struct type_list_nested_apply_impl {
+      template<typename... Lists>
+      using apply = Outer<typename Lists::template apply<Inner>...>;
+    };
+  }
+
+  template<
+    typename ListOfLists,
+    template<typename...> class Outer,
+    template<typename...> class Inner>
+  using type_list_nested_apply_t = typename ListOfLists::template apply<
+    detail::type_list_nested_apply_impl<Outer, Inner>::template apply>;
 } // namespace unifex

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -22,6 +22,7 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/type_list.hpp>
 #include <unifex/blocking.hpp>
 
 #include <atomic>
@@ -89,10 +90,9 @@ class when_all_sender {
       typename Senders::template value_types<std::variant, std::tuple>...>>;
 
   template <template <typename...> class Variant>
-  using error_types = deduplicate_t<concat_lists_t<
-      Variant,
-      Variant<std::exception_ptr>,
-      typename Senders::template error_types<Variant>...>>;
+  using error_types = typename concat_type_lists_unique_t<
+      typename Senders::template error_types<type_list>...,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   template <typename... Senders2>
   explicit when_all_sender(Senders2&&... senders)


### PR DESCRIPTION
Make the value_types/error_types calculations more robust
by doing all of the calculations in type_lists and then applying
the Tuple/Variant template parameters afterwards.

The existing deduplicate_t/concat_unique_t/etc. metafunctions
were flawed in that they deduplicated the post-transformed
type-list rather than the pre-transformed type list.
This only worked if the Tuple/Variant arguments were class
templates and could give an incorrect result if they were type-aliases
that applied metafunctions (which was often the case).

Removed the flawed metafunctions and replaced usage with
type_list-based transformations.