### PR TITLE
Refactor CPOs for improved diagnostics

### DIFF
--- a/include/unifex/detail/concept_macros.hpp
+++ b/include/unifex/detail/concept_macros.hpp
@@ -286,8 +286,21 @@ namespace unifex {
   inline constexpr std::enable_if_t<B, int> requires_ = 0;
 #endif
 
-  template <typename B>
-  UNIFEX_CONCEPT is_true = (bool) B{};
+#if UNIFEX_CXX_CONCEPTS
+  template <typename Fn, typename... As>
+  concept //
+    callable = //
+      requires (Fn&& fn, As&&... as) {
+        ((Fn&&) fn)((As&&) as...);
+      };
+#else
+  template <typename Fn, typename... As>
+  UNIFEX_CONCEPT //
+    callable = //
+      sizeof(decltype(_is_callable::_try_call(static_cast<Fn(*)(As...)>(nullptr)))) ==
+      sizeof(_is_callable::yes_type);
+#endif
+
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/concept_macros.hpp
+++ b/include/unifex/detail/concept_macros.hpp
@@ -248,8 +248,8 @@
   #define UNIFEX_AND && \
     /**/
 #else
-  #define UNIFEX_TEMPLATE \
-    UNIFEX_TEMPLATE_SFINAE \
+  #define UNIFEX_TEMPLATE(...) \
+    template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
     /**/
   #define UNIFEX_AND && UNIFEX_true_, int> = 0, std::enable_if_t< \
     /**/

--- a/include/unifex/detail/prologue.hpp
+++ b/include/unifex/detail/prologue.hpp
@@ -22,5 +22,16 @@
 #endif
 #define UNIFEX_PROLOGUE_HPP
 
-#define template(...) UNIFEX_TEMPLATE(__VA_ARGS__)
+#include <unifex/config.hpp>
+
+#if UNIFEX_CXX_CONCEPTS
+  #define template(...) \
+    template <__VA_ARGS__> UNIFEX_PP_EXPAND \
+    /**/
+#else
+  #define template(...) \
+    template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
+    /**/
+#endif
+
 #define AND UNIFEX_AND

--- a/include/unifex/executor_concepts.hpp
+++ b/include/unifex/executor_concepts.hpp
@@ -68,32 +68,31 @@ namespace _execute_cpo {
     _has_member_execute = //
       UNIFEX_FRAGMENT(_execute_cpo::_has_member_execute_, Executor, Fn);
 
+  template <typename Fn>
+  UNIFEX_CONCEPT //
+    _lvalue_callable = //
+      callable<remove_cvref_t<Fn>&> &&
+      constructible_from<remove_cvref_t<Fn>, Fn> &&
+      move_constructible<remove_cvref_t<Fn>>;
+
   inline const struct _fn {
     template(typename Executor, typename Fn)
-      (requires (invocable<remove_cvref_t<Fn>&> &&
-          constructible_from<remove_cvref_t<Fn>, Fn> &&
-          move_constructible<remove_cvref_t<Fn>>) AND
+      (requires _lvalue_callable<Fn> AND
           tag_invocable<_fn, Executor, Fn>)
-    auto operator()(Executor&& e, Fn&& fn) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Executor, Fn>) ->
-        tag_invoke_result_t<_fn, Executor, Fn> {
-      return unifex::tag_invoke(_fn{}, (Executor &&) e, (Fn &&) fn);
+    void operator()(Executor&& e, Fn&& fn) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Executor, Fn>) {
+      unifex::tag_invoke(_fn{}, (Executor &&) e, (Fn &&) fn);
     }
     template(typename Executor, typename Fn)
-      (requires (invocable<remove_cvref_t<Fn>&> &&
-          constructible_from<remove_cvref_t<Fn>, Fn> &&
-          move_constructible<remove_cvref_t<Fn>>) AND
+      (requires _lvalue_callable<Fn> AND
           (!tag_invocable<_fn, Executor, Fn>) AND
           _has_member_execute<Executor, Fn>)
-    auto operator()(Executor&& e, Fn&& fn) const
-        noexcept(noexcept(((Executor &&) e).execute((Fn &&) fn))) ->
-        _member_execute_result_t<Executor, Fn> {
-      return ((Executor &&) e).execute((Fn &&) fn);
+    void operator()(Executor&& e, Fn&& fn) const
+        noexcept(noexcept(((Executor &&) e).execute((Fn &&) fn))) {
+      ((Executor &&) e).execute((Fn &&) fn);
     }
     template(typename Sender, typename Fn)
-      (requires (invocable<remove_cvref_t<Fn>&> &&
-          constructible_from<remove_cvref_t<Fn>, Fn> &&
-          move_constructible<remove_cvref_t<Fn>>) AND
+      (requires _lvalue_callable<Fn> AND
           (!tag_invocable<_fn, Sender, Fn>) AND
           (!_has_member_execute<Sender, Fn>) AND
           _can_submit<Sender, Fn>)

--- a/include/unifex/for_each.hpp
+++ b/include/unifex/for_each.hpp
@@ -23,44 +23,59 @@
 
 namespace unifex {
 namespace _for_each {
-  inline const struct _fn {
-    private:
-      template <bool>
-      struct _impl {
-        template <typename Stream, typename Func>
-        auto operator()(Stream&& stream, Func&& func) const
-            noexcept(is_nothrow_tag_invocable_v<_fn, Stream, Func>)
-            -> tag_invoke_result_t<_fn, Stream, Func> {
-          return unifex::tag_invoke(_fn{}, (Stream&&) stream, (Func&&) func);
-        }
-      };
-    public:
-      template <typename Stream, typename Func>
-      auto operator()(Stream&& stream, Func&& func) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_fn, Stream, Func>>, Stream, Func>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_fn, Stream, Func>>, Stream, Func> {
-      return _impl<is_tag_invocable_v<_fn, Stream, Func>>{}(
-        (Stream&&) stream, (Func&&) func);
-    }
-  } for_each{};
+  namespace _impl {
+    template <typename Func>
+    struct _map {
+      Func func_;
+      template(typename... Ts)
+        (requires invocable<Func&, Ts...>)
+      unit operator()(unit s, Ts&&... values)
+          noexcept(std::is_nothrow_invocable_v<Func&, Ts...>) {
+        std::invoke(func_, (Ts&&) values...);
+        return s;
+      }
+    };
+    struct _reduce {
+      void operator()(unit s) const noexcept {}
+    };
+  } // namespace _impl
 
-  template <>
-  struct _fn::_impl<false> {
+  inline const struct _fn {
+  private:
     template <typename Stream, typename Func>
-    auto operator()(Stream&& stream, Func&& func) const {
+    using _default_result_t =
+        decltype(transform(
+          reduce_stream(
+            UNIFEX_DECLVAL(Stream),
+            unit{},
+            UNIFEX_DECLVAL(_impl::_map<remove_cvref_t<Func>>)),
+          _impl::_reduce{}));
+    template <typename Stream, typename Func>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_fn, Stream, Func>,
+        meta_tag_invoke_result<_fn>,
+        meta_quote2<_default_result_t>>::template apply<Stream, Func>;
+  public:
+    template(typename Stream, typename Func)
+      (requires tag_invocable<_fn, Stream, Func>)
+    auto operator()(Stream&& stream, Func&& func) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Stream, Func>)
+        -> _result_t<Stream, Func> {
+      return unifex::tag_invoke(_fn{}, (Stream&&) stream, (Func&&) func);
+    }
+    template(typename Stream, typename Func)
+      (requires (!tag_invocable<_fn, Stream, Func>))
+    auto operator()(Stream&& stream, Func&& func) const
+        -> _result_t<Stream, Func> {
       return transform(
           reduce_stream(
               (Stream &&) stream,
               unit{},
-              [func = (Func &&) func](unit s, auto&&... values) mutable {
-                std::invoke(func, (decltype(values))values...);
-                return s;
-              }),
-          [](unit) noexcept {});
+              _impl::_map<remove_cvref_t<Func>>{(Func &&) func}),
+          _impl::_reduce{});
     }
-  };
+  } for_each{};
 } // namespace _for_each
 
 using _for_each::for_each;

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -30,157 +30,136 @@ namespace unifex {
 namespace _rec_cpo {
   inline const struct _set_value_fn {
   private:
-    template <bool>
-    struct _impl {
     template <typename Receiver, typename... Values>
-      auto operator()(Receiver&& r, Values&&... values) const
-          noexcept(
-              is_nothrow_tag_invocable_v<_set_value_fn, Receiver, Values...>)
-          -> tag_invoke_result_t<_set_value_fn, Receiver, Values...> {
-        return unifex::tag_invoke(
-            _set_value_fn{}, (Receiver &&) r, (Values &&) values...);
-      }
-    };
+    using set_value_member_result_t =
+      decltype(UNIFEX_DECLVAL(Receiver).set_value(UNIFEX_DECLVAL(Values)...));
+    template <typename Receiver, typename... Values>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_set_value_fn, Receiver, Values...>,
+        meta_tag_invoke_result<_set_value_fn>,
+        meta_quote1_<set_value_member_result_t>>::template apply<Receiver, Values...>;
   public:
-    template <typename Receiver, typename... Values>
+    template(typename Receiver, typename... Values)
+      (requires tag_invocable<_set_value_fn, Receiver, Values...>)
     auto operator()(Receiver&& r, Values&&... values) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_set_value_fn, Receiver, Values...>>,
-            Receiver, Values...>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_set_value_fn, Receiver, Values...>>,
-            Receiver, Values...> {
-      return _impl<is_tag_invocable_v<_set_value_fn, Receiver, Values...>>{}(
-          (Receiver &&) r, (Values &&) values...);
+        noexcept(
+            is_nothrow_tag_invocable_v<_set_value_fn, Receiver, Values...>)
+        -> _result_t<Receiver, Values...> {
+      return unifex::tag_invoke(
+          _set_value_fn{}, (Receiver &&) r, (Values &&) values...);
     }
-  } set_value{};
-
-  template <>
-  struct _set_value_fn::_impl<false> {
-    template <typename Receiver, typename... Values>
+    template(typename Receiver, typename... Values)
+      (requires (!tag_invocable<_set_value_fn, Receiver, Values...>))
     auto operator()(Receiver&& r, Values&&... values) const
         noexcept(noexcept(
             static_cast<Receiver&&>(r).set_value((Values &&) values...)))
-        -> decltype(static_cast<Receiver&&>(r).set_value((Values &&) values...)) {
+        -> _result_t<Receiver, Values...> {
       return static_cast<Receiver&&>(r).set_value((Values &&) values...);
     }
-  };
+  } set_value{};
 
   inline const struct _set_next_fn {
   private:
-    template <bool>
-    struct _impl {
     template <typename Receiver, typename... Values>
-      auto operator()(Receiver&& r, Values&&... values) const
-          noexcept(
-              is_nothrow_tag_invocable_v<_set_next_fn, Receiver, Values...>)
-          -> tag_invoke_result_t<_set_next_fn, Receiver, Values...> {
-        return unifex::tag_invoke(
-            _set_next_fn{}, (Receiver &&) r, (Values &&) values...);
-      }
-    };
+    using set_next_member_result_t =
+      decltype(UNIFEX_DECLVAL(Receiver).set_next(UNIFEX_DECLVAL(Values)...));
+    template <typename Receiver, typename... Values>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_set_next_fn, Receiver, Values...>,
+        meta_tag_invoke_result<_set_next_fn>,
+        meta_quote1_<set_next_member_result_t>>::template apply<Receiver, Values...>;
   public:
-    template <typename Receiver, typename... Values>
+    template(typename Receiver, typename... Values)
+      (requires tag_invocable<_set_next_fn, Receiver, Values...>)
     auto operator()(Receiver&& r, Values&&... values) const
-        noexcept(std::is_nothrow_invocable_v<
-            _impl<is_tag_invocable_v<_set_next_fn, Receiver, Values...>>,
-            Receiver, Values...>)
-        -> std::invoke_result_t<
-            _impl<is_tag_invocable_v<_set_next_fn, Receiver, Values...>>,
-            Receiver, Values...> {
-      return _impl<is_tag_invocable_v<_set_next_fn, Receiver, Values...>>{}(
-          (Receiver &&) r, (Values &&) values...);
+        noexcept(
+            is_nothrow_tag_invocable_v<_set_next_fn, Receiver, Values...>)
+        -> _result_t<Receiver, Values...> {
+      return unifex::tag_invoke(
+          _set_next_fn{}, (Receiver &&) r, (Values &&) values...);
     }
-  } set_next{};
-
-  template <>
-  struct _set_next_fn::_impl<false> {
-    template <typename Receiver, typename... Values>
+    template(typename Receiver, typename... Values)
+      (requires (!tag_invocable<_set_next_fn, Receiver, Values...>))
     auto operator()(Receiver&& r, Values&&... values) const
         noexcept(noexcept(
             static_cast<Receiver&&>(r).set_next((Values &&) values...)))
-        -> decltype(static_cast<Receiver&&>(r).set_next((Values &&) values...)) {
+        -> _result_t<Receiver, Values...> {
       return static_cast<Receiver&&>(r).set_next((Values &&) values...);
     }
-  };
+  } set_next{};
 
   inline const struct _set_error_fn {
   private:
-    template <bool>
-    struct _impl {
     template <typename Receiver, typename Error>
-      auto operator()(Receiver&& r, Error&& error) const noexcept
-          -> tag_invoke_result_t<_set_error_fn, Receiver, Error> {
-        static_assert(
-            is_nothrow_tag_invocable_v<_set_error_fn, Receiver, Error>,
-            "set_error() invocation is required to be noexcept.");
-        static_assert(
-          std::is_void_v<tag_invoke_result_t<_set_error_fn, Receiver, Error>>
-        );
-        return unifex::tag_invoke(
-            _set_error_fn{}, (Receiver &&) r, (Error&&) error);
-      }
-    };
+    using set_error_member_result_t =
+      decltype(UNIFEX_DECLVAL(Receiver).set_error(UNIFEX_DECLVAL(Error)));
+    template <typename Receiver, typename Error>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_set_error_fn, Receiver, Error>,
+        meta_tag_invoke_result<_set_error_fn>,
+        meta_quote2<set_error_member_result_t>>::template apply<Receiver, Error>;
   public:
-    template <typename Receiver, typename Error>
+    template(typename Receiver, typename Error)
+      (requires tag_invocable<_set_error_fn, Receiver, Error>)
     auto operator()(Receiver&& r, Error&& error) const noexcept
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_set_error_fn, Receiver, Error>>,
-            Receiver, Error> {
-      return _impl<is_tag_invocable_v<_set_error_fn, Receiver, Error>>{}(
-          (Receiver &&) r, (Error&&) error);
+        -> _result_t<Receiver, Error> {
+      static_assert(
+          is_nothrow_tag_invocable_v<_set_error_fn, Receiver, Error>,
+          "set_error() invocation is required to be noexcept.");
+      static_assert(
+        std::is_void_v<tag_invoke_result_t<_set_error_fn, Receiver, Error>>
+      );
+      return unifex::tag_invoke(
+          _set_error_fn{}, (Receiver &&) r, (Error&&) error);
     }
-  } set_error{};
-
-  template <>
-  struct _set_error_fn::_impl<false> {
-    template <typename Receiver, typename Error>
+    template(typename Receiver, typename Error)
+      (requires (!tag_invocable<_set_error_fn, Receiver, Error>))
     auto operator()(Receiver&& r, Error&& error) const noexcept
-        -> decltype(static_cast<Receiver&&>(r).set_error((Error&&) error)) {
+        -> _result_t<Receiver, Error> {
       static_assert(
           noexcept(static_cast<Receiver&&>(r).set_error((Error &&) error)),
           "receiver.set_error() method must be nothrow invocable");
       return static_cast<Receiver&&>(r).set_error((Error&&) error);
     }
-  };
+  } set_error{};
 
   inline const struct _set_done_fn {
   private:
-    template <bool>
-    struct _impl {
     template <typename Receiver>
-      auto operator()(Receiver&& r) const noexcept
-          -> tag_invoke_result_t<_set_done_fn, Receiver> {
-        static_assert(
-            is_nothrow_tag_invocable_v<_set_done_fn, Receiver>,
-            "set_done() invocation is required to be noexcept.");
-        static_assert(
-          std::is_void_v<tag_invoke_result_t<_set_done_fn, Receiver>>
-        );
-        return unifex::tag_invoke(_set_done_fn{}, (Receiver &&) r);
-      }
-    };
+    using set_done_member_result_t =
+      decltype(UNIFEX_DECLVAL(Receiver).set_done());
+    template <typename Receiver>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_set_done_fn, Receiver>,
+        meta_tag_invoke_result<_set_done_fn>,
+        meta_quote1<set_done_member_result_t>>::template apply<Receiver>;
   public:
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires tag_invocable<_set_done_fn, Receiver>)
     auto operator()(Receiver&& r) const noexcept
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_set_done_fn, Receiver>>, Receiver> {
-      return _impl<is_tag_invocable_v<_set_done_fn, Receiver>>{}(
-          (Receiver &&) r);
+        -> _result_t<Receiver> {
+      static_assert(
+          is_nothrow_tag_invocable_v<_set_done_fn, Receiver>,
+          "set_done() invocation is required to be noexcept.");
+      static_assert(
+        std::is_void_v<tag_invoke_result_t<_set_done_fn, Receiver>>
+      );
+      return unifex::tag_invoke(_set_done_fn{}, (Receiver &&) r);
     }
-  } set_done{};
-
-  template <>
-  struct _set_done_fn::_impl<false> {
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires (!tag_invocable<_set_done_fn, Receiver>))
     auto operator()(Receiver&& r) const noexcept
-        -> decltype(static_cast<Receiver&&>(r).set_done()) {
+        -> _result_t<Receiver> {
       static_assert(
           noexcept(static_cast<Receiver&&>(r).set_done()),
           "receiver.set_done() method must be nothrow invocable");
       return static_cast<Receiver&&>(r).set_done();
     }
-  };
+  } set_done{};
 } // namespace _rec_cpo
 
 using _rec_cpo::set_value;
@@ -211,6 +190,28 @@ inline constexpr bool is_receiver_query_cpo_v = !is_one_of_v<
 template <typename T>
 using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;
 
+#if UNIFEX_CPP_CONCEPTS
+// Defined the receiver concepts without the macros for improved diagnostics
+template <typename R, typename E>
+concept //
+  receiver = //
+    move_constructible<remove_cvref_t<R>> &&
+    constructible_from<remove_cvref_t<R>, R> &&
+    requires(remove_cvref_t<R>&& r, E&& e)
+    {
+      { set_done(std::move(r))) } noexcept;
+      { set_error(std::move(r), (E&&) e)) } noexcept;
+    };
+
+template <typename R, typename... An>
+concept //
+  receiver_of = //
+    receiver<R> &&
+    requires(remove_cvref_t<R>&& r, An&&... an) //
+    {
+      set_value(std::move(r), (An&&) an...);
+    };
+#else
 template <typename R, typename E>
 UNIFEX_CONCEPT_FRAGMENT(
   _receiver,
@@ -221,25 +222,26 @@ UNIFEX_CONCEPT_FRAGMENT(
     ));
 
 template <typename R, typename E = std::exception_ptr>
-UNIFEX_CONCEPT
-  receiver =
+UNIFEX_CONCEPT //
+  receiver = //
     move_constructible<remove_cvref_t<R>> &&
     constructible_from<remove_cvref_t<R>, R> &&
     UNIFEX_FRAGMENT(unifex::_receiver, R, E);
 
 template <typename T, typename... An>
-UNIFEX_CONCEPT_FRAGMENT(
-  _receiver_of,
+UNIFEX_CONCEPT_FRAGMENT( //
+  _receiver_of, //
     requires(remove_cvref_t<T>&& t, An&&... an) //
     (
       set_value(std::move(t), (An&&) an...)
     ));
 
 template <typename R, typename... An>
-UNIFEX_CONCEPT
-  receiver_of =
+UNIFEX_CONCEPT //
+  receiver_of = //
     receiver<R> &&
     UNIFEX_FRAGMENT(unifex::_receiver_of, R, An...);
+#endif
 
 template <typename R, typename... An>
   inline constexpr bool is_nothrow_receiver_of_v =

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -190,17 +190,17 @@ inline constexpr bool is_receiver_query_cpo_v = !is_one_of_v<
 template <typename T>
 using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;
 
-#if UNIFEX_CPP_CONCEPTS
+#if UNIFEX_CXX_CONCEPTS
 // Defined the receiver concepts without the macros for improved diagnostics
-template <typename R, typename E>
+template <typename R, typename E = std::exception_ptr>
 concept //
   receiver = //
     move_constructible<remove_cvref_t<R>> &&
     constructible_from<remove_cvref_t<R>, R> &&
     requires(remove_cvref_t<R>&& r, E&& e)
     {
-      { set_done(std::move(r))) } noexcept;
-      { set_error(std::move(r), (E&&) e)) } noexcept;
+      { set_done(std::move(r)) } noexcept;
+      { set_error(std::move(r), (E&&) e) } noexcept;
     };
 
 template <typename R, typename... An>

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -27,38 +27,34 @@ namespace unifex {
 namespace _schedule {
   struct sender;
   inline const struct _fn {
-    template <bool>
-    struct _impl {
-      template <typename Scheduler>
-      constexpr auto operator()(Scheduler&& s) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
-          -> tag_invoke_result_t<_fn, Scheduler> {
-        return tag_invoke(_fn{}, static_cast<Scheduler&&>(s));
-      }
-    };
-
+  private:
     template <typename Scheduler>
+    using _schedule_member_result_t =
+      decltype(UNIFEX_DECLVAL(Scheduler).schedule());
+    template <typename Scheduler>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_fn, Scheduler>,
+        meta_tag_invoke_result<_fn>,
+        meta_quote1<_schedule_member_result_t>>::template apply<Scheduler>;
+  public:
+    template(typename Scheduler)
+      (requires tag_invocable<_fn, Scheduler>)
     constexpr auto operator()(Scheduler&& s) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_fn, Scheduler>>, Scheduler>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_fn, Scheduler>>, Scheduler> {
-      return _impl<is_tag_invocable_v<_fn, Scheduler>>{}(
-          static_cast<Scheduler&&>(s));
+        noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
+        -> _result_t<Scheduler> {
+      return tag_invoke(_fn{}, static_cast<Scheduler&&>(s));
+    }
+    template(typename Scheduler)
+      (requires (!tag_invocable<_fn, Scheduler>))
+    constexpr auto operator()(Scheduler&& s) const noexcept(
+        noexcept(static_cast<Scheduler&&>(s).schedule()))
+        -> _result_t<Scheduler> {
+      return static_cast<Scheduler&&>(s).schedule();
     }
 
     constexpr sender operator()() const noexcept;
   } schedule{};
-
-  template <>
-  struct _fn::_impl<false> {
-    template <typename Scheduler>
-    constexpr auto operator()(Scheduler&& s) noexcept(
-        noexcept(static_cast<Scheduler&&>(s).schedule()))
-        -> decltype(static_cast<Scheduler&&>(s).schedule()) {
-      return static_cast<Scheduler&&>(s).schedule();
-    }
-  };
 } // namespace _schedule
 using _schedule::schedule;
 
@@ -111,25 +107,32 @@ namespace _schedule_after {
   using sender = typename _sender<Duration>::type;
 
   inline const struct _fn {
-    template <bool>
-    struct _impl {
-      template <typename TimeScheduler, typename Duration>
-      constexpr auto operator()(TimeScheduler&& s, Duration&& d) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, Duration>)
-          -> tag_invoke_result_t<_fn, TimeScheduler, Duration> {
-        return tag_invoke(*this, (TimeScheduler &&) s, (Duration &&) d);
-      }
-    };
-
+  private:
     template <typename TimeScheduler, typename Duration>
+    using _schedule_after_member_result_t =
+      decltype(UNIFEX_DECLVAL(TimeScheduler).schedule_after(UNIFEX_DECLVAL(Duration)));
+    template <typename TimeScheduler, typename Duration>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_fn, TimeScheduler, Duration>,
+        meta_tag_invoke_result<_fn>,
+        meta_quote2<_schedule_after_member_result_t>>
+          ::template apply<TimeScheduler, Duration>;
+  public:
+    template(typename TimeScheduler, typename Duration)
+      (requires tag_invocable<_fn, TimeScheduler, Duration>)
     constexpr auto operator()(TimeScheduler&& s, Duration&& d) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler, Duration>>, TimeScheduler, Duration>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler, Duration>>, TimeScheduler, Duration> {
-      return _impl<is_tag_invocable_v<_fn, TimeScheduler, Duration>>{}(
-          static_cast<TimeScheduler&&>(s),
-          static_cast<Duration&&>(d));
+        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, Duration>)
+        -> _result_t<TimeScheduler, Duration> {
+      return tag_invoke(*this, (TimeScheduler &&) s, (Duration &&) d);
+    }
+
+    template(typename TimeScheduler, typename Duration)
+      (requires (!tag_invocable<_fn, TimeScheduler, Duration>))
+    constexpr auto operator()(TimeScheduler&& s, Duration&& d) const noexcept(
+        noexcept(static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d)))
+        -> _result_t<TimeScheduler, Duration> {
+      return static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d);
     }
 
     template <typename Duration>
@@ -137,16 +140,6 @@ namespace _schedule_after {
       return sender<Duration>{std::move(d)};
     }
   } schedule_after{};
-
-  template <>
-  struct _fn::_impl<false> {
-    template <typename TimeScheduler, typename Duration>
-    constexpr auto operator()(TimeScheduler&& s, Duration&& d) const noexcept(
-        noexcept(static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d)))
-        -> decltype(static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d)) {
-      return static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d);
-    }
-  };
 
   template <typename Duration>
   class _sender<Duration>::type {
@@ -183,72 +176,66 @@ using _schedule_after::schedule_after;
 
 namespace _schedule_at {
   inline const struct _fn {
-    template <bool>
-    struct _impl {
-      template <typename TimeScheduler, typename TimePoint>
-      constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, TimePoint>)
-          -> tag_invoke_result_t<_fn, TimeScheduler, TimePoint> {
-        return tag_invoke(*this, (TimeScheduler &&) s, (TimePoint &&) tp);
-      }
-    };
-
+  private:
     template <typename TimeScheduler, typename TimePoint>
+    using _schedule_at_member_result_t =
+      decltype(UNIFEX_DECLVAL(TimeScheduler).schedule_at(UNIFEX_DECLVAL(TimePoint)));
+    template <typename TimeScheduler, typename TimePoint>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_fn, TimeScheduler, TimePoint>,
+        meta_tag_invoke_result<_fn>,
+        meta_quote2<_schedule_at_member_result_t>>
+          ::template apply<TimeScheduler, TimePoint>;
+  public:
+    template(typename TimeScheduler, typename TimePoint)
+      (requires tag_invocable<_fn, TimeScheduler, TimePoint>)
     constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler, TimePoint>>, TimeScheduler, TimePoint>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler, TimePoint>>, TimeScheduler, TimePoint> {
-      return _impl<is_tag_invocable_v<_fn, TimeScheduler, TimePoint>>{}(
-          static_cast<TimeScheduler&&>(s),
-          static_cast<TimePoint&&>(tp));
+        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, TimePoint>)
+        -> _result_t<TimeScheduler, TimePoint> {
+      return tag_invoke(*this, (TimeScheduler &&) s, (TimePoint &&) tp);
     }
-  } schedule_at {};
 
-  template <>
-  struct _fn::_impl<false> {
-    template <typename TimeScheduler, typename TimePoint>
+    template(typename TimeScheduler, typename TimePoint)
+      (requires (!tag_invocable<_fn, TimeScheduler, TimePoint>))
     constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const noexcept(
         noexcept(static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp)))
-        -> decltype(static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp)) {
+        -> _result_t<TimeScheduler, TimePoint> {
       return static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp);
     }
-  };
+  } schedule_at {};
 } // namespace _schedule_at
 using _schedule_at::schedule_at;
 
 namespace _now {
   inline const struct _fn {
-    template <bool>
-    struct _impl {
-      template <typename TimeScheduler>
-      constexpr auto operator()(TimeScheduler&& s) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler>)
-          -> tag_invoke_result_t<_fn, TimeScheduler> {
-        return tag_invoke(*this, (TimeScheduler &&) s);
-      }
-    };
-
+  private:
     template <typename TimeScheduler>
+    using _now_member_result_t =
+      decltype(UNIFEX_DECLVAL(TimeScheduler).now());
+    template <typename TimeScheduler>
+    using _result_t =
+      typename conditional_t<
+        tag_invocable<_fn, TimeScheduler>,
+        meta_tag_invoke_result<_fn>,
+        meta_quote1<_now_member_result_t>>::template apply<TimeScheduler>;
+  public:
+    template(typename TimeScheduler)
+      (requires tag_invocable<_fn, TimeScheduler>)
     constexpr auto operator()(TimeScheduler&& s) const
-        noexcept(is_nothrow_callable_v<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler>>, TimeScheduler>)
-        -> callable_result_t<
-            _impl<is_tag_invocable_v<_fn, TimeScheduler>>, TimeScheduler> {
-      return _impl<is_tag_invocable_v<_fn, TimeScheduler>>{}(
-          static_cast<TimeScheduler&&>(s));
+        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler>)
+        -> _result_t<TimeScheduler> {
+      return tag_invoke(*this, (TimeScheduler &&) s);
     }
-  } now {};
 
