### PR TITLE
Remove stopToken parameter from sync_wait()

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -213,7 +213,7 @@ If you provide a customisation for a pair of senders then this customisation
 will be applied to the first two arguments and then reinvoke `sequence()`
 with the first two arguments replaced with the result of `sequence(first, second)`.
 
-### `sync_wait(Sender sender, StopToken st = {}) -> std::optional<Result>`
+### `sync_wait(Sender sender) -> std::optional<Result>`
 
 Blocks the current thread waiting for the specified sender to complete.
 

--- a/examples/linux/io_epoll_test.cpp
+++ b/examples/linux/io_epoll_test.cpp
@@ -27,6 +27,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/transform.hpp>
 #include <unifex/when_all.hpp>
+#include <unifex/with_query_value.hpp>
 
 #include <chrono>
 #include <cstdio>
@@ -59,6 +60,7 @@ int main() {
       auto start = std::chrono::steady_clock::now();
       inplace_stop_source timerStopSource;
       sync_wait(
+        with_query_value(
           when_all(
               transform(
                   schedule_at(scheduler, now(scheduler) + 1s),
@@ -72,7 +74,8 @@ int main() {
                     std::printf("timer 3 completed (1.5s) cancelling\n");
                     timerStopSource.request_stop();
                   })),
-          timerStopSource.get_token());
+          get_stop_token,
+          timerStopSource.get_token()));
       auto end = std::chrono::steady_clock::now();
 
       std::printf(

--- a/examples/linux/io_uring_test.cpp
+++ b/examples/linux/io_uring_test.cpp
@@ -28,6 +28,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/transform.hpp>
 #include <unifex/when_all.hpp>
+#include <unifex/with_query_value.hpp>
 
 #include <chrono>
 #include <cstdio>
@@ -113,6 +114,7 @@ int main() {
       auto start = std::chrono::steady_clock::now();
       inplace_stop_source timerStopSource;
       sync_wait(
+        with_query_value(
           when_all(
               transform(
                   schedule_at(scheduler, now(scheduler) + 1s),
@@ -126,7 +128,8 @@ int main() {
                     std::printf("timer 3 completed (1.5s) cancelling\n");
                     timerStopSource.request_stop();
                   })),
-          timerStopSource.get_token());
+          get_stop_token,
+          timerStopSource.get_token()));
       auto end = std::chrono::steady_clock::now();
 
       std::printf(

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -262,15 +262,15 @@ namespace _thread_unsafe_event_loop {
     thread_unsafe_event_loop& loop_;
   };
 
-  template <typename T, typename StopToken>
+  template <typename T>
   struct _sync_wait_promise {
     class type;
   };
-  template <typename T, typename StopToken>
-  using sync_wait_promise = typename _sync_wait_promise<T, StopToken>::type;
+  template <typename T>
+  using sync_wait_promise = typename _sync_wait_promise<T>::type;
 
-  template <typename T, typename StopToken>
-  class _sync_wait_promise<T, StopToken>::type {
+  template <typename T>
+  class _sync_wait_promise<T>::type {
     using sync_wait_promise = type;
     enum class state { incomplete, done, value, error };
 
@@ -296,18 +296,8 @@ namespace _thread_unsafe_event_loop {
         promise_.state_ = state::done;
       }
 
-      friend const StopToken& tag_invoke(
-          tag_t<get_stop_token>,
-          const receiver& r) noexcept {
-        return r.get_stop_token();
-      }
-
      private:
       friend sync_wait_promise;
-
-      StopToken& get_stop_token() const noexcept {
-        return promise_.stopToken_;
-      }
 
       explicit receiver(sync_wait_promise& promise) noexcept
         : promise_(promise) {}
@@ -316,8 +306,7 @@ namespace _thread_unsafe_event_loop {
     };
 
    public:
-    explicit type(StopToken&& stopToken) noexcept
-      : stopToken_((StopToken &&) stopToken) {}
+    type() noexcept {}
 
     ~type() {
       if (state_ == state::value) {
@@ -352,7 +341,6 @@ namespace _thread_unsafe_event_loop {
     };
 
     state state_ = state::incomplete;
-    StopToken stopToken_;
   };
 } // namespace _thread_unsafe_event_loop
 
@@ -378,11 +366,10 @@ class thread_unsafe_event_loop {
 
   template <
       typename Sender,
-      typename StopToken = unstoppable_token,
       typename Result = single_value_result_t<std::remove_cvref_t<Sender>>>
-  std::optional<Result> sync_wait(Sender&& sender, StopToken st = {}) {
-    using promise_t = _thread_unsafe_event_loop::sync_wait_promise<Result, StopToken&&>;
-    promise_t promise{(StopToken &&) st};
+  std::optional<Result> sync_wait(Sender&& sender) {
+    using promise_t = _thread_unsafe_event_loop::sync_wait_promise<Result>;
+    promise_t promise;
 
     auto op = connect((Sender &&) sender, promise.get_receiver());
     start(op);


### PR DESCRIPTION
Now that we have `stop_when()`, and also the fallback manual injection
of a stop-token using `with_query_value()` we don't need to have `sync_wait()`
concerned with stop-tokens. If the caller wants to be able to stop an
operation then they can apply an appropriate algorithm to the sender
before passing it to `sync_wait()`.