### PR TITLE
Use tagged release-1.8.1 of googletest

### DIFF
--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -10,7 +10,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           release-1.8.1
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Latest 'master' version seems to have broken builds under msvc.

This change pins the googletest version to the release-1.8.1 tag
which seems to build fine under MSVC.