-  template <>
-  struct _fn::_impl<false> {
-    template <typename TimeScheduler>
+    template(typename TimeScheduler)
+      (requires (!tag_invocable<_fn, TimeScheduler>))
     constexpr auto operator()(TimeScheduler&& s) const noexcept(
         noexcept(static_cast<TimeScheduler&&>(s).now()))
-        -> decltype(static_cast<TimeScheduler&&>(s).now()) {
+        -> _result_t<TimeScheduler> {
       return static_cast<TimeScheduler&&>(s).now();
     }
-  };
+  } now {};
 } // namespace _now
 using _now::now;
 

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -176,8 +176,6 @@ using _start_cpo::start;
 namespace _connect_cpo {
   using detail::_can_execute;
 
-  struct _fn;
-
   template <typename Sender, typename Receiver>
   using _member_connect_result_t =
       decltype((UNIFEX_DECLVAL(Sender&&)).connect(
@@ -221,26 +219,14 @@ namespace _connect_cpo {
     };
     template <typename Executor, typename Receiver>
     using _as_operation = typename _as_op<Executor, Receiver>::type;
-    struct _tag_invoke_result {
-      template <typename Sender, typename Receiver>
-      using apply = tag_invoke_result_t<_fn, Sender, Receiver>;
-    };
-    struct _member_connect_result {
-      template <typename Sender, typename Receiver>
-      using apply = _member_connect_result_t<Sender, Receiver>;
-    };
-    struct _execute_result {
-      template <typename Executor, typename Receiver>
-      using apply = _as_operation<Executor, Receiver>;
-    };
     template <typename Sender, typename Receiver>
     static auto _select() {
       if constexpr (_with_tag_invoke<Sender, Receiver>) {
-        return _tag_invoke_result{};
+        return meta_tag_invoke_result<_fn>{};
       } else if constexpr (_with_member_connect<Sender, Receiver>) {
-        return _member_connect_result{};
+        return meta_quote2<_member_connect_result_t>{};
       } else if constexpr (_with_execute<Sender, Receiver>) {
-        return _execute_result{};
+        return meta_quote2<_as_operation>{};
       } else {
         return type_always<void>{};
       }

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -108,6 +108,9 @@ namespace unifex {
       (sizeof(_tag_invoke::try_tag_invoke<CPO, Args...>(0)) ==
        sizeof(_tag_invoke::yes_type));
 
+  template <typename Fn>
+  using meta_tag_invoke_result =
+      meta_quote1_<tag_invoke_result_t>::bind_front<Fn>;
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_traits.hpp
+++ b/include/unifex/type_traits.hpp
@@ -55,7 +55,7 @@
 #define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible<__VA_ARGS__>::value
 #endif
 
-#define UNIFEX_DECLVAL(T) static_cast<T(*)()noexcept>(nullptr)()
+#define UNIFEX_DECLVAL(...) static_cast<__VA_ARGS__(*)()noexcept>(nullptr)()
 
 namespace unifex {
 
@@ -192,6 +192,84 @@ template <typename T>
 struct type_always {
   template <typename...>
   using apply = T;
+};
+
+template <template <typename...> class T>
+struct meta_quote {
+  template <typename... As>
+  struct bind_front {
+    template <typename... Bs>
+    using apply = T<As..., Bs...>;
+  };
+  template <typename... As>
+  using apply = T<As...>;
+};
+
+template <template <typename> class T>
+struct meta_quote1 {
+  template <typename...>
+  struct bind_front;
+  template <typename A0>
+  struct bind_front<A0> {
+    template <int = 0>
+    using apply = T<A0>;
+  };
+  template <typename A0>
+  using apply = T<A0>;
+};
+
+template <template <typename, typename> class T>
+struct meta_quote2 {
+  template <typename...>
+  struct bind_front;
+  template <typename A0>
+  struct bind_front<A0> {
+    template <typename A1>
+    using apply = T<A0, A1>;
+  };
+  template <typename A0, typename A1>
+  struct bind_front<A0, A1> {
+    template <int = 0>
+    using apply = T<A0, A1>;
+  };
+  template <typename A0, typename A1>
+  using apply = T<A0, A1>;
+};
+
+template <template <typename, typename, typename> class T>
+struct meta_quote3 {
+  template <typename...>
+  struct bind_front;
+  template <typename A0>
+  struct bind_front<A0> {
+    template <typename A1, typename A2>
+    using apply = T<A0, A1, A2>;
+  };
+  template <typename A0, typename A1>
+  struct bind_front<A0, A1> {
+    template <typename A2>
+    using apply = T<A0, A1, A2>;
+  };
+  template <typename A0, typename A1, typename A2>
+  struct bind_front<A0, A1, A2> {
+    template <int = 0>
+    using apply = T<A0, A1, A2>;
+  };
+  template <typename A0, typename A1, typename A2>
+  using apply = T<A0, A1, A2>;
+};
+
+template <template <typename, typename...> class T>
+struct meta_quote1_ {
+  template <typename A, typename... Bs>
+  using apply = T<A, Bs...>;
+  template <typename...>
+  struct bind_front;
+  template <typename A, typename... Bs>
+  struct bind_front<A, Bs...> {
+    template <typename... Cs>
+    using apply = T<A, Bs..., Cs...>;
+  };
 };
 
 } // namespace unifex


### PR DESCRIPTION
Also:
- Define the receiver concepts without the macros when the compiler supports concepts.
- Unroll some macros so diagnostics are shorter.
