### PR TITLE
Reduce the log-spam from for_each_via_trampoline example

### DIFF
--- a/examples/for_each_via_trampoline.cpp
+++ b/examples/for_each_via_trampoline.cpp
@@ -31,7 +31,7 @@ int main() {
           typed_via_stream(
               trampoline_scheduler{},
               transform_stream(
-                  range_stream{0, 10'000},
+                  range_stream{0, 10},
                   [](int value) { return value * value; })),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done"); }));


### PR DESCRIPTION
Output only 10 lines to log instead of 10k lines.