### PR TITLE
Portability fixes so that msvc 2019 compiles libunifex with /std:c++latest

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -159,7 +159,6 @@ jobs:
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20",
-            experimental: true
           }
         - {
             name: "Windows MSVC 2019 Optimised (C++20)", artifact: "Windows-MSVC.tar.xz",
@@ -168,7 +167,6 @@ jobs:
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20",
-            experimental: true
           }
 
     steps:

--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -237,7 +237,7 @@ jobs:
             COMMAND "${{ matrix.config.environment_script }}" && set
             OUTPUT_FILE environment_script_output.txt
           )
-          set(ENV{CXXFLAGS} "/permissive-")
+          set(ENV{CXXFLAGS} "/permissive- /Zc:externConstexpr")
           file(STRINGS environment_script_output.txt output_lines)
           foreach(line IN LISTS output_lines)
             if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")

--- a/cmake/unifex_flags.cmake
+++ b/cmake/unifex_flags.cmake
@@ -11,7 +11,8 @@ include(CheckSymbolExists)
 
 # Probe for coroutine TS support
 find_package(Coroutines COMPONENTS Experimental Final)
-if(CXX_COROUTINES_HAVE_COROUTINES)
+# MSVC's coroutines support is too broken to support here, sadly.
+if(CXX_COROUTINES_HAVE_COROUTINES AND NOT UNIFEX_CXX_COMPILER_MSVC)
   set(UNIFEX_NO_COROUTINES FALSE)
   set(UNIFEX_COROUTINES_HEADER ${CXX_COROUTINES_HEADER})
   set(UNIFEX_COROUTINES_NAMESPACE ${CXX_COROUTINES_NAMESPACE})

--- a/examples/p1897.cpp
+++ b/examples/p1897.cpp
@@ -45,7 +45,7 @@ struct int_iterator {
   using iterator_category = std::random_access_iterator_tag;
 
   int operator[](size_t offset) const {
-    return base_+offset;
+    return base_ + static_cast<int>(offset);
   }
 
   int operator*() const {

--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -92,7 +92,8 @@ namespace _alloc {
     template <template <typename...> class Variant>
     using error_types = typename Sender::template error_types<Variant>;
 
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires receiver<Receiver>)
     friend auto tag_invoke(tag_t<connect>, sender&& s, Receiver&& r)
         -> operation<
             connect_result_t<Sender, Receiver>,
@@ -103,7 +104,8 @@ namespace _alloc {
           (Sender &&) s.sender_, (Receiver &&) r};
     }
 
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires receiver<Receiver>)
     friend auto tag_invoke(tag_t<connect>, sender& s, Receiver&& r)
         -> operation<
             connect_result_t<Sender&, Receiver>,
@@ -114,7 +116,8 @@ namespace _alloc {
           s.sender_, (Receiver &&) r};
     }
 
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires receiver<Receiver>)
     friend auto
     tag_invoke(tag_t<connect>, const sender& s, Receiver&& r)
         -> operation<

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -104,7 +104,8 @@ private:
     template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template <typename Receiver>
