### PR TITLE
Fix clang warnings under -Wall -Wextra.

### DIFF
--- a/examples/async_trace.cpp
+++ b/examples/async_trace.cpp
@@ -111,6 +111,8 @@ int main() {
             << duration_cast<milliseconds>(std::get<0>(std::get<0>(a))).count()
             << ", "
             << duration_cast<milliseconds>(std::get<0>(std::get<0>(b))).count()
+            << ", "
+            << std::get<0>(std::get<0>(c))
             << "]\n";
       }));
 

--- a/examples/let.cpp
+++ b/examples/let.cpp
@@ -60,8 +60,6 @@ int main() {
   // More complicated 'let' example that shows recursive let-scopes,
   // additional
 
-  auto start = steady_clock::now();
-
   sync_wait(transform(
       when_all(
           let(asyncVector(),

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -44,11 +44,11 @@ struct int_iterator {
   using pointer = value_type*;
   using iterator_category = std::random_access_iterator_tag;
 
-  const int operator[](size_t offset) const {
+  int operator[](size_t offset) const {
     return base_+offset;
   }
 
-  const int operator*() const {
+  int operator*() const {
     return base_;
   }
 

--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -29,23 +29,6 @@
 
 using namespace unifex;
 
-struct increment_receiver {
-  int &value_;
-  manual_event_loop &loop_;
-
-  void set_value() && noexcept {
-    if (++value_ == 3) {
-      loop_.stop();
-    }
-  }
-
-  template <typename E>[[noreturn]] void set_error(E &&error) && noexcept {
-    std::terminate();
-  }
-
-  [[noreturn]] void set_done() && noexcept { std::terminate(); }
-};
-
 #if !UNIFEX_NO_MEMORY_RESOURCE
 using namespace unifex::pmr;
 

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -66,7 +66,7 @@ struct indexed_for_sender {
 
     // sequenced_policy version supports forward range
     template<typename... Values>
-    static void apply_func_with_policy(const execution::sequenced_policy& policy, Range&& range, Func&& func, Values&... values)
+    static void apply_func_with_policy(const execution::sequenced_policy&, Range&& range, Func&& func, Values&... values)
         noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
       for(auto idx : range) {
         std::invoke(func, idx, values...);
@@ -75,10 +75,11 @@ struct indexed_for_sender {
 
     // parallel_policy version requires random access range
     template<typename... Values>
-    static void apply_func_with_policy(const execution::parallel_policy& policy, Range&& range, Func&& func, Values&... values)
+    static void apply_func_with_policy(const execution::parallel_policy&, Range&& range, Func&& func, Values&... values)
         noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
       auto start = range.begin();
-      for(auto idx = 0; idx < range.size(); ++idx) {
+      using size_type = decltype(range.size());
+      for (size_type idx = 0; idx < range.size(); ++idx) {
         std::invoke(func, start[idx], values...);
       }
     }

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -81,7 +81,7 @@ struct reduce_stream_sender {
         return std::move(cpo)(std::as_const(r.op_.receiver_));
       }
 
-      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const error_cleanup_receiver& r) noexcept {
+      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const error_cleanup_receiver&) noexcept {
         return {};
       }
 
@@ -121,7 +121,7 @@ struct reduce_stream_sender {
         return std::move(cpo)(std::as_const(r.op_.receiver_));
       }
 
-      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const done_cleanup_receiver& r) noexcept {
+      friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const done_cleanup_receiver&) noexcept {
         return {};
       }
 

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -101,8 +101,11 @@ private:
     }
   };
 
-  struct schedule_sender {
-    std::size_t maxRecursionDepth_;
+  class schedule_sender {
+  public:
+    explicit schedule_sender(std::size_t maxDepth) noexcept
+    : maxRecursionDepth_(maxDepth)
+    {}
 
     template <
         template <typename...> class Variant,
@@ -117,6 +120,9 @@ private:
       return operation<std::remove_cvref_t<Receiver>>{(Receiver &&) receiver,
                                                       maxRecursionDepth_};
     }
+
+  private:
+    std::size_t maxRecursionDepth_;
   };
 
 public:

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -137,7 +137,8 @@ private:
 
 template <typename Sender, typename CPO, typename Value>
 with_query_value_sender<CPO, std::decay_t<Value>, std::decay_t<Sender>>
-with_query_value(Sender &&sender, CPO cpo, Value &&value) {
+with_query_value(Sender &&sender, CPO, Value &&value) {
+  static_assert(std::is_empty_v<CPO>, "with_query_value() does not support stateful CPOs");
   return with_query_value_sender<CPO, std::decay_t<Value>,
                                  std::decay_t<Sender>>{(Sender &&) sender,
                                                        (Value &&) value};

--- a/source/linux/io_epoll_context.cpp
+++ b/source/linux/io_epoll_context.cpp
@@ -267,7 +267,7 @@ void io_epoll_context::acquire_completion_queue_items() {
           read(remoteQueueEventFd_.get(), &buffer, sizeof(buffer));
       if (bytesRead < 0) {
         // read() failed
-        int errorCode = errno;
+        [[maybe_unused]] int errorCode = errno;
         LOGX("read on eventfd failed with %i\n", errorCode);
 
         std::terminate();
@@ -290,7 +290,7 @@ void io_epoll_context::acquire_completion_queue_items() {
           read(timerFd_.get(), &buffer, sizeof(buffer));
       if (bytesRead < 0) {
         // read() failed
-        int errorCode = errno;
+        [[maybe_unused]] int errorCode = errno;
         LOGX("read on timerfd failed with %i\n", errorCode);
 
         std::terminate();
@@ -333,7 +333,7 @@ void io_epoll_context::signal_remote_queue() {
   if (bytesWritten < 0) {
     // What to do here? Terminate/abort/ignore?
     // Try to dequeue the item before returning?
-    int errorCode = errno;
+    [[maybe_unused]] int errorCode = errno;
     LOGX("writing to remote queue eventfd failed with %i\n", errorCode);
 
     std::terminate();
@@ -432,7 +432,7 @@ bool io_epoll_context::try_submit_timer_io(const time_point& dueTime) noexcept {
   time.it_value.tv_nsec = dueTime.nanoseconds_part();
   int result = timerfd_settime(timerFd_.get(), TFD_TIMER_ABSTIME, &time, NULL);
   if (result < 0) {
-    int errorCode = errno;
+    [[maybe_unused]] int errorCode = errno;
     LOGX("timerfd_settime failed with %i\n", errorCode);
     return false;
   }

--- a/source/linux/io_uring_context.cpp
+++ b/source/linux/io_uring_context.cpp
@@ -554,7 +554,7 @@ void io_uring_context::acquire_completion_queue_items() noexcept {
             read(remoteQueueEventFd_.get(), &buffer, sizeof(buffer));
         if (bytesRead < 0) {
           // read() failed
-          int errorCode = errno;
+          [[maybe_unused]] int errorCode = errno;
           LOGX("read on eventfd failed with %i\n", errorCode);
 
           std::terminate();

--- a/test/retry_when_test.cpp
+++ b/test/retry_when_test.cpp
@@ -67,7 +67,7 @@ int main() {
     // Should have thrown an exception.
     std::printf("error: operation should have failed with an exception\n");
     return 1;
-  } catch (some_error) {
+  } catch (const some_error&) {
     std::printf("[%d] caught some_error in main()\n", (int)timeSinceStartInMs());
   }
 

--- a/test/submit_allocator_customisation_test.cpp
+++ b/test/submit_allocator_customisation_test.cpp
@@ -31,23 +31,6 @@
 
 using namespace unifex;
 
-struct increment_receiver {
-  int &value_;
-  manual_event_loop &loop_;
-
-  void value() && noexcept {
-    if (++value_ == 3) {
-      loop_.stop();
-    }
-  }
-
-  template <typename E>[[noreturn]] void error(E &&error) && noexcept {
-    std::terminate();
-  }
-
-  [[noreturn]] void done() && noexcept { std::terminate(); }
-};
-
 #if !UNIFEX_NO_MEMORY_RESOURCE
 using namespace unifex::pmr;
 


### PR DESCRIPTION
Fixes a few things that clang was complaining about:
- unused parameters
- unused variables
- const-qualification on returned prvalues
- signed/unsigned comparison
- mismatched struct/class usage in forward declaration
