### PR TITLE
[RFC] Initial prototype of a bulk_sender concept

### DIFF
--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/execution_policy.hpp>
+#include <unifex/get_execution_policy.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+namespace _bulk_join {
+
+template<typename Receiver>
+struct _join_receiver {
+    class type;
+};
+
+template<typename Receiver>
+using join_receiver = typename _join_receiver<Receiver>::type;
+
+template<typename Receiver>
+class _join_receiver<Receiver>::type {
+public:
+    template<typename Receiver2>
+    explicit type(Receiver2&& r) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>)
+    : receiver_((Receiver2&&)r)
+    {}
+
+    void set_next() & noexcept {}
+
+    template(typename... Values)
+        (requires is_value_receiver_v<Receiver, Values...>)
+    void set_value(Values&&... values) noexcept(is_nothrow_value_receiver_v<Receiver, Values...>) {
+        unifex::set_value(std::move(receiver_), (Values&&)values...);
+    }
+
+    template(typename Error)
+        (requires is_error_receiver_v<Receiver, Error>)
+    void set_error(Error&& error) noexcept {
+        unifex::set_error(std::move(receiver_), (Error&&)error);
+    }
+
+    template(typename R = Receiver)
+        (requires is_done_receiver_v<Receiver>)
+    void set_done() noexcept {
+        unifex::set_done(std::move(receiver_));
+    }
+
+    friend constexpr unifex::parallel_unsequenced_policy tag_invoke(
+            tag_t<get_execution_policy>, [[maybe_unused]] const type& r) noexcept {
+        return {};
+    }
+
+    template(typename CPO, typename Self)
+        (requires
+            is_receiver_query_cpo_v<CPO> AND
+            same_as<Self, type>)
+    friend auto tag_invoke(CPO cpo, const Self& self)
+        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+        -> callable_result_t<CPO, const Receiver&> {
+        return cpo(self.receiver_);
+    }
+
+private:
+    Receiver receiver_;
+};
+
+template<typename Source>
+struct _join_sender {
+    class type;
+};
+
+template<typename Source>
+using join_sender = typename _join_sender<Source>::type;
+
+template<typename Source>
+class _join_sender<Source>::type {
+public:
+    template<template<typename...> class Variant, template<typename...> class Tuple>
+    using value_types = typename Source::template value_types<Variant, Tuple>;
+
+    template<template<typename...> class Variant>
+    using error_types = typename Source::template error_types<Variant>;
+
+    static constexpr bool sends_done = Source::sends_done;
+
+    template<typename Source2>
+    explicit type(Source2&& s)
+        noexcept(std::is_nothrow_constructible_v<Source, Source2>)
+    : source_((Source2&&)s)
+    {}
+
+    template(typename Self, typename Receiver)
+        (requires
+            same_as<remove_cvref_t<Self>, type> AND
+            sender_to<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>)
+    friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
+        noexcept(
+            std::is_nothrow_constructible_v<remove_cvref_t<Receiver>> &&
+            is_nothrow_connectable_v<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>)
+        -> connect_result_t<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>
+        {
+        return unifex::connect(
+            static_cast<Self&&>(self).source_,
+            join_receiver<remove_cvref_t<Receiver>>{static_cast<Receiver&&>(r)});
+    }
+
+private:
+    Source source_;
+};
+
+struct _fn {
+    template(typename Source)
+        (requires
+            typed_bulk_sender<Source> &&
+            tag_invocable<_fn, Source>)
+    auto operator()(Source&& source) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Source>)
+        -> tag_invoke_result_t<_fn, Source> {
+        return tag_invoke(_fn{}, (Source&&)source);
+    }
+
+    template(typename Source)
+        (requires
+            typed_bulk_sender<Source> &&
+            (!tag_invocable<_fn, Source>))
+    auto operator()(Source&& source) const
+        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>)
+        -> join_sender<remove_cvref_t<Source>> {
+        return join_sender<remove_cvref_t<Source>>{
+            (Source&&)source};
+    }
+};
+
+} // namespace _bulk_join
+
+inline constexpr _bulk_join::_fn bulk_join{};
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -119,13 +119,13 @@ public:
 
     template(typename Self, typename BulkReceiver)
         (requires
-            same_as<std::remove_cvref_t<Self>, type> AND
+            same_as<remove_cvref_t<Self>, type> AND
             receiver_of<BulkReceiver> AND
             is_next_receiver_v<BulkReceiver, Integral>)
     friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, BulkReceiver&& r) {
         return unifex::connect(
             unifex::schedule(static_cast<Self&&>(s).scheduler_),
-            schedule_receiver<Integral, std::remove_cvref_t<BulkReceiver>>{
+            schedule_receiver<Integral, remove_cvref_t<BulkReceiver>>{
                 static_cast<Self&&>(s).count_,
                 static_cast<BulkReceiver&&>(r)});
     }
@@ -151,7 +151,7 @@ struct _fn {
             (!tag_invocable<_fn, Scheduler, Integral>))
     auto operator()(Scheduler&& s, Integral n) const
         noexcept(
-            std::is_nothrow_constructible_v<std::remove_cvref_t<Scheduler>, Scheduler> &&
+            std::is_nothrow_constructible_v<remove_cvref_t<Scheduler>, Scheduler> &&
             std::is_nothrow_move_constructible_v<Integral>)
         -> default_sender<remove_cvref_t<Scheduler>, Integral> {
         return default_sender<remove_cvref_t<Scheduler>, Integral>{(Scheduler&&)s, std::move(n)};

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/get_execution_policy.hpp>
+#include <unifex/execution_policy.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _bulk_schedule {
+
+template<typename Integral, typename Receiver>
+struct _schedule_receiver {
+    class type;
+};
+
+template<typename Integral, typename Receiver>
+using schedule_receiver = typename _schedule_receiver<Integral, Receiver>::type;
+
+template<typename Integral, typename Receiver>
+class _schedule_receiver<Integral, Receiver>::type {
+public:
+    template<typename Receiver2>
+    explicit type(Integral count, Receiver2&& r)
+    : count_(std::move(count))
+    , receiver_((Receiver2&&)r)
+    {}
+
+    void set_value()
+        noexcept(is_nothrow_value_receiver_v<Receiver> &&
+                 is_nothrow_next_receiver_v<Receiver, Integral>) {
+        using policy_t = decltype(get_execution_policy(receiver_));
+        if constexpr (is_one_of_v<policy_t, unsequenced_policy, parallel_unsequenced_policy>) {
+            // Vectorisable version
+#if defined(__clang__)
+            #pragma clang loop vectorize(enable) interleave(enable)
+#elif defined(__GNUC__)
+            #pragma GCC ivdep
+#elif defined(_MSC_VER)
+            #pragma loop(ivdep)
+#endif
+            for (Integral i(0); i < count_; ++i) {
+                unifex::set_next(receiver_, Integral(i));
+            }
+        } else {
+            // Sequenced version
+            for (Integral i(0); i < count_; ++i) {
+                unifex::set_next(receiver_, Integral(i));
+            }
+        }
+
+        unifex::set_value(std::move(receiver_));
+    }
+
+    template(typename Error)
+        (requires is_error_receiver_v<Receiver, Error>)
+    void set_error(Error&& e) noexcept {
+        unifex::set_error(std::move(receiver_), (Error&&)e);
+    }
+
+    template(typename R = Receiver)
+        (requires is_done_receiver_v<Receiver>)
+    void set_done() noexcept {
+        unifex::set_done(std::move(receiver_));
+    }
+
+private:
+    Receiver receiver_;
+    Integral count_;
+};
+
+template<typename Scheduler, typename Integral>
+struct _default_sender {
+    class type;
+};
+
+template<typename Scheduler, typename Integral>
+using default_sender = typename _default_sender<Scheduler, Integral>::type;
+
+template<typename Scheduler, typename Integral>
+class _default_sender<Scheduler, Integral>::type {
+    using schedule_sender_t = decltype(unifex::schedule(UNIFEX_DECLVAL(const Scheduler&)));
+
+public:
+    template<template<typename...> class Variant, template<typename...> class Tuple>
+    using value_types = Variant<Tuple<>>;
+
+    template<template<typename...> class Variant, template<typename...> class Tuple>
+    using next_types = Variant<Tuple<Integral>>;
+
+    template<template<typename...> class Variant>
+    using error_types = typename schedule_sender_t::template error_types<Variant>;
+
+    static constexpr bool sends_done = schedule_sender_t::sends_done;
+
+    template<typename Scheduler2>
+    explicit type(Scheduler2&& s, Integral count)
+    : scheduler_(static_cast<Scheduler2&&>(s))
+    , count_(std::move(count))
+    {}
+
+    template(typename Self, typename BulkReceiver)
+        (requires
+            same_as<std::remove_cvref_t<Self>, type> AND
+            receiver_of<BulkReceiver> AND
+            is_next_receiver_v<BulkReceiver, Integral>)
+    friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, BulkReceiver&& r) {
+        return unifex::connect(
+            unifex::schedule(static_cast<Self&&>(s).scheduler_),
+            schedule_receiver<Integral, std::remove_cvref_t<BulkReceiver>>{
+                static_cast<Self&&>(s).count_,
+                static_cast<BulkReceiver&&>(r)});
+    }
+
+private:
+    Scheduler scheduler_;
+    Integral count_;
+};
+
+struct _fn {
+    template(typename Scheduler, typename Integral)
+        (requires
+            tag_invocable<_fn, Scheduler, Integral>)
+    auto operator()(Scheduler&& s, Integral n) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler, Integral>)
+        -> tag_invoke_result_t<_fn, Scheduler, Integral> {
+        return tag_invoke(_fn{}, (Scheduler&&)s, std::move(n));
+    }
+
+    template(typename Scheduler, typename Integral)
+        (requires
+            scheduler<Scheduler> AND
+            (!tag_invocable<_fn, Scheduler, Integral>))
+    auto operator()(Scheduler&& s, Integral n) const
+        noexcept(
+            std::is_nothrow_constructible_v<std::remove_cvref_t<Scheduler>, Scheduler> &&
+            std::is_nothrow_move_constructible_v<Integral>)
+        -> default_sender<remove_cvref_t<Scheduler>, Integral> {
+        return default_sender<remove_cvref_t<Scheduler>, Integral>{(Scheduler&&)s, std::move(n)};
+    }
+};
+
+} // namespace _bulk_schedule
+
+inline constexpr _bulk_schedule::_fn bulk_schedule{};
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/execution_policy.hpp>
+#include <unifex/get_execution_policy.hpp>
+#include <unifex/type_list.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+namespace _bulk_tfx {
+
+template<typename Func, typename Policy, typename Receiver>
+struct _tfx_receiver {
+    class type;
+};
+
+template<typename Func, typename Policy, typename Receiver>
+using tfx_receiver = typename _tfx_receiver<Func, Policy, Receiver>::type;
+
+template<typename Func, typename Policy, typename Receiver>
+class _tfx_receiver<Func, Policy, Receiver>::type {
+public:
+    template<typename Func2, typename Receiver2>
+    explicit type(Func2&& f, Policy policy, Receiver2&& r)
+    : receiver_((Receiver2&&)r)
+    , func_((Func2&&)f)
+    , policy_(std::move(policy))
+    {}
+
+    template(typename... Values)
+        (requires
+            invocable<Func&, Values...> AND
+            std::is_void_v<std::invoke_result_t<Func&, Values...>>)
+    void set_next(Values&&... values) &
+        noexcept(
+            std::is_nothrow_invocable_v<Func&, Values...> &&
+            is_nothrow_next_receiver_v<Receiver>) {
+        std::invoke(func_, (Values&&)values...);
+        unifex::set_next(receiver_);
+    }
+
+    template(typename... Values)
+        (requires
+            invocable<Func&, Values...> AND
+            (!std::is_void_v<std::invoke_result_t<Func&, Values...>>))
+    void set_next(Values&&... values) &
+        noexcept(
+            std::is_nothrow_invocable_v<Func&, Values...> &&
+            is_nothrow_next_receiver_v<Receiver, std::invoke_result_t<Func&, Values...>>) {
+        unifex::set_next(receiver_, std::invoke(func_, (Values&&)values...));
+    }
+
+    template(typename... Values)
+        (requires is_value_receiver_v<Receiver, Values...>)
+    void set_value(Values&&... values) noexcept(is_nothrow_value_receiver_v<Receiver, Values...>) {
+        unifex::set_value(std::move(receiver_), (Values&&)values...);
+    }
+
+    template(typename Error)
+        (requires is_error_receiver_v<Receiver, Error>)
+    void set_error(Error&& error) noexcept {
+        unifex::set_error(std::move(receiver_), (Error&&)error);
+    }
+
+    template(typename R = Receiver)
+        (requires is_done_receiver_v<Receiver>)
+    void set_done() noexcept {
+        unifex::set_done(std::move(receiver_));
+    }
+
+    friend auto tag_invoke(tag_t<get_execution_policy>, const type& r) noexcept {
+        using receiver_policy = decltype(get_execution_policy(r.receiver_));
+        constexpr bool allowUnsequenced =
+          is_one_of_v<receiver_policy, unsequenced_policy, parallel_unsequenced_policy> &&
+          is_one_of_v<Policy, unsequenced_policy, parallel_unsequenced_policy>;
+        constexpr bool allowParallel =
+          is_one_of_v<receiver_policy, parallel_policy, parallel_unsequenced_policy> &&
+          is_one_of_v<Policy, parallel_policy, parallel_unsequenced_policy>;
+        
+        if constexpr (allowUnsequenced && allowParallel) {
+            return unifex::par_unseq;
+        } else if constexpr (allowUnsequenced) {
+            return unifex::unseq;
+        } else if constexpr (allowParallel) {
+            return unifex::par;
+        } else {
+            return unifex::seq;
+        }
+    }
+
+    template(typename CPO, typename Self)
+        (requires
+            is_receiver_query_cpo_v<CPO> AND
+            same_as<Self, type>)
+    friend auto tag_invoke(CPO cpo, const Self& self)
+        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+        -> callable_result_t<CPO, const Receiver&> {
+        return cpo(self.receiver_);
+    }
+
+private:
+    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+    UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+    UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+};
+
+template<typename Source, typename Func, typename Policy>
+struct _tfx_sender {
+    class type;
+};
+
+template<typename Source, typename Func, typename Policy>
+using tfx_sender = typename _tfx_sender<Source, Func, Policy>::type;
+
+template <typename Result, typename = void>
+struct result_overload {
+using type = type_list<Result>;
+};
+template <typename Result>
+struct result_overload<Result, std::enable_if_t<std::is_void_v<Result>>> {
+using type = type_list<>;
+};
+
+template<typename Source, typename Func, typename Policy>
+class _tfx_sender<Source, Func, Policy>::type {
+    template<typename... Values>
+    using result = type_list<
+        typename result_overload<std::invoke_result_t<Func&, Values...>>::type>;
+
+public:
+    template<
+        template<typename...> class Variant,
+        template<typename...> class Tuple>
+    using next_types = type_list_nested_apply_t<
+        typename Source::template next_types<concat_type_lists_unique_t, result>,
+        Variant,
+        Tuple>;
+
+    template<template<typename...> class Variant, template<typename...> class Tuple>
+    using value_types = typename Source::template value_types<Variant, Tuple>;
+
+    template<template<typename...> class Variant>
+    using error_types = typename Source::template error_types<Variant>;
+
+    static constexpr bool sends_done = Source::sends_done;
+
+    template<typename Source2, typename Func2>
+    explicit type(Source2&& source, Func2&& func, Policy policy)
+    : source_((Source2&&)source)
+    , func_((Func2&&)func)
+    , policy_(std::move(policy))
+    {}
+
+    template(typename Self, typename Receiver)
+        (requires
+            same_as<remove_cvref_t<Self>, type> AND
+            constructible_from<Func, member_t<Self, Func>> AND
+            sender_to<member_t<Self, Source>, tfx_receiver<Func, Policy, remove_cvref_t<Receiver>>>)
+    friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
+        noexcept(
+            std::is_nothrow_constructible_v<Source, member_t<Self, Source>> &&
+            std::is_nothrow_constructible_v<Func, member_t<Self, Func>> &&
+            std::is_nothrow_constructible_v<Policy, member_t<Self, Policy>> &&
+            std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>) {
+        return unifex::connect(
+            static_cast<Self&&>(self).source_,
+            tfx_receiver<Func, Policy, remove_cvref_t<Receiver>>{
+                static_cast<Self&&>(self).func_,
+                static_cast<Self&&>(self).policy_,
+                static_cast<Receiver&&>(r)});
+    }
+
+private:
+    UNIFEX_NO_UNIQUE_ADDRESS Source source_;
+    UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+    UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+};
+
+struct _fn {
+    template(typename Source, typename Func, typename FuncPolicy = decltype(get_execution_policy(UNIFEX_DECLVAL(Func&))))
+        (requires typed_bulk_sender<Source>)
+    auto operator()(Source&& s, Func&& f) const
+        noexcept(is_nothrow_callable_v<_fn, Source, Func, FuncPolicy>)
+        -> callable_result_t<_fn, Source, Func, FuncPolicy> {
+        return operator()((Source&&)s, (Func&&)f, get_execution_policy(f));
+    }
+
+    template(typename Source, typename Func, typename FuncPolicy)
+        (requires
+            typed_bulk_sender<Source> AND
+            tag_invocable<_fn, Source, Func, FuncPolicy>)
+    auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func, FuncPolicy>)
+        -> tag_invoke_result_t<_fn, Source, Func, FuncPolicy> {
+        return tag_invoke(_fn{}, (Source&&)s, (Func&&)f, (FuncPolicy&&)policy);
+    }
+
+    template(typename Source, typename Func, typename FuncPolicy)
+        (requires
+            typed_bulk_sender<Source> AND
+            (!tag_invocable<_fn, Source, FuncPolicy, FuncPolicy>))
+    auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
+        noexcept(
+            std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source> &&
+            std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func> &&
+            std::is_nothrow_move_constructible_v<FuncPolicy>)
+        -> tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy> {
+        return tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy>{
+            (Source&&)s, (Func&&)f, std::move(policy)
+            };
+    }
+};
+
+} // namespace _bulk_transform
+
+inline constexpr _bulk_tfx::_fn bulk_transform{};
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/execution_policy.hpp
+++ b/include/unifex/execution_policy.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex
+{
+    // Execution policies are used to describe constraints on the safe execution
+    // of bulk operations with respect to each other.
+    //
+    // sequenced - Operations must be sequenced with respect to each other.
+    //             They are not safe to executed concurrently on differen threads or to
+    //             interleaved with each other on the same thread.
+    //
+    // unsequenced - Operations are safe to be interleaved with each other, e.g. using vectorised
+    //               SIMD instructions, but may not be executed concurrently on different
+    //               threads. This generally implies that forward progress of one operation
+    //               is not dependent on forward progress of other operations.   
+    //
+    // parallel - Operations are safe to be executed concurrently with each other on different
+    //            threads but operations on each thread must not be interleaved.
+    //
+    // parallel_unsequenced - Operations are safe to be executed concurrently on different
+    //            threads and may be interleaved with each other on the same thread.
+
+    inline constexpr struct sequenced_policy {} seq;
+    inline constexpr struct unsequenced_policy {} unseq;
+    inline constexpr struct parallel_policy {} par;
+    inline constexpr struct parallel_unsequenced_policy {} par_unseq;
+}
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_execution_policy.hpp
+++ b/include/unifex/get_execution_policy.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/execution_policy.hpp>
+#include <unifex/tag_invoke.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex
+{
+    namespace _get_execution_policy {
+        struct _fn {
+            template(typename PolicyProvider)
+                (requires tag_invocable<_fn, const PolicyProvider&>)
+            constexpr auto operator()(const PolicyProvider& provider) const noexcept
+                -> tag_invoke_result_t<_fn, const PolicyProvider&> {
+                return tag_invoke(_fn{}, provider);
+            }
+
+            template(typename PolicyProvider)
+                (requires (!tag_invocable<_fn, const PolicyProvider&>))
+            constexpr sequenced_policy operator()([[maybe_unused]] const PolicyProvider&) const noexcept {
+                return {};
+            }
+        };
+    }
+
+    inline constexpr _get_execution_policy::_fn get_execution_policy{};
+}
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -91,6 +91,8 @@ class context {
       template <template <typename...> class Variant>
       using error_types = Variant<>;
 
+      static constexpr bool sends_done = true;
+
       template <typename Receiver>
       operation<Receiver> connect(Receiver&& receiver) const& {
         return operation<Receiver>{(Receiver &&) receiver, loop_};

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -269,7 +269,7 @@ inline constexpr bool is_done_receiver_v =
 
 template <typename R, typename... An>
 inline constexpr bool is_nothrow_next_receiver_v =
-    is_nothrow_callable_v<decltype(set_next), R, An...>;
+    is_nothrow_callable_v<decltype(set_next), R&, An...>;
 
 template <typename R, typename... An>
 inline constexpr bool is_nothrow_value_receiver_v =

--- a/test/bulk_schedule_test.cpp
+++ b/test/bulk_schedule_test.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/bulk_schedule.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/bulk_transform.hpp>
+#include <unifex/bulk_join.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(bulk, bulk_transform) {
+    unifex::single_thread_context ctx;
+    auto sched = ctx.get_scheduler();
+
+    const std::size_t count = 1000;
+
+    std::vector<int> output;
+    output.resize(count);
+
+    unifex::sync_wait(
+        unifex::bulk_join(
+            unifex::bulk_transform(
+                unifex::bulk_transform(
+                    unifex::bulk_schedule(sched, count),
+                    [count](std::size_t index) noexcept {
+                        // Reverse indices
+                        return count - 1 - index;
+                    }, unifex::par_unseq),
+                [&](std::size_t index) noexcept {
+                    output[index] = index;
+                }, unifex::par_unseq)));
+
+    for (std::size_t i = 0; i < count; ++i) {
+        EXPECT_EQ(i, output[i]);
+    }
+}


### PR DESCRIPTION
Adds a typed_bulk_sender concept which checks for the
'next_types' type-alias on senders.

Adds a few basic bulk algorithms:
- bulk_schedule()
- bulk_transform()
- bulk_join()

The bulk_schedule() concept currently just takes a count and
calls set_next() on the receiver with integral values from [0, count).
Default implementation just dispatches a single task via schedule()
and calls in a loop. Supports vectorised execution for 'unsequenced'
execution policies.

Adds some execution policies that mirror the policies available in C++20.
They are defined locally in libunifex for now because not all standard
libraries provide the <execution> header yet.

Adds get_execution_policy() CPO for receivers and/or functions to customise
so that they specify more relaxed constraints on how bulk-senders can call
the receiver's set_next() methods. The default is sequenced execution.