### PR TITLE
clean up sequence() CPO and constrain on()

### DIFF
--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -416,14 +416,17 @@ namespace unifex
               is_nothrow_callable_v<
                   _fn,
                   callable_result_t<_fn, First, Second>,
+                  Third,
                   Rest...>)
           -> callable_result_t<
               _fn,
               callable_result_t<_fn, First, Second>,
+              Third,
               Rest...> {
         // Fall-back to pair-wise invocation of the sequence() CPO.
         return (*this)(
             (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
+            static_cast<Third&&>(third),
             static_cast<Rest&&>(rest)...);
       }
     } sequence{};

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -399,12 +399,13 @@ namespace unifex
         (requires sender<First> AND sender<Second> AND sender<Third> AND
           (sender<Rest> &&...) AND tag_invocable<_fn, First, Second, Third, Rest...>)
       auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Rest...>)
-          -> tag_invoke_result_t<_fn, First, Second, Rest...> {
+          noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Third, Rest...>)
+          -> tag_invoke_result_t<_fn, First, Second, Third, Rest...> {
         return unifex::tag_invoke(
             _fn{},
             static_cast<First&&>(first),
             static_cast<Second&&>(second),
+            static_cast<Third&&>(third),
             static_cast<Rest&&>(rest)...);
       }
 

--- a/include/unifex/type_traits.hpp
+++ b/include/unifex/type_traits.hpp
@@ -131,8 +131,8 @@ Member Self::*_memptr(const Self&);
 
 template <typename Self, typename Member>
 using member_t = decltype(
-    (UNIFEX_DECLVAL(Self) .*
-        unifex::_memptr<Member>(UNIFEX_DECLVAL(Self))));
+    (UNIFEX_DECLVAL(Self&&) .*
+        unifex::_memptr<Member>(UNIFEX_DECLVAL(Self&&))));
 
 template <typename T>
 using decay_rvalue_t =
@@ -158,7 +158,7 @@ inline constexpr bool is_one_of_v = (UNIFEX_IS_SAME(T, Ts) || ...);
 
 template <typename Fn, typename... As>
 using callable_result_t =
-    decltype(UNIFEX_DECLVAL(Fn)(UNIFEX_DECLVAL(As)...));
+    decltype(UNIFEX_DECLVAL(Fn&&)(UNIFEX_DECLVAL(As&&)...));
 
 namespace _is_callable {
   struct yes_type { char dummy; };
@@ -170,7 +170,7 @@ namespace _is_callable {
       typename... As,
       typename = callable_result_t<Fn, As...>>
   yes_type _try_call(Fn(*)(As...))
-      noexcept(noexcept(UNIFEX_DECLVAL(Fn)(UNIFEX_DECLVAL(As)...)));
+      noexcept(noexcept(UNIFEX_DECLVAL(Fn&&)(UNIFEX_DECLVAL(As&&)...)));
   no_type _try_call(...) noexcept(false);
 } // namespace _is_callable
 


### PR DESCRIPTION
Drive-by: make is_callable traits work with incomplete CPO types.