### PR TITLE
Forward progress delegation blocking optimisation

### DIFF
--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -126,7 +126,7 @@ std::optional<Result> _impl(Sender&& sender) {
   // Store state for the operation on the stack.
   auto operation = connect(
       (Sender&&)sender,
-      _sync_wait::receiver_t<Result>{promise, completesInline ? &(ctx.get()) : nullptr});
+      _sync_wait::receiver_t<Result>{promise, completesInline ? nullptr : &(ctx.get())});
 
   start(operation);
 


### PR DESCRIPTION
Bring back optimisation for sync_wait to allow inline tasks to complete without involving the scheduler.