### PR TITLE
Modify unifex::on() algorithm so it only stores scheduler once

### DIFF
--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -42,10 +42,11 @@ namespace unifex
         std::enable_if_t<!is_tag_invocable_v<on_cpo, Sender, Scheduler>, int> =
             0>
     auto operator()(Sender&& sender, Scheduler&& scheduler) const {
-      return sequence(
-          schedule(scheduler),
-          with_query_value((Sender &&) sender, get_scheduler, scheduler));
+      return with_query_value(
+          sequence(schedule(), (Sender&&)sender),
+          get_scheduler,
+          (Scheduler&&)scheduler);
     }
   } on;
-
+  
 }  // namespace unifex


### PR DESCRIPTION
Previous implementation required both the `with_query_value()` and the `schedule()` operation to hold a copy of the scheduler.

By putting the `with_query_value()` as the outer sender we can then use the parametereless `schedule()` operation which uses this context and avoid needing to store the scheduler twice.

This also allows us to then move the scheduler instead of copying, which could be more efficient for scheduler types that perform reference-counting.