### PR TITLE
Fix potential race in submit_with_allocator_customisation tests.

### DIFF
--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -83,15 +83,20 @@ void test(Scheduler scheduler, Allocator allocator) {
 }
 
 int main() {
-  single_thread_context thread;
-
-  test(thread.get_scheduler(), std::allocator<std::byte>{});
+  {
+    single_thread_context thread;
+    test(thread.get_scheduler(), std::allocator<std::byte>{});
+  }
 
 #if !UNIFEX_NO_MEMORY_RESOURCE
   {
     counting_memory_resource res{new_delete_resource()};
     polymorphic_allocator<char> alloc{&res};
-    test(thread.get_scheduler(), alloc);
+    
+    {
+      single_thread_context thread;
+      test(thread.get_scheduler(), alloc);
+    }
 
     // Check that it freed all the memory it allocated
     if (res.total_allocated_bytes() != 0) {


### PR DESCRIPTION
It's possible that the `sync_wait()` call might return before the
`submit()` algorithm has finished deallocating the memory.
So we need to join the thread it was being executed before
checking the allocation counts so that we know the deallocation
has completed.