### PR TITLE
Define some concept portability macros and replace enable_if with requires clauses

### DIFF
--- a/include/unifex/adapt_stream.hpp
+++ b/include/unifex/adapt_stream.hpp
@@ -20,6 +20,8 @@
 #include <functional>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _adapt_stream {
 template <typename Stream, typename NextAdaptFunc, typename CleanupAdaptFunc>
@@ -96,3 +98,5 @@ namespace _adapt_stream_cpo {
 } // namespace _adapt_stream_cpo
 using _adapt_stream_cpo::adapt_stream;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -24,6 +24,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _alloc {
   template <typename Operation, typename Allocator>
@@ -130,7 +132,7 @@ namespace _alloc {
 namespace _alloc_cpo {
   inline constexpr struct _fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename Sender>
       auto operator()(Sender&& predecessor) const
@@ -147,7 +149,7 @@ namespace _alloc_cpo {
     }
   } allocate{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename Sender>
     auto operator()(Sender&& predecessor) const
@@ -160,3 +162,5 @@ namespace _alloc_cpo {
 using _alloc_cpo::allocate;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -21,6 +21,8 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 class async_mutex {
@@ -124,3 +126,5 @@ inline bool async_mutex::try_lock() noexcept {
 }
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <unifex/detail/concept_macros.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
@@ -26,6 +27,8 @@
 #include <typeindex>
 #include <vector>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 namespace _visit_continuations {
@@ -35,10 +38,8 @@ namespace _visit_continuations {
     tag_invoke(_fn, const Continuation&, Func&&) noexcept {}
 
 #if !UNIFEX_NO_COROUTINES
-    template <
-        typename Promise,
-        typename Func,
-        std::enable_if_t<!std::is_void_v<Promise>, int> = 0>
+    template(typename Promise, typename Func)
+        (requires (!std::is_void_v<Promise>))
     friend void tag_invoke(
         _fn cpo,
         coro::coroutine_handle<Promise> h,
@@ -211,3 +212,5 @@ namespace _async_trace {
 using async_trace_sender = _async_trace::sender;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <unifex/detail/concept_macros.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>

--- a/include/unifex/awaitable_sender.hpp
+++ b/include/unifex/awaitable_sender.hpp
@@ -29,6 +29,8 @@
 #include <optional>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _await {
 namespace detail {
@@ -174,3 +176,5 @@ namespace _await_cpo {
 } // namespace _await_cpo
 using _await_cpo::awaitable_sender;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/blocking.hpp
+++ b/include/unifex/blocking.hpp
@@ -18,6 +18,8 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 enum class blocking_kind {
@@ -76,3 +78,5 @@ struct _fn::_impl<true> {
 using _blocking::blocking;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -86,3 +86,46 @@
 # define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) typename NAME = __VA_ARGS__
 # define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) __VA_ARGS__
 #endif
+
+#if !defined(UNIFEX_CXX_CONCEPTS)
+#ifdef UNIFEX_DOXYGEN_INVOKED
+#define UNIFEX_CXX_CONCEPTS 201800L
+#elif defined(__cpp_concepts) && __cpp_concepts > 0
+#define UNIFEX_CXX_CONCEPTS __cpp_concepts
+#else
+#define UNIFEX_CXX_CONCEPTS 0L
+#endif
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+  #define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
+  #define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
+  #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+  #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+  #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+#else // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
+  #if defined(__GNUC__) || defined(__clang__)
+    #define UNIFEX_PRAGMA(X) _Pragma(#X)
+    #define UNIFEX_DIAGNOSTIC_PUSH UNIFEX_PRAGMA(GCC diagnostic push)
+    #define UNIFEX_DIAGNOSTIC_POP UNIFEX_PRAGMA(GCC diagnostic pop)
+    #define UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
+      UNIFEX_PRAGMA(GCC diagnostic ignored "-Wpragmas")
+    #define UNIFEX_DIAGNOSTIC_IGNORE(X) \
+      UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
+      UNIFEX_PRAGMA(GCC diagnostic ignored "-Wunknown-pragmas") \
+      UNIFEX_PRAGMA(GCC diagnostic ignored X)
+    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME \
+      UNIFEX_DIAGNOSTIC_IGNORE("-Wunknown-warning-option") \
+      UNIFEX_DIAGNOSTIC_IGNORE("-Winit-list-lifetime")
+    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL \
+      UNIFEX_DIAGNOSTIC_IGNORE("-Wfloat-equal")
+    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT \
+      UNIFEX_DIAGNOSTIC_IGNORE("-Wc++2a-compat")
+  #else
+    #define UNIFEX_DIAGNOSTIC_PUSH
+    #define UNIFEX_DIAGNOSTIC_POP
+    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+  #endif
+#endif // MSVC/Generic configuration switch

--- a/include/unifex/coroutine.hpp
+++ b/include/unifex/coroutine.hpp
@@ -19,6 +19,7 @@
 
 #if !UNIFEX_NO_COROUTINES
 #include UNIFEX_COROUTINES_HEADER
+
 namespace unifex {
     namespace coro = UNIFEX_COROUTINES_NAMESPACE;
 }

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -23,6 +23,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 namespace detail {
@@ -78,3 +80,5 @@ using await_result_t =
     typename detail::await_result_impl<awaiter_type_t<Awaitable>>::type;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/delay.hpp
+++ b/include/unifex/delay.hpp
@@ -22,6 +22,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex
 {
   namespace _delay {
@@ -40,4 +42,6 @@ namespace unifex
     } delay{};
   } // namespace _delay
   using _delay::delay;
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -22,8 +22,11 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/std_concepts.hpp>
 
 #include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _demat {
@@ -37,19 +40,14 @@ namespace _demat {
   template <typename Receiver>
   class _receiver<Receiver>::type {
    public:
-    template <
-      typename Receiver2,
-      std::enable_if_t<std::is_constructible_v<Receiver, Receiver2>, int> = 0>
+    template(typename Receiver2)
+      (requires constructible_from<Receiver, Receiver2>)
     explicit type(Receiver2&& receiver) noexcept(
         std::is_nothrow_constructible_v<Receiver, Receiver2>)
       : receiver_(static_cast<Receiver2&&>(receiver)) {}
 
-    template <
-        typename CPO,
-        typename... Values,
-        std::enable_if_t<
-            is_receiver_cpo_v<CPO> && is_callable_v<CPO, Receiver, Values...>,
-            int> = 0>
+    template(typename CPO, typename... Values)
+        (requires is_receiver_cpo_v<CPO> AND is_callable_v<CPO, Receiver, Values...>)
     void set_value(CPO cpo, Values&&... values) && noexcept(
         is_nothrow_callable_v<CPO, Receiver, Values...>) {
       static_cast<CPO&&>(cpo)(
@@ -57,33 +55,22 @@ namespace _demat {
           static_cast<Values&&>(values)...);
     }
 
-    template <
-        typename Error,
-        std::enable_if_t<
-            is_callable_v<decltype(unifex::set_error), Receiver, Error>,
-            int> = 0>
+    template(typename Error)
+        (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
     void set_error(Error&& error) && noexcept {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), static_cast<Error&&>(error));
     }
 
-    template <
-        typename... DummyPack,
-        std::enable_if_t<
-            sizeof...(DummyPack) == 0 &&
-                is_callable_v<decltype(unifex::set_done), Receiver>,
-            int> = 0>
+    template(typename... DummyPack)
+        (requires (sizeof...(DummyPack) == 0) AND
+            is_callable_v<decltype(unifex::set_done), Receiver>)
     void set_done(DummyPack...) && noexcept {
       unifex::set_done(static_cast<Receiver&&>(receiver_));
     }
 
-    template <
-        typename CPO,
-        UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type),
-        std::enable_if_t<
-            !is_receiver_cpo_v<CPO>, int> = 0,
-        std::enable_if_t<
-            is_callable_v<CPO, const Receiver&>, int> = 0>
+    template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))
+        (requires (!is_receiver_cpo_v<CPO>) AND is_callable_v<CPO, const Receiver&>)
     friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r)
         noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
@@ -174,13 +161,9 @@ namespace _demat {
         noexcept(std::is_nothrow_constructible_v<Source, Source2>)
       : source_(static_cast<Source2&&>(source)) {}
 
-    template <
-        typename Self,
-        typename Receiver,
-        std::enable_if_t<std::is_same_v<remove_cvref_t<Self>, type>, int> = 0,
-        std::enable_if_t<
-          is_connectable_v<member_t<Self, Source>, receiver<Receiver>>,
-          int> = 0>
+    template(typename Self, typename Receiver)
+        (requires same_as<remove_cvref_t<Self>, type> AND
+          is_connectable_v<member_t<Self, Source>, receiver<Receiver>>)
     friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
         noexcept(is_nothrow_connectable_v<member_t<Self, Source>, receiver<Receiver>> &&
                  std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
@@ -198,7 +181,7 @@ namespace _demat {
 namespace _demat_cpo {
   inline constexpr struct _fn {
    private:
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename Sender>
       auto operator()(Sender&& predecessor) const
@@ -215,7 +198,7 @@ namespace _demat_cpo {
     }
   } dematerialize{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename Sender>
     auto operator()(Sender&& predecessor) const
@@ -227,4 +210,6 @@ namespace _demat_cpo {
 } // namespace _demat_cpo
 using _demat_cpo::dematerialize;
 
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/atomic_intrusive_queue.hpp
+++ b/include/unifex/detail/atomic_intrusive_queue.hpp
@@ -21,6 +21,8 @@
 #include <cassert>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 // An intrusive queue that supports multiple threads concurrently
@@ -165,3 +167,5 @@ public:
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/concept_macros.hpp
+++ b/include/unifex/detail/concept_macros.hpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <type_traits>
+
+#include <unifex/config.hpp>
+#include <unifex/type_traits.hpp>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define UNIFEX_WORKAROUND_MSVC_779763 // FATAL_UNREACHABLE calling constexpr function via template parameter
+#define UNIFEX_WORKAROUND_MSVC_780775 // Incorrect substitution in function template return type
+#endif
+
+#define UNIFEX_PP_CAT_(X, ...)  X ## __VA_ARGS__
+#define UNIFEX_PP_CAT(X, ...)   UNIFEX_PP_CAT_(X, __VA_ARGS__)
+
+#define UNIFEX_PP_CAT2_(X, ...)  X ## __VA_ARGS__
+#define UNIFEX_PP_CAT2(X, ...)   UNIFEX_PP_CAT2_(X, __VA_ARGS__)
+
+#define UNIFEX_PP_CAT3_(X, ...)  X ## __VA_ARGS__
+#define UNIFEX_PP_CAT3(X, ...)   UNIFEX_PP_CAT3_(X, __VA_ARGS__)
+
+#define UNIFEX_PP_CAT4_(X, ...)  X ## __VA_ARGS__
+#define UNIFEX_PP_CAT4(X, ...)   UNIFEX_PP_CAT4_(X, __VA_ARGS__)
+
+#define UNIFEX_PP_EVAL_(X, ARGS) X ARGS
+#define UNIFEX_PP_EVAL(X, ...) UNIFEX_PP_EVAL_(X, (__VA_ARGS__))
+
+#define UNIFEX_PP_EVAL2_(X, ARGS) X ARGS
+#define UNIFEX_PP_EVAL2(X, ...) UNIFEX_PP_EVAL2_(X, (__VA_ARGS__))
+
+#define UNIFEX_PP_EXPAND(...) __VA_ARGS__
+#define UNIFEX_PP_EAT(...)
+
+#define UNIFEX_PP_CHECK(...) UNIFEX_PP_EXPAND(UNIFEX_PP_CHECK_N(__VA_ARGS__, 0,))
+#define UNIFEX_PP_CHECK_N(x, n, ...) n
+#define UNIFEX_PP_PROBE(x) x, 1,
+#define UNIFEX_PP_PROBE_N(x, n) x, n,
+
+#define UNIFEX_PP_IS_PAREN(x) UNIFEX_PP_CHECK(UNIFEX_PP_IS_PAREN_PROBE x)
+#define UNIFEX_PP_IS_PAREN_PROBE(...) UNIFEX_PP_PROBE(~)
+
+// The final UNIFEX_PP_EXPAND here is to avoid
+// https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
+#define UNIFEX_PP_COUNT(...) \
+  UNIFEX_PP_EXPAND(UNIFEX_PP_COUNT_(__VA_ARGS__, \
+    50, 49, 48, 47, 46, 45, 44, 43, 42, 41, \
+    40, 39, 38, 37, 36, 35, 34, 33, 32, 31, \
+    30, 29, 28, 27, 26, 25, 24, 23, 22, 21, \
+    20, 19, 18, 17, 16, 15, 14, 13, 12, 11, \
+    10, 9, 8, 7, 6, 5, 4, 3, 2, 1,)) \
+  /**/
+#define UNIFEX_PP_COUNT_( \
+  _01, _02, _03, _04, _05, _06, _07, _08, _09, _10, \
+  _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+  _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+  _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+  _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, N, ...) \
+  N \
+  /**/
+
+#define UNIFEX_PP_IIF(BIT) UNIFEX_PP_CAT_(UNIFEX_PP_IIF_, BIT)
+#define UNIFEX_PP_IIF_0(TRUE, ...) __VA_ARGS__
+#define UNIFEX_PP_IIF_1(TRUE, ...) TRUE
+
+#define UNIFEX_PP_LPAREN (
+
+#define UNIFEX_PP_NOT(BIT) UNIFEX_PP_CAT_(UNIFEX_PP_NOT_, BIT)
+#define UNIFEX_PP_NOT_0 1
+#define UNIFEX_PP_NOT_1 0
+
+#define UNIFEX_PP_EMPTY()
+#define UNIFEX_PP_COMMA() ,
+#define UNIFEX_PP_LBRACE() {
+#define UNIFEX_PP_RBRACE() }
+#define UNIFEX_PP_COMMA_IIF(X) \
+  UNIFEX_PP_IIF(X)(UNIFEX_PP_EMPTY, UNIFEX_PP_COMMA)() \
+  /**/
+
+#define UNIFEX_PP_FOR_EACH(M, ...) \
+  UNIFEX_PP_FOR_EACH_N(UNIFEX_PP_COUNT(__VA_ARGS__), M, __VA_ARGS__)
+#define UNIFEX_PP_FOR_EACH_N(N, M, ...) \
+  UNIFEX_PP_CAT2(UNIFEX_PP_FOR_EACH_, N)(M, __VA_ARGS__)
+#define UNIFEX_PP_FOR_EACH_1(M, _1) \
+  M(_1)
+#define UNIFEX_PP_FOR_EACH_2(M, _1, _2) \
+  M(_1) M(_2)
+#define UNIFEX_PP_FOR_EACH_3(M, _1, _2, _3) \
+  M(_1) M(_2) M(_3)
+#define UNIFEX_PP_FOR_EACH_4(M, _1, _2, _3, _4) \
+  M(_1) M(_2) M(_3) M(_4)
+#define UNIFEX_PP_FOR_EACH_5(M, _1, _2, _3, _4, _5) \
+  M(_1) M(_2) M(_3) M(_4) M(_5)
+#define UNIFEX_PP_FOR_EACH_6(M, _1, _2, _3, _4, _5, _6) \
+  M(_1) M(_2) M(_3) M(_4) M(_5) M(_6)
+#define UNIFEX_PP_FOR_EACH_7(M, _1, _2, _3, _4, _5, _6, _7) \
+  M(_1) M(_2) M(_3) M(_4) M(_5) M(_6) M(_7)
+#define UNIFEX_PP_FOR_EACH_8(M, _1, _2, _3, _4, _5, _6, _7, _8) \
+  M(_1) M(_2) M(_3) M(_4) M(_5) M(_6) M(_7) M(_8)
+
+#define UNIFEX_PP_PROBE_EMPTY_PROBE_UNIFEX_PP_PROBE_EMPTY \
+  UNIFEX_PP_PROBE(~) \
+
+#define UNIFEX_PP_PROBE_EMPTY()
+#define UNIFEX_PP_IS_NOT_EMPTY(...) \
+  UNIFEX_PP_EVAL( \
+    UNIFEX_PP_CHECK, \
+    UNIFEX_PP_CAT( \
+      UNIFEX_PP_PROBE_EMPTY_PROBE_, \
+      UNIFEX_PP_PROBE_EMPTY __VA_ARGS__ ())) \
+  /**/
+
+#define UNIFEX_PP_TAIL(_, ...) __VA_ARGS__
+
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_M0(REQ) \
+  UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_(REQ)(REQ)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_M1(REQ) UNIFEX_PP_EXPAND REQ
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_(...) \
+  { UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) }
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_(REQ) \
+  UNIFEX_PP_CAT3(UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_, \
+    UNIFEX_PP_EVAL(UNIFEX_PP_CHECK, UNIFEX_PP_CAT3( \
+      UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_, \
+      REQ))) \
+  /**/
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_requires UNIFEX_PP_PROBE_N(~, 1)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_noexcept UNIFEX_PP_PROBE_N(~, 2)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_typename UNIFEX_PP_PROBE_N(~, 3)
+
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_0 UNIFEX_PP_EXPAND
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_1 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_2 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_3 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT(REQ) \
+  UNIFEX_PP_CAT4( \
+    UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_, \
+    REQ)
+#define UNIFEX_PP_EAT_TYPENAME_PROBE_typename UNIFEX_PP_PROBE(~)
+#define UNIFEX_PP_EAT_TYPENAME_SELECT_(X,...) \
+  UNIFEX_PP_CAT3(UNIFEX_PP_EAT_TYPENAME_SELECT_, \
+    UNIFEX_PP_EVAL(UNIFEX_PP_CHECK, UNIFEX_PP_CAT3( \
+      UNIFEX_PP_EAT_TYPENAME_PROBE_, \
+      X)))
+#define UNIFEX_PP_EAT_TYPENAME_(...) \
+  UNIFEX_PP_EVAL2(UNIFEX_PP_EAT_TYPENAME_SELECT_, __VA_ARGS__,)(__VA_ARGS__)
+#define UNIFEX_PP_EAT_TYPENAME_SELECT_0(...) __VA_ARGS__
+#define UNIFEX_PP_EAT_TYPENAME_SELECT_1(...) \
+  UNIFEX_PP_CAT3(UNIFEX_PP_EAT_TYPENAME_, __VA_ARGS__)
+#define UNIFEX_PP_EAT_TYPENAME_typename
+
+#if UNIFEX_CXX_CONCEPTS || defined(UNIFEX_DOXYGEN_INVOKED)
+
+  #define UNIFEX_CONCEPT concept
+
+  #define UNIFEX_CONCEPT_FRAGMENT(NAME, ...) \
+    concept NAME = UNIFEX_PP_CAT(UNIFEX_CONCEPT_FRAGMENT_REQS_, __VA_ARGS__)
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
+    requires(__VA_ARGS__) UNIFEX_CONCEPT_FRAGMENT_REQS_
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ) \
+    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ))(REQ);
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
+    requires __VA_ARGS__
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
+    typename UNIFEX_PP_EAT_TYPENAME_(__VA_ARGS__)
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
+    { __VA_ARGS__ } noexcept
+
+  #define UNIFEX_FRAGMENT(NAME, ...) \
+    NAME<__VA_ARGS__>
+
+#else
+
+  #define UNIFEX_CONCEPT inline constexpr bool
+
+  #define UNIFEX_CONCEPT_FRAGMENT(NAME, ...) \
+    auto NAME ## UNIFEX_CONCEPT_FRAGMENT_impl_ \
+      UNIFEX_CONCEPT_FRAGMENT_REQS_ ## __VA_ARGS__> {} \
+    template <typename... As> \
+    char NAME ## UNIFEX_CONCEPT_FRAGMENT_( \
+      ::unifex::_concept::tag<As...> *, \
+      decltype(&NAME ## UNIFEX_CONCEPT_FRAGMENT_impl_<As...>)); \
+    char (&NAME ## UNIFEX_CONCEPT_FRAGMENT_(...))[2] \
+    /**/
+  #define M(ARG) ARG,
+  #if defined(_MSC_VER) && !defined(__clang__)
+    #define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
+      ::unifex::_concept::true_<decltype( \
+        UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) \
+        void())>()
+  #else
+    #define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
+      !(decltype(UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) \
+      void(), \
+      false){})
+  #endif
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
+    (__VA_ARGS__) -> std::enable_if_t<UNIFEX_CONCEPT_FRAGMENT_REQS_2_
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_2_(...) \
+    UNIFEX_CONCEPT_FRAGMENT_TRUE(__VA_ARGS__)
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ) \
+    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ))(REQ),
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
+    ::unifex::requires_<__VA_ARGS__>
+  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
+    static_cast<::unifex::_concept::tag<__VA_ARGS__> *>(nullptr)
+  #if defined(__GNUC__) && !defined(__clang__)
+    // GCC can't mangle noexcept expressions, so just check that the
+    // expression is well-formed.
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70790
+    #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
+      __VA_ARGS__
+  #else
+    #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
+      ::unifex::requires_<noexcept(__VA_ARGS__)>
+  #endif
+
+  #define UNIFEX_FRAGMENT(NAME, ...) \
+    (1u==sizeof(NAME ## UNIFEX_CONCEPT_FRAGMENT_( \
+      static_cast<::unifex::_concept::tag<__VA_ARGS__> *>(nullptr), nullptr)))
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// UNIFEX_TEMPLATE
+// Usage:
+//   UNIFEX_TEMPLATE(typename A, typename B)
+//     (requires Concept1<A> UNIFEX_AND Concept2<B>)
+//   void foo(A a, B b)
+//   {}
+#if UNIFEX_CXX_CONCEPTS
+  #define UNIFEX_TEMPLATE(...) \
+    template <__VA_ARGS__> UNIFEX_PP_EXPAND \
+    /**/
+  #define UNIFEX_AND && \
+    /**/
+#else
+  #define UNIFEX_TEMPLATE \
+    UNIFEX_TEMPLATE_SFINAE \
+    /**/
+  #define UNIFEX_AND && UNIFEX_true_, int> = 0, std::enable_if_t< \
+    /**/
+#endif
+
+#define UNIFEX_TEMPLATE_SFINAE(...) \
+  template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
+  /**/
+#define UNIFEX_TEMPLATE_SFINAE_AUX_(...) , \
+  bool UNIFEX_true_ = true, \
+  std::enable_if_t< \
+    UNIFEX_PP_CAT(UNIFEX_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) && UNIFEX_true_, \
+    int> = 0> \
+  /**/
+#define UNIFEX_TEMPLATE_SFINAE_AUX_3_requires
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+  namespace _concept {
+    template <typename...>
+    struct tag;
+    template <class>
+    inline constexpr bool true_() {
+      return true;
+    }
+  } // namespace _concept
+
+#if defined(__clang__) || defined(_MSC_VER)
+  template <bool B>
+  std::enable_if_t<B> requires_() {}
+#else
+  template <bool B>
+  inline constexpr std::enable_if_t<B, int> requires_ = 0;
+#endif
+
+  template <typename B>
+  UNIFEX_CONCEPT is_true = (bool) B{};
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/epilogue.hpp
+++ b/include/unifex/detail/epilogue.hpp
@@ -13,35 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#include <thread>
+// No include guard or pragma once. This file is intended to be included
+// multiple times.
 
-#include <unifex/detail/prologue.hpp>
+#ifndef UNIFEX_PROLOGUE_HPP
+#error Epilogue included but prologue has not
+#endif
+#undef UNIFEX_PROLOGUE_HPP
 
-namespace unifex {
-
-class spin_wait {
- public:
-  spin_wait() noexcept = default;
-
-  void wait() noexcept {
-    if (count_++ < yield_threshold) {
-      // TODO: _mm_pause();
-    } else {
-      if (count_ == 0) {
-        count_ = yield_threshold;
-      }
-      std::this_thread::yield();
-    }
-  }
-
- private:
-  static constexpr std::uint32_t yield_threshold = 20;
-
-  std::uint32_t count_ = 0;
-};
-
-} // namespace unifex
-
-#include <unifex/detail/epilogue.hpp>
+#undef template
+#undef AND

--- a/include/unifex/detail/intrusive_heap.hpp
+++ b/include/unifex/detail/intrusive_heap.hpp
@@ -17,6 +17,8 @@
 
 #include <cassert>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 // A doubly-linked intrusive list maintained in ascending order of the 'SortKey'
@@ -110,3 +112,5 @@ class intrusive_heap {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/intrusive_queue.hpp
+++ b/include/unifex/detail/intrusive_queue.hpp
@@ -19,6 +19,8 @@
 #include <tuple>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 template <typename Item, Item* Item::*Next>
@@ -121,3 +123,5 @@ class intrusive_queue {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/prologue.hpp
+++ b/include/unifex/detail/prologue.hpp
@@ -13,35 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#include <thread>
+// No include guard or pragma once. This file is intended to be included
+// multiple times.
 
-#include <unifex/detail/prologue.hpp>
+#ifdef UNIFEX_PROLOGUE_HPP
+#error Prologue has already been included
+#endif
+#define UNIFEX_PROLOGUE_HPP
 
-namespace unifex {
-
-class spin_wait {
- public:
-  spin_wait() noexcept = default;
-
-  void wait() noexcept {
-    if (count_++ < yield_threshold) {
-      // TODO: _mm_pause();
-    } else {
-      if (count_ == 0) {
-        count_ = yield_threshold;
-      }
-      std::this_thread::yield();
-    }
-  }
-
- private:
-  static constexpr std::uint32_t yield_threshold = 20;
-
-  std::uint32_t count_ = 0;
-};
-
-} // namespace unifex
-
-#include <unifex/detail/epilogue.hpp>
+#define template(...) UNIFEX_TEMPLATE(__VA_ARGS__)
+#define AND UNIFEX_AND

--- a/include/unifex/execute.hpp
+++ b/include/unifex/execute.hpp
@@ -22,13 +22,15 @@
 
 #include <exception>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex
 {
   namespace _execute
   {
     struct default_execute_receiver {
       void set_done() && noexcept {}
-      template<typename Error>
+      template <typename Error>
       [[noreturn]] void set_error(Error&&) && noexcept {
         std::terminate();
       }
@@ -36,7 +38,7 @@ namespace unifex
     };
 
     inline constexpr struct _fn {
-      template<typename Scheduler, typename Func>
+      template <typename Scheduler, typename Func>
       void operator()(Scheduler&& s, Func&& func) const {
         if constexpr (is_tag_invocable_v<_fn, Scheduler, Func>) {
           unifex::tag_invoke(*this, (Scheduler&&)s, (Func&&)func);
@@ -51,3 +53,5 @@ namespace unifex
   } // namespace _execute
   using _execute::execute;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/file_concepts.hpp
+++ b/include/unifex/file_concepts.hpp
@@ -21,6 +21,8 @@
 
 #include <unifex/filesystem.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _filesystem {
 inline constexpr struct open_file_read_only_cpo {
@@ -73,3 +75,5 @@ using _filesystem::open_file_read_only;
 using _filesystem::open_file_write_only;
 using _filesystem::open_file_read_write;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/filesystem.hpp
+++ b/include/unifex/filesystem.hpp
@@ -22,6 +22,7 @@
 #   if __cpp_lib_filesystem >= 201703L && __has_include(<filesystem>)
 #    include <filesystem>
 #    define UNIFEX_HAVE_FILESYSTEM 1
+
 namespace unifex
 {
     namespace filesystem
@@ -35,6 +36,7 @@ namespace unifex
 #   if __has_include(<experimental/filesystem>)
 #    include <experimental/filesystem>
 #    define UNIFEX_HAVE_FILESYSTEM 1
+
 namespace unifex
 {
     namespace filesystem

--- a/include/unifex/for_each.hpp
+++ b/include/unifex/for_each.hpp
@@ -19,11 +19,13 @@
 #include <unifex/transform.hpp>
 #include <unifex/type_traits.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _for_each {
   inline constexpr struct _fn {
     private:
-      template<bool>
+      template <bool>
       struct _impl {
         template <typename Stream, typename Func>
         auto operator()(Stream&& stream, Func&& func) const
@@ -44,7 +46,7 @@ namespace _for_each {
     }
   } for_each{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename Stream, typename Func>
     auto operator()(Stream&& stream, Func&& func) const {
@@ -63,3 +65,5 @@ namespace _for_each {
 
 using _for_each::for_each;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_allocator.hpp
+++ b/include/unifex/get_allocator.hpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _get_alloc {
   inline constexpr struct _fn {
@@ -40,7 +42,9 @@ namespace _get_alloc {
 
 using _get_alloc::get_allocator;
 
-template<typename T>
+template <typename T>
 using get_allocator_t = decltype(get_allocator(std::declval<T>()));
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -20,6 +20,8 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/unstoppable_token.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _get_stop_token {
   inline constexpr struct _fn {
@@ -52,3 +54,5 @@ using stop_token_type_t =
     remove_cvref_t<get_stop_token_result_t<Receiver>>;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -42,11 +42,10 @@ struct _receiver {
   struct type;
 };
 template <typename Policy, typename Range, typename Func, typename Receiver>
-using receiver =
+using receiver_t =
     typename _receiver<Policy, Range, Func, remove_cvref_t<Receiver>>::type;
 template <typename Policy, typename Range, typename Func, typename Receiver>
 struct _receiver<Policy, Range, Func, Receiver>::type {
-  using receiver = type;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
   UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
   UNIFEX_NO_UNIQUE_ADDRESS Range range_;
@@ -98,7 +97,7 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
 
   template(typename CPO)
       (requires (!is_receiver_cpo_v<CPO>))
-  friend auto tag_invoke(CPO cpo, const receiver& r) noexcept(
+  friend auto tag_invoke(CPO cpo, const type& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
@@ -107,7 +106,7 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
   template <typename Visit>
   friend void tag_invoke(
       tag_t<visit_continuations>,
-      const receiver& r,
+      const type& r,
       Visit&& visit) {
     std::invoke(visit, r.receiver_);
   }
@@ -152,7 +151,7 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
   auto connect(Receiver&& receiver) && {
     return unifex::connect(
         std::forward<Predecessor>(pred_),
-        _ifor::receiver<Policy, Range, Func, Receiver>{
+        _ifor::receiver_t<Policy, Range, Func, Receiver>{
             (Func &&) func_,
             (Policy &&) policy_,
             (Range &&) range_,

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -25,6 +25,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _inline_sched {
   template <typename Receiver>
@@ -87,3 +89,5 @@ namespace _inline_sched {
 
 using inline_scheduler = _inline_sched::scheduler;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/inplace_stop_token.hpp
+++ b/include/unifex/inplace_stop_token.hpp
@@ -24,6 +24,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 class inplace_stop_source;
@@ -156,3 +158,5 @@ class inplace_stop_callback final : private inplace_stop_callback_base {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/io_concepts.hpp
+++ b/include/unifex/io_concepts.hpp
@@ -44,6 +44,8 @@
 //     sync_wait();
 //
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _io_cpo {
 //
@@ -199,3 +201,5 @@ using _io_cpo::async_read_some_at;
 using _io_cpo::async_write_some_at;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/io_epoll_context.hpp
+++ b/include/unifex/linux/io_epoll_context.hpp
@@ -41,6 +41,8 @@
 #include <sys/uio.h>
 #include <sys/epoll.h>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace linuxos {
 
@@ -964,5 +966,7 @@ class io_epoll_context::async_writer {
 
 } // namespace linuxos
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>
 
 #endif // !UNIFEX_NO_EPOLL

--- a/include/unifex/linux/io_epoll_context.hpp
+++ b/include/unifex/linux/io_epoll_context.hpp
@@ -236,7 +236,7 @@ class io_epoll_context::schedule_sender {
           return;
         }
       }
-      if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver>) {
+      if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
         try {
@@ -329,7 +329,7 @@ class io_epoll_context::schedule_at_sender {
         }
       }
 
-      if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver>) {
+      if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(std::move(timerOp).receiver_);
       } else {
         try {
@@ -571,7 +571,7 @@ class io_epoll_context::read_sender {
       if (result == -ECANCELED) {
         unifex::set_done(std::move(receiver_));
       } else if (result >= 0) {
-        if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver, ssize_t>) {
+        if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
           try {
@@ -612,7 +612,7 @@ class io_epoll_context::read_sender {
       if (result == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
       } else if (result >= 0) {
-        if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver, ssize_t>) {
+        if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
           try {
@@ -782,7 +782,7 @@ class io_epoll_context::write_sender {
       if (result == -ECANCELED) {
         unifex::set_done(std::move(receiver_));
       } else if (result >= 0) {
-        if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver, ssize_t>) {
+        if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
           try {
@@ -823,7 +823,7 @@ class io_epoll_context::write_sender {
       if (result == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
       } else if (result >= 0) {
-        if constexpr (is_nothrow_callable_v<unifex::tag_t<unifex::set_value>&, Receiver, ssize_t>) {
+        if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
           try {

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -43,6 +43,8 @@
 
 #include <sys/uio.h>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace linuxos {
 
@@ -934,5 +936,7 @@ inline io_uring_context::scheduler io_uring_context::get_scheduler() noexcept {
 
 } // namespace linuxos
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>
 
 #endif // __has_include(<liburing.h>)

--- a/include/unifex/linux/mmap_region.hpp
+++ b/include/unifex/linux/mmap_region.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace linuxos {
 
@@ -54,3 +56,5 @@ struct mmap_region {
 
 } // namespace linuxos
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/monotonic_clock.hpp
+++ b/include/unifex/linux/monotonic_clock.hpp
@@ -20,6 +20,8 @@
 #include <limits>
 #include <ratio>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace linuxos {
 
@@ -192,3 +194,5 @@ inline void monotonic_clock::time_point::normalize() noexcept {
 
 } // namespace linuxos
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/safe_file_descriptor.hpp
+++ b/include/unifex/linux/safe_file_descriptor.hpp
@@ -17,6 +17,8 @@
 
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace linuxos {
 
@@ -56,3 +58,5 @@ class safe_file_descriptor {
 
 } // namespace linuxos
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _manual_event_loop {
 class context;
@@ -144,3 +146,5 @@ inline void _op<Receiver>::type::start() noexcept {
 
 using manual_event_loop = _manual_event_loop::context;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_lifetime.hpp
+++ b/include/unifex/manual_lifetime.hpp
@@ -22,6 +22,8 @@
 #include <memory>
 #include <new>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 template <typename T>
@@ -142,3 +144,5 @@ class manual_lifetime<void> {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_lifetime_union.hpp
+++ b/include/unifex/manual_lifetime_union.hpp
@@ -16,8 +16,11 @@
 #pragma once
 
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/std_concepts.hpp>
 
 #include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 
@@ -26,9 +29,8 @@ class manual_lifetime_union {
  public:
   manual_lifetime_union() = default;
 
-  template <
-      typename T,
-      std::enable_if_t<std::disjunction_v<std::is_same<T, Ts>...>, int> = 0>
+  template(typename T)
+      (requires is_one_of_v<T, Ts...>)
   manual_lifetime<T>& get() noexcept {
     return *reinterpret_cast<manual_lifetime<T>*>(&storage_);
   }
@@ -41,3 +43,5 @@ template <>
 class manual_lifetime_union<> {};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/memory_resource.hpp
+++ b/include/unifex/memory_resource.hpp
@@ -19,6 +19,7 @@
 
 #if !UNIFEX_NO_MEMORY_RESOURCE
 #include UNIFEX_MEMORY_RESOURCE_HEADER
+
 namespace unifex {
     namespace pmr = UNIFEX_MEMORY_RESOURCE_NAMESPACE;
 }

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -26,6 +26,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _never {
 
@@ -97,3 +99,5 @@ struct stream {
 using never_sender = _never::sender;
 using never_stream = _never::stream;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/new_thread_context.hpp
+++ b/include/unifex/new_thread_context.hpp
@@ -25,21 +25,23 @@
 #include <mutex>
 #include <thread>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _new_thread {
 class context;
 
-template<typename Receiver>
+template <typename Receiver>
 struct _op {
   class type;
 };
-template<typename Receiver>
+template <typename Receiver>
 using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-template<typename Receiver>
+template <typename Receiver>
 class _op<Receiver>::type final {
  public:
-  template<typename Receiver2>
+  template <typename Receiver2>
   explicit type(context* ctx, Receiver2&& r)
     : ctx_(ctx), receiver_((Receiver2&&)r) {}
 
@@ -66,17 +68,17 @@ private:
 
   class schedule_sender {
   public:
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     explicit schedule_sender(context* ctx) noexcept
       : context_(ctx) {}
 
-    template<typename Receiver>
+    template <typename Receiver>
     operation<Receiver> connect(Receiver&& r) const {
       return operation<Receiver>{context_, (Receiver&&)r};
     }
@@ -143,7 +145,7 @@ private:
   std::atomic<size_t> activeThreadCount_ = 1;
 };
 
-template<typename Receiver>
+template <typename Receiver>
 inline void _op<Receiver>::type::start() & noexcept {
   try {
     // Acquire the lock before launching the thread.
@@ -166,7 +168,7 @@ inline void _op<Receiver>::type::start() & noexcept {
   }
 }
 
-template<typename Receiver>
+template <typename Receiver>
 inline void _op<Receiver>::type::run() noexcept {
   // Read the thread_ and ctx_ members out from the operation-state
   // and store them as local variables on the stack before calling the
@@ -206,3 +208,5 @@ inline void _op<Receiver>::type::run() noexcept {
 using new_thread_context = _new_thread::context;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/next_adapt_stream.hpp
+++ b/include/unifex/next_adapt_stream.hpp
@@ -20,6 +20,8 @@
 #include <functional>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _next_adapt {
   template <typename Stream, typename AdaptFunc>
@@ -63,3 +65,5 @@ namespace _next_adapt_cpo {
 using _next_adapt_cpo::next_adapt_stream;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/null_receiver.hpp
+++ b/include/unifex/null_receiver.hpp
@@ -17,6 +17,8 @@
 
 #include <exception>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _null {
   struct receiver {
@@ -32,3 +34,5 @@ namespace _null {
 } // namespace _null
 using null_receiver = _null::receiver;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -22,25 +22,21 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _on {
   inline constexpr struct _fn {
-    template <
-        typename Sender,
-        typename Scheduler,
-        std::enable_if_t<is_tag_invocable_v<_fn, Sender, Scheduler>, int> =
-            0>
+    template(typename Sender, typename Scheduler)
+        (requires is_tag_invocable_v<_fn, Sender, Scheduler>)
     auto operator()(Sender&& sender, Scheduler&& scheduler) const
         noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Scheduler>) {
       return unifex::tag_invoke(
           _fn{}, (Sender &&) sender, (Scheduler &&) scheduler);
     }
 
-    template <
-        typename Sender,
-        typename Scheduler,
-        std::enable_if_t<!is_tag_invocable_v<_fn, Sender, Scheduler>, int> =
-            0>
+    template(typename Sender, typename Scheduler)
+        (requires (!is_tag_invocable_v<_fn, Sender, Scheduler>))
     auto operator()(Sender&& sender, Scheduler&& scheduler) const {
       return with_query_value(
           sequence(schedule(), (Sender&&)sender),
@@ -52,4 +48,6 @@ namespace _on {
 
 using _on::on;
 
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/on_stream.hpp
+++ b/include/unifex/on_stream.hpp
@@ -19,6 +19,8 @@
 #include <unifex/on.hpp>
 #include <unifex/scheduler_concepts.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _on_stream {
   inline constexpr struct _fn {
@@ -36,3 +38,5 @@ namespace _on_stream {
 using _on_stream::on_stream;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/overload.hpp
+++ b/include/unifex/overload.hpp
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 namespace detail {
@@ -51,3 +53,5 @@ constexpr auto& overload(CPO) {
 }
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/pipe_concepts.hpp
+++ b/include/unifex/pipe_concepts.hpp
@@ -19,6 +19,8 @@
 
 #include <unifex/io_concepts.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _pipe_cpo {
 inline constexpr struct open_pipe_cpo {
@@ -37,3 +39,5 @@ inline constexpr struct open_pipe_cpo {
 
 using _pipe_cpo::open_pipe;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -23,6 +23,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _range {
 struct stream;
@@ -96,3 +98,5 @@ void _op<Receiver>::type::start() noexcept {
 using range_stream = _range::stream;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -21,6 +21,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _ready_done {
   template <typename Receiver>
@@ -64,3 +66,5 @@ namespace _ready_done {
 using ready_done_sender = _ready_done::sender;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -15,9 +15,12 @@
  */
 #pragma once
 
+#include <unifex/config.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/std_concepts.hpp>
 
+#include <exception>
 #include <type_traits>
 
 #include <unifex/detail/prologue.hpp>
@@ -185,7 +188,7 @@ using _rec_cpo::set_error;
 using _rec_cpo::set_done;
 
 template <typename T>
-constexpr bool is_receiver_cpo_v = is_one_of_v<
+inline constexpr bool is_receiver_cpo_v = is_one_of_v<
     remove_cvref_t<T>,
     _rec_cpo::_set_value_fn,
     _rec_cpo::_set_next_fn,
@@ -194,6 +197,41 @@ constexpr bool is_receiver_cpo_v = is_one_of_v<
 
 template <typename T>
 using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;
+
+template <typename R, typename E>
+UNIFEX_CONCEPT_FRAGMENT(
+  _receiver,
+    requires(remove_cvref_t<R>&& r, E&& e) //
+    (
+      noexcept(set_done(std::move(r))),
+      noexcept(set_error(std::move(r), (E&&) e))
+    ));
+
+template <typename R, typename E = std::exception_ptr>
+UNIFEX_CONCEPT
+  receiver =
+    move_constructible<remove_cvref_t<R>> &&
+    constructible_from<remove_cvref_t<R>, R> &&
+    UNIFEX_FRAGMENT(unifex::_receiver, R, E);
+
+template <typename T, typename... An>
+UNIFEX_CONCEPT_FRAGMENT(
+  _receiver_of,
+    requires(remove_cvref_t<T>&& t, An&&... an) //
+    (
+      set_value(std::move(t), (An&&) an...)
+    ));
+
+template <typename R, typename... An>
+UNIFEX_CONCEPT
+  receiver_of =
+    receiver<R> &&
+    UNIFEX_FRAGMENT(unifex::_receiver_of, R, An...);
+
+template <typename R, typename... An>
+  inline constexpr bool is_nothrow_receiver_of_v =
+    receiver_of<R, An...> &&
+    is_nothrow_callable_v<decltype(set_value), R, An...>;
 
 } // namespace unifex
 

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -20,11 +20,13 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _rec_cpo {
   inline constexpr struct _set_value_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
     template <typename Receiver, typename... Values>
       auto operator()(Receiver&& r, Values&&... values) const
@@ -49,7 +51,7 @@ namespace _rec_cpo {
     }
   } set_value{};
 
-  template<>
+  template <>
   struct _set_value_fn::_impl<false> {
     template <typename Receiver, typename... Values>
     auto operator()(Receiver&& r, Values&&... values) const
@@ -62,7 +64,7 @@ namespace _rec_cpo {
 
   inline constexpr struct _set_next_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
     template <typename Receiver, typename... Values>
       auto operator()(Receiver&& r, Values&&... values) const
@@ -87,7 +89,7 @@ namespace _rec_cpo {
     }
   } set_next{};
 
-  template<>
+  template <>
   struct _set_next_fn::_impl<false> {
     template <typename Receiver, typename... Values>
     auto operator()(Receiver&& r, Values&&... values) const
@@ -100,7 +102,7 @@ namespace _rec_cpo {
 
   inline constexpr struct _set_error_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
     template <typename Receiver, typename Error>
       auto operator()(Receiver&& r, Error&& error) const noexcept
@@ -126,7 +128,7 @@ namespace _rec_cpo {
     }
   } set_error{};
 
-  template<>
+  template <>
   struct _set_error_fn::_impl<false> {
     template <typename Receiver, typename Error>
     auto operator()(Receiver&& r, Error&& error) const noexcept
@@ -140,7 +142,7 @@ namespace _rec_cpo {
 
   inline constexpr struct _set_done_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
     template <typename Receiver>
       auto operator()(Receiver&& r) const noexcept
@@ -164,7 +166,7 @@ namespace _rec_cpo {
     }
   } set_done{};
 
-  template<>
+  template <>
   struct _set_done_fn::_impl<false> {
     template <typename Receiver>
     auto operator()(Receiver&& r) const noexcept
@@ -194,3 +196,5 @@ template <typename T>
 using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -28,28 +28,30 @@
 #include <cassert>
 #include <exception>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _repeat_effect_until {
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 struct _op {
   class type;
 };
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 using operation_type = typename _op<Source, Predicate, Receiver>::type;
 
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 struct _rcvr {
   class type;
 };
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 using receiver_type = typename _rcvr<Source, Predicate, Receiver>::type;
 
-template<typename Source, typename Predicate>
+template <typename Source, typename Predicate>
 struct _sndr {
   class type;
 };
 
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 class _rcvr<Source, Predicate, Receiver>::type {
   using operation = operation_type<Source, Predicate, Receiver>;
 public:
@@ -99,27 +101,24 @@ public:
     }
   }
 
-  template<
-    typename R = Receiver,
-    std::enable_if_t<is_callable_v<decltype(unifex::set_done), R>, int> = 0>
+  template(typename R = Receiver)
+    (requires is_callable_v<decltype(unifex::set_done), R>)
   void set_done() noexcept {
     assert(op_ != nullptr);
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  template<
-    typename Error,
-    std::enable_if_t<is_callable_v<decltype(unifex::set_error), Receiver, Error>, int> = 0>
+  template(typename Error)
+    (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
   void set_error(Error&& error) noexcept {
     assert(op_ != nullptr);
     unifex::set_error(std::move(op_->receiver_), (Error&&)error);
   }
 
 private:
-  template<
-    typename CPO, 
-    std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0,
-    std::enable_if_t<is_callable_v<CPO, const Receiver&>, int> = 0>
+  template(typename CPO)
+      (requires (!is_receiver_cpo_v<CPO>) AND
+          is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const type& r)
       noexcept(std::is_nothrow_invocable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -144,12 +143,12 @@ private:
   operation* op_;
 };
 
-template<typename Source, typename Predicate, typename Receiver>
+template <typename Source, typename Predicate, typename Receiver>
 class _op<Source, Predicate, Receiver>::type {
   using receiver = receiver_type<Source, Predicate, Receiver>;
 
 public:
-  template<typename Source2, typename Predicate2, typename Receiver2>
+  template <typename Source2, typename Predicate2, typename Receiver2>
   explicit type(Source2&& source, Predicate2&& predicate, Receiver2&& dest)
       noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2> &&
                std::is_nothrow_constructible_v<Predicate, Predicate2> &&
@@ -187,12 +186,12 @@ private:
   manual_lifetime<source_op_t> sourceOp_;
 };
 
-template<typename Source, typename Predicate>
+template <typename Source, typename Predicate>
 class _sndr<Source, Predicate>::type {
 
 public:
-  template<template<typename...> class Variant,
-          template<typename...> class Tuple>
+  template <template <typename...> class Variant,
+          template <typename...> class Tuple>
   using value_types = Variant<Tuple<>>;
 
   template <template <typename...> class Variant>
@@ -200,7 +199,7 @@ public:
       typename Source::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
 
-  template<typename Source2, typename Predicate2>
+  template <typename Source2, typename Predicate2>
   explicit type(Source2&& source, Predicate2&& predicate)
     noexcept(
       std::is_nothrow_constructible_v<Source, Source2> &&
@@ -209,15 +208,12 @@ public:
   , predicate_((Predicate2&&)predicate)
   {}
 
-  template<
-    typename Sender,
-    typename Receiver,
-    std::enable_if_t<
-        std::is_same_v<remove_cvref_t<Sender>, type>, int> = 0,
-    std::enable_if_t<
-        std::is_constructible_v<remove_cvref_t<Receiver>, Receiver>, int> = 0,
-    std::enable_if_t<
-        is_connectable_v<Source&, receiver_type<Source, Predicate, remove_cvref_t<Receiver>>>, int> = 0>
+  template(typename Sender, typename Receiver)
+    (requires same_as<remove_cvref_t<Sender>, type> AND
+        constructible_from<remove_cvref_t<Receiver>, Receiver> AND
+        is_connectable_v<
+            Source&,
+            receiver_type<Source, Predicate, remove_cvref_t<Receiver>>>)
   friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
        noexcept(
         std::is_nothrow_constructible_v<Source, decltype((static_cast<Sender&&>(s).source_))> &&
@@ -239,24 +235,21 @@ private:
 
 } // namespace _repeat_effect_until
 
-template<class Source, class Predicate>
+template <class Source, class Predicate>
 using repeat_effect_until_sender = typename _repeat_effect_until::_sndr<Source, Predicate>::type;
 
 inline constexpr struct repeat_effect_until_cpo {
-  template<typename Source, typename Predicate>
+  template <typename Source, typename Predicate>
   auto operator()(Source&& source, Predicate&& predicate) const
       noexcept(is_nothrow_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate>)
       -> tag_invoke_result_t<repeat_effect_until_cpo, Source, Predicate> {
     return tag_invoke(*this, (Source&&)source, (Predicate&&)predicate);
   }
 
-  template<
-    typename Source,
-    typename Predicate,
-    std::enable_if_t<
-        !is_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate> &&
-        std::is_constructible_v<remove_cvref_t<Source>, Source> &&
-        std::is_constructible_v<std::decay_t<Predicate>, Predicate>, int> = 0>
+  template(typename Source, typename Predicate)
+    (requires (!is_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate>) AND
+        constructible_from<remove_cvref_t<Source>, Source> AND
+        constructible_from<std::decay_t<Predicate>, Predicate>)
   auto operator()(Source&& source, Predicate&& predicate) const
       noexcept(std::is_nothrow_constructible_v<
                    repeat_effect_until_sender<remove_cvref_t<Source>, std::decay_t<Predicate>>,
@@ -272,18 +265,16 @@ inline constexpr struct repeat_effect_cpo {
   struct forever {
     bool operator()() const { return false; }
   };
-  template<typename Source, typename Predicate>
+  template <typename Source, typename Predicate>
   auto operator()(Source&& source) const
       noexcept(is_nothrow_tag_invocable_v<repeat_effect_cpo, Source>)
       -> tag_invoke_result_t<repeat_effect_cpo, Source> {
     return tag_invoke(*this, (Source&&)source);
   }
 
-  template<
-    typename Source,
-    std::enable_if_t<
-        !is_tag_invocable_v<repeat_effect_cpo, Source> &&
-        std::is_constructible_v<remove_cvref_t<Source>, Source>, int> = 0>
+  template(typename Source)
+    (requires (!is_tag_invocable_v<repeat_effect_cpo, Source>) AND
+        constructible_from<remove_cvref_t<Source>, Source>)
   auto operator()(Source&& source) const
       noexcept(std::is_nothrow_constructible_v<
                    repeat_effect_until_sender<remove_cvref_t<Source>, forever>,
@@ -295,3 +286,5 @@ inline constexpr struct repeat_effect_cpo {
 } repeat_effect{};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -97,7 +97,7 @@ public:
   }
 
   template(typename R = Receiver)
-    (requires is_callable_v<decltype(unifex::set_done), Receiver>)
+    (requires receiver<R>)
   void set_done() && noexcept {
     assert(op_ != nullptr);
 
@@ -107,7 +107,7 @@ public:
   }
 
   template(typename Error)
-    (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
+    (requires receiver<Receiver, Error>)
   void set_error(Error error) && noexcept {
     assert(op_ != nullptr);
 
@@ -166,15 +166,13 @@ public:
   {}
 
   template(typename... Values)
-    (requires is_callable_v<decltype(unifex::set_value), Receiver, Values...>)
+    (requires receiver_of<Receiver, Values...>)
   void set_value(Values&&... values)
-      noexcept(is_nothrow_callable_v<decltype(unifex::set_value), Receiver, Values...>) {
+      noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     assert(op_ != nullptr);
     unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
   }
 
-  template(typename R = Receiver)
-    (requires is_callable_v<decltype(unifex::set_done), R>)
   void set_done() noexcept {
     assert(op_ != nullptr);
     unifex::set_done(std::move(op_->receiver_));

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -19,6 +19,8 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/transform.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _subschedule {
   inline constexpr struct _fn {
@@ -44,7 +46,7 @@ namespace _subschedule {
     template <typename T>
     using return_value = typename _return_value<std::decay_t<T>>::type;
 
-    template<bool>
+    template <bool>
     struct _impl {
     template <typename Scheduler>
       auto operator()(Scheduler&& sched) const
@@ -65,7 +67,7 @@ namespace _subschedule {
     }
   } schedule_with_subscheduler{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename Scheduler>
     auto operator()(Scheduler&& sched) const
@@ -83,3 +85,5 @@ namespace _subschedule {
 using _subschedule::schedule_with_subscheduler;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -21,11 +21,13 @@
 #include <type_traits>
 #include <exception>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _schedule {
   struct sender;
   inline constexpr struct _fn {
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename Scheduler>
       constexpr auto operator()(Scheduler&& s) const
@@ -48,7 +50,7 @@ namespace _schedule {
     constexpr sender operator()() const noexcept;
   } schedule{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename Scheduler>
     constexpr auto operator()(Scheduler&& s) noexcept(
@@ -76,12 +78,12 @@ namespace _get_scheduler {
 using _get_scheduler::get_scheduler;
 
 struct _schedule::sender {
-  template<
-    template<typename...> class Variant,
-    template<typename...> class Tuple>
+  template <
+    template <typename...> class Variant,
+    template <typename...> class Tuple>
   using value_types = Variant<Tuple<>>;
 
-  template<template<typename...> class Variant>
+  template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
   template <
@@ -101,15 +103,15 @@ inline constexpr _schedule::sender _schedule::_fn::operator()() const noexcept {
 }
 
 namespace _schedule_after {
-  template<typename Duration>
+  template <typename Duration>
   struct _sender {
     class type;
   };
-  template<typename Duration>
+  template <typename Duration>
   using sender = typename _sender<Duration>::type;
 
   inline constexpr struct _fn {
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename TimeScheduler, typename Duration>
       constexpr auto operator()(TimeScheduler&& s, Duration&& d) const
@@ -130,13 +132,13 @@ namespace _schedule_after {
           static_cast<Duration&&>(d));
     }
 
-    template<typename Duration>
+    template <typename Duration>
     constexpr sender<Duration> operator()(Duration d) const {
       return sender<Duration>{std::move(d)};
     }
   } schedule_after{};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename TimeScheduler, typename Duration>
     constexpr auto operator()(TimeScheduler&& s, Duration&& d) const noexcept(
@@ -146,13 +148,13 @@ namespace _schedule_after {
     }
   };
 
-  template<typename Duration>
+  template <typename Duration>
   class _sender<Duration>::type {
   public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
+    template <template <typename...> class Variant, template <typename...> class Tuple>
     using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     explicit type(Duration d)
@@ -162,7 +164,7 @@ namespace _schedule_after {
   private:
     friend _fn;
 
-    template<
+    template <
       typename Receiver,
       typename Scheduler =
         std::decay_t<callable_result_t<decltype(get_scheduler), const Receiver&>>,
@@ -181,7 +183,7 @@ using _schedule_after::schedule_after;
 
 namespace _schedule_at {
   inline constexpr struct _fn {
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename TimeScheduler, typename TimePoint>
       constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const
@@ -203,7 +205,7 @@ namespace _schedule_at {
     }
   } schedule_at {};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename TimeScheduler, typename TimePoint>
     constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const noexcept(
@@ -217,7 +219,7 @@ using _schedule_at::schedule_at;
 
 namespace _now {
   inline constexpr struct _fn {
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename TimeScheduler>
       constexpr auto operator()(TimeScheduler&& s) const
@@ -238,7 +240,7 @@ namespace _now {
     }
   } now {};
 
-  template<>
+  template <>
   struct _fn::_impl<false> {
     template <typename TimeScheduler>
     constexpr auto operator()(TimeScheduler&& s) const noexcept(
@@ -251,3 +253,5 @@ namespace _now {
 using _now::now;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/scope_guard.hpp
+++ b/include/unifex/scope_guard.hpp
@@ -17,6 +17,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 template <typename Func>
@@ -37,3 +39,5 @@ template <typename Func>
 scope_guard(Func&& func)->scope_guard<Func>;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -30,6 +30,8 @@
 #include <exception>
 #include <optional>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _coroutine {
 template <typename Sender, typename Value>
@@ -44,7 +46,7 @@ struct _sender_awaiter<Sender, Value>::type {
   struct coroutine_receiver {
     type& awaiter_;
 
-    template<typename... Values>
+    template <typename... Values>
     void set_value(Values&&... values) && noexcept {
       if constexpr (std::is_nothrow_constructible_v<Value, Values...>) {
         awaiter_.value_.construct((Values&&)values...);
@@ -61,7 +63,7 @@ struct _sender_awaiter<Sender, Value>::type {
       awaiter_.continuation_.resume();
     }
 
-    template<typename Error>
+    template <typename Error>
     void set_error(Error&& error) && noexcept {
       std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
     }
@@ -155,21 +157,20 @@ private:
 };
 } // namespace _coroutine
 
-template<
+template <
   typename Sender,
   typename Result = single_value_result_t<std::remove_reference_t<Sender>>>
 auto operator co_await(Sender&& sender) {
   return _coroutine::sender_awaiter<Sender, Result>{(Sender&&)sender};
 }
 
-template<
-    typename Sender,
-    std::enable_if_t<
-      std::remove_reference_t<Sender>::template value_types<
-        is_empty_list, is_empty_list>::value,
-      int> = 0>
+template(typename Sender)
+    (requires (std::remove_reference_t<Sender>::template value_types<
+        is_empty_list, is_empty_list>::value))
 auto operator co_await(Sender&& sender) {
   return _coroutine::sender_awaiter<Sender, void>{(Sender&&)sender};
 }
 
-}
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -21,6 +21,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _start {
   inline constexpr struct _fn {
@@ -149,3 +151,5 @@ constexpr bool is_sender_nofail_v =
     Sender::template error_types<is_empty_list>::value;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -176,16 +176,14 @@ namespace unifex
       }
 
       template(typename Error)
-          (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
+          (requires receiver<Receiver, Error>)
       void set_error(Error&& error) && noexcept {
         unifex::set_error(
             static_cast<Receiver&&>(op_->receiver_),
             static_cast<Error&&>(error));
       }
 
-      template(typename... Args)
-          (requires is_callable_v<decltype(unifex::set_done), Receiver, Args...>)
-      void set_done(Args...) && noexcept {
+      void set_done() && noexcept {
         unifex::set_done(static_cast<Receiver&&>(op_->receiver_));
       }
 

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -25,6 +25,8 @@
 #include <optional>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _single {
 template <typename Sender, typename Receiver>
@@ -88,11 +90,11 @@ struct _stream<Sender>::type {
   struct next_sender {
     std::optional<Sender> sender_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types = typename Sender::template value_types<Variant, Tuple>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = typename Sender::template error_types<Variant>;
 
     template <typename Receiver>
@@ -132,3 +134,5 @@ namespace _single_cpo {
 using _single_cpo::single;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/single_thread_context.hpp
+++ b/include/unifex/single_thread_context.hpp
@@ -19,6 +19,8 @@
 
 #include <thread>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _single_thread {
 class context {
@@ -42,3 +44,5 @@ public:
 using single_thread_context = _single_thread::context;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -29,6 +29,8 @@
 #include <mutex>
 #include <condition_variable>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _static_thread_pool {
   struct task_base {
@@ -65,7 +67,7 @@ namespace _static_thread_pool {
         using error_types = Variant<>;
 
       private:
-        template<typename Receiver>
+        template <typename Receiver>
         operation<Receiver> make_operation_(Receiver&& r) const {
           return operation<Receiver>{pool_, (Receiver &&) r};
         }
@@ -166,4 +168,6 @@ namespace _static_thread_pool {
 
 using static_thread_pool = _static_thread_pool::context;
 
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/std_concepts.hpp
+++ b/include/unifex/std_concepts.hpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/detail/concept_macros.hpp>
+#include <unifex/swap.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <functional>
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+  template <typename A, typename B>
+  UNIFEX_CONCEPT
+    same_as =
+      UNIFEX_IS_SAME(A, B) &&
+      UNIFEX_IS_SAME(B, A);
+
+  template <typename From, typename To>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _explicitly_convertible_to,
+      requires(From(*from)()) //
+      (
+        static_cast<To>(from())
+      ));
+  template <typename From, typename To>
+  UNIFEX_CONCEPT
+    convertible_to =
+      std::is_convertible_v<std::add_rvalue_reference_t<From>, To> &&
+      UNIFEX_FRAGMENT(unifex::_explicitly_convertible_to, From, To);
+
+  /// \cond
+  namespace detail {
+    template <typename T>
+    using _cref_t = std::remove_reference_t<T> const &;
+
+    template <class T>
+    UNIFEX_CONCEPT_FRAGMENT(
+      _boolean_testable_impl,
+        requires(T && t)
+        (
+          requires(convertible_to<decltype(! (T &&) t), bool>)
+        ));
+    template <class T>
+    UNIFEX_CONCEPT
+      _boolean_testable =
+        UNIFEX_FRAGMENT(_boolean_testable_impl, T) &&
+        convertible_to<T, bool>;
+
+    UNIFEX_DIAGNOSTIC_PUSH
+    UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+
+    template <typename T, typename U>
+    UNIFEX_CONCEPT_FRAGMENT(
+      _weakly_equality_comparable_with,
+        requires(_cref_t<T> t, _cref_t<U> u) //
+        (
+          requires(_boolean_testable<decltype(t == u)>),
+          requires(_boolean_testable<decltype(t != u)>),
+          requires(_boolean_testable<decltype(u == t)>),
+          requires(_boolean_testable<decltype(u != t)>)
+        ));
+    template <typename T, typename U>
+    UNIFEX_CONCEPT
+      weakly_equality_comparable_with_ =
+        UNIFEX_FRAGMENT(detail::_weakly_equality_comparable_with, T, U);
+
+    UNIFEX_DIAGNOSTIC_POP
+  } // namespace detail
+  /// \endcond
+
+  template <typename T, typename U>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _derived_from,
+      requires()(0) &&
+      convertible_to<T const volatile *, U const volatile *>);
+  template <typename T, typename U>
+  UNIFEX_CONCEPT
+    derived_from =
+      UNIFEX_IS_BASE_OF(U, T) &&
+      UNIFEX_FRAGMENT(unifex::_derived_from, T, U);
+
+  template <typename T, typename U>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _assignable_from,
+      requires(T t, U && u) //
+      (
+        t = (U &&) u,
+        requires(same_as<T, decltype(t = (U &&) u)>)
+      ));
+  template <typename T, typename U>
+  UNIFEX_CONCEPT
+    assignable_from =
+      std::is_lvalue_reference_v<T> &&
+      UNIFEX_FRAGMENT(unifex::_assignable_from, T, U);
+
+  template <typename T>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _swappable,
+      requires(T & t, T & u) //
+      (
+        unifex::swap(t, u)
+      ));
+  template <typename T>
+  UNIFEX_CONCEPT
+    swappable =
+      UNIFEX_FRAGMENT(unifex::_swappable, T);
+
+  template <typename T, typename U>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _swappable_with,
+      requires(T && t, U && u) //
+      (
+        unifex::swap((T &&) t, (T &&) t),
+        unifex::swap((U &&) u, (U &&) u),
+        unifex::swap((U &&) u, (T &&) t),
+        unifex::swap((T &&) t, (U &&) u)
+      ));
+  template <typename T, typename U>
+  UNIFEX_CONCEPT
+    swappable_with =
+      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+      UNIFEX_FRAGMENT(unifex::_swappable_with, T, U);
+
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  // Comparison concepts
+  ////////////////////////////////////////////////////////////////////////////////////////////
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    equality_comparable =
+      detail::weakly_equality_comparable_with_<T, T>;
+
+  // template <typename T, typename U>
+  // UNIFEX_CONCEPT_FRAGMENT(
+  //   _equality_comparable_with,
+  //     requires()(0) &&
+  //     equality_comparable<
+  //       common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>);
+  template <typename T, typename U>
+  UNIFEX_CONCEPT
+    equality_comparable_with =
+      equality_comparable<T> &&
+      equality_comparable<U> &&
+      detail::weakly_equality_comparable_with_<T, U>;// &&
+      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+      //UNIFEX_FRAGMENT(unifex::_equality_comparable_with, T, U);
+
+  template <typename T>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _totally_ordered,
+      requires(detail::_cref_t<T> t, detail::_cref_t<T> u) //
+      (
+        requires(detail::_boolean_testable<decltype(t < u)>),
+        requires(detail::_boolean_testable<decltype(t > u)>),
+        requires(detail::_boolean_testable<decltype(u <= t)>),
+        requires(detail::_boolean_testable<decltype(u >= t)>)
+      ));
+  template <typename T>
+  UNIFEX_CONCEPT
+    totally_ordered =
+      equality_comparable<T> &&
+      UNIFEX_FRAGMENT(unifex::_totally_ordered, T);
+
+  template <typename T, typename U>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _totally_ordered_with,
+      requires(detail::_cref_t<T> t, detail::_cref_t<U> u) //
+      (
+        requires(detail::_boolean_testable<decltype(t < u)>),
+        requires(detail::_boolean_testable<decltype(t > u)>),
+        requires(detail::_boolean_testable<decltype(t <= u)>),
+        requires(detail::_boolean_testable<decltype(t >= u)>),
+        requires(detail::_boolean_testable<decltype(u < t)>),
+        requires(detail::_boolean_testable<decltype(u > t)>),
+        requires(detail::_boolean_testable<decltype(u <= t)>),
+        requires(detail::_boolean_testable<decltype(u >= t)>)
+      ));
+      //&& totally_ordered<
+      //   common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>
+  template <typename T, typename U>
+  UNIFEX_CONCEPT
+    totally_ordered_with =
+      totally_ordered<T> &&
+      totally_ordered<U> &&
+      equality_comparable_with<T, U> &&
+      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+      UNIFEX_FRAGMENT(unifex::_totally_ordered_with, T, U);
+
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  // Object concepts
+  ////////////////////////////////////////////////////////////////////////////////////////////
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    destructible =
+      std::is_nothrow_destructible_v<T>;
+
+  template <typename T, typename... Args>
+  UNIFEX_CONCEPT
+    constructible_from =
+      destructible<T> &&
+      UNIFEX_IS_CONSTRUCTIBLE(T, Args...);
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    default_constructible =
+      constructible_from<T>;
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    move_constructible =
+      constructible_from<T, T> &&
+      convertible_to<T, T>;
+
+  template <typename T>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _copy_constructible,
+      requires()(0) &&
+      constructible_from<T, T &> &&
+      constructible_from<T, T const &> &&
+      constructible_from<T, T const> &&
+      convertible_to<T &, T> &&
+      convertible_to<T const &, T> &&
+      convertible_to<T const, T>);
+  template <typename T>
+  UNIFEX_CONCEPT
+    copy_constructible =
+      move_constructible<T> &&
+      UNIFEX_FRAGMENT(unifex::_copy_constructible, T);
+
+  template <typename T>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _move_assignable,
+      requires()(0) &&
+      assignable_from<T &, T>);
+  template <typename T>
+  UNIFEX_CONCEPT
+    movable =
+      std::is_object_v<T> &&
+      move_constructible<T> &&
+      UNIFEX_FRAGMENT(unifex::_move_assignable, T) &&
+      swappable<T>;
+
+  template <typename T>
+  UNIFEX_CONCEPT_FRAGMENT(
+    _copy_assignable,
+      requires()(0) &&
+      assignable_from<T &, T const &>);
+  template <typename T>
+  UNIFEX_CONCEPT
+    copyable =
+      copy_constructible<T> &&
+      movable<T> &&
+      UNIFEX_FRAGMENT(unifex::_copy_assignable, T);
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    semiregular =
+      copyable<T> &&
+      default_constructible<T>;
+      // Axiom: copies are independent. See Fundamentals of Generic Programming
+      // http://www.stepanovpapers.com/DeSt98.pdf
+
+  template <typename T>
+  UNIFEX_CONCEPT
+    regular =
+      semiregular<T> &&
+      equality_comparable<T>;
+
+  template <typename Fn, typename... As>
+  UNIFEX_CONCEPT  //
+    invocable = //
+      std::is_invocable_v<Fn, As...>;
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -32,16 +32,18 @@
 #include <type_traits>
 #include <cassert>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _stop_immediately {
-template<typename SourceStream, typename... Values>
+template <typename SourceStream, typename... Values>
 struct _stream {
   struct type;
 };
-template<typename SourceStream, typename... Values>
+template <typename SourceStream, typename... Values>
 using stream = typename _stream<remove_cvref_t<SourceStream>, Values...>::type;
 
-template<typename SourceStream, typename... Values>
+template <typename SourceStream, typename... Values>
 struct _stream<SourceStream, Values...>::type {
  private:
   using stream = type;
@@ -131,7 +133,7 @@ struct _stream<SourceStream, Values...>::type {
       });
     }
 
-    template<typename Error>
+    template <typename Error>
     void set_error(Error&& error) && noexcept {
       std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
     }
@@ -144,7 +146,7 @@ struct _stream<SourceStream, Values...>::type {
       });
     }
 
-    template<typename Func>
+    template <typename Func>
     void handle_signal(Func deliverSignalTo) noexcept {
       auto& strm = stream_;
       strm.nextOp_.destruct();
@@ -199,16 +201,16 @@ struct _stream<SourceStream, Values...>::type {
   struct next_sender {
     stream& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types =
       typename next_sender_t<SourceStream>::template value_types<Variant, Tuple>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types =
       typename next_sender_t<SourceStream>::template error_types<Variant>;
 
-    template<typename Receiver>
+    template <typename Receiver>
     struct _op {
       struct type {
         struct concrete_receiver final : next_receiver_base {
@@ -243,7 +245,7 @@ struct _stream<SourceStream, Values...>::type {
           typename ST::template callback_type<cancel_next_callback>>
             stopCallback_;
 
-        template<typename Receiver2>
+        template <typename Receiver2>
         explicit type(stream& strm, Receiver2&& receiver)
           : stream_(strm)
           , concreteReceiver_(*this)
@@ -292,22 +294,22 @@ struct _stream<SourceStream, Values...>::type {
     template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template<typename Receiver>
+    template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
       return operation<Receiver>{stream_, (Receiver&&)receiver};
     }
-    template<typename Receiver>
+    template <typename Receiver>
     void connect(Receiver&& receiver) const& =delete;
   };
 
   struct cleanup_sender {
     stream& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types = Variant<>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = typename concat_type_lists_unique_t<
       typename cleanup_sender_t<SourceStream>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
@@ -330,7 +332,7 @@ struct _stream<SourceStream, Values...>::type {
             }
           }
 
-          template<typename Error>
+          template <typename Error>
           void set_error(Error&& error) && noexcept {
             auto& op = op_;
             op.cleanupOp_.destruct();
@@ -352,7 +354,7 @@ struct _stream<SourceStream, Values...>::type {
         manual_lifetime<cleanup_operation_t<SourceStream, receiver_wrapper>>
             cleanupOp_;
 
-        template<typename Receiver2>
+        template <typename Receiver2>
         explicit type(stream& strm, Receiver2&& receiver)
           : stream_(strm)
           , receiver_((Receiver2&&)receiver)
@@ -411,11 +413,11 @@ struct _stream<SourceStream, Values...>::type {
     template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template<typename Receiver>
+    template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
       return operation<Receiver>{stream_, (Receiver &&) receiver};
     }
-    template<typename Receiver>
+    template <typename Receiver>
     void connect(Receiver&& receiver) const& = delete;
   };
 
@@ -429,7 +431,7 @@ struct _stream<SourceStream, Values...>::type {
 
 public:
 
-  template<typename SourceStream2>
+  template <typename SourceStream2>
   explicit type(SourceStream2&& source)
     : source_((SourceStream2&&)source)
   {}
@@ -449,7 +451,7 @@ public:
 } // namespace _stop_immediately
 
 namespace _stop_immediately_cpo {
-  template<typename... Values>
+  template <typename... Values>
   struct _fn {
     template <typename SourceStream>
     auto operator()(SourceStream&& source) const {
@@ -459,7 +461,9 @@ namespace _stop_immediately_cpo {
   };
 } // namespace _stop_immediately_cpo
 
-template<typename... Values>
+template <typename... Values>
 inline constexpr _stop_immediately_cpo::_fn<Values...> stop_immediately{};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_token_concepts.hpp
+++ b/include/unifex/stop_token_concepts.hpp
@@ -17,6 +17,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 template <typename T, typename = void>
@@ -33,3 +35,5 @@ template <typename T>
 using is_stop_never_possible = std::bool_constant<is_stop_never_possible_v<T>>;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <unifex/detail/concept_macros.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
@@ -30,6 +31,8 @@
 #include <tuple>
 #include <type_traits>
 #include <variant>
+
+#include <unifex/detail/prologue.hpp>
 
 namespace unifex
 {
@@ -90,10 +93,8 @@ namespace unifex
         return r.get_stop_token();
       }
 
-      template <
-          typename CPO,
-          typename... Args,
-          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+      template(typename CPO, typename... Args)
+          (requires (!is_receiver_cpo_v<CPO>))
       friend auto tag_invoke(
           CPO cpo,
           const type& r,
@@ -150,10 +151,8 @@ namespace unifex
         return r.get_stop_token();
       }
 
-      template <
-          typename CPO,
-          typename... Args,
-          std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+      template(typename CPO, typename... Args)
+          (requires (!is_receiver_cpo_v<CPO>))
       friend auto tag_invoke(
           CPO cpo,
           const type& r,
@@ -333,22 +332,20 @@ namespace unifex
         : source_((Source2 &&) source)
         , trigger_((Trigger2 &&) trigger) {}
 
-      template <
-          typename Receiver,
-          std::enable_if_t<
+      template(typename Receiver)
+          (requires
               is_connectable_v<
                   Source,
                   stop_when_source_receiver<
                       Source,
                       Trigger,
-                      remove_cvref_t<Receiver>>> &&
-                  is_connectable_v<
+                      remove_cvref_t<Receiver>>> AND
+              is_connectable_v<
+                  Trigger,
+                  stop_when_trigger_receiver<
+                      Source,
                       Trigger,
-                      stop_when_trigger_receiver<
-                          Source,
-                          Trigger,
-                          remove_cvref_t<Receiver>>>,
-              int> = 0>
+                      remove_cvref_t<Receiver>>>)
       auto connect(Receiver&& r) && -> stop_when_operation<
           Source,
           Trigger,
@@ -360,22 +357,20 @@ namespace unifex
             (Source &&) source_, (Trigger &&) trigger_, (Receiver &&) r};
       }
 
-      template <
-          typename Receiver,
-          std::enable_if_t<
+      template(typename Receiver)
+          (requires
               is_connectable_v<
                   Source&,
                   stop_when_source_receiver<
                       const Source&,
                       const Trigger&,
-                      remove_cvref_t<Receiver>>> &&
-                  is_connectable_v<
-                      Trigger&,
-                      stop_when_trigger_receiver<
-                          const Source&,
-                          const Trigger&,
-                          remove_cvref_t<Receiver>>>,
-              int> = 0>
+                      remove_cvref_t<Receiver>>> AND
+              is_connectable_v<
+                  Trigger&,
+                  stop_when_trigger_receiver<
+                      const Source&,
+                      const Trigger&,
+                      remove_cvref_t<Receiver>>>)
       auto connect(Receiver&& r) const& -> stop_when_operation<
           const Source&,
           const Trigger&,
@@ -404,10 +399,8 @@ namespace unifex
             *this, (Source &&) source, (Trigger &&) trigger);
       }
 
-      template <
-          typename Source,
-          typename Trigger,
-          std::enable_if_t<!is_tag_invocable_v<_fn, Source, Trigger>, int> = 0>
+      template(typename Source, typename Trigger)
+          (requires (!is_tag_invocable_v<_fn, Source, Trigger>))
       auto operator()(Source&& source, Trigger&& trigger) const noexcept(
           std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>&&
               std::is_nothrow_constructible_v<
@@ -427,4 +420,6 @@ namespace unifex
 
   inline constexpr _stop_when_cpo::_fn stop_when{};
 
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <unifex/detail/concept_macros.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/stream_concepts.hpp
+++ b/include/unifex/stream_concepts.hpp
@@ -18,11 +18,13 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/sender_concepts.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _streams {
   inline constexpr struct _next_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename Stream>
       auto operator()(Stream& stream) const
@@ -42,7 +44,7 @@ namespace _streams {
     }
   } next{};
 
-  template<>
+  template <>
   struct _next_fn::_impl<false> {
     template <typename Stream>
     auto operator()(Stream& stream) const
@@ -54,7 +56,7 @@ namespace _streams {
 
   inline constexpr struct _cleanup_fn {
   private:
-    template<bool>
+    template <bool>
     struct _impl {
       template <typename Stream>
       auto operator()(Stream& stream) const
@@ -74,7 +76,7 @@ namespace _streams {
     }
   } cleanup{};
 
-  template<>
+  template <>
   struct _cleanup_fn::_impl<false> {
     template <typename Stream>
     auto operator()(Stream& stream) const
@@ -101,3 +103,5 @@ template <typename Stream, typename Receiver>
 using cleanup_operation_t = operation_t<cleanup_sender_t<Stream>, Receiver>;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -45,14 +45,16 @@ class _op<Sender, Receiver>::type {
   public:
     explicit wrapped_receiver(type* op) noexcept : op_(op) {}
 
-    template <typename... Values>
+    template(typename... Values)
+      (requires receiver_of<Receiver, Values...>)
     void set_value(Values&&... values) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
       unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
       destroy(std::move(allocator));
     }
 
-    template <typename Error>
+    template(typename Error)
+      (requires receiver<Receiver, Error>)
     void set_error(Error&& error) && noexcept {
       auto allocator = get_allocator(op_->receiver_);
       unifex::set_error(std::move(op_->receiver_), (Error &&) error);

--- a/include/unifex/swap.hpp
+++ b/include/unifex/swap.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/detail/concept_macros.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+template <typename T, typename U, typename = void>
+extern bool const is_swappable_with_v;
+
+template <typename T, typename U, typename = void>
+extern bool const is_nothrow_swappable_with_v;
+
+namespace _swap {
+    struct nope;
+
+    // Intentionally create an ambiguity with std::swap, which is
+    // (possibly) unconstrained.
+    template <typename T>
+    nope* swap(T &, T &) = delete;
+
+    template <typename T, std::size_t N>
+    nope* swap(T (&)[N], T (&)[N]) = delete;
+
+#ifdef CPP_WORKAROUND_MSVC_895622
+    nope swap();
+#endif
+
+    template <typename T, typename U>
+    decltype(swap(std::declval<T>(), std::declval<U>())) try_adl_swap_(int);
+
+    template <typename T, typename U>
+    nope* try_adl_swap_(long);
+
+    template <typename T, typename U = T>
+    inline constexpr bool is_adl_swappable_v =
+        !UNIFEX_IS_SAME(decltype(_swap::try_adl_swap_<T, U>(42)), nope*);
+
+    struct _fn {
+        // Dispatch to user-defined swap found via ADL:
+        UNIFEX_TEMPLATE(typename T, typename U)
+            (requires is_adl_swappable_v<T, U>)
+        constexpr void operator()(T &&t, U &&u) const
+            noexcept(noexcept(swap((T &&) t, (U &&) u))) {
+            swap((T &&) t, (U &&) u);
+        }
+
+        // For intrinsically swappable (i.e., movable) types for which
+        // a swap overload cannot be found via ADL, swap by moving.
+        UNIFEX_TEMPLATE(typename T)
+            (requires (!is_adl_swappable_v<T &>))
+        constexpr auto operator()(T &a, T &b) const
+            noexcept(noexcept(a = T(static_cast<T&&>(b)))) ->
+            decltype(static_cast<void>(a = T(static_cast<T&&>(b)))) {
+            T tmp = static_cast<T &&>(a);
+            a = static_cast<T &&>(b);
+            b = static_cast<T &&>(tmp);
+        }
+
+        // For arrays of intrinsically swappable (i.e., movable) types
+        // for which a swap overload cannot be found via ADL, swap array
+        // elements by moving.
+        UNIFEX_TEMPLATE(typename T, typename U, std::size_t N)
+            (requires (!is_adl_swappable_v<T (&)[N], U (&)[N]>) &&
+                is_swappable_with_v<T &, U &>)
+        constexpr void operator()(T (&t)[N], U (&u)[N]) const
+            noexcept(is_nothrow_swappable_with_v<T &, U &>) {
+            for(std::size_t i = 0; i < N; ++i)
+                (*this)(t[i], u[i]);
+        }
+    };
+} // namespace _swap
+
+namespace _swap_cpo {
+inline constexpr _swap::_fn swap {};
+} // namespace _swap_cpo
+using _swap_cpo::swap;
+
+template <typename, typename, typename>
+inline constexpr bool is_swappable_with_v = false;
+
+template <typename T, typename U>
+inline constexpr bool is_swappable_with_v<
+    T, U, decltype(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)))> = true;
+
+template <typename, typename, typename>
+inline constexpr bool is_nothrow_swappable_with_v = false;
+
+template <typename T, typename U>
+inline constexpr bool is_nothrow_swappable_with_v<
+    T, U, decltype(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)))> = 
+    noexcept(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)));
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -27,6 +27,8 @@
 #include <optional>
 #include <cassert>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _sync_wait {
 
@@ -186,3 +188,5 @@ template <typename Result>
 inline constexpr _sync_wait_r_cpo::_fn<Result> sync_wait_r {};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -76,8 +76,6 @@ struct promise {
 template <typename T>
 struct _receiver {
   struct type {
-    using receiver = type;
-
     promise<T>& promise_;
 
     template <typename... Values>
@@ -123,7 +121,7 @@ struct _receiver {
 };
 
 template <typename T>
-using receiver = typename _receiver<T>::type;
+using receiver_t = typename _receiver<T>::type;
 
 } // namespace _sync_wait
 
@@ -148,7 +146,7 @@ namespace _sync_wait_cpo {
       // Store state for the operation on the stack.
       auto operation = connect(
           ((Sender &&) sender),
-          _sync_wait::receiver<Result>{promise});
+          _sync_wait::receiver_t<Result>{promise});
 
       start(operation);
 

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -18,6 +18,8 @@
 #include <unifex/config.hpp>
 #include <unifex/type_traits.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
   namespace _tag_invoke {
     void tag_invoke();
@@ -32,9 +34,8 @@ namespace unifex {
     };
 
     template <typename CPO, typename... Args>
-    using tag_invoke_result_t = decltype(tag_invoke(
-        static_cast<CPO && (*)() noexcept>(nullptr)(),
-        static_cast<Args && (*)() noexcept>(nullptr)()...));
+    using tag_invoke_result_t = decltype(
+        tag_invoke(UNIFEX_DECLVAL(CPO && ), UNIFEX_DECLVAL(Args && )...));
 
     struct yes_type {
       char dummy;
@@ -44,14 +45,11 @@ namespace unifex {
     };
 
     template <typename CPO, typename... Args>
-    auto try_tag_invoke(int) noexcept(noexcept(tag_invoke(
-        static_cast<CPO && (*)() noexcept>(nullptr)(),
-        static_cast<Args && (*)() noexcept>(nullptr)()...)))
-        -> decltype(
-            static_cast<void>(tag_invoke(
-                static_cast<CPO && (*)() noexcept>(nullptr)(),
-                static_cast<Args && (*)() noexcept>(nullptr)()...)),
-            yes_type{});
+    auto try_tag_invoke(int) //
+        noexcept(noexcept(tag_invoke(
+            UNIFEX_DECLVAL(CPO && ), UNIFEX_DECLVAL(Args && )...)))
+        -> decltype(static_cast<void>(tag_invoke(
+            UNIFEX_DECLVAL(CPO && ), UNIFEX_DECLVAL(Args && )...)), yes_type{});
 
     template <typename CPO, typename... Args>
     no_type try_tag_invoke(...) noexcept(false);
@@ -104,4 +102,6 @@ namespace unifex {
   using is_nothrow_tag_invocable =
       std::bool_constant<is_nothrow_tag_invocable_v<CPO, Args...>>;
 
-}  // namespace unifex
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -30,31 +30,33 @@
 #include <utility>
 #include <cassert>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _take_until {
-template<typename SourceStream, typename TriggerStream>
+template <typename SourceStream, typename TriggerStream>
 struct _stream {
   struct type;
 };
-template<typename SourceStream, typename TriggerStream>
+template <typename SourceStream, typename TriggerStream>
 using stream =
     typename _stream<
         remove_cvref_t<SourceStream>,
         remove_cvref_t<TriggerStream>>::type;
 
-template<typename SourceStream, typename TriggerStream>
+template <typename SourceStream, typename TriggerStream>
 struct _stream<SourceStream, TriggerStream>::type {
  private:
   using take_until_stream = type;
   struct trigger_next_receiver {
     take_until_stream& stream_;
 
-    template<typename... Values>
+    template <typename... Values>
     void set_value(Values&&...) && noexcept {
       std::move(*this).set_done();
     }
 
-    template<typename Error>
+    template <typename Error>
     void set_error(Error&&) && noexcept {
       std::move(*this).set_done();
     }
@@ -90,23 +92,23 @@ struct _stream<SourceStream, TriggerStream>::type {
   struct next_sender {
     take_until_stream& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types =
       typename next_sender_t<SourceStream>::
         template value_types<Variant, Tuple>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types =
       typename next_sender_t<SourceStream>::template error_types<Variant>;
 
-    template<typename Receiver>
+    template <typename Receiver>
     struct _op {
       struct type {
         struct receiver_wrapper {
           type& op_;
 
-          template<typename... Values>
+          template <typename... Values>
           void set_value(Values&&... values) && noexcept {
             op_.stopCallback_.destruct();
             unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
@@ -118,7 +120,7 @@ struct _stream<SourceStream, TriggerStream>::type {
             unifex::set_done(std::move(op_.receiver_));
           }
 
-          template<typename Error>
+          template <typename Error>
           void set_error(Error&& error) && noexcept {
             op_.stopCallback_.destruct();
             op_.stream_.stopSource_.request_stop();
@@ -150,7 +152,7 @@ struct _stream<SourceStream, TriggerStream>::type {
           stopCallback_;
         next_operation_t<SourceStream, receiver_wrapper> innerOp_;
 
-        template<typename Receiver2>
+        template <typename Receiver2>
         explicit type(take_until_stream& stream, Receiver2&& receiver)
           : stream_(stream)
           , receiver_((Receiver2&&)receiver)
@@ -181,10 +183,10 @@ struct _stream<SourceStream, TriggerStream>::type {
         }
       };
     };
-    template<typename Receiver>
+    template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template<typename Receiver>
+    template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
       return operation<Receiver>{
         stream_,
@@ -195,17 +197,17 @@ struct _stream<SourceStream, TriggerStream>::type {
   struct cleanup_sender {
     take_until_stream& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types =
       typename cleanup_sender_t<SourceStream>::
         template value_types<Variant, Tuple>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types =
       typename cleanup_sender_t<SourceStream>::template error_types<Variant>;
 
-    template<typename Receiver>
+    template <typename Receiver>
     struct _op {
       struct type final : cleanup_operation_base {
         struct source_receiver {
@@ -217,7 +219,7 @@ struct _stream<SourceStream, TriggerStream>::type {
             op.source_cleanup_done();
           }
 
-          template<typename Error>
+          template <typename Error>
           void set_error(Error&& error) && noexcept {
             std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
           }
@@ -246,7 +248,7 @@ struct _stream<SourceStream, TriggerStream>::type {
             op.trigger_cleanup_done();
           }
 
-          template<typename Error>
+          template <typename Error>
           void set_error(Error&& error) && noexcept {
             std::move(*this).set_error(std::make_exception_ptr((Error&&)error));
           }
@@ -277,7 +279,7 @@ struct _stream<SourceStream, TriggerStream>::type {
         manual_lifetime<cleanup_operation_t<TriggerStream, trigger_receiver>>
           triggerOp_;
 
-        template<typename Receiver2>
+        template <typename Receiver2>
         explicit type(take_until_stream& stream, Receiver2&& receiver)
           : stream_(stream)
           , receiver_((Receiver2&&)receiver)
@@ -396,10 +398,10 @@ struct _stream<SourceStream, TriggerStream>::type {
         }
       };
     };
-    template<typename Receiver>
+    template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template<typename Receiver>
+    template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) {
       return operation<Receiver>{stream_, (Receiver &&) receiver};
     }
@@ -436,7 +438,7 @@ struct _stream<SourceStream, TriggerStream>::type {
 
 public:
 
-  template<typename SourceStream2, typename TriggerStream2>
+  template <typename SourceStream2, typename TriggerStream2>
   explicit type(SourceStream2&& source, TriggerStream2&& trigger)
   : source_((SourceStream2&&)source)
   , trigger_((TriggerStream2&&)trigger)
@@ -459,7 +461,7 @@ public:
 
 namespace _take_until_cpo {
   inline constexpr struct _fn {
-    template<typename SourceStream, typename TriggerStream>
+    template <typename SourceStream, typename TriggerStream>
     auto operator()(SourceStream&& source, TriggerStream&& trigger) const {
       return _take_until::stream<SourceStream, TriggerStream>{
         (SourceStream&&)source,
@@ -471,3 +473,5 @@ namespace _take_until_cpo {
 using _take_until_cpo::take_until;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -18,6 +18,7 @@
 #include <unifex/async_trace.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/coroutine.hpp>
+#include <unifex/std_concepts.hpp>
 
 #if UNIFEX_NO_COROUTINES
 # error "C++20 coroutine support is required to use this header"
@@ -25,6 +26,8 @@
 
 #include <exception>
 #include <optional>
+
+#include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 
@@ -60,9 +63,8 @@ struct task {
       state_ = state::exception;
     }
 
-    template <
-        typename Value,
-        std::enable_if_t<std::is_convertible_v<Value, T>, int> = 0>
+    template(typename Value)
+        (requires convertible_to<Value, T>)
     void return_value(Value&& value) noexcept(
         std::is_nothrow_constructible_v<T, Value>) {
       reset_value();
@@ -158,3 +160,5 @@ public:
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/then_execute.hpp
+++ b/include/unifex/then_execute.hpp
@@ -19,6 +19,8 @@
 #include <unifex/transform.hpp>
 #include <unifex/typed_via.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 namespace _then_execute_cpo {
@@ -33,3 +35,5 @@ namespace _then_execute_cpo {
 } // namespace _then_execute_cpo
 inline constexpr _then_execute_cpo::_fn then_execute {};
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/this.hpp
+++ b/include/unifex/this.hpp
@@ -18,6 +18,8 @@
 #include <unifex/config.hpp>
 #include <unifex/type_traits.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 struct this_ {};
@@ -112,3 +114,5 @@ struct extract_this<FirstType, RestTypes...> {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -29,6 +29,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 class thread_unsafe_event_loop;
 
@@ -387,3 +389,5 @@ namespace _thread_unsafe_event_loop {
 }
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -28,6 +28,8 @@
 #include <thread>
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 class timed_single_thread_context;
 
@@ -246,9 +248,9 @@ class timed_single_thread_context {
   using cancel_callback = _timed_single_thread_context::cancel_callback;
   friend cancel_callback;
   friend scheduler;
-  template<typename Duration, typename Receiver>
+  template <typename Duration, typename Receiver>
   friend class _timed_single_thread_context::_after_op;
-  template<typename Receiver>
+  template <typename Receiver>
   friend class _timed_single_thread_context::_at_op;
 
   void enqueue(task_base* task) noexcept;
@@ -291,3 +293,5 @@ namespace _timed_single_thread_context {
   }
 } // namespace _timed_single_thread_context
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -24,6 +24,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _trampoline {
 class scheduler {
@@ -102,7 +104,7 @@ private:
       }
     };
   };
-  template<typename Receiver>
+  template <typename Receiver>
   using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
   class schedule_sender {
@@ -138,3 +140,5 @@ public:
 using trampoline_scheduler = _trampoline::scheduler;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -74,14 +74,14 @@ public:
   : op_(std::exchange(other.op_, {}))
   {}
  
-  template <typename... Values>
-  void set_value(Values&&... values) noexcept(is_nothrow_callable_v<tag_t<unifex::set_value>&, Receiver, Values...>) {
+  template(typename... Values)
+    (requires receiver_of<Receiver, Values...>)
+  void set_value(Values&&... values) noexcept(
+      is_nothrow_receiver_of_v<Receiver, Values...>) {
     assert(op_ != nullptr);
     unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
   }
 
-  template(typename R = Receiver)
-    (requires is_callable_v<decltype(unifex::set_done), R>)
   void set_done() noexcept {
     assert(op_ != nullptr);
     auto op = op_; // preserve pointer value.
@@ -111,7 +111,7 @@ public:
   }
 
   template(typename Error)
-      (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
+      (requires receiver<Receiver, Error>)
   void set_error(Error&& error) noexcept {
     assert(op_ != nullptr);
     unifex::set_error(std::move(op_->receiver_), (Error&&)error);
@@ -159,21 +159,20 @@ public:
   {}
  
   template(typename... Values)
-    (requires is_callable_v<decltype(unifex::set_value), Receiver, Values...>)
-  void set_value(Values&&... values) noexcept(is_nothrow_callable_v<tag_t<unifex::set_value>&, Receiver, Values...>) {
+    (requires receiver_of<Receiver, Values...>)
+  void set_value(Values&&... values) noexcept(
+      is_nothrow_receiver_of_v<Receiver, Values...>) {
     assert(op_ != nullptr);
     unifex::set_value(std::move(op_->receiver_));
   }
 
-  template(typename R = Receiver)
-    (requires is_callable_v<decltype(unifex::set_done), R>)
   void set_done() noexcept {
     assert(op_ != nullptr);
     unifex::set_done(std::move(op_->receiver_));
   }
 
   template(typename Error)
-    (requires is_callable_v<decltype(unifex::set_error), Receiver, Error>)
+    (requires receiver<Receiver, Error>)
   void set_error(Error&& error) noexcept {
     assert(op_ != nullptr);
     unifex::set_error(std::move(op_->receiver_), (Error&&)error);

--- a/include/unifex/transform_stream.hpp
+++ b/include/unifex/transform_stream.hpp
@@ -20,6 +20,8 @@
 
 #include <functional>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _tfx_stream {
   struct _fn {
@@ -35,3 +37,5 @@ namespace _tfx_stream {
 
 inline constexpr _tfx_stream::_fn transform_stream {};
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -26,6 +26,8 @@
 
 #include <unifex/get_stop_token.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _type_erase {
 
@@ -273,11 +275,11 @@ struct _stream<Values...>::type {
   struct next_sender {
     stream_base& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types = Variant<Tuple<Values...>>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     template <typename Receiver>
@@ -328,11 +330,11 @@ struct _stream<Values...>::type {
   struct cleanup_sender {
     stream_base& stream_;
 
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+    template <template <typename...> class Variant,
+             template <typename...> class Tuple>
     using value_types = Variant<>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     template <typename Receiver>
@@ -391,3 +393,5 @@ template <typename... Ts>
 inline constexpr _type_erase_cpo::_fn<Ts...> type_erase {};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -19,6 +19,8 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex
 {
   // A template metaprogramming data-structure used to represent an
@@ -97,19 +99,21 @@ namespace unifex
 
   namespace detail
   {
-    template<
-      template<typename...> class Outer,
-      template<typename...> class Inner>
+    template <
+      template <typename...> class Outer,
+      template <typename...> class Inner>
     struct type_list_nested_apply_impl {
-      template<typename... Lists>
+      template <typename... Lists>
       using apply = Outer<typename Lists::template apply<Inner>...>;
     };
   }
 
-  template<
+  template <
     typename ListOfLists,
-    template<typename...> class Outer,
-    template<typename...> class Inner>
+    template <typename...> class Outer,
+    template <typename...> class Inner>
   using type_list_nested_apply_t = typename ListOfLists::template apply<
     detail::type_list_nested_apply_impl<Outer, Inner>::template apply>;
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -21,15 +21,13 @@
 
 #include <type_traits>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _typed_via {
   struct _fn {
-    template <
-        typename Source,
-        typename Scheduler,
-        std::enable_if_t<
-            is_tag_invocable_v<_fn, Source, Scheduler>,
-            int> = 0>
+    template(typename Source, typename Scheduler)
+        (requires is_tag_invocable_v<_fn, Source, Scheduler>)
     auto operator()(Source&& source, Scheduler&& scheduler) const
         noexcept(is_nothrow_tag_invocable_v<_fn, Source, Scheduler>)
             -> tag_invoke_result_t<_fn, Source, Scheduler> {
@@ -39,12 +37,8 @@ namespace _typed_via {
           static_cast<Scheduler&&>(scheduler));
     }
 
-    template <
-        typename Source,
-        typename Scheduler,
-        std::enable_if_t<
-            !is_tag_invocable_v<_fn, Source, Scheduler>,
-            int> = 0>
+    template(typename Source, typename Scheduler)
+        (requires (!is_tag_invocable_v<_fn, Source, Scheduler>))
     auto operator()(Source&& source, Scheduler&& scheduler) const
         noexcept(noexcept(finally(
             static_cast<Source&&>(source),
@@ -61,3 +55,5 @@ namespace _typed_via {
 
 inline constexpr _typed_via::_fn typed_via {};
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/typed_via_stream.hpp
+++ b/include/unifex/typed_via_stream.hpp
@@ -19,6 +19,8 @@
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/typed_via.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _typed_via_stream {
   struct _fn {
@@ -36,3 +38,5 @@ namespace _typed_via_stream {
 inline constexpr _typed_via_stream::_fn typed_via_stream {};
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/unstoppable_token.hpp
+++ b/include/unifex/unstoppable_token.hpp
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 
 struct unstoppable_token {
@@ -31,3 +33,5 @@ struct unstoppable_token {
 };
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -23,7 +23,6 @@
 #include <unifex/submit.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/get_stop_token.hpp>
-#include <unifex/detail/concept_macros.hpp>
 
 #include <tuple>
 #include <utility>

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -23,11 +23,14 @@
 #include <unifex/submit.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/get_stop_token.hpp>
+#include <unifex/detail/concept_macros.hpp>
 
 #include <tuple>
 #include <utility>
 #include <exception>
 #include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _via {
@@ -65,9 +68,8 @@ struct _value_receiver<Receiver, Values...>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template <
-      typename CPO,
-      std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+  template(typename CPO)
+      (requires (!is_receiver_cpo_v<CPO>))
   friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -110,9 +112,8 @@ struct _error_receiver<Receiver, Error>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template <
-      typename CPO,
-      std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+  template(typename CPO)
+      (requires (!is_receiver_cpo_v<CPO>))
   friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -154,9 +155,8 @@ struct _done_receiver<Receiver>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template <
-      typename CPO,
-      std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+  template(typename CPO)
+      (requires (!is_receiver_cpo_v<CPO>))
   friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -223,9 +223,8 @@ struct _predecessor_receiver<Successor, Receiver>::type {
     }
   }
 
-  template <
-      typename CPO,
-      std::enable_if_t<!is_receiver_cpo_v<CPO>, int> = 0>
+  template(typename CPO)
+      (requires (!is_receiver_cpo_v<CPO>))
   friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -256,7 +255,7 @@ struct _sender<Predecessor, Successor>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Successor succ_;
 
-  template<typename... Ts>
+  template <typename... Ts>
   using overload_list = type_list<type_list<std::decay_t<Ts>...>>;
 
   template <
@@ -323,3 +322,5 @@ namespace _via_cpo {
 using _via_cpo::via;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via_stream.hpp
+++ b/include/unifex/via_stream.hpp
@@ -20,6 +20,8 @@
 #include <unifex/typed_via.hpp>
 #include <unifex/via.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _via_stream_cpo {
   struct _fn {
@@ -39,3 +41,5 @@ namespace _via_stream_cpo {
 
 inline constexpr _via_stream_cpo::_fn via_stream {};
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/with_allocator.hpp
+++ b/include/unifex/with_allocator.hpp
@@ -18,6 +18,8 @@
 #include <unifex/get_allocator.hpp>
 #include <unifex/with_query_value.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _with_alloc_cpo {
   struct _fn {
@@ -31,3 +33,5 @@ namespace _with_alloc_cpo {
 
 inline constexpr _with_alloc_cpo::_fn with_allocator {};
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -20,17 +20,19 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 
+#include <unifex/detail/prologue.hpp>
+
 namespace unifex {
 namespace _with_query_value {
 
-template<typename CPO, typename Value, typename Receiver>
+template <typename CPO, typename Value, typename Receiver>
 struct _receiver_wrapper {
   class type;
 };
-template<typename CPO, typename Value, typename Receiver>
+template <typename CPO, typename Value, typename Receiver>
 using receiver_wrapper = typename _receiver_wrapper<CPO, Value, Receiver>::type;
 
-template<typename CPO, typename Value, typename Receiver>
+template <typename CPO, typename Value, typename Receiver>
 class _receiver_wrapper<CPO, Value, Receiver>::type {
  public:
   template <typename Receiver2>
@@ -118,18 +120,12 @@ public:
   explicit type(Sender2 &&sender, Value2 &&value)
     : sender_((Sender2 &&) sender), value_((Value &&) value) {}
 
-  template <
-    typename Self,
-    typename Receiver,
-    std::enable_if_t<
-      std::is_same_v<remove_cvref_t<Self>, type>, int> = 0,
-    std::enable_if_t<
-      std::is_constructible_v<Value, member_t<Self, Value>>, int> = 0,
-    std::enable_if_t<
+  template(typename Self, typename Receiver)
+    (requires same_as<remove_cvref_t<Self>, type> AND
+      constructible_from<Value, member_t<Self, Value>> AND
       is_connectable_v<
         member_t<Self, Sender>,
-        receiver_wrapper<CPO, Value, remove_cvref_t<Receiver>>>,
-      int> = 0>
+        receiver_wrapper<CPO, Value, remove_cvref_t<Receiver>>>)
   friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, Receiver &&receiver)
       noexcept(std::is_nothrow_constructible_v<Value, member_t<Self, Value>> &&
                is_nothrow_connectable_v<
@@ -165,3 +161,5 @@ namespace _with_query_value_cpo {
 using _with_query_value_cpo::with_query_value;
 
 } // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>


### PR DESCRIPTION
This is a minimal change that doesn't add any additional checks. It should not effect compile times. It just uses `requires` clauses instead of `enable_if` when the compiler supports concepts.

Let's get at least this much in, and then I can proceed in future PRs to add additional checks, being careful not to regress compile times by too much.

The syntax for a constrained function template is:

```c++
template( class A, class B )
  (requires Concept<A> AND Concept<B>)
void foo( A a, B b )
{ ... }
```

In emulation mode, the clauses separated by the `AND` are placed in separate `enable_if`s, preserving short-circuiting.