### PR TITLE
Forward progress delegation

### DIFF
--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/for_each.hpp>
+#include <unifex/range_stream.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/timed_single_thread_context.hpp>
+#include <unifex/transform_stream.hpp>
+#include <unifex/via_stream.hpp>
+#include <unifex/with_query_value.hpp>
+
+#include <chrono>
+
+using namespace unifex;
+using namespace std::chrono_literals;
+
+namespace {
+template <typename Receiver>
+struct _delegating_op {
+  class type;
+};
+
+template <typename OperationState>
+class delegating_operation final {
+  public:
+  inline void start() noexcept {
+    std::printf("start()\n");
+    target_op_.start();
+  }
+
+  OperationState target_op_;
+};
+
+class delegating_sender {
+
+  public:
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+
+  template <typename Receiver>
+  auto connect(Receiver&& receiver) {
+    auto target_scheduler = unifex::get_scheduler(std::as_const(receiver));
+    auto target_op = unifex::connect(unifex::schedule(target_scheduler), (Receiver&&)receiver);
+    std::printf("connect\n");
+    return delegating_operation<
+      remove_cvref_t<decltype(target_op)>>{
+        std::move(target_op)};
+  }
+};
+
+class delegating_scheduler {
+  public:
+  auto schedule() const noexcept {
+    return delegating_sender{};
+  }
+};
+} // namespace
+
+int main() {
+  timed_single_thread_context ctx;
+
+  // Check that the schedule() operation can pick up the current
+  // scheduler from the receiver which we inject by using 'with_query_value()'.
+  sync_wait(with_query_value(schedule(), get_scheduler,
+                             ctx.get_scheduler()));
+
+  // Check that the schedule_after(d) operation can pick up the current
+  // scheduler from the receiver.
+  sync_wait(with_query_value(
+      schedule_after(200ms), get_scheduler, ctx.get_scheduler()));
+
+  // Check that this can propagate through multiple levels of
+  // composed operations.
+  sync_wait(with_query_value(
+      transform(
+          for_each(via_stream(delegating_scheduler{},
+                              transform_stream(range_stream{0, 10},
+                                               [](int value) {
+                                                 return value * value;
+                                               })),
+                   [](int value) { std::printf("got %i\n", value); }),
+          []() { std::printf("done\n"); }),
+      get_scheduler, ctx.get_scheduler()));
+
+  return 0;
+}

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <unifex/for_each.hpp>
+#include <unifex/manual_event_loop.hpp>
 #include <unifex/range_stream.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