+    template(typename Receiver)
+      (requires receiver<Receiver>)
     friend operation<Receiver>
     tag_invoke(tag_t<connect>, lock_sender &&s, Receiver &&r) noexcept {
       return operation<Receiver>{s.mutex_, (Receiver &&) r};

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -24,7 +24,7 @@ namespace unifex {
     template <typename E, typename R, typename = void>
     extern const bool _can_execute;
 
-    template <typename Sender, typename Fn, typename = void>
+    template <typename S, typename F, typename = void>
     extern const bool _can_submit;
   } // detail
 

--- a/include/unifex/executor_concepts.hpp
+++ b/include/unifex/executor_concepts.hpp
@@ -28,10 +28,10 @@
 namespace unifex {
 /// \cond
 namespace detail {
-  template <typename, typename>
+  template <typename R, typename E>
   struct _as_invocable;
 
-  template <typename F, typename>
+  template <typename F, typename S>
   struct _as_receiver {
     F f_;
     void set_value() noexcept(is_nothrow_callable_v<F&>) {

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -664,6 +664,7 @@ namespace unifex
         (requires
           same_as<CPO, tag_t<connect>> AND
           same_as<remove_cvref_t<S>, sender> AND
+          receiver<Receiver> AND
           sender_to<
             member_t<S, SourceSender>,
             receiver_t<

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -84,6 +84,7 @@ class _sender<Values...>::type {
 
   template(typename This, typename Receiver)
       (requires same_as<remove_cvref_t<This>, type> AND
+        receiver<Receiver> AND
         constructible_from<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)
   friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
       noexcept(std::is_nothrow_constructible_v<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)

--- a/include/unifex/manual_lifetime.hpp
+++ b/include/unifex/manual_lifetime.hpp
@@ -40,7 +40,7 @@ class manual_lifetime {
   }
 
   template <typename Func>
-  T& construct_from(Func&& func) noexcept(noexcept(T(((Func &&) func)()))) {
+  T& construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(
         std::is_same_v<callable_result_t<Func>, T>,
         "Return type of func() must be exactly T to permit copy-elision.");
@@ -83,7 +83,7 @@ class manual_lifetime<T&> {
   }
 
   template <typename Func>
-  T& construct_from(Func&& func) noexcept(noexcept(((Func &&) func)())) {
+  T& construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(std::is_same_v<callable_result_t<Func>, T&>);
     value_ = std::addressof(((Func &&) func)());
     return value_;
@@ -111,7 +111,7 @@ class manual_lifetime<T&&> {
   }
 
   template <typename Func>
-  T&& construct_from(Func&& func) noexcept(noexcept(((Func &&) func)())) {
+  T&& construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(std::is_same_v<callable_result_t<Func>, T&&>);
     value_ = std::addressof(((Func &&) func)());
     return (T &&) value_;
@@ -135,7 +135,7 @@ class manual_lifetime<void> {
 
   void construct() noexcept {}
   template <typename Func>
-  void construct_from(Func&& func) noexcept(noexcept(((Func &&) func)())) {
+  void construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(std::is_void_v<callable_result_t<Func>>);
     ((Func &&) func)();
   }

--- a/include/unifex/manual_lifetime.hpp
+++ b/include/unifex/manual_lifetime.hpp
@@ -86,7 +86,7 @@ class manual_lifetime<T&> {
   T& construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(std::is_same_v<callable_result_t<Func>, T&>);
     value_ = std::addressof(((Func &&) func)());
-    return value_;
+    return get();
   }
 
   void destruct() noexcept {}
@@ -114,7 +114,7 @@ class manual_lifetime<T&&> {
   T&& construct_from(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     static_assert(std::is_same_v<callable_result_t<Func>, T&&>);
     value_ = std::addressof(((Func &&) func)());
-    return (T &&) value_;
+    return get();
   }
 
   void destruct() noexcept {}

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -186,6 +186,7 @@ namespace unifex
 
       template(typename Self, typename Receiver)
           (requires same_as<remove_cvref_t<Self>, type> AND
+            receiver<Receiver> AND
             sender_to<member_t<Self, Source>, receiver_t<Receiver>>)
       friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(
           is_nothrow_connectable_v<member_t<Self, Source>, receiver_t<Receiver>> &&

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -339,6 +339,7 @@ public:
 
   template(typename Self, typename Receiver)
       (requires same_as<remove_cvref_t<Self>, type> AND
+          receiver<Receiver> AND
           constructible_from<Source, member_t<Self, Source>> AND
           constructible_from<Func, member_t<Self, Func>> AND
           constructible_from<remove_cvref_t<Receiver>, Receiver> AND

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -270,7 +270,7 @@ private:
   friend source_receiver_t;
 
   template <typename Source2, typename Func2, typename Receiver2, typename Trigger>
-  friend class _trigger_receiver;
+  friend struct _trigger_receiver;
 
   using source_op_t = connect_result_t<Source&, source_receiver_t>;
 

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -73,9 +73,10 @@ namespace _subschedule {
     auto operator()(Scheduler&& sched) const
         -> _result_t<Scheduler> {
       auto&& scheduleOp = schedule(sched);
-      return transform(
+      return _result_t<Scheduler>{
         static_cast<decltype(scheduleOp)>(scheduleOp),
-        _return_value<Scheduler>{(Scheduler &&) sched});
+        {(Scheduler &&) sched}
+      };
     }
   } schedule_with_subscheduler{};
 } // namespace _subschedule

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -51,10 +51,9 @@ namespace _subschedule {
       typename _detail::_return_value<remove_cvref_t<T>>::type;
 
     template <typename Scheduler>
-    using _default_result_t =
-      decltype(transform(
-        UNIFEX_DECLVAL(callable_result_t<decltype(schedule), Scheduler&>),
-        UNIFEX_DECLVAL(_return_value<Scheduler>)));
+    using _default_result_t = _tfx::sender<
+        callable_result_t<decltype(schedule), Scheduler&>,
+        _return_value<Scheduler>>;
     template <typename Scheduler>
     using _result_t =
       typename conditional_t<

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -178,11 +178,12 @@ struct _schedule::sender {
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
-  template <
+  template(
     typename Receiver,
     typename Scheduler =
       std::decay_t<callable_result_t<decltype(get_scheduler), const Receiver&>>,
-    typename ScheduleSender = callable_result_t<decltype(schedule), Scheduler&>>
+    typename ScheduleSender = callable_result_t<decltype(schedule), Scheduler&>)
+    (requires receiver<Receiver>)
   friend auto tag_invoke(tag_t<connect>, sender, Receiver &&r)
       -> connect_result_t<ScheduleSender, Receiver> {
     auto scheduler = get_scheduler(std::as_const(r));
@@ -253,12 +254,13 @@ namespace _schedule_after {
   private:
     friend _fn;
 
-    template <
+    template(
       typename Receiver,
       typename Scheduler =
         std::decay_t<callable_result_t<decltype(get_scheduler), const Receiver&>>,
       typename ScheduleAfterSender =
-        callable_result_t<_fn, Scheduler&, const Duration&>>
+        callable_result_t<_fn, Scheduler&, const Duration&>)
+      (requires receiver<Receiver>)
     friend auto tag_invoke(tag_t<connect>, const type& s, Receiver&& r)
         -> connect_result_t<ScheduleAfterSender, Receiver> {
       auto scheduler = get_scheduler(std::as_const(r));

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -43,7 +43,7 @@ namespace detail {
   template <template <template <typename...> class> class>
   struct _has_error_types;
 
-  template <typename, typename>
+  template <typename F, typename S>
   struct _as_receiver;
 
   template <typename R, typename E>
@@ -323,7 +323,7 @@ using is_nothrow_connectable = is_nothrow_callable<decltype(connect), Sender, Re
 namespace detail {
   template <typename S, typename F, typename>
   inline constexpr bool _can_submit =
-    sender_to<S, _as_receiver<remove_cvref_t<F>, S>>;
+      sender_to<S, _as_receiver<remove_cvref_t<F>, S>>;
 #if UNIFEX_CXX_CONCEPTS
   template <typename S1, typename R, typename S2>
     requires same_as<remove_cvref_t<S1>, remove_cvref_t<S2>>

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -72,7 +72,8 @@ namespace _static_thread_pool {
           return operation<Receiver>{pool_, (Receiver &&) r};
         }
 
-        template <typename Receiver>
+        template(typename Receiver)
+          (requires receiver<Receiver>)
         friend operation<Receiver>
         tag_invoke(tag_t<connect>, schedule_sender s, Receiver&& r) {
           return s.make_operation_((Receiver &&) r);

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -124,7 +124,6 @@ using sender = typename _sender<remove_cvref_t<Predecessor>, std::decay_t<Func>>
 
 template <typename Predecessor, typename Func>
 struct _sender<Predecessor, Func>::type {
-  using sender = type;
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
@@ -155,12 +154,12 @@ public:
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, Func>;
 
-  friend constexpr auto tag_invoke(tag_t<blocking>, const sender& sender) {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type& sender) {
     return blocking(sender.pred_);
   }
 
   template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type>)
+    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver>)
   friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
     noexcept(
       std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -83,7 +83,7 @@ namespace _static_thread_pool {
   }
 
   void context::enqueue(task_base* task) noexcept {
-    const std::uint32_t threadCount = threads_.size();
+    const std::uint32_t threadCount = static_cast<std::uint32_t>(threads_.size());
     const std::uint32_t startIndex =
         nextThread_.fetch_add(1, std::memory_order_relaxed) % threadCount;
 


### PR DESCRIPTION
Requires `/std:c++latest /permissive- /Zc:externConstexpr`. `/std:c++17` will cause msvc to ICE. Leaving that for another PR.