### PR TITLE
Handful of fixes for msvc

### DIFF
--- a/examples/async_mutex.cpp
+++ b/examples/async_mutex.cpp
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
+#include <unifex/async_mutex.hpp>
+#include <unifex/sync_wait.hpp>
+
 #include <unifex/coroutine.hpp>
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <unifex/async_mutex.hpp>
 #include <unifex/awaitable_sender.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_awaitable.hpp>
-#include <unifex/single_thread_context.hpp>
-#include <unifex/sync_wait.hpp>
 #include <unifex/task.hpp>
 #include <unifex/when_all.hpp>
+#include <unifex/single_thread_context.hpp>
 
 #include <cstdio>
 
@@ -65,8 +66,13 @@ int main() {
 #include <cstdio>
 
 int main() {
-  std::printf("warning: skipping test as coroutines are not available\n");
-  return 0;
+    // Very simple usage of async_mutex.
+
+    unifex::async_mutex m;
+    unifex::sync_wait(m.async_lock());
+    m.unlock();
+    
+    return 0;
 }
 
 #endif // UNIFEX_NO_COROUTINES

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -82,15 +82,19 @@ private:
         }
 
         type(type &&) = delete;
-        
+
        private:
         friend void tag_invoke(tag_t<start>, type &op) noexcept {
-          if (!op.mutex_.try_enqueue(&op)) {
+          if (!op.try_enqueue()) {
             // Failed to enqueue because we acquired the lock
             // synchronously. Invoke the continuation inline
             // without type-erasure here.
             set_value((Receiver &&) op.receiver_);
           }
+        }
+
+        bool try_enqueue() noexcept {
+          return mutex_.try_enqueue(this);
         }
 
         async_mutex &mutex_;

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -71,7 +71,7 @@ private:
     struct _op {
       class type : waiter_base {
         friend lock_sender;
-
+      public:
         template <typename Receiver2>
         explicit type(async_mutex &mutex, Receiver2 &&r) noexcept
             : mutex_(mutex), receiver_((Receiver2 &&) r) {
@@ -82,7 +82,8 @@ private:
         }
 
         type(type &&) = delete;
-
+        
+       private:
         friend void tag_invoke(tag_t<start>, type &op) noexcept {
           if (!op.mutex_.try_enqueue(&op)) {
             // Failed to enqueue because we acquired the lock

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -67,7 +67,7 @@ namespace _demat {
     }
 
     template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))
-        (requires (!is_receiver_cpo_v<CPO>) AND is_callable_v<CPO, const Receiver&>)
+        (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>)
     friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r)
         noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -509,14 +509,14 @@ namespace unifex
           typename CompletionSender2,
           typename Receiver2,
           typename... Values>
-      friend class _value_receiver;
+      friend struct _value_receiver;
 
       template <
           typename SourceSender2,
           typename CompletionSender2,
           typename Receiver2,
           typename Error>
-      friend class _error_receiver;
+      friend struct _error_receiver;
 
       template <typename... Values>
       using value_operation = operation_t<

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -154,7 +154,7 @@ namespace unifex
       }
 
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
             same_as<R, value_receiver> AND
             is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(
@@ -266,7 +266,7 @@ namespace unifex
       }
 
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
             same_as<R, error_receiver> AND
             is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(
@@ -336,7 +336,7 @@ namespace unifex
       }
 
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
             same_as<R, done_receiver> AND
             is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(
@@ -472,7 +472,7 @@ namespace unifex
       }
 
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
             same_as<R, type> AND
             is_callable_v<CPO, const Receiver&>)
       friend auto

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -96,7 +96,7 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const type& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -84,9 +84,9 @@ class _sender<Values...>::type {
 
   template(typename This, typename Receiver)
       (requires same_as<remove_cvref_t<This>, type> AND
-        (constructible_from<Values, member_t<This, Values>> &&...))
+        constructible_from<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)
   friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