@@ -146,8 +147,9 @@ delegating_scheduler delegating_context::get_scheduler() noexcept {
 // a thread rather than inline on the caller
 template<class Sender>
 auto sync_wait_with_context(Sender&& s) {
-  timed_single_thread_context ctx;
-  return sync_wait(with_query_value((Sender&&)s, get_scheduler, ctx.get_scheduler()));
+  //timed_single_thread_context ctx;
+  //return sync_wait(with_query_value((Sender&&)s, get_scheduler, ctx.get_scheduler()));
+  return sync_wait((Sender&&)s);
 }
 
 int main() {

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -134,7 +134,7 @@ delegating_scheduler delegating_context::get_scheduler() noexcept {
 template<class Sender>
 auto sync_wait_with_context(Sender&& s) {
   timed_single_thread_context ctx;
-  return with_query_value((Sender&&)s, get_scheduler, ctx.get_scheduler());
+  return sync_wait(with_query_value((Sender&&)s, get_scheduler, ctx.get_scheduler()));
 }
 
 int main() {

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -142,22 +142,12 @@ delegating_scheduler delegating_context::get_scheduler() noexcept {
 }
 } // namespace
 
-// sync_wait_with_context simulates P1898R1's sync_wait by always providing a
-// context that will run the work, although for simplicity of reuse here it is
-// a thread rather than inline on the caller
-template<class Sender>
-auto sync_wait_with_context(Sender&& s) {
-  //timed_single_thread_context ctx;
-  //return sync_wait(with_query_value((Sender&&)s, get_scheduler, ctx.get_scheduler()));
-  return sync_wait((Sender&&)s);
-}
-
 int main() {
   delegating_context inner_delegating_ctx{2};
   delegating_context outer_delegating_ctx{3};
 
   // Try inner context, then outer context, delegating to ctx if necessary
-  sync_wait_with_context(
+  sync_wait(
       transform(
           for_each(via_stream(outer_delegating_ctx.get_scheduler(),
                               transform_stream(via_stream(inner_delegating_ctx.get_scheduler(),

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -72,7 +72,7 @@ class delegating_operation final {
   public:
   template<class InitFunc>
   delegating_operation(InitFunc&& func, delegating_context* context) :
-    op_{std::in_place_type_t<std::remove_cvref_t<decltype(func())>>{}, func()}, context_{context} {
+    op_{std::in_place_type_t<remove_cvref_t<decltype(func())>>{}, func()}, context_{context} {
   }
 
 

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -24,6 +24,7 @@
 #include <unifex/with_query_value.hpp>
 
 #include <chrono>
+#include <atomic>
 
 using namespace unifex;
 using namespace std::chrono_literals;

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -127,7 +127,7 @@ delegating_scheduler delegating_context::get_scheduler() noexcept {
 }
 } // namespace
 
-// sync_wait_with_context simulates P1897R3's sync_wait by always providing a
+// sync_wait_with_context simulates P1898R1's sync_wait by always providing a
 // context that will run the work, although for simplicity of reuse here it is
 // a thread rather than inline on the caller
 template<class Sender>

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -67,12 +67,23 @@ class delegating_context {
   timed_single_thread_context single_thread_context_;
 };
 
+template<typename T>
+struct FuncWrapper {
+  T func_;
+  operator std::invoke_result_t<T&&>() {
+    return func_();
+  }
+};
+
 template <typename DelegatedOperationState, typename LocalOperationState>
 class delegating_operation final {
   public:
   template<class InitFunc>
   delegating_operation(InitFunc&& func, delegating_context* context) :
-    op_{std::in_place_type_t<remove_cvref_t<decltype(func())>>{}, func()}, context_{context} {
+    op_{
+      std::in_place_type_t<remove_cvref_t<decltype(func())>>{},
+      FuncWrapper<InitFunc>{std::forward<InitFunc>(func)}},
+    context_{context} {
   }
 
 

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -70,7 +70,7 @@ class delegating_context {
 template<typename T>
 struct FuncWrapper {
   T func_;
-  operator std::invoke_result_t<T&&>() {
+  operator std::invoke_result_t<T>() {
     return func_();
   }
 };
@@ -132,14 +132,14 @@ class delegating_sender {
           unifex::schedule(unifex::get_scheduler(std::as_const(receiver))), (Receiver&&)receiver))>,
         LC>;
     if(context_->reserve()) {
-      auto local_op = [receiver = (Receiver&&)receiver, context = context_]() mutable {
+      auto local_op = [&receiver, context = context_]() mutable {
         return LC{unifex::connect(
           unifex::schedule(context->single_thread_context_.get_scheduler()),
           (Receiver&&)receiver)};};
       return op{std::move(local_op), context_};
     }
 
-    auto target_op = [receiver = (Receiver&&)receiver]() mutable {
+    auto target_op = [&receiver]() mutable {
       return unifex::connect(unifex::schedule(unifex::get_scheduler(std::as_const(receiver))), (Receiver&&)receiver);
     };
     return op{std::move(target_op), context_};

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -18,7 +18,6 @@
 #include <unifex/blocking.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
-#include <unifex/scheduler_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
 
 #include <condition_variable>

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -18,6 +18,7 @@
 #include <unifex/blocking.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
 
 #include <condition_variable>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -17,6 +17,7 @@
 
 #include <unifex/manual_event_loop.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/with_query_value.hpp>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -93,6 +93,11 @@ struct _receiver {
       signal_complete();
     }
 
+    friend auto
+    tag_invoke(tag_t<get_scheduler>, const type& r) noexcept {
+      return r.ctx_.get_scheduler();
+    }
+
   private:
     void signal_complete() noexcept {
       ctx_.stop();
@@ -111,7 +116,7 @@ std::optional<Result> _impl(Sender&& sender) {
 
   // Store state for the operation on the stack.
   auto operation = connect(
-      with_query_value((Sender&&)sender, get_scheduler, ctx.get_scheduler()),
+      (Sender&&)sender,
       _sync_wait::receiver_t<Result>{promise, ctx});
 
   start(operation);


### PR DESCRIPTION
Adds P1898R1 style forward progress delegation using example executors that try to reserve capacity, if there is capacity submit to an internal thread context, if not delegate downstream to the scheduler provided by the receiver.

Adds sync_wait_with_context to wrap a threading context to achieve this rather than making sync_wait always provide a scheduler, to avoid breaking other tests. P1898R1 would require that sync_wait provide a scheduler that runs work on the calling thread.