-      noexcept((std::is_nothrow_constructible_v<Values, member_t<This, Values>> &&...))
+      noexcept(std::is_nothrow_constructible_v<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)
       -> operation<Receiver, Values...> {
     return {static_cast<This&&>(that).values_, static_cast<Receiver&&>(r)};
   }

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -85,7 +85,7 @@ private:
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const typename Operation::receiver_type&>)
       -> callable_result_t<CPO, const typename Operation::receiver_type&> {
@@ -164,7 +164,7 @@ struct _predecessor_receiver<Operation>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const receiver_type&>)
       -> callable_result_t<CPO, const receiver_type&> {

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -99,7 +99,7 @@ namespace unifex
       }
 
       template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
               is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(
           CPO cpo,

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -26,6 +26,10 @@
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
+    namespace _connect {
+        struct _fn;
+    }
+
 namespace _rec_cpo {
   inline constexpr struct _set_value_fn {
   private:
@@ -194,6 +198,18 @@ inline constexpr bool is_receiver_cpo_v = is_one_of_v<
     _rec_cpo::_set_next_fn,
     _rec_cpo::_set_error_fn,
     _rec_cpo::_set_done_fn>;
+
+
+// HACK: Approximation for CPOs that should be forwarded through receivers
+// as query operations.
+template <typename T>
+inline constexpr bool is_receiver_query_cpo_v = !is_one_of_v<
+    remove_cvref_t<T>,
+    _rec_cpo::_set_value_fn,
+    _rec_cpo::_set_next_fn,
+    _rec_cpo::_set_error_fn,
+    _rec_cpo::_set_done_fn,
+    _connect::_fn>;
 
 template <typename T>
 using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -67,7 +67,7 @@ struct _error_cleanup_receiver<Operation>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const error_cleanup_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const receiver_type&>)
       -> callable_result_t<CPO, const receiver_type&> {
@@ -119,7 +119,7 @@ struct _done_cleanup_receiver<Operation>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const done_cleanup_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const receiver_type&>)
       -> callable_result_t<CPO, const receiver_type&> {
@@ -156,7 +156,7 @@ struct _next_receiver<Operation>::type {
   Operation& op_;
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const next_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const receiver_type&>)
       -> callable_result_t<CPO, const receiver_type&> {

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -115,7 +115,7 @@ public:
 
 private:
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>) AND
+      (requires is_receiver_query_cpo_v<CPO> AND
           is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const type& r)
       noexcept(std::is_nothrow_invocable_v<CPO, const Receiver&>)

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -123,7 +123,7 @@ public:
 private:
 
   template(typename CPO)
-    (requires (!is_receiver_cpo_v<CPO>) AND
+    (requires is_receiver_query_cpo_v<CPO> AND
         is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const trigger_receiver& r)
       noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
@@ -211,7 +211,7 @@ public:
 
 private:
   template(typename CPO)
-    (requires (!is_receiver_cpo_v<CPO>) AND
+    (requires is_receiver_query_cpo_v<CPO> AND
         is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const source_receiver& r)
       noexcept(is_nothrow_callable_v<CPO, const Receiver&>)

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -91,7 +91,8 @@ namespace unifex
 
       template(typename CPO, typename R)
           (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, successor_receiver>)
+            same_as<R, successor_receiver> AND
+            is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(
           CPO cpo,
           const R& r) noexcept(is_nothrow_callable_v<

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -73,7 +73,8 @@ namespace unifex
 
     private:
       template(typename CPO, typename R, typename... Args)
-          (requires is_receiver_cpo_v<CPO> AND
+          (requires 
+              is_receiver_cpo_v<CPO> AND
               same_as<R, successor_receiver> AND
               is_callable_v<CPO, Receiver, Args...>)
       friend auto tag_invoke(
@@ -89,9 +90,8 @@ namespace unifex
       }
 
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
-            same_as<R, successor_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
+          (requires is_receiver_query_cpo_v<CPO> AND
+            same_as<R, successor_receiver>)
       friend auto tag_invoke(
           CPO cpo,
           const R& r) noexcept(is_nothrow_callable_v<
@@ -189,7 +189,7 @@ namespace unifex
 
     private:
       template(typename CPO, typename R)
-          (requires (!is_receiver_cpo_v<CPO>) AND
+          (requires is_receiver_query_cpo_v<CPO> AND
             same_as<R, predecessor_receiver> AND
             is_callable_v<CPO, const Receiver&>)
       friend auto tag_invoke(

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -93,7 +93,7 @@ namespace unifex
       }
 
       template(typename CPO, typename... Args)
-          (requires (!is_receiver_cpo_v<CPO>))
+          (requires is_receiver_query_cpo_v<CPO>)
       friend auto tag_invoke(
           CPO cpo,
           const type& r,
@@ -151,7 +151,7 @@ namespace unifex
       }
 
       template(typename CPO, typename... Args)
-          (requires (!is_receiver_cpo_v<CPO>))
+          (requires is_receiver_query_cpo_v<CPO>)
       friend auto tag_invoke(
           CPO cpo,
           const type& r,

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -82,7 +82,7 @@ class _op<Sender, Receiver>::type {
     Receiver& get_receiver() const { return op_->receiver_; }
 
     template(typename CPO)
-        (requires (!is_receiver_cpo_v<CPO>))
+        (requires is_receiver_query_cpo_v<CPO>)
     friend auto tag_invoke(CPO cpo, const wrapped_receiver& r) noexcept(
         is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -58,7 +58,7 @@ namespace _timed_single_thread_context {
     void operator()() noexcept;
   };
 
-  struct scheduler;
+  class scheduler;
 
   template <typename Duration>
   struct _schedule_after_sender {

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -249,9 +249,9 @@ class timed_single_thread_context {
   friend cancel_callback;
   friend scheduler;
   template <typename Duration, typename Receiver>
-  friend class _timed_single_thread_context::_after_op;
+  friend struct _timed_single_thread_context::_after_op;
   template <typename Receiver>
-  friend class _timed_single_thread_context::_at_op;
+  friend struct _timed_single_thread_context::_at_op;
 
   void enqueue(task_base* task) noexcept;
   void run();

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -102,7 +102,7 @@ struct _receiver<Receiver, Func>::type {
   }
 
   template(typename CPO, typename R)
-      (requires (!is_receiver_cpo_v<CPO>) AND same_as<R, type>)
+      (requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>)
   friend auto tag_invoke(CPO cpo, const R& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -119,7 +119,7 @@ public:
 
 private:
   template(typename CPO, typename Self)
-    (requires (!is_receiver_cpo_v<CPO>) AND
+    (requires is_receiver_query_cpo_v<CPO> AND
         same_as<remove_cvref_t<Self>, type> AND
         is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, Self&& r)
@@ -180,7 +180,7 @@ public:
 
 private:
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>) AND
+      (requires is_receiver_query_cpo_v<CPO> AND
           is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const type& r)
       noexcept(is_nothrow_callable_v<CPO, const Receiver&>)

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -68,7 +68,7 @@ struct _value_receiver<Receiver, Values...>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -112,7 +112,7 @@ struct _error_receiver<Receiver, Error>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -155,7 +155,7 @@ struct _done_receiver<Receiver>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
@@ -223,7 +223,7 @@ struct _predecessor_receiver<Successor, Receiver>::type {
   }
 
   template(typename CPO)
-      (requires (!is_receiver_cpo_v<CPO>))
+      (requires is_receiver_query_cpo_v<CPO>)
   friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -168,7 +168,7 @@ struct _element_receiver<Index, Receiver, Senders...>::type final {
   Receiver& get_receiver() const { return op_.receiver_; }
 
   template(typename CPO, typename R)
-      (requires (!is_receiver_cpo_v<CPO>) AND
+      (requires is_receiver_query_cpo_v<CPO> AND
           same_as<R, element_receiver> AND
           is_callable_v<CPO, const Receiver&>)
   friend auto tag_invoke(CPO cpo, const R& r) noexcept(

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -201,7 +201,7 @@ struct _op<Receiver, Senders...>::type {
   using operation = type;
   using receiver_type = Receiver;
   template <std::size_t Index, typename Receiver2, typename... Senders2>
-  friend class _element_receiver;
+  friend struct _element_receiver;
 
   explicit type(Receiver&& receiver, Senders&&... senders)
     : receiver_((Receiver &&) receiver),


### PR DESCRIPTION
Fix some easy problems that were causing msvc to fail to compile.
There are still more things but this gets a bit closer.

- Fix some access-control issues.
- Fix mismatched class/struct usage.
- Adds `is_receiver_query_cpo_v<CPO>` which is now used to filter receivers
  forwarding queries rather than `!is_receiver_cpo_v<CPO>`. This now explicitly
  excludes the `connect` CPO in an attempt to try to fix some recursive template
  instantiations under msvc.
- Work around lack of msvc support for fold-expressions in `noexcept` clauses.