### PR TITLE
Add windows low_latency_iocp_context execution context

### DIFF
--- a/include/unifex/detail/intrusive_list.hpp
+++ b/include/unifex/detail/intrusive_list.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+#include <utility>
+
+namespace unifex {
+
+template<typename T, T* T::*Next, T* T::*Prev>
+class intrusive_list {
+public:
+    intrusive_list() noexcept : head_(nullptr), tail_(nullptr) {}
+
+    intrusive_list(intrusive_list&& other) noexcept
+    : head_(std::exchange(other.head_, nullptr))
+    , tail_(std::exchange(other.tail_, nullptr))
+    {}
+
+    ~intrusive_list() {
+        assert(empty());
+    }
+
+    intrusive_list& operator=(const intrusive_list&) = delete;
+    intrusive_list& operator=(intrusive_list&&) = delete;
+
+    [[nodiscard]] bool empty() const noexcept {
+        return head_ == nullptr;
+    }
+
+    void swap(intrusive_list& other) noexcept {
+        std::swap(head_, other.head_);
+        std::swap(tail_, other.tail_);
+    }
+
+    void push_back(T* item) noexcept {
+        item->*Prev = tail_;
+        item->*Next = nullptr;
+        if (tail_ == nullptr) {
+            head_ = item;
+        } else {
+            tail_->*Next = item;
+        }
+        tail_ = item;
+    }
+
+    void push_front(T* item) noexcept {
+        item->*Prev = nullptr;
+        item->*Next = head_;
+        if (head_ == nullptr) {
+            tail_ = item;
+        } else {
+            head_->*Prev = item;
+        }
+        head_ = item;
+    }
+
+    [[nodiscard]] T* pop_front() noexcept {
+        assert(!empty());
+        T* item = head_;
+        head_ = item->*Next;
+        if (head_ != nullptr) {
+            head_->*Prev = nullptr;
+        } else {
+            tail_ = nullptr;
+        }
+        return item;
+    }
+
+    [[nodiscard]] T* pop_back() noexcept {
+        assert(!empty());
+        T* item = tail_;
+        tail_ = item->*Prev;
+        if (tail_ != nullptr) {
+            tail_->*Next = nullptr;
+        } else {
+            head_ = nullptr;
+        }
+        return item;
+    }
+
+    void remove(T* item) noexcept {
+        assert(!empty());
+        auto* prev = item->*Prev;
+        auto* next = item->*Next;
+        if (prev != nullptr) {
+            prev->*Next = next;
+        } else {
+            head_ = next;
+        }
+        if (next != nullptr) {
+            next->*Prev = prev;
+        } else {
+            tail_ = prev;
+        }
+    }
+
+    void append(intrusive_list other) noexcept {
+        if (empty()) {
+            swap(other);
+        } else if (!other.empty()) {
+            tail_->*Next = other.head_;
+            tail_->*Next->*Prev = tail_;
+            tail_ = other.tail_;
+            other.head_ = nullptr;
+            other.tail_ = nullptr;
+        }
+    }
+
+private:
+    T* head_;
+    T* tail_;
+};
+
+} // namespace unifex

--- a/include/unifex/detail/intrusive_stack.hpp
+++ b/include/unifex/detail/intrusive_stack.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+#include <utility>
+
+namespace unifex {
+
+template<typename T, T* T::*Next>
+class intrusive_stack {
+public:
+    intrusive_stack() : head_(nullptr) {}
+
+    intrusive_stack(intrusive_stack&& other) noexcept : head_(std::exchange(other.head_, nullptr)) {}
+
+    intrusive_stack(const intrusive_stack&) = delete;
+    intrusive_stack& operator=(const intrusive_stack&) = delete;
+    intrusive_stack& operator=(intrusive_stack&&) = delete;
+
+    ~intrusive_stack() {
+        assert(empty());
+    }
+
+    // Adopt an existing linked-list as a stack.
+    static intrusive_stack adopt(T* head) noexcept {
+        intrusive_stack stack;
+        stack.head_ = head;
+        return stack;
+    }
+
+    T* release() noexcept {
+        return std::exchange(head_, nullptr);
+    }
+
+    [[nodiscard]] bool empty() const noexcept {
+        return head_ == nullptr;
+    }
+
+    void push_front(T* item) noexcept {
+        item->*Next = head_;
+        head_ = item;
+    }
+
+    [[nodiscard]] T* pop_front() noexcept {
+        assert(!empty());
+        T* item = head_;
+        head_ = item->*Next;
+        return item;
+    }
+
+private:
+    T* head_;
+};
+
+} // namespace unifex

--- a/include/unifex/span.hpp
+++ b/include/unifex/span.hpp
@@ -93,6 +93,10 @@ struct span {
     return Extent;
   }
 
+  constexpr bool empty() const noexcept {
+    return Extent == 0;
+  }
+
   T* begin() const noexcept {
     return data();
   }
@@ -171,6 +175,10 @@ struct span<T, dynamic_extent> {
 
   T* data() const noexcept {
     return data_;
+  }
+
+  bool empty() const noexcept {
+    return size_ == 0;
   }
 
   std::size_t size() const noexcept {
@@ -294,7 +302,7 @@ span<std::byte, Extent * sizeof(T)> as_writable_bytes(
     const span<T, Extent>& s) noexcept {
   constexpr std::size_t maxSize = std::size_t(-1) / sizeof(T);
   static_assert(Extent <= maxSize);
-  return span<const std::byte, Extent * sizeof(T)>{
+  return span<std::byte, Extent * sizeof(T)>{
       reinterpret_cast<std::byte*>(s.data())};
 }
 

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+// Mirror definition of NTAPI without depending on windows headers.
+#if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED)
+#define UNIFEX_NTAPI __stdcall
+#else
+#define _cdecl
+#define __cdecl
+#define UNIFEX_NTAPI
+#endif
+
+#ifdef _MSC_VER
+#include <sal.h>
+#else
+#define _In_
+#define _In_opt_
+#define _Out_
+#define _Out_writes_to(A,B)
+#endif
+
+namespace unifex::win32::ntapi {
+
+using HANDLE = void*;
+using PHANDLE = HANDLE*;
+using LONG = long;
+using NTSTATUS = LONG;
+using ULONG_PTR = std::uintptr_t;
+using LONG_PTR = std::intptr_t;
+using PVOID = void*;
+using USHORT = unsigned short;
+using LONG = long;
+using LONGLONG = long long;
+using ULONG = unsigned long;
+using PULONG = ULONG*;
+using DWORD = unsigned long;
+using WCHAR = wchar_t;
+using PWSTR = WCHAR*;
+using BYTE = unsigned char;
+using BOOLEAN = BYTE;
+
+union LARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    LONG  HighPart;
+  } u;
+  LONGLONG QuadPart;
+};
+using PLARGE_INTEGER = LARGE_INTEGER*;
+
+struct UNICODE_STRING {
+  USHORT Length;
+  USHORT MaximumLength;
+  PWSTR  Buffer;
+};
+using PUNICODE_STRING = UNICODE_STRING*;
+
+struct IO_STATUS_BLOCK {
+  // Corresponds to OVERLAPPED::Internal
+  union {
+    NTSTATUS Status;
+    void* Pointer;
+  };
+
+  // Corresponds to OVERLAPPED::InternalHigh
+  ULONG_PTR Information;
+};
+using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
+
+using ACCESS_MASK = DWORD;
+using PACCESS_MASK = ACCESS_MASK*;
+
+struct OBJECT_ATTRIBUTES {
+  ULONG           Length;
+  HANDLE          RootDirectory;
+  PUNICODE_STRING ObjectName;
+  ULONG           Attributes;
+  PVOID           SecurityDescriptor;
+  PVOID           SecurityQualityOfService;
+};
+using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
+
+struct FILE_COMPLETION_INFORMATION {
+  HANDLE Port;
+  PVOID Key;
+};
+using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
+
+struct FILE_IO_COMPLETION_INFORMATION
+{
+  PVOID KeyContext;
+  PVOID ApcContext;
+  IO_STATUS_BLOCK IoStatusBlock;
+};
+using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
+
+using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
+  _In_ PVOID ApcContext,
+  _In_ PIO_STATUS_BLOCK IoStatusBlock,
+  _In_ ULONG Reserved);
+
+// From http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
+using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _Out_ PHANDLE FileHandle,
+  _In_ ACCESS_MASK DesiredAccess,
+  _In_ POBJECT_ATTRIBUTES ObjectAttributes,
+  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+  _In_opt_ PLARGE_INTEGER AllocationSize,
+  _In_ ULONG FileAttributes,
+  _In_ ULONG ShareAccess,
+  _In_ ULONG CreateDisposition,
+  _In_ ULONG CreateOptions,
+  _In_opt_ PVOID EaBuffer,
+  _In_ ULONG EaLength);
+extern NtCreateFile_t NtCreateFile;
+
+using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE hFile,
+  _Out_ PIO_STATUS_BLOCK iosb,
+  _Out_ PIO_STATUS_BLOCK io_status);
+extern NtCancelIoFileEx_t NtCancelIoFileEx;
+
+using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE FileHandle,
+  _In_opt_ HANDLE Event,
+  _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+  _In_opt_ PVOID ApcContext,
+  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+  _Out_ PVOID Buffer,
+  _In_ ULONG Length,
+  _In_opt_ PLARGE_INTEGER ByteOffset,
+  _In_opt_ PULONG Key);
+extern NtReadFile_t NtReadFile;
+
+using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE FileHandle,
+  _In_opt_ HANDLE Event,
+  _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+  _In_opt_ PVOID ApcContext,
+  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+  _In_ PVOID Buffer,
+  _In_ ULONG Length,
+  _In_opt_ PLARGE_INTEGER ByteOffset,
+  _In_opt_ PULONG Key);
+extern NtWriteFile_t NtWriteFile;
+
+using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE IoCompletionHandle,
+  _In_ ULONG KeyContext,
+  _In_ PVOID ApcContext,
+  _In_ NTSTATUS IoStatus,
+  _In_ ULONG IoStatusInformation);
+extern NtSetIoCompletion_t NtSetIoCompletion;
+
+using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE IoCompletionHandle,
+  _Out_ PVOID* CompletionKey,
+  _Out_ PVOID* ApcContext,
+  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+  _In_opt_ PLARGE_INTEGER Timeout);
+extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
+
+using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+  _In_ HANDLE IoCompletionHandle,
+  _Out_writes_to_(Count, *NumEntriesRemoved) PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
+  _In_ ULONG Count,
+  _Out_ PULONG NumEntriesRemoved,
+  _In_opt_ PLARGE_INTEGER Timeout,
+  _In_ BOOLEAN Alertable);
+extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
+
+using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(
+  _In_ NTSTATUS Status);
+extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
+
+void ensure_initialised() noexcept;
+
+constexpr bool ntstatus_success(NTSTATUS status) {
+  return status >= 0;
+}
+
+} // namespace unifex::win32::ntapi
+
+#undef UNIFEX_NTAPI

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -19,182 +19,180 @@
 
 // Mirror definition of NTAPI without depending on windows headers.
 #if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED)
-#define UNIFEX_NTAPI __stdcall
+#  define UNIFEX_NTAPI __stdcall
 #else
-#define _cdecl
-#define __cdecl
-#define UNIFEX_NTAPI
+#  define _cdecl
+#  define __cdecl
+#  define UNIFEX_NTAPI
 #endif
 
 #ifdef _MSC_VER
-#include <sal.h>
+#  include <sal.h>
 #else
-#define _In_
-#define _In_opt_
-#define _Out_
-#define _Out_writes_to(A,B)
+#  define _In_
+#  define _In_opt_
+#  define _Out_
+#  define _Out_writes_to(A, B)
 #endif
 
-namespace unifex::win32::ntapi {
-
-using HANDLE = void*;
-using PHANDLE = HANDLE*;
-using LONG = long;
-using NTSTATUS = LONG;
-using ULONG_PTR = std::uintptr_t;
-using LONG_PTR = std::intptr_t;
-using PVOID = void*;
-using USHORT = unsigned short;
-using LONG = long;
-using LONGLONG = long long;
-using ULONG = unsigned long;
-using PULONG = ULONG*;
-using DWORD = unsigned long;
-using WCHAR = wchar_t;
-using PWSTR = WCHAR*;
-using BYTE = unsigned char;
-using BOOLEAN = BYTE;
-
-union LARGE_INTEGER {
-  struct {
-    DWORD LowPart;
-    LONG  HighPart;
-  } u;
-  LONGLONG QuadPart;
-};
-using PLARGE_INTEGER = LARGE_INTEGER*;
-
-struct UNICODE_STRING {
-  USHORT Length;
-  USHORT MaximumLength;
-  PWSTR  Buffer;
-};
-using PUNICODE_STRING = UNICODE_STRING*;
-
-struct IO_STATUS_BLOCK {
-  // Corresponds to OVERLAPPED::Internal
-  union {
-    NTSTATUS Status;
-    void* Pointer;
-  };
-
-  // Corresponds to OVERLAPPED::InternalHigh
-  ULONG_PTR Information;
-};
-using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
-
-using ACCESS_MASK = DWORD;
-using PACCESS_MASK = ACCESS_MASK*;
-
-struct OBJECT_ATTRIBUTES {
-  ULONG           Length;
-  HANDLE          RootDirectory;
-  PUNICODE_STRING ObjectName;
-  ULONG           Attributes;
-  PVOID           SecurityDescriptor;
-  PVOID           SecurityQualityOfService;
-};
-using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
-
-struct FILE_COMPLETION_INFORMATION {
-  HANDLE Port;
-  PVOID Key;
-};
-using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
-
-struct FILE_IO_COMPLETION_INFORMATION
+namespace unifex::win32::ntapi
 {
-  PVOID KeyContext;
-  PVOID ApcContext;
-  IO_STATUS_BLOCK IoStatusBlock;
-};
-using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
+  using HANDLE = void*;
+  using PHANDLE = HANDLE*;
+  using LONG = long;
+  using NTSTATUS = LONG;
+  using ULONG_PTR = std::uintptr_t;
+  using LONG_PTR = std::intptr_t;
+  using PVOID = void*;
+  using USHORT = unsigned short;
+  using LONG = long;
+  using LONGLONG = long long;
+  using ULONG = unsigned long;
+  using PULONG = ULONG*;
+  using DWORD = unsigned long;
+  using WCHAR = wchar_t;
+  using PWSTR = WCHAR*;
+  using BYTE = unsigned char;
+  using BOOLEAN = BYTE;
 
-using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
-  _In_ PVOID ApcContext,
-  _In_ PIO_STATUS_BLOCK IoStatusBlock,
-  _In_ ULONG Reserved);
+  union LARGE_INTEGER {
+    struct {
+      DWORD LowPart;
+      LONG HighPart;
+    } u;
+    LONGLONG QuadPart;
+  };
+  using PLARGE_INTEGER = LARGE_INTEGER*;
 
-// From http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
-using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _Out_ PHANDLE FileHandle,
-  _In_ ACCESS_MASK DesiredAccess,
-  _In_ POBJECT_ATTRIBUTES ObjectAttributes,
-  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-  _In_opt_ PLARGE_INTEGER AllocationSize,
-  _In_ ULONG FileAttributes,
-  _In_ ULONG ShareAccess,
-  _In_ ULONG CreateDisposition,
-  _In_ ULONG CreateOptions,
-  _In_opt_ PVOID EaBuffer,
-  _In_ ULONG EaLength);
-extern NtCreateFile_t NtCreateFile;
+  struct UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR Buffer;
+  };
+  using PUNICODE_STRING = UNICODE_STRING*;
 
-using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE hFile,
-  _Out_ PIO_STATUS_BLOCK iosb,
-  _Out_ PIO_STATUS_BLOCK io_status);
-extern NtCancelIoFileEx_t NtCancelIoFileEx;
+  struct IO_STATUS_BLOCK {
+    // Corresponds to OVERLAPPED::Internal
+    union {
+      NTSTATUS Status;
+      void* Pointer;
+    };
 
-using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE FileHandle,
-  _In_opt_ HANDLE Event,
-  _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-  _In_opt_ PVOID ApcContext,
-  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-  _Out_ PVOID Buffer,
-  _In_ ULONG Length,
-  _In_opt_ PLARGE_INTEGER ByteOffset,
-  _In_opt_ PULONG Key);
-extern NtReadFile_t NtReadFile;
+    // Corresponds to OVERLAPPED::InternalHigh
+    ULONG_PTR Information;
+  };
+  using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
 
-using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE FileHandle,
-  _In_opt_ HANDLE Event,
-  _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-  _In_opt_ PVOID ApcContext,
-  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-  _In_ PVOID Buffer,
-  _In_ ULONG Length,
-  _In_opt_ PLARGE_INTEGER ByteOffset,
-  _In_opt_ PULONG Key);
-extern NtWriteFile_t NtWriteFile;
+  using ACCESS_MASK = DWORD;
+  using PACCESS_MASK = ACCESS_MASK*;
 
-using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE IoCompletionHandle,
-  _In_ ULONG KeyContext,
-  _In_ PVOID ApcContext,
-  _In_ NTSTATUS IoStatus,
-  _In_ ULONG IoStatusInformation);
-extern NtSetIoCompletion_t NtSetIoCompletion;
+  struct OBJECT_ATTRIBUTES {
+    ULONG Length;
+    HANDLE RootDirectory;
+    PUNICODE_STRING ObjectName;
+    ULONG Attributes;
+    PVOID SecurityDescriptor;
+    PVOID SecurityQualityOfService;
+  };
+  using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
 
-using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE IoCompletionHandle,
-  _Out_ PVOID* CompletionKey,
-  _Out_ PVOID* ApcContext,
-  _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-  _In_opt_ PLARGE_INTEGER Timeout);
-extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
+  struct FILE_COMPLETION_INFORMATION {
+    HANDLE Port;
+    PVOID Key;
+  };
+  using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
 
-using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-  _In_ HANDLE IoCompletionHandle,
-  _Out_writes_to_(Count, *NumEntriesRemoved) PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
-  _In_ ULONG Count,
-  _Out_ PULONG NumEntriesRemoved,
-  _In_opt_ PLARGE_INTEGER Timeout,
-  _In_ BOOLEAN Alertable);
-extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
+  struct FILE_IO_COMPLETION_INFORMATION {
+    PVOID KeyContext;
+    PVOID ApcContext;
+    IO_STATUS_BLOCK IoStatusBlock;
+  };
+  using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
 
-using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(
-  _In_ NTSTATUS Status);
-extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
+  using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
+      _In_ PVOID ApcContext,
+      _In_ PIO_STATUS_BLOCK IoStatusBlock,
+      _In_ ULONG Reserved);
 
-void ensure_initialised() noexcept;
+  // From
+  // http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
+  using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _Out_ PHANDLE FileHandle,
+      _In_ ACCESS_MASK DesiredAccess,
+      _In_ POBJECT_ATTRIBUTES ObjectAttributes,
+      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+      _In_opt_ PLARGE_INTEGER AllocationSize,
+      _In_ ULONG FileAttributes,
+      _In_ ULONG ShareAccess,
+      _In_ ULONG CreateDisposition,
+      _In_ ULONG CreateOptions,
+      _In_opt_ PVOID EaBuffer,
+      _In_ ULONG EaLength);
+  extern NtCreateFile_t NtCreateFile;
 
-constexpr bool ntstatus_success(NTSTATUS status) {
-  return status >= 0;
-}
+  using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE hFile,
+      _Out_ PIO_STATUS_BLOCK iosb,
+      _Out_ PIO_STATUS_BLOCK io_status);
+  extern NtCancelIoFileEx_t NtCancelIoFileEx;
 
-} // namespace unifex::win32::ntapi
+  using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE FileHandle,
+      _In_opt_ HANDLE Event,
+      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+      _In_opt_ PVOID ApcContext,
+      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+      _Out_ PVOID Buffer,
+      _In_ ULONG Length,
+      _In_opt_ PLARGE_INTEGER ByteOffset,
+      _In_opt_ PULONG Key);
+  extern NtReadFile_t NtReadFile;
+
+  using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE FileHandle,
+      _In_opt_ HANDLE Event,
+      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+      _In_opt_ PVOID ApcContext,
+      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+      _In_ PVOID Buffer,
+      _In_ ULONG Length,
+      _In_opt_ PLARGE_INTEGER ByteOffset,
+      _In_opt_ PULONG Key);
+  extern NtWriteFile_t NtWriteFile;
+
+  using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE IoCompletionHandle,
+      _In_ ULONG KeyContext,
+      _In_ PVOID ApcContext,
+      _In_ NTSTATUS IoStatus,
+      _In_ ULONG IoStatusInformation);
+  extern NtSetIoCompletion_t NtSetIoCompletion;
+
+  using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE IoCompletionHandle,
+      _Out_ PVOID* CompletionKey,
+      _Out_ PVOID* ApcContext,
+      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+      _In_opt_ PLARGE_INTEGER Timeout);
+  extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
+
+  using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+      _In_ HANDLE IoCompletionHandle,
+      _Out_writes_to_(Count, *NumEntriesRemoved)
+          PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
+      _In_ ULONG Count,
+      _Out_ PULONG NumEntriesRemoved,
+      _In_opt_ PLARGE_INTEGER Timeout,
+      _In_ BOOLEAN Alertable);
+  extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
+
+  using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(_In_ NTSTATUS Status);
+  extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
+
+  void ensure_initialised() noexcept;
+
+  constexpr bool ntstatus_success(NTSTATUS status) { return status >= 0; }
+
+}  // namespace unifex::win32::ntapi
 
 #undef UNIFEX_NTAPI

--- a/include/unifex/win32/detail/safe_handle.hpp
+++ b/include/unifex/win32/detail/safe_handle.hpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/win32/detail/types.hpp>
+
+#include <utility>
+
+namespace unifex::win32 {
+
+class safe_handle {
+public:
+    safe_handle() noexcept : handle_(nullptr) {}
+
+    explicit safe_handle(handle_t h) noexcept : handle_(h) {}
+
+    safe_handle(safe_handle&& h) noexcept : handle_(std::exchange(h.handle_, nullptr)) {}
+
+    ~safe_handle() { reset(); }
+
+    safe_handle(const safe_handle&) = delete;
+
+    safe_handle& operator=(safe_handle h) noexcept {
+        swap(h);
+        return *this;
+    }
+
+    handle_t get() const noexcept { return handle_; }
+
+    handle_t release() noexcept { return std::exchange(handle_, nullptr); }
+
+    void reset() noexcept;
+
+    void swap(safe_handle& other) noexcept {
+        std::swap(handle_, other.handle_);
+    }
+
+    friend bool operator==(const safe_handle& a, const safe_handle& b) noexcept {
+        return a.handle_ == b.handle_;
+    }
+    friend bool operator==(const safe_handle& a, handle_t b) noexcept {
+        return a.handle_ == b;
+    }
+    friend bool operator==(handle_t a, const safe_handle& b) noexcept {
+        return a == b.handle_;
+    }
+
+    friend bool operator!=(const safe_handle& a, const safe_handle& b) noexcept {
+        return !(a == b);
+    }
+    friend bool operator!=(const safe_handle& a, handle_t b) noexcept {
+        return !(a == b);
+    }
+    friend bool operator!=(handle_t a, const safe_handle& b) noexcept {
+        return !(a == b);
+    }
+
+private:
+    handle_t handle_;
+};
+
+} // namespace unifex::win32

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -17,49 +17,46 @@
 
 #include <cstdint>
 
-namespace unifex::win32 {
-
-using handle_t = void*;             // HANDLE
-using ulong_ptr_t = std::uintptr_t; // ULONG_PTR
-using long_ptr_t = std::intptr_t;   // LONG_PTR
-using dword_t = unsigned long;      // DWORD
-using socket_t = std::uintptr_t;    // SOCKET
-using ulong_t = unsigned long;      // ULONG
-using long_t = long;                // LONG
-
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable : 4201) // non-standard anonymous struct/union
-#endif
-    struct overlapped {
-        ulong_ptr_t Internal;
-        ulong_ptr_t InternalHigh;
-        union
-        {
-            struct
-            {
-              dword_t Offset;
-              dword_t OffsetHigh;  
-            };
-            void* Pointer;
-        };
-        handle_t hEvent;
-    };
+namespace unifex::win32
+{
+  using handle_t = void*;              // HANDLE
+  using ulong_ptr_t = std::uintptr_t;  // ULONG_PTR
+  using long_ptr_t = std::intptr_t;    // LONG_PTR
+  using dword_t = unsigned long;       // DWORD
+  using socket_t = std::uintptr_t;     // SOCKET
+  using ulong_t = unsigned long;       // ULONG
+  using long_t = long;                 // LONG
 
 #if defined(_MSC_VER)
-# pragma warning(pop)
+#  pragma warning(push)
+#  pragma warning(disable : 4201)  // non-standard anonymous struct/union
+#endif
+  struct overlapped {
+    ulong_ptr_t Internal;
+    ulong_ptr_t InternalHigh;
+    union {
+      struct {
+        dword_t Offset;
+        dword_t OffsetHigh;
+      };
+      void* Pointer;
+    };
+    handle_t hEvent;
+  };
+
+#if defined(_MSC_VER)
+#  pragma warning(pop)
 #endif
 
-    struct wsabuf
-    {
-        constexpr wsabuf() noexcept
-        : len(0), buf(nullptr) {}
+  struct wsabuf {
+    constexpr wsabuf() noexcept : len(0), buf(nullptr) {}
 
-        wsabuf(void* p, ulong_t sz) noexcept
-        : len(sz), buf(reinterpret_cast<char*>(p)) {}
+    wsabuf(void* p, ulong_t sz) noexcept
+      : len(sz)
+      , buf(reinterpret_cast<char*>(p)) {}
 
-        ulong_t len;
-        char* buf;
-    };
+    ulong_t len;
+    char* buf;
+  };
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -26,7 +26,6 @@ using dword_t = unsigned long;      // DWORD
 using socket_t = std::uintptr_t;    // SOCKET
 using ulong_t = unsigned long;      // ULONG
 using long_t = long;                // LONG
-using ntstatus_t = long_t;          // NTSTATUS
 
 #if defined(_MSC_VER)
 # pragma warning(push)
@@ -45,19 +44,6 @@ using ntstatus_t = long_t;          // NTSTATUS
             void* Pointer;
         };
         handle_t hEvent;
-    };
-
-    // This is the internal structure of the 'overlapped' type's
-    // Internal/InternalHigh fields.
-    struct io_status_block {
-        // overlapped::Internal
-        union {
-            ntstatus_t Status;
-            void* Pointer;
-        };
-
-        // overlapped::InternalHigh
-        ulong_ptr_t Information;
     };
 
 #if defined(_MSC_VER)

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace unifex::win32 {
+
+using handle_t = void*;             // HANDLE
+using ulong_ptr_t = std::uintptr_t; // ULONG_PTR
+using long_ptr_t = std::intptr_t;   // LONG_PTR
+using dword_t = unsigned long;      // DWORD
+using socket_t = std::uintptr_t;    // SOCKET
+using ulong_t = unsigned long;      // ULONG
+using long_t = long;                // LONG
+using ntstatus_t = long_t;          // NTSTATUS
+
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable : 4201) // non-standard anonymous struct/union
+#endif
+    struct overlapped {
+        ulong_ptr_t Internal;
+        ulong_ptr_t InternalHigh;
+        union
+        {
+            struct
+            {
+              dword_t Offset;
+              dword_t OffsetHigh;  
+            };
+            void* Pointer;
+        };
+        handle_t hEvent;
+    };
+
+    // This is the internal structure of the 'overlapped' type's
+    // Internal/InternalHigh fields.
+    struct io_status_block {
+        // overlapped::Internal
+        union {
+            ntstatus_t Status;
+            void* Pointer;
+        };
+
+        // overlapped::InternalHigh
+        ulong_ptr_t Information;
+    };
+
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
+
+    struct wsabuf
+    {
+        constexpr wsabuf() noexcept
+        : len(0), buf(nullptr) {}
+
+        wsabuf(void* p, ulong_t sz) noexcept
+        : len(sz), buf(reinterpret_cast<char*>(p)) {}
+
+        ulong_t len;
+        char* buf;
+    };
+
+} // namespace unifex::win32

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -1,0 +1,814 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/io_concepts.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/pipe_concepts.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/span.hpp>
+#include <unifex/std_concepts.hpp>
+
+#include <unifex/detail/intrusive_list.hpp>
+#include <unifex/detail/intrusive_stack.hpp>
+#include <unifex/detail/atomic_intrusive_queue.hpp>
+
+#include <unifex/win32/detail/types.hpp>
+#include <unifex/win32/detail/safe_handle.hpp>
+
+#include <cstdint>
+#include <array>
+#include <thread>
+#include <cassert>
+#include <system_error>
+#include <tuple>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex::win32 {
+
+class low_latency_iocp_context {
+    class scheduler;
+
+    class readable_byte_stream;
+    class writable_byte_stream;
+
+    class schedule_sender;
+
+    template<typename Receiver>
+    struct _schedule_op {
+        class type;
+    };
+    template<typename Receiver>
+    using schedule_op = typename _schedule_op<Receiver>::type;
+
+    template<typename Buffer>
+    struct _read_file_sender {
+        class type;
+    };
+    template<typename Buffer>
+    using read_file_sender = typename _read_file_sender<Buffer>::type;
+
+    template<typename Buffer>
+    struct _write_file_sender {
+        class type;
+    };
+    template<typename Buffer>
+    using write_file_sender = typename _write_file_sender<Buffer>::type;
+
+    template<typename Buffer, typename Receiver>
+    struct _read_file_op {
+        class type;
+    };
+    template<typename Buffer, typename Receiver>
+    using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
+
+    template<typename Buffer, typename Receiver>
+    struct _write_file_op {
+        class type;
+    };
+    template<typename Buffer, typename Receiver>
+    using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
+
+public:
+    // Initialise the IOCP context and pre-allocate storage for I/O
+    // state needed to support at most 'maxIoOperations' concurrent I/O
+    // operations.
+    explicit low_latency_iocp_context(std::size_t maxIoOperations);
+
+    low_latency_iocp_context(low_latency_iocp_context&&) = delete;
+    low_latency_iocp_context(const low_latency_iocp_context&) = delete;
+    low_latency_iocp_context& operator=(const low_latency_iocp_context&) = delete;
+    low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
+
+    ~low_latency_iocp_context();
+
+    // Drive the event loop until a request to stop is communicated via
+    // the passed StopToken.
+    template<typename StopToken>
+    void run(StopToken st);
+
+    // Obtain a handle to this execution context that can be used to
+    // schedule work and open I/O resources.
+    scheduler get_scheduler() noexcept;
+
+private:
+    struct vectored_io_state;
+
+    // This value chosen so that vectored_io_state is 1024 bytes on 64-bit architectures
+    // and 512 bytes on 32-bit architectures.
+    static constexpr std::size_t max_vectored_io_size = 31;
+
+    struct operation_base {
+        explicit operation_base(low_latency_iocp_context& ctx) noexcept
+        : context(ctx)
+        {}
+
+        using callback_t = void(operation_base*) noexcept;
+        low_latency_iocp_context& context;
+        callback_t* callback = nullptr;
+        operation_base* next = nullptr;
+        operation_base* prev = nullptr;
+    };
+
+    using operation_queue = intrusive_list<operation_base, &operation_base::next, &operation_base::prev>;
+
+    struct io_operation : operation_base {
+        explicit io_operation(low_latency_iocp_context& context, handle_t fileHandle, bool skipNotificationOnSuccess) noexcept
+        : operation_base(context)
+        , fileHandle(fileHandle)
+        , skipNotificationOnSuccess(skipNotificationOnSuccess)
+        , ioState(nullptr)
+        {}
+
+        const handle_t fileHandle;
+        const bool skipNotificationOnSuccess;
+        vectored_io_state* ioState;
+
+        // Cancel outstanding I/O operations (if any)
+        void cancel_io() noexcept;
+
+        // Poll for whether or not the operation has completed.
+        // Returns 'true' if the operation is completed (in which case the operation
+        // has 'acquire' semantics), 'false' otherwise. 
+        bool is_complete() noexcept;
+
+        // Start reading the next 'buffer.size()' bytes into 'buffer'.
+        //
+        // Returns 'true' if a additional read-operations can be submitted.
+        // This will only be the case if all of the following are true:
+        // - a read of the entirety of 'buffer' was successfully started
+        // - we haven't reached the maximum number of I/O operations in
+        //   this batch.
+        //
+        // Once all I/O operations have been started, the caller should
+        // schedule a 'poll' of this operation by setting this->callback
+        // and calling context.schedule_poll(this). This will schedule the
+        // callback to be run immediately (if it completed synchronously).
+        bool start_read(span<std::byte> buffer) noexcept;
+
+        // Start writing the context of 'buffer' to fileHandle.
+        bool start_write(span<const std::byte> buffer) noexcept;
+
+        std::size_t get_result(std::error_code& ec) noexcept;
+    };
+
+    struct vectored_io_state {
+        // Parent operation.
+        //
+        // May be nullptr if this operation already completed due to a poll.
+        // If this is the case then when all pending completion notifications
+        // are received then this will just go straight back on the free-list.
+        io_operation* parent = nullptr;
+
+        // Intrusive list ptr.
+        vectored_io_state* next = nullptr;
+        vectored_io_state* prev = nullptr;
+
+        // Total number of operations started
+        std::uint8_t operationCount = 0;
+
+        // Number of operations not yet received completion-notification
+        // via the IOCP. This structure is not free to be reused until
+        // this number reaches zero.
+        std::uint8_t pendingCompletionNotifications = 0;
+
+        // Whether or not the 'parent' has already been notified of completion.
+        bool completed = false;
+
+        std::array<overlapped, max_vectored_io_size> operations;
+    };
+
+    struct stop_operation : operation_base {
+        explicit stop_operation(low_latency_iocp_context& ctx) noexcept
+        : operation_base(ctx) {
+            this->callback = &request_stop_callback;
+        }
+
+        ~stop_operation() {
+            if (isEnqueued) {
+                // Flush any items in the remote-queue into the ready queue
+                // just in case this operation is still in the remote queue.
+                (void)context.try_dequeue_remote_work();
+                
+                // This operation should now be in the ready queue, remove it.
+                context.readyQueue_.remove(this);
+            }
+        }
+
+        void start() noexcept {
+            if (context.is_running_on_io_thread()) {
+                stopRequestedFlag = true;
+            } else {
+                isEnqueued = true;
+                context.schedule_remote(this);
+            }
+        }
+
+        static void request_stop_callback(operation_base* op) noexcept {
+            auto& self = *static_cast<stop_operation*>(op);
+            self.stopRequestedFlag = true;
+            self.isEnqueued = false;
+        }
+
+        bool stopRequestedFlag = false;
+
+    private:
+        bool isEnqueued = false;
+    };
+
+    struct stop_callback {
+        stop_operation& op;
+
+        void operator()() noexcept {
+            op.start();
+        }
+    };
+
+    void run_impl(bool& stopFlag);
+
+    // Dequeue items from remote queue and move them to the
+    // ready-to-run queue.
+    // Returns true if any items were dequeued.
+    bool try_dequeue_remote_work() noexcept;
+
+    bool poll_is_complete(vectored_io_state& state) noexcept;
+
+    // Obtain the I/O state that contains a given overlapped structure.
+    vectored_io_state* to_io_state(overlapped* o) noexcept;
+
+    bool is_running_on_io_thread() const noexcept {
+        return activeThreadId_.load(std::memory_order_relaxed) == std::this_thread::get_id();
+    }
+
+    void schedule(operation_base* op) noexcept;
+    void schedule_local(operation_base* op) noexcept;
+    void schedule_remote(operation_base* op) noexcept;
+
+    // If an I/O state is available, attaches an unused I/O state to
+    // op->ioState and returns true, otherwise returns false if no
+    // I/O state is currently available.
+    //
+    // If 'true' is returned then the caller can populate op->ioState
+    // and initiate the I/O using its OVERLAPPED structures.
+    [[nodiscard]] bool try_allocate_io_state_for(io_operation* op) noexcept;
+
+    // Schedule the specified 'op' to be called back (calling op->callback)
+    // when an I/O state becomes available and has been allocated to 'op'.
+    //
+    // Do this only after an unsuccessful call to try_allocate_io_state_for()
+    // asynchronously wait until some other I/O operation completes and frees
+    // up an other I/O state.
+    void schedule_when_io_state_available(io_operation* op) noexcept;
+
+    // Mark the io state as released and let it return to the pool.
+    void release_io_state(vectored_io_state* state) noexcept;
+
+    // Schedule this operation to be polled next time we run out of work
+    // in the ready-queue before going back to the OS for completion-events.
+    void schedule_poll_io(io_operation* op) noexcept;
+
+    // Attempt to associate the specified file-handle with this I/O context
+    // so that its I/O completion events are posted to this context's IOCP.
+    void associate_file_handle(handle_t fileHandle);
+
+private:
+
+    ////
+    // State that won't change after initialisation or that change rarely
+    // e.g. only on each call to run().
+
+    std::atomic<std::thread::id> activeThreadId_;
+    safe_handle iocp_;
+    std::size_t ioPoolSize_;
+    std::unique_ptr<vectored_io_state[]> ioPool_;
+
+    /////
+    // State that is accessed/modified by the I/O thread only.
+
+    alignas(64)
+    intrusive_stack<vectored_io_state, &vectored_io_state::next> ioFreeList_;
+
+    // Newly launched operations that we want to poll for completion as soon as we run
+    // out of 'ready-to-run' work to do.
+    operation_queue pollQueue_;
+
+    // Operations waiting to acquire a vectored_io_operation.
+    // These will be resumed in-order as vectored_io_operations are returned to the pool.
+    operation_queue pendingIoQueue_;
+
+    // Operations that are ready to run.
+    operation_queue readyQueue_;
+
+    /////
+    // State that may be accessed/modified by other threads.
+
+    alignas(64)
+    atomic_intrusive_queue<operation_base, &operation_base::next> remoteQueue_;
+};
+
+template<typename StopToken>
+void low_latency_iocp_context::run(StopToken stopToken) {
+    stop_operation op{*this};
+    typename StopToken::template callback_type<stop_callback> cb{std::move(stopToken), stop_callback{op}};
+    run_impl(op.stopRequestedFlag);
+}
+
+///////////////////////////
+// schedule
+
+template<typename Receiver>
+class low_latency_iocp_context::_schedule_op<Receiver>::type
+    : private low_latency_iocp_context::operation_base {
+public:
+    template<typename Receiver2>
+    explicit type(low_latency_iocp_context& context, Receiver2&& r)
+    : operation_base(context)
+    , receiver_((Receiver2&&)r)
+    {
+        this->callback = &execute_callback;
+    }
+
+    void start() & noexcept {
+        this->context.schedule(this);
+    }
+
+private:
+    static void execute_callback(operation_base* op) noexcept {
+        auto& self = *static_cast<type*>(op);
+
+        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+            if (get_stop_token(self.receiver_).stop_requested()) {
+                unifex::set_done(std::move(self.receiver_));
+                return;
+            }
+        }
+
+        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
+            unifex::set_value(std::move(self.receiver_));
+        } else {
+            try {
+                unifex::set_value(std::move(self.receiver_));
+            } catch (...) {
+                unifex::set_error(std::move(self.receiver_), std::current_exception());
+            }
+        }
+    }
+
+    Receiver receiver_;
+};
+
+class low_latency_iocp_context::schedule_sender {
+public:
+    template<template<typename...> class Variant, template<typename...> class Tuple>
+    using value_types = Variant<Tuple<>>;
+
+    template<template<typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = true;
+
+    explicit schedule_sender(low_latency_iocp_context& context) noexcept
+    : context_(context)
+    {}
+
+    template(typename Receiver)
+        (requires receiver_of<Receiver>)
+    friend auto tag_invoke(tag_t<connect>, const schedule_sender& s, Receiver&& r)
+        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+        -> schedule_op<remove_cvref_t<Receiver>> {
+        return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver&&)r};
+    }
+
+private:
+    low_latency_iocp_context& context_;
+};
+
+///////////////////////////
+// read_file
+
+template<typename Buffer, typename Receiver>
+class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
+    : private low_latency_iocp_context::io_operation {
+public:
+    template<typename Receiver2, typename Buffer2>
+    explicit type(low_latency_iocp_context& ctx, handle_t fileHandle, bool skipNotificationOnSuccess, Buffer2&& buffer, Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2&&)r)
+    , buffer_((Buffer2&&)buffer)
+    {}
+
+    void start() & noexcept {
+        if (this->context.is_running_on_io_thread()) {
+            acquire_io_state(this);
+        } else {
+            this->callback = &acquire_io_state;
+            this->context.schedule_remote(this);
+        }
+    }
+
+private:
+    struct cancel_callback {
+        type& op;
+        void operator()() noexcept {
+            op.cancel_io();
+        }
+    };
+
+    static void acquire_io_state(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+        if (self.context.try_allocate_io_state_for(&self)) {
+            start_io(op);
+        } else {
+            // TODO: Add support for cancellation while waiting in the
+            // pendingIoQueue_.
+
+            self.callback = &start_io;
+            self.context.schedule_when_io_state_available(&self);
+        }
+    }
+
+    static void start_io(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+        assert(self.context.is_running_on_io_thread());
+        
+        // TODO: Add support for a BufferSequence concept to allow
+        // vectorised I/O here.
+        // For now, just assume that 'Buffer' is convertible to a 'span<std::byte>'.
+
+        self.start_read(self.buffer_);
+
+        if (self.ioState->pendingCompletionNotifications == 0) {
+            self.ioState->completed = true;
+            on_complete(op);
+        } else {
+            if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+                self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});
+                self.callback = &on_cancellable_complete;
+            } else {
+                self.callback = &on_complete;
+            }
+
+            self.context.schedule_poll_io(&self);
+        }
+    }
+
+    static void on_cancellable_complete(operation_base* op) noexcept {
+        auto& self = *static_cast<type*>(op);
+        assert(self.context.is_running_on_io_thread());
+
+        self.stopCallback_.destruct();
+        
+        on_complete(op);
+    }
+
+    static void on_complete(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+
+        std::error_code ec;
+        std::size_t totalBytesTransferred = self.get_result(ec);
+
+        self.context.release_io_state(self.ioState);
+
+        // Treat partial failure as a success case.
+        // TODO: Should we be sending tuple of (bytesTransferred, ec) here instead?
+        if (!ec || totalBytesTransferred > 0) {
+            if constexpr (is_nothrow_callable_v<decltype(set_value), Receiver, std::size_t>) {
+                unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+            } else {
+                try {
+                    unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+                } catch (...) {
+                    unifex::set_error(std::move(self.receiver_), std::current_exception());
+                }
+            }
+        } else if (ec == std::errc::operation_canceled) {
+            unifex::set_done(std::move(self.receiver_));
+        } else {
+            unifex::set_error(std::move(self.receiver_), std::move(ec));
+        }
+    }
+
+    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<
+        typename stop_token_type_t<Receiver>::
+        template callback_type<cancel_callback>> stopCallback_;
+};
+
+template<typename Buffer>
+class low_latency_iocp_context::_read_file_sender<Buffer>::type {
+public:
+    template<template<typename...> class Variant,
+             template<typename...> class Tuple>
+    using value_types = Variant<Tuple<std::size_t>>;
+
+    template<template<typename...> class Variant>
+    using error_types = Variant<std::exception_ptr, std::error_code>;
+
+    static constexpr bool sends_done = true;
+
+    template<typename Buffer2>
+    explicit type(
+        low_latency_iocp_context& context,
+        handle_t fileHandle,
+        bool skipNotificationsOnSuccess,
+        Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2&&)buffer)
+    {}
+
+    template(typename Receiver)
+        (requires receiver_of<Receiver, std::size_t>)
+    friend auto tag_invoke(tag_t<unifex::connect>, type&& self, Receiver&& r)
+        noexcept(std::is_nothrow_move_constructible_v<Buffer> &&
+                 std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+        -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
+        return read_file_op<Buffer, remove_cvref_t<Receiver>>{
+            self.context_,
+            self.fileHandle_,
+            self.skipNotificationsOnSuccess_,
+            std::move(self.buffer_),
+            (Receiver&&)r
+        };
+    }
+
+private:
+    low_latency_iocp_context& context_;
+    handle_t fileHandle_;
+    bool skipNotificationsOnSuccess_;
+    Buffer buffer_;
+};
+
+//////////////////////////
+// write_file
+
+template<typename Buffer, typename Receiver>
+class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
+    : private low_latency_iocp_context::io_operation {
+public:
+    template<typename Receiver2, typename Buffer2>
+    explicit type(
+        low_latency_iocp_context& ctx,
+        handle_t fileHandle,
+        bool skipNotificationOnSuccess,
+        Buffer2&& buffer,
+        Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2&&)r)
+    , buffer_((Buffer2&&)buffer)
+    {}
+
+    void start() & noexcept {
+        if (this->context.is_running_on_io_thread()) {
+            acquire_io_state(this);
+        } else {
+            this->callback = &acquire_io_state;
+            this->context.schedule_remote(this);
+        }
+    }
+
+private:
+    struct cancel_callback {
+        type& op;
+        void operator()() noexcept {
+            op.cancel_io();
+        }
+    };
+
+    static void acquire_io_state(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+        assert(self.context.is_running_on_io_thread());
+
+        if (self.context.try_allocate_io_state_for(&self)) {
+            start_io(op);
+        } else {
+            // TODO: Add support for cancellation while waiting in the
+            // pendingIoQueue_.
+
+            self.callback = &start_io;
+            self.context.schedule_when_io_state_available(&self);
+        }
+    }
+
+    static void start_io(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+        assert(self.context.is_running_on_io_thread());
+        
+        // TODO: Add support for a BufferSequence concept to allow
+        // vectorised I/O here.
+        // For now, just assume that 'Buffer' is convertible to a 'span<std::byte>'.
+
+        self.start_write(self.buffer_);
+
+        if (self.ioState->pendingCompletionNotifications == 0) {
+            self.ioState->completed = true;
+            on_complete(op);
+        } else {
+            if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+                self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});
+                self.callback = &on_cancellable_complete;
+            } else {
+                self.callback = &on_complete;
+            }
+
+            self.context.schedule_poll_io(&self);
+        }
+    }
+
+    static void on_cancellable_complete(operation_base* op) noexcept {
+        auto& self = *static_cast<type*>(op);
+        assert(self.context.is_running_on_io_thread());
+
+        self.stopCallback_.destruct();
+        
+        on_complete(op);
+    }
+
+    static void on_complete(operation_base* op) noexcept {
+        type& self = *static_cast<type*>(op);
+
+        std::error_code ec;
+        std::size_t totalBytesTransferred = self.get_result(ec);
+
+        self.context.release_io_state(self.ioState);
+
+        // Treat partial failure as a success case.
+        // TODO: Should we be sending tuple of (bytesTransferred, ec) here instead?
+        if (!ec || totalBytesTransferred > 0) {
+            if constexpr (is_nothrow_callable_v<decltype(set_value), Receiver, std::size_t>) {
+                unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+            } else {
+                try {
+                    unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+                } catch (...) {
+                    unifex::set_error(std::move(self.receiver_), std::current_exception());
+                }
+            }
+        } else if (ec == std::errc::operation_canceled) {
+            unifex::set_done(std::move(self.receiver_));
+        } else {
+            unifex::set_error(std::move(self.receiver_), std::move(ec));
+        }
+    }
+
+    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<
+        typename stop_token_type_t<Receiver>::
+        template callback_type<cancel_callback>> stopCallback_;
+};
+
+template<typename Buffer>
+class low_latency_iocp_context::_write_file_sender<Buffer>::type {
+public:
+    template<template<typename...> class Variant,
+             template<typename...> class Tuple>
+    using value_types = Variant<Tuple<std::size_t>>;
+
+    template<template<typename...> class Variant>
+    using error_types = Variant<std::exception_ptr, std::error_code>;
+
+    static constexpr bool sends_done = true;
+
+    template<typename Buffer2>
+    explicit type(
+        low_latency_iocp_context& context,
+        handle_t fileHandle,
+        bool skipNotificationsOnSuccess,
+        Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2&&)buffer)
+    {}
+
+    template(typename Receiver)
+        (requires receiver_of<Receiver, std::size_t>)
+    friend auto tag_invoke(tag_t<unifex::connect>, type&& self, Receiver&& r)
+        noexcept(std::is_nothrow_move_constructible_v<Buffer> &&
+                 std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+        -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
+        return write_file_op<Buffer, remove_cvref_t<Receiver>>{
+            self.context_,
+            self.fileHandle_,
+            self.skipNotificationsOnSuccess_,
+            std::move(self.buffer_),
+            (Receiver&&)r
+        };
+    }
+
+private:
+    low_latency_iocp_context& context_;
+    handle_t fileHandle_;
+    bool skipNotificationsOnSuccess_;
+    Buffer buffer_;
+};
+
+class low_latency_iocp_context::readable_byte_stream {
+public:
+    explicit readable_byte_stream(
+        low_latency_iocp_context& context,
+        safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle))
+    {}
+
+    template(typename Buffer)
+        (requires convertible_to<Buffer, span<std::byte>>)
+    friend read_file_sender<remove_cvref_t<Buffer>> tag_invoke(
+            tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
+        return read_file_sender<remove_cvref_t<Buffer>>{
+            stream.context_,
+            stream.fileHandle_.get(),
+            true,
+            (Buffer&&)buffer
+        };
+    }
+
+private:
+    low_latency_iocp_context& context_;
+    safe_handle fileHandle_;
+    bool skipNotificationOnCompletion_;
+};
+
+class low_latency_iocp_context::writable_byte_stream {
+public:
+    explicit writable_byte_stream(
+        low_latency_iocp_context& context,
+        safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle))
+    {}
+
+    template(typename Buffer)
+        (requires convertible_to<Buffer, span<const std::byte>>)
+    friend write_file_sender<remove_cvref_t<Buffer>> tag_invoke(
+            tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
+        return write_file_sender<remove_cvref_t<Buffer>>{
+            stream.context_,
+            stream.fileHandle_.get(),
+            true,
+            (Buffer&&)buffer
+        };
+    }
+
+private:
+    low_latency_iocp_context& context_;
+    safe_handle fileHandle_;
+};
+
+class low_latency_iocp_context::scheduler {
+public:
+    explicit scheduler(low_latency_iocp_context& context) noexcept
+    : context_(&context)
+    {}
+
+    schedule_sender schedule() const noexcept {
+        return schedule_sender{*context_};
+    }
+
+    friend std::tuple<readable_byte_stream, writable_byte_stream> tag_invoke(
+        tag_t<unifex::open_pipe>,
+        scheduler s) {
+        return open_pipe_impl(*s.context_);
+    }
+
+    friend bool operator==(scheduler a, scheduler b) noexcept {
+        return a.context_ == b.context_;
+    }
+
+    friend bool operator!=(scheduler a, scheduler b) noexcept {
+        return !(a == b);
+    }
+
+private:
+    static std::tuple<readable_byte_stream, writable_byte_stream> open_pipe_impl(low_latency_iocp_context& ctx);
+
+    low_latency_iocp_context* context_;
+};
+
+inline low_latency_iocp_context::scheduler low_latency_iocp_context::get_scheduler() noexcept {
+    return scheduler{*this};
+}
+
+} // namespace uniex::win32
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -24,26 +24,26 @@
 #include <unifex/span.hpp>
 #include <unifex/std_concepts.hpp>
 
+#include <unifex/detail/atomic_intrusive_queue.hpp>
 #include <unifex/detail/intrusive_list.hpp>
 #include <unifex/detail/intrusive_stack.hpp>
-#include <unifex/detail/atomic_intrusive_queue.hpp>
 
-#include <unifex/win32/detail/types.hpp>
 #include <unifex/win32/detail/ntapi.hpp>
 #include <unifex/win32/detail/safe_handle.hpp>
+#include <unifex/win32/detail/types.hpp>
 
-#include <cstdint>
 #include <array>
-#include <thread>
 #include <cassert>
+#include <cstdint>
 #include <system_error>
+#include <thread>
 #include <tuple>
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex::win32 {
-
-class low_latency_iocp_context {
+namespace unifex::win32
+{
+  class low_latency_iocp_context {
     class scheduler;
 
     class readable_byte_stream;
@@ -51,42 +51,42 @@ class low_latency_iocp_context {
 
     class schedule_sender;
 
-    template<typename Receiver>
+    template <typename Receiver>
     struct _schedule_op {
-        class type;
+      class type;
     };
-    template<typename Receiver>
+    template <typename Receiver>
     using schedule_op = typename _schedule_op<Receiver>::type;
 
-    template<typename Buffer>
+    template <typename Buffer>
     struct _read_file_sender {
-        class type;
+      class type;
     };
-    template<typename Buffer>
+    template <typename Buffer>
     using read_file_sender = typename _read_file_sender<Buffer>::type;
 
-    template<typename Buffer>
+    template <typename Buffer>
     struct _write_file_sender {
-        class type;
+      class type;
     };
-    template<typename Buffer>
+    template <typename Buffer>
     using write_file_sender = typename _write_file_sender<Buffer>::type;
 
-    template<typename Buffer, typename Receiver>
+    template <typename Buffer, typename Receiver>
     struct _read_file_op {
-        class type;
+      class type;
     };
-    template<typename Buffer, typename Receiver>
+    template <typename Buffer, typename Receiver>
     using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
 
-    template<typename Buffer, typename Receiver>
+    template <typename Buffer, typename Receiver>
     struct _write_file_op {
-        class type;
+      class type;
     };
-    template<typename Buffer, typename Receiver>
+    template <typename Buffer, typename Receiver>
     using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
 
-public:
+  public:
     // Initialise the IOCP context and pre-allocate storage for I/O
     // state needed to support at most 'maxIoOperations' concurrent I/O
     // operations.
@@ -94,151 +94,154 @@ public:
 
     low_latency_iocp_context(low_latency_iocp_context&&) = delete;
     low_latency_iocp_context(const low_latency_iocp_context&) = delete;
-    low_latency_iocp_context& operator=(const low_latency_iocp_context&) = delete;
+    low_latency_iocp_context&
+    operator=(const low_latency_iocp_context&) = delete;
     low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
 
     ~low_latency_iocp_context();
 
     // Drive the event loop until a request to stop is communicated via
     // the passed StopToken.
-    template<typename StopToken>
+    template <typename StopToken>
     void run(StopToken st);
 
     // Obtain a handle to this execution context that can be used to
     // schedule work and open I/O resources.
     scheduler get_scheduler() noexcept;
 
-private:
+  private:
     struct vectored_io_state;
 
-    // This value chosen so that vectored_io_state is 512 bytes on 64-bit architectures
-    // and 256 bytes on 32-bit architectures.
+    // This value chosen so that vectored_io_state is 512 bytes on 64-bit
+    // architectures and 256 bytes on 32-bit architectures.
     static constexpr std::size_t max_vectored_io_size = 30;
 
     struct operation_base {
-        explicit operation_base(low_latency_iocp_context& ctx) noexcept
-        : context(ctx)
-        {}
+      explicit operation_base(low_latency_iocp_context& ctx) noexcept
+        : context(ctx) {}
 
-        using callback_t = void(operation_base*) noexcept;
-        low_latency_iocp_context& context;
-        callback_t* callback = nullptr;
-        operation_base* next = nullptr;
-        operation_base* prev = nullptr;
+      using callback_t = void(operation_base*) noexcept;
+      low_latency_iocp_context& context;
+      callback_t* callback = nullptr;
+      operation_base* next = nullptr;
+      operation_base* prev = nullptr;
     };
 
-    using operation_queue = intrusive_list<operation_base, &operation_base::next, &operation_base::prev>;
+    using operation_queue = intrusive_list<
+        operation_base,
+        &operation_base::next,
+        &operation_base::prev>;
 
     struct io_operation : operation_base {
-        explicit io_operation(low_latency_iocp_context& context, handle_t fileHandle, bool skipNotificationOnSuccess) noexcept
+      explicit io_operation(
+          low_latency_iocp_context& context,
+          handle_t fileHandle,
+          bool skipNotificationOnSuccess) noexcept
         : operation_base(context)
         , fileHandle(fileHandle)
         , skipNotificationOnSuccess(skipNotificationOnSuccess)
-        , ioState(nullptr)
-        {}
+        , ioState(nullptr) {}
 
-        const handle_t fileHandle;
-        const bool skipNotificationOnSuccess;
-        vectored_io_state* ioState;
+      const handle_t fileHandle;
+      const bool skipNotificationOnSuccess;
+      vectored_io_state* ioState;
 
-        // Cancel outstanding I/O operations (if any)
-        void cancel_io() noexcept;
+      // Cancel outstanding I/O operations (if any)
+      void cancel_io() noexcept;
 
-        // Poll for whether or not the operation has completed.
-        // Returns 'true' if the operation is completed (in which case the operation
-        // has 'acquire' semantics), 'false' otherwise. 
-        bool is_complete() noexcept;
+      // Poll for whether or not the operation has completed.
+      // Returns 'true' if the operation is completed (in which case the
+      // operation has 'acquire' semantics), 'false' otherwise.
+      bool is_complete() noexcept;
 
-        // Start reading the next 'buffer.size()' bytes into 'buffer'.
-        //
-        // Returns 'true' if a additional read-operations can be submitted.
-        // This will only be the case if all of the following are true:
-        // - a read of the entirety of 'buffer' was successfully started
-        // - we haven't reached the maximum number of I/O operations in
-        //   this batch.
-        //
-        // Once all I/O operations have been started, the caller should
-        // schedule a 'poll' of this operation by setting this->callback
-        // and calling context.schedule_poll(this). This will schedule the
-        // callback to be run immediately (if it completed synchronously).
-        bool start_read(span<std::byte> buffer) noexcept;
+      // Start reading the next 'buffer.size()' bytes into 'buffer'.
+      //
+      // Returns 'true' if a additional read-operations can be submitted.
+      // This will only be the case if all of the following are true:
+      // - a read of the entirety of 'buffer' was successfully started
+      // - we haven't reached the maximum number of I/O operations in
+      //   this batch.
+      //
+      // Once all I/O operations have been started, the caller should
+      // schedule a 'poll' of this operation by setting this->callback
+      // and calling context.schedule_poll(this). This will schedule the
+      // callback to be run immediately (if it completed synchronously).
+      bool start_read(span<std::byte> buffer) noexcept;
 
-        // Start writing the context of 'buffer' to fileHandle.
-        bool start_write(span<const std::byte> buffer) noexcept;
+      // Start writing the context of 'buffer' to fileHandle.
+      bool start_write(span<const std::byte> buffer) noexcept;
 
-        std::size_t get_result(std::error_code& ec) noexcept;
+      std::size_t get_result(std::error_code& ec) noexcept;
     };
 
     struct vectored_io_state {
-        // Parent operation.
-        //
-        // May be nullptr if this operation already completed due to a poll.
-        // If this is the case then when all pending completion notifications
-        // are received then this will just go straight back on the free-list.
-        io_operation* parent = nullptr;
+      // Parent operation.
+      //
+      // May be nullptr if this operation already completed due to a poll.
+      // If this is the case then when all pending completion notifications
+      // are received then this will just go straight back on the free-list.
+      io_operation* parent = nullptr;
 
-        // Intrusive list ptr.
-        vectored_io_state* next = nullptr;
-        vectored_io_state* prev = nullptr;
+      // Intrusive list ptr.
+      vectored_io_state* next = nullptr;
+      vectored_io_state* prev = nullptr;
 
-        // Total number of operations started
-        std::uint8_t operationCount = 0;
+      // Total number of operations started
+      std::uint8_t operationCount = 0;
 
-        // Number of operations not yet received completion-notification
-        // via the IOCP. The vectored_io_state structure is not free to
-        // be reused until this number reaches zero.
-        std::uint8_t pendingCompletionNotifications = 0;
+      // Number of operations not yet received completion-notification
+      // via the IOCP. The vectored_io_state structure is not free to
+      // be reused until this number reaches zero.
+      std::uint8_t pendingCompletionNotifications = 0;
 
-        // Whether or not the 'parent' has already been notified of completion.
-        bool completed = false;
+      // Whether or not the 'parent' has already been notified of completion.
+      bool completed = false;
 
-        ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
+      ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
     };
 
     struct stop_operation : operation_base {
-        explicit stop_operation(low_latency_iocp_context& ctx) noexcept
+      explicit stop_operation(low_latency_iocp_context& ctx) noexcept
         : operation_base(ctx) {
-            this->callback = &request_stop_callback;
-        }
+        this->callback = &request_stop_callback;
+      }
 
-        ~stop_operation() {
-            if (isEnqueued) {
-                // Flush any items in the remote-queue into the ready queue
-                // just in case this operation is still in the remote queue.
-                (void)context.try_dequeue_remote_work();
-                
-                // This operation should now be in the ready queue, remove it.
-                context.readyQueue_.remove(this);
-            }
-        }
+      ~stop_operation() {
+        if (isEnqueued) {
+          // Flush any items in the remote-queue into the ready queue
+          // just in case this operation is still in the remote queue.
+          (void)context.try_dequeue_remote_work();
 
-        void start() noexcept {
-            if (context.is_running_on_io_thread()) {
-                stopRequestedFlag = true;
-            } else {
-                isEnqueued = true;
-                context.schedule_remote(this);
-            }
+          // This operation should now be in the ready queue, remove it.
+          context.readyQueue_.remove(this);
         }
+      }
 
-        static void request_stop_callback(operation_base* op) noexcept {
-            auto& self = *static_cast<stop_operation*>(op);
-            self.stopRequestedFlag = true;
-            self.isEnqueued = false;
+      void start() noexcept {
+        if (context.is_running_on_io_thread()) {
+          stopRequestedFlag = true;
+        } else {
+          isEnqueued = true;
+          context.schedule_remote(this);
         }
+      }
 
-        bool stopRequestedFlag = false;
+      static void request_stop_callback(operation_base* op) noexcept {
+        auto& self = *static_cast<stop_operation*>(op);
+        self.stopRequestedFlag = true;
+        self.isEnqueued = false;
+      }
+
+      bool stopRequestedFlag = false;
 
     private:
-        bool isEnqueued = false;
+      bool isEnqueued = false;
     };
 
     struct stop_callback {
-        stop_operation& op;
+      stop_operation& op;
 
-        void operator()() noexcept {
-            op.start();
-        }
+      void operator()() noexcept { op.start(); }
     };
 
     void run_impl(bool& stopFlag);
@@ -254,7 +257,8 @@ private:
     vectored_io_state* to_io_state(ntapi::IO_STATUS_BLOCK* io) noexcept;
 
     bool is_running_on_io_thread() const noexcept {
-        return activeThreadId_.load(std::memory_order_relaxed) == std::this_thread::get_id();
+      return activeThreadId_.load(std::memory_order_relaxed) ==
+          std::this_thread::get_id();
     }
 
     void schedule(operation_base* op) noexcept;
@@ -288,8 +292,7 @@ private:
     // so that its I/O completion events are posted to this context's IOCP.
     void associate_file_handle(handle_t fileHandle);
 
-private:
-
+  private:
     ////
     // State that won't change after initialisation or that change rarely
     // e.g. only on each call to run().
@@ -302,15 +305,17 @@ private:
     /////
     // State that is accessed/modified by the I/O thread only.
 
-    alignas(64)
-    intrusive_stack<vectored_io_state, &vectored_io_state::next> ioFreeList_;
+    alignas(64) intrusive_stack<
+        vectored_io_state,
+        &vectored_io_state::next> ioFreeList_;
 
-    // Newly launched operations that we want to poll for completion as soon as we run
-    // out of 'ready-to-run' work to do.
+    // Newly launched operations that we want to poll for completion as soon as
+    // we run out of 'ready-to-run' work to do.
     operation_queue pollQueue_;
 
     // Operations waiting to acquire a vectored_io_operation.
-    // These will be resumed in-order as vectored_io_operations are returned to the pool.
+    // These will be resumed in-order as vectored_io_operations are returned to
+    // the pool.
     operation_queue pendingIoQueue_;
 
     // Operations that are ready to run.
@@ -319,498 +324,511 @@ private:
     /////
     // State that may be accessed/modified by other threads.
 
-    alignas(64)
-    atomic_intrusive_queue<operation_base, &operation_base::next> remoteQueue_;
-};
+    alignas(64) atomic_intrusive_queue<
+        operation_base,
+        &operation_base::next> remoteQueue_;
+  };
 
-template<typename StopToken>
-void low_latency_iocp_context::run(StopToken stopToken) {
+  template <typename StopToken>
+  void low_latency_iocp_context::run(StopToken stopToken) {
     stop_operation op{*this};
-    typename StopToken::template callback_type<stop_callback> cb{std::move(stopToken), stop_callback{op}};
+    typename StopToken::template callback_type<stop_callback> cb{
+        std::move(stopToken), stop_callback{op}};
     run_impl(op.stopRequestedFlag);
-}
+  }
 
-///////////////////////////
-// schedule
+  ///////////////////////////
+  // schedule
 
-template<typename Receiver>
-class low_latency_iocp_context::_schedule_op<Receiver>::type
+  template <typename Receiver>
+  class low_latency_iocp_context::_schedule_op<Receiver>::type
     : private low_latency_iocp_context::operation_base {
-public:
-    template<typename Receiver2>
+  public:
+    template <typename Receiver2>
     explicit type(low_latency_iocp_context& context, Receiver2&& r)
-    : operation_base(context)
-    , receiver_((Receiver2&&)r)
-    {
-        this->callback = &execute_callback;
+      : operation_base(context)
+      , receiver_((Receiver2 &&) r) {
+      this->callback = &execute_callback;
     }
 
-    void start() & noexcept {
-        this->context.schedule(this);
-    }
+    void start() & noexcept { this->context.schedule(this); }
 
-private:
+  private:
     static void execute_callback(operation_base* op) noexcept {
-        auto& self = *static_cast<type*>(op);
+      auto& self = *static_cast<type*>(op);
 
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-            if (get_stop_token(self.receiver_).stop_requested()) {
-                unifex::set_done(std::move(self.receiver_));
-                return;
-            }
+      if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+        if (get_stop_token(self.receiver_).stop_requested()) {
+          unifex::set_done(std::move(self.receiver_));
+          return;
         }
+      }
 
-        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(self.receiver_));
-        } else {
-            try {
-                unifex::set_value(std::move(self.receiver_));
-            } catch (...) {
-                unifex::set_error(std::move(self.receiver_), std::current_exception());
-            }
+      if constexpr (is_nothrow_callable_v<
+                        decltype(unifex::set_value),
+                        Receiver>) {
+        unifex::set_value(std::move(self.receiver_));
+      } else {
+        try {
+          unifex::set_value(std::move(self.receiver_));
+        } catch (...) {
+          unifex::set_error(
+              std::move(self.receiver_), std::current_exception());
         }
+      }
     }
 
     Receiver receiver_;
-};
+  };
 
-class low_latency_iocp_context::schedule_sender {
-public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
+  class low_latency_iocp_context::schedule_sender {
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     static constexpr bool sends_done = true;
 
     explicit schedule_sender(low_latency_iocp_context& context) noexcept
-    : context_(context)
-    {}
+      : context_(context) {}
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, const schedule_sender& s, Receiver&& r)
-        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+    template(typename Receiver)(requires receiver_of<Receiver>) friend auto tag_invoke(
+        tag_t<connect>,
+        const schedule_sender& s,
+        Receiver&& r) noexcept(std::
+                                   is_nothrow_constructible_v<
+                                       remove_cvref_t<Receiver>,
+                                       Receiver>)
         -> schedule_op<remove_cvref_t<Receiver>> {
-        return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver&&)r};
+      return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver &&) r};
     }
 
-private:
+  private:
     low_latency_iocp_context& context_;
-};
+  };
 
-///////////////////////////
-// read_file
+  ///////////////////////////
+  // read_file
 
-template<typename Buffer, typename Receiver>
-class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
+  template <typename Buffer, typename Receiver>
+  class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
     : private low_latency_iocp_context::io_operation {
-public:
-    template<typename Receiver2, typename Buffer2>
-    explicit type(low_latency_iocp_context& ctx, handle_t fileHandle, bool skipNotificationOnSuccess, Buffer2&& buffer, Receiver2&& r)
-    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-    , receiver_((Receiver2&&)r)
-    , buffer_((Buffer2&&)buffer)
-    {}
-
-    void start() & noexcept {
-        if (this->context.is_running_on_io_thread()) {
-            acquire_io_state(this);
-        } else {
-            this->callback = &acquire_io_state;
-            this->context.schedule_remote(this);
-        }
-    }
-
-private:
-    struct cancel_callback {
-        type& op;
-        void operator()() noexcept {
-            op.cancel_io();
-        }
-    };
-
-    static void acquire_io_state(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
-        if (self.context.try_allocate_io_state_for(&self)) {
-            start_io(op);
-        } else {
-            // TODO: Add support for cancellation while waiting in the
-            // pendingIoQueue_.
-
-            self.callback = &start_io;
-            self.context.schedule_when_io_state_available(&self);
-        }
-    }
-
-    static void start_io(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
-        assert(self.context.is_running_on_io_thread());
-        
-        // TODO: Add support for a BufferSequence concept to allow
-        // vectorised I/O here.
-        // For now, just assume that 'Buffer' is convertible to a 'span<std::byte>'.
-
-        self.start_read(self.buffer_);
-
-        if (self.ioState->pendingCompletionNotifications == 0) {
-            self.ioState->completed = true;
-            self.callback = &on_complete;
-            self.context.readyQueue_.push_front(op);
-        } else {
-            if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-                self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});
-                self.callback = &on_cancellable_complete;
-            } else {
-                self.callback = &on_complete;
-            }
-
-            self.context.schedule_poll_io(&self);
-        }
-    }
-
-    static void on_cancellable_complete(operation_base* op) noexcept {
-        auto& self = *static_cast<type*>(op);
-        assert(self.context.is_running_on_io_thread());
-
-        self.stopCallback_.destruct();
-        
-        on_complete(op);
-    }
-
-    static void on_complete(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
-
-        std::error_code ec;
-        std::size_t totalBytesTransferred = self.get_result(ec);
-
-        self.context.release_io_state(self.ioState);
-
-        // Treat partial failure as a success case.
-        // TODO: Should we be sending tuple of (bytesTransferred, ec) here instead?
-        if (!ec || totalBytesTransferred > 0) {
-            if constexpr (is_nothrow_callable_v<decltype(set_value), Receiver, std::size_t>) {
-                unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-            } else {
-                try {
-                    unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-                } catch (...) {
-                    unifex::set_error(std::move(self.receiver_), std::current_exception());
-                }
-            }
-        } else if (ec == std::errc::operation_canceled) {
-            unifex::set_done(std::move(self.receiver_));
-        } else {
-            unifex::set_error(std::move(self.receiver_), std::move(ec));
-        }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<
-        typename stop_token_type_t<Receiver>::
-        template callback_type<cancel_callback>> stopCallback_;
-};
-
-template<typename Buffer>
-class low_latency_iocp_context::_read_file_sender<Buffer>::type {
-public:
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
-    using value_types = Variant<Tuple<std::size_t>>;
-
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr, std::error_code>;
-
-    static constexpr bool sends_done = true;
-
-    template<typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& context,
-        handle_t fileHandle,
-        bool skipNotificationsOnSuccess,
-        Buffer2&& buffer)
-    : context_(context)
-    , fileHandle_(fileHandle)
-    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-    , buffer_((Buffer2&&)buffer)
-    {}
-
-    template(typename Receiver)
-        (requires receiver_of<Receiver, std::size_t>)
-    friend auto tag_invoke(tag_t<unifex::connect>, type&& self, Receiver&& r)
-        noexcept(std::is_nothrow_move_constructible_v<Buffer> &&
-                 std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
-        -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
-        return read_file_op<Buffer, remove_cvref_t<Receiver>>{
-            self.context_,
-            self.fileHandle_,
-            self.skipNotificationsOnSuccess_,
-            std::move(self.buffer_),
-            (Receiver&&)r
-        };
-    }
-
-private:
-    low_latency_iocp_context& context_;
-    handle_t fileHandle_;
-    bool skipNotificationsOnSuccess_;
-    Buffer buffer_;
-};
-
-//////////////////////////
-// write_file
-
-template<typename Buffer, typename Receiver>
-class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
-    : private low_latency_iocp_context::io_operation {
-public:
-    template<typename Receiver2, typename Buffer2>
+  public:
+    template <typename Receiver2, typename Buffer2>
     explicit type(
         low_latency_iocp_context& ctx,
         handle_t fileHandle,
         bool skipNotificationOnSuccess,
         Buffer2&& buffer,
         Receiver2&& r)
-    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-    , receiver_((Receiver2&&)r)
-    , buffer_((Buffer2&&)buffer)
-    {}
+      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+      , receiver_((Receiver2 &&) r)
+      , buffer_((Buffer2 &&) buffer) {}
 
     void start() & noexcept {
-        if (this->context.is_running_on_io_thread()) {
-            acquire_io_state(this);
-        } else {
-            this->callback = &acquire_io_state;
-            this->context.schedule_remote(this);
-        }
+      if (this->context.is_running_on_io_thread()) {
+        acquire_io_state(this);
+      } else {
+        this->callback = &acquire_io_state;
+        this->context.schedule_remote(this);
+      }
     }
 
-private:
+  private:
     struct cancel_callback {
-        type& op;
-        void operator()() noexcept {
-            op.cancel_io();
-        }
+      type& op;
+      void operator()() noexcept { op.cancel_io(); }
     };
 
     static void acquire_io_state(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
-        assert(self.context.is_running_on_io_thread());
+      type& self = *static_cast<type*>(op);
+      if (self.context.try_allocate_io_state_for(&self)) {
+        start_io(op);
+      } else {
+        // TODO: Add support for cancellation while waiting in the
+        // pendingIoQueue_.
 
-        if (self.context.try_allocate_io_state_for(&self)) {
-            start_io(op);
-        } else {
-            // TODO: Add support for cancellation while waiting in the
-            // pendingIoQueue_.
-
-            self.callback = &start_io;
-            self.context.schedule_when_io_state_available(&self);
-        }
+        self.callback = &start_io;
+        self.context.schedule_when_io_state_available(&self);
+      }
     }
 
     static void start_io(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
-        assert(self.context.is_running_on_io_thread());
-        
-        // TODO: Add support for a BufferSequence concept to allow
-        // vectorised I/O here.
-        // For now, just assume that 'Buffer' is convertible to a 'span<std::byte>'.
+      type& self = *static_cast<type*>(op);
+      assert(self.context.is_running_on_io_thread());
 
-        self.start_write(self.buffer_);
+      // TODO: Add support for a BufferSequence concept to allow
+      // vectorised I/O here.
+      // For now, just assume that 'Buffer' is convertible to a
+      // 'span<std::byte>'.
 
-        if (self.ioState->pendingCompletionNotifications == 0) {
-            self.ioState->completed = true;
-            self.callback = &on_complete;
-            self.context.readyQueue_.push_front(op);
+      self.start_read(self.buffer_);
+
+      if (self.ioState->pendingCompletionNotifications == 0) {
+        self.ioState->completed = true;
+        self.callback = &on_complete;
+        self.context.readyQueue_.push_front(op);
+      } else {
+        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+          self.stopCallback_.construct(
+              get_stop_token(self.receiver_), cancel_callback{self});
+          self.callback = &on_cancellable_complete;
         } else {
-            if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-                self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});
-                self.callback = &on_cancellable_complete;
-            } else {
-                self.callback = &on_complete;
-            }
-
-            self.context.schedule_poll_io(&self);
+          self.callback = &on_complete;
         }
+
+        self.context.schedule_poll_io(&self);
+      }
     }
 
     static void on_cancellable_complete(operation_base* op) noexcept {
-        auto& self = *static_cast<type*>(op);
-        assert(self.context.is_running_on_io_thread());
+      auto& self = *static_cast<type*>(op);
+      assert(self.context.is_running_on_io_thread());
 
-        self.stopCallback_.destruct();
-        
-        on_complete(op);
+      self.stopCallback_.destruct();
+
+      on_complete(op);
     }
 
     static void on_complete(operation_base* op) noexcept {
-        type& self = *static_cast<type*>(op);
+      type& self = *static_cast<type*>(op);
 
-        std::error_code ec;
-        std::size_t totalBytesTransferred = self.get_result(ec);
+      std::error_code ec;
+      std::size_t totalBytesTransferred = self.get_result(ec);
 
-        self.context.release_io_state(self.ioState);
+      self.context.release_io_state(self.ioState);
 
-        // Treat partial failure as a success case.
-        // TODO: Should we be sending tuple of (bytesTransferred, ec) here instead?
-        if (!ec || totalBytesTransferred > 0) {
-            if constexpr (is_nothrow_callable_v<decltype(set_value), Receiver, std::size_t>) {
-                unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-            } else {
-                try {
-                    unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-                } catch (...) {
-                    unifex::set_error(std::move(self.receiver_), std::current_exception());
-                }
-            }
-        } else if (ec == std::errc::operation_canceled) {
-            unifex::set_done(std::move(self.receiver_));
+      // Treat partial failure as a success case.
+      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+      // instead?
+      if (!ec || totalBytesTransferred > 0) {
+        if constexpr (is_nothrow_callable_v<
+                          decltype(set_value),
+                          Receiver,
+                          std::size_t>) {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
         } else {
-            unifex::set_error(std::move(self.receiver_), std::move(ec));
+          try {
+            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+          } catch (...) {
+            unifex::set_error(
+                std::move(self.receiver_), std::current_exception());
+          }
         }
+      } else if (ec == std::errc::operation_canceled) {
+        unifex::set_done(std::move(self.receiver_));
+      } else {
+        unifex::set_error(std::move(self.receiver_), std::move(ec));
+      }
     }
 
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
     UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<
-        typename stop_token_type_t<Receiver>::
-        template callback_type<cancel_callback>> stopCallback_;
-};
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+        Receiver>::template callback_type<cancel_callback>>
+        stopCallback_;
+  };
 
-template<typename Buffer>
-class low_latency_iocp_context::_write_file_sender<Buffer>::type {
-public:
-    template<template<typename...> class Variant,
-             template<typename...> class Tuple>
+  template <typename Buffer>
+  class low_latency_iocp_context::_read_file_sender<Buffer>::type {
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<std::size_t>>;
 
-    template<template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr, std::error_code>;
 
     static constexpr bool sends_done = true;
 
-    template<typename Buffer2>
+    template <typename Buffer2>
     explicit type(
         low_latency_iocp_context& context,
         handle_t fileHandle,
         bool skipNotificationsOnSuccess,
         Buffer2&& buffer)
-    : context_(context)
-    , fileHandle_(fileHandle)
-    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-    , buffer_((Buffer2&&)buffer)
-    {}
+      : context_(context)
+      , fileHandle_(fileHandle)
+      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+      , buffer_((Buffer2 &&) buffer) {}
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver, std::size_t>)
-    friend auto tag_invoke(tag_t<unifex::connect>, type&& self, Receiver&& r)
-        noexcept(std::is_nothrow_move_constructible_v<Buffer> &&
-                 std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
-        -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
-        return write_file_op<Buffer, remove_cvref_t<Receiver>>{
-            self.context_,
-            self.fileHandle_,
-            self.skipNotificationsOnSuccess_,
-            std::move(self.buffer_),
-            (Receiver&&)r
-        };
+    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
+        tag_t<unifex::connect>,
+        type&& self,
+        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                   std::is_nothrow_constructible_v<
+                                       remove_cvref_t<Receiver>,
+                                       Receiver>)
+        -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
+      return read_file_op<Buffer, remove_cvref_t<Receiver>>{
+          self.context_,
+          self.fileHandle_,
+          self.skipNotificationsOnSuccess_,
+          std::move(self.buffer_),
+          (Receiver &&) r};
     }
 
-private:
+  private:
     low_latency_iocp_context& context_;
     handle_t fileHandle_;
     bool skipNotificationsOnSuccess_;
     Buffer buffer_;
-};
+  };
 
-class low_latency_iocp_context::readable_byte_stream {
-public:
+  //////////////////////////
+  // write_file
+
+  template <typename Buffer, typename Receiver>
+  class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
+    : private low_latency_iocp_context::io_operation {
+  public:
+    template <typename Receiver2, typename Buffer2>
+    explicit type(
+        low_latency_iocp_context& ctx,
+        handle_t fileHandle,
+        bool skipNotificationOnSuccess,
+        Buffer2&& buffer,
+        Receiver2&& r)
+      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+      , receiver_((Receiver2 &&) r)
+      , buffer_((Buffer2 &&) buffer) {}
+
+    void start() & noexcept {
+      if (this->context.is_running_on_io_thread()) {
+        acquire_io_state(this);
+      } else {
+        this->callback = &acquire_io_state;
+        this->context.schedule_remote(this);
+      }
+    }
+
+  private:
+    struct cancel_callback {
+      type& op;
+      void operator()() noexcept { op.cancel_io(); }
+    };
+
+    static void acquire_io_state(operation_base* op) noexcept {
+      type& self = *static_cast<type*>(op);
+      assert(self.context.is_running_on_io_thread());
+
+      if (self.context.try_allocate_io_state_for(&self)) {
+        start_io(op);
+      } else {
+        // TODO: Add support for cancellation while waiting in the
+        // pendingIoQueue_.
+
+        self.callback = &start_io;
+        self.context.schedule_when_io_state_available(&self);
+      }
+    }
+
+    static void start_io(operation_base* op) noexcept {
+      type& self = *static_cast<type*>(op);
+      assert(self.context.is_running_on_io_thread());
+
+      // TODO: Add support for a BufferSequence concept to allow
+      // vectorised I/O here.
+      // For now, just assume that 'Buffer' is convertible to a
+      // 'span<std::byte>'.
+
+      self.start_write(self.buffer_);
+
+      if (self.ioState->pendingCompletionNotifications == 0) {
+        self.ioState->completed = true;
+        self.callback = &on_complete;
+        self.context.readyQueue_.push_front(op);
+      } else {
+        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+          self.stopCallback_.construct(
+              get_stop_token(self.receiver_), cancel_callback{self});
+          self.callback = &on_cancellable_complete;
+        } else {
+          self.callback = &on_complete;
+        }
+
+        self.context.schedule_poll_io(&self);
+      }
+    }
+
+    static void on_cancellable_complete(operation_base* op) noexcept {
+      auto& self = *static_cast<type*>(op);
+      assert(self.context.is_running_on_io_thread());
+
+      self.stopCallback_.destruct();
+
+      on_complete(op);
+    }
+
+    static void on_complete(operation_base* op) noexcept {
+      type& self = *static_cast<type*>(op);
+
+      std::error_code ec;
+      std::size_t totalBytesTransferred = self.get_result(ec);
+
+      self.context.release_io_state(self.ioState);
+
+      // Treat partial failure as a success case.
+      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+      // instead?
+      if (!ec || totalBytesTransferred > 0) {
+        if constexpr (is_nothrow_callable_v<
+                          decltype(set_value),
+                          Receiver,
+                          std::size_t>) {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+        } else {
+          try {
+            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+          } catch (...) {
+            unifex::set_error(
+                std::move(self.receiver_), std::current_exception());
+          }
+        }
+      } else if (ec == std::errc::operation_canceled) {
+        unifex::set_done(std::move(self.receiver_));
+      } else {
+        unifex::set_error(std::move(self.receiver_), std::move(ec));
+      }
+    }
+
+    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+        Receiver>::template callback_type<cancel_callback>>
+        stopCallback_;
+  };
+
+  template <typename Buffer>
+  class low_latency_iocp_context::_write_file_sender<Buffer>::type {
+  public:
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = Variant<Tuple<std::size_t>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr, std::error_code>;
+
+    static constexpr bool sends_done = true;
+
+    template <typename Buffer2>
+    explicit type(
+        low_latency_iocp_context& context,
+        handle_t fileHandle,
+        bool skipNotificationsOnSuccess,
+        Buffer2&& buffer)
+      : context_(context)
+      , fileHandle_(fileHandle)
+      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+      , buffer_((Buffer2 &&) buffer) {}
+
+    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
+        tag_t<unifex::connect>,
+        type&& self,
+        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                   std::is_nothrow_constructible_v<
+                                       remove_cvref_t<Receiver>,
+                                       Receiver>)
+        -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
+      return write_file_op<Buffer, remove_cvref_t<Receiver>>{
+          self.context_,
+          self.fileHandle_,
+          self.skipNotificationsOnSuccess_,
+          std::move(self.buffer_),
+          (Receiver &&) r};
+    }
+
+  private:
+    low_latency_iocp_context& context_;
+    handle_t fileHandle_;
+    bool skipNotificationsOnSuccess_;
+    Buffer buffer_;
+  };
+
+  class low_latency_iocp_context::readable_byte_stream {
+  public:
     explicit readable_byte_stream(
-        low_latency_iocp_context& context,
-        safe_handle fileHandle) noexcept
-    : context_(context)
-    , fileHandle_(std::move(fileHandle))
-    {}
+        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+      : context_(context)
+      , fileHandle_(std::move(fileHandle)) {}
 
-    template(typename Buffer)
-        (requires convertible_to<Buffer, span<std::byte>>)
-    friend read_file_sender<remove_cvref_t<Buffer>> tag_invoke(
-            tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
-        return read_file_sender<remove_cvref_t<Buffer>>{
-            stream.context_,
-            stream.fileHandle_.get(),
-            true,
-            (Buffer&&)buffer
-        };
+    template(typename Buffer)(requires convertible_to<Buffer, span<std::byte>>) friend read_file_sender<
+        remove_cvref_t<
+            Buffer>> tag_invoke(tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
+      return read_file_sender<remove_cvref_t<Buffer>>{
+          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
     }
 
-private:
+  private:
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
-};
+  };
 
-class low_latency_iocp_context::writable_byte_stream {
-public:
+  class low_latency_iocp_context::writable_byte_stream {
+  public:
     explicit writable_byte_stream(
-        low_latency_iocp_context& context,
-        safe_handle fileHandle) noexcept
-    : context_(context)
-    , fileHandle_(std::move(fileHandle))
-    {}
+        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+      : context_(context)
+      , fileHandle_(std::move(fileHandle)) {}
 
-    template(typename Buffer)
-        (requires convertible_to<Buffer, span<const std::byte>>)
-    friend write_file_sender<remove_cvref_t<Buffer>> tag_invoke(
-            tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
-        return write_file_sender<remove_cvref_t<Buffer>>{
-            stream.context_,
-            stream.fileHandle_.get(),
-            true,
-            (Buffer&&)buffer
-        };
+    template(typename Buffer)(requires convertible_to<Buffer, span<const std::byte>>) friend write_file_sender<
+        remove_cvref_t<
+            Buffer>> tag_invoke(tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
+      return write_file_sender<remove_cvref_t<Buffer>>{
+          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
     }
 
-private:
+  private:
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
-};
+  };
 
-class low_latency_iocp_context::scheduler {
-public:
+  class low_latency_iocp_context::scheduler {
+  public:
     explicit scheduler(low_latency_iocp_context& context) noexcept
-    : context_(&context)
-    {}
+      : context_(&context) {}
 
     schedule_sender schedule() const noexcept {
-        return schedule_sender{*context_};
+      return schedule_sender{*context_};
     }
 
-    friend std::tuple<readable_byte_stream, writable_byte_stream> tag_invoke(
-        tag_t<unifex::open_pipe>,
-        scheduler s) {
-        return open_pipe_impl(*s.context_);
+    friend std::tuple<readable_byte_stream, writable_byte_stream>
+    tag_invoke(tag_t<unifex::open_pipe>, scheduler s) {
+      return open_pipe_impl(*s.context_);
     }
 
     friend bool operator==(scheduler a, scheduler b) noexcept {
-        return a.context_ == b.context_;
+      return a.context_ == b.context_;
     }
 
     friend bool operator!=(scheduler a, scheduler b) noexcept {
-        return !(a == b);
+      return !(a == b);
     }
 
-private:
-    static std::tuple<readable_byte_stream, writable_byte_stream> open_pipe_impl(low_latency_iocp_context& ctx);
+  private:
+    static std::tuple<readable_byte_stream, writable_byte_stream>
+    open_pipe_impl(low_latency_iocp_context& ctx);
 
     low_latency_iocp_context* context_;
-};
+  };
 
-inline low_latency_iocp_context::scheduler low_latency_iocp_context::get_scheduler() noexcept {
+  inline low_latency_iocp_context::scheduler
+  low_latency_iocp_context::get_scheduler() noexcept {
     return scheduler{*this};
-}
+  }
 
-} // namespace uniex::win32
+}  // namespace unifex::win32
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -455,7 +455,8 @@ private:
 
         if (self.ioState->pendingCompletionNotifications == 0) {
             self.ioState->completed = true;
-            on_complete(op);
+            self.callback = &on_complete;
+            self.context.readyQueue_.push_front(op);
         } else {
             if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
                 self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});
@@ -620,7 +621,8 @@ private:
 
         if (self.ioState->pendingCompletionNotifications == 0) {
             self.ioState->completed = true;
-            on_complete(op);
+            self.callback = &on_complete;
+            self.context.readyQueue_.push_front(op);
         } else {
             if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
                 self.stopCallback_.construct(get_stop_token(self.receiver_), cancel_callback{self});

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -54,7 +54,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
       win32/filetime_clock.cpp
       win32/safe_handle.cpp
       win32/windows_thread_pool.cpp
-      win32/low_latency_iocp_context.cpp)
+      win32/low_latency_iocp_context.cpp
+      win32/ntapi.cpp)
 
 endif()
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -53,7 +53,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     PRIVATE
       win32/filetime_clock.cpp
       win32/safe_handle.cpp
-      win32/windows_thread_pool.cpp)
+      win32/windows_thread_pool.cpp
+      win32/low_latency_iocp_context.cpp)
 
 endif()
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -52,6 +52,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
   target_sources(unifex
     PRIVATE
       win32/filetime_clock.cpp
+      win32/safe_handle.cpp
       win32/windows_thread_pool.cpp)
 
 endif()

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -26,27 +26,31 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-namespace unifex::win32 {
-
-namespace {
-
-static safe_handle create_iocp() {
-    HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
-    if (h == NULL) {
+namespace unifex::win32
+{
+  namespace
+  {
+    static safe_handle create_iocp() {
+      HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+      if (h == NULL) {
         DWORD errorCode = ::GetLastError();
-        throw std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateIoCompletionPort()"};
+        throw std::system_error{
+            static_cast<int>(errorCode),
+            std::system_category(),
+            "CreateIoCompletionPort()"};
+      }
+
+      return safe_handle{h};
     }
 
-    return safe_handle{h};
-}
+  }  // namespace
 
-} // namespace
-
-low_latency_iocp_context::low_latency_iocp_context(std::size_t maxIoOperations)
-: activeThreadId_(std::thread::id())
-, iocp_(create_iocp())
-, ioPoolSize_(maxIoOperations)
-, ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
+  low_latency_iocp_context::low_latency_iocp_context(
+      std::size_t maxIoOperations)
+    : activeThreadId_(std::thread::id())
+    , iocp_(create_iocp())
+    , ioPoolSize_(maxIoOperations)
+    , ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
     // Make sure the WinNT APIs are initialised and available.
     // Only need to do this on construction as this will be guaranteed
     // to run before anything else needs to call them.
@@ -55,55 +59,56 @@ low_latency_iocp_context::low_latency_iocp_context(std::size_t maxIoOperations)
     // Build the I/O free-list in reverse so front of free-list
     // is first element in array.
     for (std::size_t i = 0; i < maxIoOperations; ++i) {
-        ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
+      ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
     }
-}
+  }
 
-low_latency_iocp_context::~low_latency_iocp_context() {
-    // Wait until the completion-event for every io-state has been 
+  low_latency_iocp_context::~low_latency_iocp_context() {
+    // Wait until the completion-event for every io-state has been
     // received before we free the memory for the io-states.
     std::size_t remaining = ioPoolSize_;
     while (!ioFreeList_.empty()) {
-        (void)ioFreeList_.pop_front();
-        --remaining;
+      (void)ioFreeList_.pop_front();
+      --remaining;
     }
 
     if (remaining > 0) {
-        constexpr std::uint32_t completionBufferSize = 128;
-        ntapi::FILE_IO_COMPLETION_INFORMATION completionBuffer[completionBufferSize];
-        std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+      constexpr std::uint32_t completionBufferSize = 128;
+      ntapi::FILE_IO_COMPLETION_INFORMATION
+          completionBuffer[completionBufferSize];
+      std::memset(&completionBuffer, 0, sizeof(completionBuffer));
 
-        do {
-            ntapi::ULONG numEntriesRemoved = 0;
-            ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
-                iocp_.get(),
-                completionBuffer,
-                completionBufferSize,
-                &numEntriesRemoved,
-                NULL,    // no timeout
-                FALSE);  // not alertable
-            if (!ntapi::ntstatus_success(ntstat)) {
-                std::terminate();
-            }
+      do {
+        ntapi::ULONG numEntriesRemoved = 0;
+        ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
+            iocp_.get(),
+            completionBuffer,
+            completionBufferSize,
+            &numEntriesRemoved,
+            NULL,    // no timeout
+            FALSE);  // not alertable
+        if (!ntapi::ntstatus_success(ntstat)) {
+          std::terminate();
+        }
 
-            for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
-                auto& entry = completionBuffer[i];
-                if (entry.ApcContext != nullptr) {
-                    ntapi::IO_STATUS_BLOCK* iosb =
-                        reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-                    auto* state = to_io_state(iosb);
-                    assert(state->pendingCompletionNotifications > 0);
-                    --state->pendingCompletionNotifications;
-                    if (state->pendingCompletionNotifications == 0) {
-                        --remaining;
-                    }
-                }
+        for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
+          auto& entry = completionBuffer[i];
+          if (entry.ApcContext != nullptr) {
+            ntapi::IO_STATUS_BLOCK* iosb =
+                reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
+            auto* state = to_io_state(iosb);
+            assert(state->pendingCompletionNotifications > 0);
+            --state->pendingCompletionNotifications;
+            if (state->pendingCompletionNotifications == 0) {
+              --remaining;
             }
-        } while (remaining > 0);
+          }
+        }
+      } while (remaining > 0);
     }
-}
+  }
 
-void low_latency_iocp_context::run_impl(bool& stopFlag) {
+  void low_latency_iocp_context::run_impl(bool& stopFlag) {
     ntapi::LARGE_INTEGER zero;
     zero.QuadPart = 0;
 
@@ -115,7 +120,7 @@ void low_latency_iocp_context::run_impl(bool& stopFlag) {
     assert(prevId == std::thread::id());
 
     scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
-        activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
+      activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
     };
 
     constexpr std::uint32_t completionBufferSize = 128;
@@ -129,150 +134,151 @@ void low_latency_iocp_context::run_impl(bool& stopFlag) {
     // state such that the  'shouldCheckRemoteQueue = true'
     // is a valid initial state for the next caller to run().
     scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
-        if (!shouldCheckRemoteQueue) {
-            (void)remoteQueue_.try_mark_active();
-        }
+      if (!shouldCheckRemoteQueue) {
+        (void)remoteQueue_.try_mark_active();
+      }
     };
 
     while (!stopFlag) {
-    process_ready_queue:
-        // Process/drain all ready-to-run work.
-        while (!readyQueue_.empty()) {
-            operation_base* task = readyQueue_.pop_front();
-            task->callback(task);
+process_ready_queue:
+      // Process/drain all ready-to-run work.
+      while (!readyQueue_.empty()) {
+        operation_base* task = readyQueue_.pop_front();
+        task->callback(task);
+      }
+
+      // Check whether the stop request was processed
+      // when draining the ready queue.
+      if (stopFlag) {
+        break;
+      }
+
+      // Check the poll-queue for I/O operations that might have completed
+      // already but where we have not yet seen the IOCP event.
+
+      while (!pollQueue_.empty()) {
+        io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
+        auto* state = op->ioState;
+        assert(state->pendingCompletionNotifications > 0);
+        assert(!state->completed);
+
+        if (poll_is_complete(*state)) {
+          // Completed before we received any notifications via IOCP.
+          // Schedule it to resume now, before polling any other I/Os
+          // to give those other I/Os time to complete.
+          state->completed = true;
+          schedule_local(state->parent);
+          goto process_ready_queue;
         }
+      }
 
-        // Check whether the stop request was processed
-        // when draining the ready queue.
-        if (stopFlag) {
-            break;
+process_remote_queue:
+      if (shouldCheckRemoteQueue) {
+        if (try_dequeue_remote_work()) {
+          goto process_ready_queue;
         }
+      }
 
-        // Check the poll-queue for I/O operations that might have completed
-        // already but where we have not yet seen the IOCP event.
+      // Now check if there are any IOCP events.
+get_iocp_entries:
+      const ntapi::BOOLEAN alertable = FALSE;
+      ntapi::ULONG completionEntriesRetrieved = 0;
+      ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
+          iocp_.get(),
+          completionBuffer,
+          completionBufferSize,
+          &completionEntriesRetrieved,
+          shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
+          alertable);
+      if (ntstat == STATUS_TIMEOUT) {
+        assert(shouldCheckRemoteQueue);
 
-        while (!pollQueue_.empty()) {
-           io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
-           auto* state = op->ioState;
-           assert(state->pendingCompletionNotifications > 0);
-           assert(!state->completed);
-
-           if (poll_is_complete(*state)) {
-               // Completed before we received any notifications via IOCP.
-               // Schedule it to resume now, before polling any other I/Os
-               // to give those other I/Os time to complete.
-               state->completed = true;
-               schedule_local(state->parent);
-               goto process_ready_queue;
-           }
+        // Previous call was non-blocking.
+        // About to transition to blocking-call, but first need to
+        // mark remote queue inactive so that remote threads know
+        // they need to post an event to wake this thread up.
+        if (remoteQueue_.try_mark_inactive()) {
+          shouldCheckRemoteQueue = false;
+          goto get_iocp_entries;
+        } else {
+          goto process_remote_queue;
         }
+      } else if (!ntapi::ntstatus_success(ntstat)) {
+        DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
+        throw std::system_error{
+            static_cast<int>(errorCode),
+            std::system_category(),
+            "NtRemoveIoCompletionEx()"};
+      }
 
-    process_remote_queue:
-        if (shouldCheckRemoteQueue) {
-            if (try_dequeue_remote_work()) {
-                goto process_ready_queue;
-            }
-        }
+      // Process completion-entries we received from the OS.
+      for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
+        ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
+        if (entry.ApcContext != nullptr) {
+          ntapi::IO_STATUS_BLOCK* iosb =
+              reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
+          // TODO: Do we need to store the error-code/bytes-transferred here?
+          // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
+          // Should we be copying entry.IoStatusBlock to '*iosb'?
 
-        // Now check if there are any IOCP events.
-    get_iocp_entries:
-        const ntapi::BOOLEAN alertable = FALSE;
-        ntapi::ULONG completionEntriesRetrieved = 0;
-        ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
-            iocp_.get(),
-            completionBuffer,
-            completionBufferSize,
-            &completionEntriesRetrieved,
-            shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
-            alertable);
-        if (ntstat == STATUS_TIMEOUT) {
-            assert(shouldCheckRemoteQueue);
+          assert(iosb->Status != STATUS_PENDING);
 
-            // Previous call was non-blocking.
-            // About to transition to blocking-call, but first need to
-            // mark remote queue inactive so that remote threads know
-            // they need to post an event to wake this thread up.
-            if (remoteQueue_.try_mark_inactive()) {
-                shouldCheckRemoteQueue = false;
-                goto get_iocp_entries;
+          vectored_io_state* state = to_io_state(iosb);
+
+          assert(state->pendingCompletionNotifications > 0);
+          if (--state->pendingCompletionNotifications == 0) {
+            // This was the last pending notification for this state.
+            if (state->parent != nullptr) {
+              // An operation is still attached to this state.
+              // Notify it if we hadn't already done so.
+              if (!state->completed) {
+                state->completed = true;
+                schedule_local(state->parent);
+              }
             } else {
-                goto process_remote_queue;
+              // Otherwise the operation has already detached
+              // from this I/O state and so we can immediately
+              // return it to the pool.
+              release_io_state(state);
             }
-        } else if (!ntapi::ntstatus_success(ntstat)) {
-            DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
-            throw std::system_error{
-                static_cast<int>(errorCode),
-                std::system_category(),
-                "NtRemoveIoCompletionEx()"};
+          }
+        } else {
+          // A remote-thread wake-up notification.
+          shouldCheckRemoteQueue = true;
         }
-
-        // Process completion-entries we received from the OS.
-        for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
-            ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
-            if (entry.ApcContext != nullptr) {
-                ntapi::IO_STATUS_BLOCK* iosb =
-                    reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-                // TODO: Do we need to store the error-code/bytes-transferred here?
-                // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
-                // Should we be copying entry.IoStatusBlock to '*iosb'?
-
-                assert(iosb->Status != STATUS_PENDING);
-
-                vectored_io_state* state = to_io_state(iosb);
-
-                assert(state->pendingCompletionNotifications > 0);
-                if (--state->pendingCompletionNotifications == 0) {
-                    // This was the last pending notification for this state.
-                    if (state->parent != nullptr) {
-                        // An operation is still attached to this state.
-                        // Notify it if we hadn't already done so.
-                        if (!state->completed) {
-                            state->completed = true;
-                            schedule_local(state->parent);
-                        }
-                    } else {
-                        // Otherwise the operation has already detached
-                        // from this I/O state and so we can immediately
-                        // return it to the pool.
-                        release_io_state(state);
-                    }
-                }
-            } else {
-                // A remote-thread wake-up notification.
-                shouldCheckRemoteQueue = true;
-            }
-        }
+      }
     }
-}
+  }
 
-bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
+  bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
     auto items = remoteQueue_.dequeue_all_reversed();
     if (items.empty()) {
-        return false;
+      return false;
     }
 
     // Note that this ends up enqueueing entries in reverse.
     // TODO: Modify this so it enqueues items in a way that
     // preserves order.
     do {
-        schedule_local(items.pop_front());
+      schedule_local(items.pop_front());
     } while (!items.empty());
 
     return true;
-}
+  }
 
-bool low_latency_iocp_context::poll_is_complete(vectored_io_state& state) noexcept {
+  bool low_latency_iocp_context::poll_is_complete(
+      vectored_io_state& state) noexcept {
     // TODO: Double check the memory barriers/atomics we need to use
     // here to ensure we perform this read, that it doesn't tear and
     // that it has the appropriate memory semantics.
 
     for (std::size_t i = 0; i < state.operationCount; ++i) {
-        // Mark volatile to indicate to the compiler that it might change in the
-        // background. The kernel might update it as the I/O completes.
-        volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
-        if (iosb->Status == STATUS_PENDING) {
-            return false;
-        }
+      // Mark volatile to indicate to the compiler that it might change in the
+      // background. The kernel might update it as the I/O completes.
+      volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
+      if (iosb->Status == STATUS_PENDING) {
+        return false;
+      }
     }
 
     // Make sure that we have visibility of the results of the I/O operations
@@ -281,61 +287,63 @@ bool low_latency_iocp_context::poll_is_complete(vectored_io_state& state) noexce
     std::atomic_thread_fence(std::memory_order_acquire);
 
     return true;
-}
+  }
 
-low_latency_iocp_context::vectored_io_state*
-low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
+  low_latency_iocp_context::vectored_io_state*
+  low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
     vectored_io_state* const pool = ioPool_.get();
 
-    std::ptrdiff_t offset = reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
+    std::ptrdiff_t offset =
+        reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
     assert(offset >= 0);
 
     std::ptrdiff_t index = offset / sizeof(vectored_io_state);
     assert(index < ioPoolSize_);
 
     return &pool[index];
-}
+  }
 
-void low_latency_iocp_context::schedule(operation_base* op) noexcept {
+  void low_latency_iocp_context::schedule(operation_base* op) noexcept {
     if (is_running_on_io_thread()) {
-        schedule_local(op);
+      schedule_local(op);
     } else {
-        schedule_remote(op);
+      schedule_remote(op);
     }
-}
+  }
 
-void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
+  void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
     assert(is_running_on_io_thread());
     readyQueue_.push_back(op);
-}
+  }
 
-void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
+  void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
     assert(!is_running_on_io_thread());
     if (remoteQueue_.enqueue(op)) {
-        // I/O thread is potentially sleeping.
-        // Post a wake-up NOP event to the queue.
+      // I/O thread is potentially sleeping.
+      // Post a wake-up NOP event to the queue.
 
-        // BUGBUG: This could potentially fail and if it does then
-        // the I/O thread might never respond to remote enqueues.
-        // For now we just treat this as a (hopefully rare) unrecoverable error.
-        ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
-            iocp_.get(),
-            0,        // KeyContext
-            nullptr,  // ApcContext
-            0,        // NTSTATUS (0 = success)
-            0);       // IoStatusInformation
-        if (!ntapi::ntstatus_success(ntstat)) {
-            // Failed to post an event to the I/O completion port.
-            std::terminate();
-        }
+      // BUGBUG: This could potentially fail and if it does then
+      // the I/O thread might never respond to remote enqueues.
+      // For now we just treat this as a (hopefully rare) unrecoverable error.
+      ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
+          iocp_.get(),
+          0,        // KeyContext
+          nullptr,  // ApcContext
+          0,        // NTSTATUS (0 = success)
+          0);       // IoStatusInformation
+      if (!ntapi::ntstatus_success(ntstat)) {
+        // Failed to post an event to the I/O completion port.
+        std::terminate();
+      }
     }
-}
+  }
 
-bool low_latency_iocp_context::try_allocate_io_state_for(io_operation* op) noexcept {
+  bool low_latency_iocp_context::try_allocate_io_state_for(
+      io_operation* op) noexcept {
     assert(is_running_on_io_thread());
 
     if (ioFreeList_.empty()) {
-        return false;
+      return false;
     }
 
     assert(pendingIoQueue_.empty());
@@ -349,85 +357,87 @@ bool low_latency_iocp_context::try_allocate_io_state_for(io_operation* op) noexc
     op->ioState = state;
 
     return true;
-}
+  }
 
-void low_latency_iocp_context::schedule_when_io_state_available(io_operation* op) noexcept {
+  void low_latency_iocp_context::schedule_when_io_state_available(
+      io_operation* op) noexcept {
     assert(is_running_on_io_thread());
     assert(ioFreeList_.empty());
     pendingIoQueue_.push_back(op);
-}
+  }
 
-void low_latency_iocp_context::release_io_state(vectored_io_state* state) noexcept {
+  void low_latency_iocp_context::release_io_state(
+      vectored_io_state* state) noexcept {
     assert(is_running_on_io_thread());
 
     if (state->pendingCompletionNotifications == 0) {
-        // Can be freed immediately.
+      // Can be freed immediately.
 
-        if (pendingIoQueue_.empty()) {
-            ioFreeList_.push_front(state);
-        } else {
-            assert(ioFreeList_.empty());
+      if (pendingIoQueue_.empty()) {
+        ioFreeList_.push_front(state);
+      } else {
+        assert(ioFreeList_.empty());
 
-            // Another operation was waiting for an I/O state.
-            // Give the I/O state directly to the operation instead
-            // of adding it to the free-list. This prevents some other
-            // operation from skipping the queue and acquiring it
-            // before this I/O operation can run.
-            auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
+        // Another operation was waiting for an I/O state.
+        // Give the I/O state directly to the operation instead
+        // of adding it to the free-list. This prevents some other
+        // operation from skipping the queue and acquiring it
+        // before this I/O operation can run.
+        auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
 
-            state->parent = op;
-            state->completed = false;
-            state->operationCount = 0;
-            state->pendingCompletionNotifications = 0;
-            op->ioState = state;
+        state->parent = op;
+        state->completed = false;
+        state->operationCount = 0;
+        state->pendingCompletionNotifications = 0;
+        op->ioState = state;
 
-            schedule_local(op);
-        }
+        schedule_local(op);
+      }
     } else {
-        // Mark it to be freed once all of its I/O completion
-        // notifications have been received.
-        state->parent = nullptr;
+      // Mark it to be freed once all of its I/O completion
+      // notifications have been received.
+      state->parent = nullptr;
     }
-}
+  }
 
-void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
+  void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
     assert(is_running_on_io_thread());
     assert(op != nullptr);
     assert(op->ioState != nullptr);
 
     if (op->ioState->pendingCompletionNotifications > 0) {
-        pollQueue_.push_back(op);
+      pollQueue_.push_back(op);
     } else {
-        // No need to poll, schedule straight to the front of the ready-to-run queue.
-        readyQueue_.push_front(op);
+      // No need to poll, schedule straight to the front of the ready-to-run
+      // queue.
+      readyQueue_.push_front(op);
     }
-}
+  }
 
-void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
-    const HANDLE result = ::CreateIoCompletionPort(
-        fileHandle,
-        iocp_.get(),
-        0, 0);
+  void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
+    const HANDLE result =
+        ::CreateIoCompletionPort(fileHandle, iocp_.get(), 0, 0);
     if (result == nullptr) {
-        DWORD errorCode = ::GetLastError();
-        throw std::system_error{
-            static_cast<int>(errorCode), std::system_category(),
-            "CreateIoCompletionPort"};
+      DWORD errorCode = ::GetLastError();
+      throw std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "CreateIoCompletionPort"};
     }
 
     const BOOL ok = ::SetFileCompletionNotificationModes(
         fileHandle,
-        FILE_SKIP_COMPLETION_PORT_ON_SUCCESS |
-        FILE_SKIP_SET_EVENT_ON_HANDLE);
+        FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE);
     if (!ok) {
-        DWORD errorCode = ::GetLastError();
-        throw std::system_error{
-            static_cast<int>(errorCode), std::system_category(),
-            "SetFileCompletionNotificationModes"};
+      DWORD errorCode = ::GetLastError();
+      throw std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "SetFileCompletionNotificationModes"};
     }
-}
+  }
 
-void low_latency_iocp_context::io_operation::cancel_io() noexcept {
+  void low_latency_iocp_context::io_operation::cancel_io() noexcept {
     assert(ioState != nullptr);
 
     // Cancel operations in reverse order so that later operations
@@ -435,31 +445,31 @@ void low_latency_iocp_context::io_operation::cancel_io() noexcept {
     // operations being cancelled and later ones completing due to
     // a race.
     for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
-        ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
-        ntapi::IO_STATUS_BLOCK ioStatus;
-        [[maybe_unused]] ntapi::NTSTATUS ntstat =
-            ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
-        // TODO: Check ntstat for failure.
-        // Can't really do much here even if there is failure, anyway.
+      ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
+      ntapi::IO_STATUS_BLOCK ioStatus;
+      [[maybe_unused]] ntapi::NTSTATUS ntstat =
+          ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
+      // TODO: Check ntstat for failure.
+      // Can't really do much here even if there is failure, anyway.
     }
-}
+  }
 
-bool low_latency_iocp_context::io_operation::is_complete() noexcept {
+  bool low_latency_iocp_context::io_operation::is_complete() noexcept {
     assert(context.is_running_on_io_thread());
     assert(ioState != nullptr);
 
     if (ioState->pendingCompletionNotifications == 0) {
-        return true;
+      return true;
     }
 
     for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-        volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
+      volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
 
-        // Mark volatile to indicate to the compiler that it might change in the
-        // background. The kernel might update it as the I/O completes.
-        if (iosb->Status == STATUS_PENDING) {
-            return false;
-        }
+      // Mark volatile to indicate to the compiler that it might change in the
+      // background. The kernel might update it as the I/O completes.
+      if (iosb->Status == STATUS_PENDING) {
+        return false;
+      }
     }
 
     // Make sure that we have visibility of the results of all of the I/O
@@ -469,10 +479,10 @@ bool low_latency_iocp_context::io_operation::is_complete() noexcept {
     std::atomic_thread_fence(std::memory_order_acquire);
 
     return true;
-}
+  }
 
-bool low_latency_iocp_context::io_operation::start_read(
-        span<std::byte> buffer) noexcept {
+  bool low_latency_iocp_context::io_operation::start_read(
+      span<std::byte> buffer) noexcept {
     assert(context.is_running_on_io_thread());
     assert(ioState != nullptr);
     assert(ioState->operationCount < max_vectored_io_size);
@@ -481,65 +491,65 @@ bool low_latency_iocp_context::io_operation::start_read(
 
     std::size_t offset = 0;
     while (offset < buffer.size()) {
-        ntapi::IO_STATUS_BLOCK& iosb =
-            ioState->operations[ioState->operationCount];
-        ++ioState->operationCount;
+      ntapi::IO_STATUS_BLOCK& iosb =
+          ioState->operations[ioState->operationCount];
+      ++ioState->operationCount;
 
-        iosb.Status = STATUS_PENDING;
-        iosb.Information = 0;
+      iosb.Status = STATUS_PENDING;
+      iosb.Information = 0;
 
-        // Truncate over-large chunks to a number of bytes that will still
-        // preserve alignment requirements of the underlying device if this
-        // happens to be an unbuffered storage device.
-        // In this case we truncate to the largest multiple of 64k less than
-        // 2^32 to allow for up to 64k alignment.
-        // TODO: Ideally we'd just use the underlying alignment of the
-        // file-handle.
-        static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-        static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+      // Truncate over-large chunks to a number of bytes that will still
+      // preserve alignment requirements of the underlying device if this
+      // happens to be an unbuffered storage device.
+      // In this case we truncate to the largest multiple of 64k less than
+      // 2^32 to allow for up to 64k alignment.
+      // TODO: Ideally we'd just use the underlying alignment of the
+      // file-handle.
+      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
 
-        std::size_t chunkSize = buffer.size() - offset;
-        if (chunkSize > maxChunkSize) {
-            chunkSize = truncatedChunkSize;
+      std::size_t chunkSize = buffer.size() - offset;
+      if (chunkSize > maxChunkSize) {
+        chunkSize = truncatedChunkSize;
+      }
+
+      ntapi::NTSTATUS status = ntapi::NtReadFile(
+          fileHandle,
+          NULL,                                  // Event
+          NULL,                                  // ApcRoutine
+          &iosb,                                 // ApcContext
+          &iosb,                                 // IoStatusBlock
+          buffer.data() + offset,                // Buffer
+          static_cast<ntapi::ULONG>(chunkSize),  // Length
+          nullptr,                               // ByteOffset
+          nullptr);                              // Key
+      if (status == STATUS_PENDING) {
+        ++ioState->pendingCompletionNotifications;
+      } else if (ntapi::ntstatus_success(status)) {
+        // Succeeded synchronously.
+        if (!skipNotificationOnSuccess) {
+          ++ioState->pendingCompletionNotifications;
         }
+      } else {
+        // Immediate failure.
+        // Don't launch any more operations.
+        // TODO: Should we cancel any prior launched operations?
+        return false;
+      }
 
-        ntapi::NTSTATUS status = ntapi::NtReadFile(
-            fileHandle,
-            NULL,                                  // Event
-            NULL,                                  // ApcRoutine
-            &iosb,                                 // ApcContext
-            &iosb,                                 // IoStatusBlock
-            buffer.data() + offset,                // Buffer
-            static_cast<ntapi::ULONG>(chunkSize),  // Length
-            nullptr,                               // ByteOffset
-            nullptr);                              // Key
-        if (status == STATUS_PENDING) {
-            ++ioState->pendingCompletionNotifications;
-        } else if (ntapi::ntstatus_success(status)) {
-            // Succeeded synchronously.
-            if (!skipNotificationOnSuccess) {
-                ++ioState->pendingCompletionNotifications;
-            }
-        } else {
-            // Immediate failure.
-            // Don't launch any more operations.
-            // TODO: Should we cancel any prior launched operations?
-            return false;
-        }
+      if (ioState->operationCount == max_vectored_io_size) {
+        // We've launched as many operations as we can.
+        return false;
+      }
 
-        if (ioState->operationCount == max_vectored_io_size) {
-            // We've launched as many operations as we can.
-            return false;
-        }
-
-        offset += chunkSize;
+      offset += chunkSize;
     }
 
     return true;
-}
+  }
 
-bool low_latency_iocp_context::io_operation::start_write(
-        span<const std::byte> buffer) noexcept {
+  bool low_latency_iocp_context::io_operation::start_write(
+      span<const std::byte> buffer) noexcept {
     assert(context.is_running_on_io_thread());
     assert(ioState != nullptr);
     assert(ioState->operationCount < max_vectored_io_size);
@@ -548,63 +558,64 @@ bool low_latency_iocp_context::io_operation::start_write(
 
     std::size_t offset = 0;
     while (offset < buffer.size()) {
-        ntapi::IO_STATUS_BLOCK& iosb =
-            ioState->operations[ioState->operationCount];
-        ++ioState->operationCount;
+      ntapi::IO_STATUS_BLOCK& iosb =
+          ioState->operations[ioState->operationCount];
+      ++ioState->operationCount;
 
-        iosb.Status = STATUS_PENDING;
-        iosb.Information = 0;
+      iosb.Status = STATUS_PENDING;
+      iosb.Information = 0;
 
-        // Truncate over-large chunks to a number of bytes that will still
-        // preserve alignment requirements of the underlying device if this
-        // happens to be an unbuffered storage device.
-        // In this case we truncate to the largest multiple of 64k less than
-        // 2^32 to allow for up to 64k alignment.
-        // TODO: Ideally we'd just use the underlying alignment of the
-        // file-handle.
-        static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-        static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+      // Truncate over-large chunks to a number of bytes that will still
+      // preserve alignment requirements of the underlying device if this
+      // happens to be an unbuffered storage device.
+      // In this case we truncate to the largest multiple of 64k less than
+      // 2^32 to allow for up to 64k alignment.
+      // TODO: Ideally we'd just use the underlying alignment of the
+      // file-handle.
+      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
 
-        std::size_t chunkSize = buffer.size() - offset;
-        if (chunkSize > maxChunkSize) {
-            chunkSize = truncatedChunkSize;
+      std::size_t chunkSize = buffer.size() - offset;
+      if (chunkSize > maxChunkSize) {
+        chunkSize = truncatedChunkSize;
+      }
+
+      ntapi::NTSTATUS status = ntapi::NtWriteFile(
+          fileHandle,
+          NULL,                                            // Event
+          NULL,                                            // ApcRoutine
+          &iosb,                                           // ApcContext
+          &iosb,                                           // IoStatusBlock
+          const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
+          static_cast<ntapi::ULONG>(chunkSize),            // Length
+          nullptr,                                         // ByteOffset
+          nullptr);                                        // Key
+      if (status == STATUS_PENDING) {
+        ++ioState->pendingCompletionNotifications;
+      } else if (ntapi::ntstatus_success(status)) {
+        // Succeeded synchronously.
+        if (!skipNotificationOnSuccess) {
+          ++ioState->pendingCompletionNotifications;
         }
+      } else {
+        // Immediate failure.
+        // Don't launch any more operations.
+        // TODO: Should we cancel any prior launched operations?
+        return false;
+      }
 
-        ntapi::NTSTATUS status = ntapi::NtWriteFile(
-            fileHandle,
-            NULL,                                            // Event
-            NULL,                                            // ApcRoutine
-            &iosb,                                           // ApcContext
-            &iosb,                                           // IoStatusBlock
-            const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
-            static_cast<ntapi::ULONG>(chunkSize),            // Length
-            nullptr,                                         // ByteOffset
-            nullptr);                                        // Key
-        if (status == STATUS_PENDING) {
-            ++ioState->pendingCompletionNotifications;
-        } else if (ntapi::ntstatus_success(status)) {
-            // Succeeded synchronously.
-            if (!skipNotificationOnSuccess) {
-                ++ioState->pendingCompletionNotifications;
-            }
-        } else {
-            // Immediate failure.
-            // Don't launch any more operations.
-            // TODO: Should we cancel any prior launched operations?
-            return false;
-        }
+      if (ioState->operationCount == max_vectored_io_size) {
+        return false;
+      }
 
-        if (ioState->operationCount == max_vectored_io_size) {
-            return false;
-        }
-
-        offset += chunkSize;
+      offset += chunkSize;
     }
 
     return true;
-}
+  }
 
-std::size_t low_latency_iocp_context::io_operation::get_result(std::error_code& ec) noexcept {
+  std::size_t low_latency_iocp_context::io_operation::get_result(
+      std::error_code& ec) noexcept {
     assert(context.is_running_on_io_thread());
     assert(ioState != nullptr);
     assert(ioState->completed);
@@ -613,35 +624,36 @@ std::size_t low_latency_iocp_context::io_operation::get_result(std::error_code& 
 
     std::size_t totalBytesTransferred = 0;
     for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-        DWORD bytesTransferred = 0;
+      DWORD bytesTransferred = 0;
 
-        const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
+      const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
 
-        assert(iosb.Status != STATUS_PENDING);
+      assert(iosb.Status != STATUS_PENDING);
 
-        totalBytesTransferred += iosb.Information;
+      totalBytesTransferred += iosb.Information;
 
-        if (!ntapi::ntstatus_success(iosb.Status)) {
-            ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
-            ec = std::error_code(
-                static_cast<int>(errorCode), std::system_category());
-            break;
-        }
+      if (!ntapi::ntstatus_success(iosb.Status)) {
+        ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
+        ec = std::error_code(
+            static_cast<int>(errorCode), std::system_category());
+        break;
+      }
     }
 
     return totalBytesTransferred;
-}
+  }
 
-std::tuple<low_latency_iocp_context::readable_byte_stream,
-           low_latency_iocp_context::writable_byte_stream>
-low_latency_iocp_context::scheduler::open_pipe_impl(
-    low_latency_iocp_context& context) {
+  std::tuple<
+      low_latency_iocp_context::readable_byte_stream,
+      low_latency_iocp_context::writable_byte_stream>
+  low_latency_iocp_context::scheduler::open_pipe_impl(
+      low_latency_iocp_context& context) {
     std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
 
     safe_handle serverHandle;
 
     auto toHex = [](std::uint8_t value) noexcept -> char {
-        return value < 10 ? char('0' + value) : char('a' - 10 + value);
+      return value < 10 ? char('0' + value) : char('a' - 10 + value);
     };
 
     char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
@@ -652,52 +664,56 @@ low_latency_iocp_context::scheduler::open_pipe_impl(
     const DWORD pipeBufferSize = 16 * 1024;
     const int maxAttempts = 100;
 
-    for (int attempt = 1; ; ++attempt) {
-        const std::uint64_t randomNumber = rand();
-        for (int i = 0; i < 16; ++i) {
-            pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
-        }
-        pipeName[25] = '\0';
+    for (int attempt = 1;; ++attempt) {
+      const std::uint64_t randomNumber = rand();
+      for (int i = 0; i < 16; ++i) {
+        pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
+      }
+      pipeName[25] = '\0';
 
-        HANDLE pipe = ::CreateNamedPipeA(
-            pipeName,
-            PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
-            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS | PIPE_WAIT,
-            1, // nMaxInstances
-            0, // nOutBufferSize
-            pipeBufferSize, // nInBufferSize
-            0, // nDefaultTimeout
-            nullptr); // lpSecurityAttributes
-        if (pipe == INVALID_HANDLE_VALUE) {
-            DWORD errorCode = ::GetLastError();
-            if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
-                // Try again with a different random name
-                continue;
-            }
-
-            throw std::system_error{
-                static_cast<int>(errorCode), std::system_category(),
-                "open_pipe: CreateNamedPipe"};
+      HANDLE pipe = ::CreateNamedPipeA(
+          pipeName,
+          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED |
+              FILE_FLAG_FIRST_PIPE_INSTANCE,
+          PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS |
+              PIPE_WAIT,
+          1,               // nMaxInstances
+          0,               // nOutBufferSize
+          pipeBufferSize,  // nInBufferSize
+          0,               // nDefaultTimeout
+          nullptr);        // lpSecurityAttributes
+      if (pipe == INVALID_HANDLE_VALUE) {
+        DWORD errorCode = ::GetLastError();
+        if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
+          // Try again with a different random name
+          continue;
         }
 
-        serverHandle = safe_handle{pipe};
-        break;
+        throw std::system_error{
+            static_cast<int>(errorCode),
+            std::system_category(),
+            "open_pipe: CreateNamedPipe"};
+      }
+
+      serverHandle = safe_handle{pipe};
+      break;
     }
 
     // Open the client-side of this named-pipe
     safe_handle clientHandle{::CreateFileA(
         pipeName,
         GENERIC_WRITE,
-        0, // dwShareMode
-        nullptr, // lpSecurityAttributes
-        OPEN_EXISTING, // dwCreationDisposition
+        0,              // dwShareMode
+        nullptr,        // lpSecurityAttributes
+        OPEN_EXISTING,  // dwCreationDisposition
         FILE_FLAG_OVERLAPPED,
         nullptr)};
     if (clientHandle == INVALID_HANDLE_VALUE) {
-        DWORD errorCode = ::GetLastError();
-        throw std::system_error{
-            static_cast<int>(errorCode), std::system_category(),
-            "open_pipe: CreateFile"};
+      DWORD errorCode = ::GetLastError();
+      throw std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "open_pipe: CreateFile"};
     }
 
     context.associate_file_handle(serverHandle.get());
@@ -705,8 +721,7 @@ low_latency_iocp_context::scheduler::open_pipe_impl(
 
     return {
         readable_byte_stream{context, std::move(serverHandle)},
-        writable_byte_stream{context, std::move(clientHandle)}
-        };
-}
+        writable_byte_stream{context, std::move(clientHandle)}};
+  }
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -1,0 +1,645 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/win32/low_latency_iocp_context.hpp>
+#include <unifex/scope_guard.hpp>
+
+#include <atomic>
+#include <system_error>
+#include <random>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace unifex::win32 {
+
+namespace {
+
+static safe_handle create_iocp() {
+    HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+    if (h == NULL) {
+        DWORD errorCode = ::GetLastError();
+        throw std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateIoCompletionPort()"};
+    }
+
+    return safe_handle{h};
+}
+
+} // namespace
+
+low_latency_iocp_context::low_latency_iocp_context(std::size_t maxIoOperations)
+: activeThreadId_(std::thread::id())
+, iocp_(create_iocp())
+, ioPoolSize_(maxIoOperations)
+, ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
+
+    // Build the I/O free-list in reverse so front of free-list
+    // is first element in array.
+    for (std::size_t i = 0; i < maxIoOperations; ++i) {
+        ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
+    }
+}
+
+low_latency_iocp_context::~low_latency_iocp_context() {
+    // Clear the free-list (to avoid hitting assertion in dtor)
+    ioFreeList_.release();
+}
+
+void low_latency_iocp_context::run_impl(bool& stopFlag) {
+
+    [[maybe_unused]] auto prevId = activeThreadId_.exchange(std::this_thread::get_id(), std::memory_order_relaxed);
+    assert(prevId == std::thread::id());
+
+    scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
+        activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
+    };
+
+    constexpr std::uint32_t completionBufferSize = 128;
+    OVERLAPPED_ENTRY completionBuffer[completionBufferSize];
+    std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+
+    bool shouldCheckRemoteQueue = true;
+
+    // Make sure that we leave the remote queue in a
+    // state such that the  'shouldCheckRemoteQueue = true'
+    // is a valid initial state for the next caller to run().
+    scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
+        if (!shouldCheckRemoteQueue) {
+            (void)remoteQueue_.try_mark_active();
+        }
+    };
+
+    while (!stopFlag) {
+    process_ready_queue:
+        // Process/drain all ready-to-run work.
+        while (!readyQueue_.empty()) {
+            operation_base* task = readyQueue_.pop_front();
+            task->callback(task);
+        }
+
+        // Check whether the stop request was processed
+        // when draining the ready queue.
+        if (stopFlag) {
+            break;
+        }
+
+        // Check the poll-queue for I/O operations that might have completed
+        // already but where we have not yet seen the IOCP event.
+
+        while (!pollQueue_.empty()) {
+           io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
+           auto* state = op->ioState;
+           assert(state->pendingCompletionNotifications > 0);
+           assert(!state->completed);
+
+           if (poll_is_complete(*state)) {
+               // Completed before we received any notifications via IOCP.
+               // Schedule it to resume now, before polling any other I/Os
+               // to give those other I/Os time to complete.
+               state->completed = true;
+               schedule_local(state->parent);
+               goto process_ready_queue;
+           }
+        }
+
+    process_remote_queue:
+        if (shouldCheckRemoteQueue) {
+            if (try_dequeue_remote_work()) {
+                goto process_ready_queue;
+            }
+        }
+
+        // Now check if there are any IOCP events.
+    get_iocp_entries:
+        ULONG completionEntriesRetrieved = 0;
+        BOOL ok = ::GetQueuedCompletionStatusEx(
+            iocp_.get(),
+            completionBuffer,
+            completionBufferSize,
+            &completionEntriesRetrieved,
+            shouldCheckRemoteQueue ? 0 : INFINITE,
+            FALSE);
+        if (!ok) {
+            DWORD errorCode = ::GetLastError();
+            if (errorCode == WAIT_TIMEOUT) {
+                assert(shouldCheckRemoteQueue);
+
+                // Previous call was non-blocking.
+                // About to transition to blocking-call, but first need to
+                // mark remote queue inactive so that remote threads know
+                // they need to post an event to wake this thread up.
+                if (remoteQueue_.try_mark_inactive()) {
+                    shouldCheckRemoteQueue = false;
+                    goto get_iocp_entries;
+                } else {
+                    goto process_remote_queue;
+                }
+            }
+
+            throw std::system_error{static_cast<int>(errorCode), std::system_category(), "GetQueuedCompletionStatusEx()"};
+        }
+
+        // Process completion-entries we received from the OS.
+        for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
+            auto& entry = completionBuffer[i];
+            if (entry.lpOverlapped != nullptr) {
+                win32::overlapped* o = reinterpret_cast<win32::overlapped*>(entry.lpOverlapped);
+                // TODO: Do we need to store the error-code/bytes-transferred here?
+
+                auto* state = to_io_state(o);
+
+                assert(state->pendingCompletionNotifications > 0);
+                if (--state->pendingCompletionNotifications == 0) {
+                    // This was the last pending notification for this state. 
+                    if (state->parent != nullptr) {
+                        // An operation is still attached to this state.
+                        // Notify it if we hadn't already done so.
+                        if (!state->completed) {
+                            state->completed = true;
+                            schedule_local(state->parent);
+                        }
+                    } else {
+                        // Otherwise the operation has already detached
+                        // from this I/O state and so we can immediately
+                        // return it to the pool.
+                        release_io_state(state);
+                    }
+                }
+            } else {
+                // A remote-thread wake-up notification.
+                shouldCheckRemoteQueue = true;
+            }
+        }
+    }
+}
+
+bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
+    auto items = remoteQueue_.dequeue_all_reversed();
+    if (items.empty()) {
+        return false;
+    }
+
+    do {
+        schedule_local(items.pop_front());
+    } while (!items.empty());
+
+    return true;
+}
+
+bool low_latency_iocp_context::poll_is_complete(vectored_io_state& state) noexcept {
+    // TODO: Double check the memory barriers/atomics we need to use
+    // here to ensure we perform this read, that it doesn't tear and
+    // that it has the appropriate memory semantics.
+
+    for (std::size_t i = 0; i < state.operationCount; ++i) {
+        overlapped* o = &state.operations[i];
+
+        // Mark volatile to indicate to the compiler that it might change in the
+        // background. The kernel might update it as the I/O completes.
+        volatile io_status_block* iosb = reinterpret_cast<io_status_block*>(o);
+        if (iosb->Status == STATUS_PENDING) {
+            return false;
+        }
+    }
+
+    // Make sure that we have visibility of the results of the I/O operations
+    // (assuming that the OS used a "release" memory semantic when writing
+    // to the 'Status' field).
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+    return true;
+}
+
+low_latency_iocp_context::vectored_io_state* low_latency_iocp_context::to_io_state(overlapped* o) noexcept {
+    vectored_io_state* const pool = ioPool_.get();
+    
+    std::ptrdiff_t offset = reinterpret_cast<char*>(o) - reinterpret_cast<char*>(pool);
+    assert(offset >= 0);
+
+    std::ptrdiff_t index = offset / sizeof(vectored_io_state);
+
+    return &pool[index];
+}
+
+void low_latency_iocp_context::schedule(operation_base* op) noexcept {
+    if (is_running_on_io_thread()) {
+        schedule_local(op);
+    } else {
+        schedule_remote(op);
+    }
+}
+
+void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
+    assert(is_running_on_io_thread());
+    readyQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
+    assert(!is_running_on_io_thread());
+    if (remoteQueue_.enqueue(op)) {
+        // I/O thread is potentially sleeping.
+        // Post a wake-up NOP event to the queue.
+
+        // BUGBUG: This could potentially fail and if it does then
+        // the I/O thread might never respond to remote enqueues.
+        // For now we just treat this as a (hopefully rare) unrecoverable error.
+        BOOL ok = ::PostQueuedCompletionStatus(iocp_.get(), 0, 0, nullptr);
+        if (!ok) {
+            std::terminate();
+        }
+    }
+}
+
+bool low_latency_iocp_context::try_allocate_io_state_for(io_operation* op) noexcept {
+    assert(is_running_on_io_thread());
+
+    if (ioFreeList_.empty()) {
+        return false;
+    }
+
+    assert(pendingIoQueue_.empty());
+
+    // An operation is already available
+    auto* state = ioFreeList_.pop_front();
+    state->parent = op;
+    state->completed = false;
+    state->operationCount = 0;
+    state->pendingCompletionNotifications = 0;
+    op->ioState = state;
+
+    return true;
+}
+
+void low_latency_iocp_context::schedule_when_io_state_available(io_operation* op) noexcept {
+    assert(is_running_on_io_thread());
+    assert(ioFreeList_.empty());
+    pendingIoQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::release_io_state(vectored_io_state* state) noexcept {
+    assert(is_running_on_io_thread());
+
+    if (state->pendingCompletionNotifications == 0) {
+        // Can be freed immediately.
+
+        if (pendingIoQueue_.empty()) {
+            ioFreeList_.push_front(state);
+        } else {
+            assert(ioFreeList_.empty());
+
+            // Another operation was waiting for an I/O state.
+            // Give the I/O state directly to the operation instead
+            // of adding it to the free-list. This prevents some other
+            // operation from skipping the queue and acquiring it
+            // before this I/O operation can run.
+            auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
+
+            state->parent = op;
+            state->completed = false;
+            state->operationCount = 0;
+            state->pendingCompletionNotifications = 0;
+            op->ioState = state;
+
+            schedule_local(op);
+        }
+    } else {
+        // Mark it to be freed once all of its I/O completion
+        // notifications have been received.
+        state->parent = nullptr;
+    }
+}
+
+void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
+    assert(is_running_on_io_thread());
+    assert(op != nullptr);
+    assert(op->ioState != nullptr);
+
+    if (op->ioState->pendingCompletionNotifications > 0) {
+        pollQueue_.push_back(op);
+    } else {
+        // No need to poll, schedule straight to the front of the ready-to-run queue.
+        readyQueue_.push_front(op);
+    }
+}
+
+void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
+    const HANDLE result = ::CreateIoCompletionPort(
+        fileHandle,
+        iocp_.get(),
+        0, 0);
+    if (result == nullptr) {
+        DWORD errorCode = ::GetLastError();
+        throw std::system_error{
+            static_cast<int>(errorCode), std::system_category(),
+            "CreateIoCompletionPort"};
+    }
+
+    const BOOL ok = ::SetFileCompletionNotificationModes(
+        fileHandle,
+        FILE_SKIP_COMPLETION_PORT_ON_SUCCESS |
+        FILE_SKIP_SET_EVENT_ON_HANDLE);
+    if (!ok) {
+        DWORD errorCode = ::GetLastError();
+        throw std::system_error{
+            static_cast<int>(errorCode), std::system_category(),
+            "SetFileCompletionNotificationModes"};
+    }
+}
+
+void low_latency_iocp_context::io_operation::cancel_io() noexcept {
+    assert(ioState != nullptr);
+
+    // Cancel operations in reverse order so that later operations
+    // are cancelled first and don't accidentally end up with earlier
+    // operations being cancelled and later ones completing due to
+    // a race.
+    for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
+        win32::overlapped* o = &ioState->operations[i-1];
+        (void)::CancelIoEx(fileHandle, reinterpret_cast<OVERLAPPED*>(o));
+    }
+}
+
+bool low_latency_iocp_context::io_operation::is_complete() noexcept {
+    assert(context.is_running_on_io_thread());
+    assert(ioState != nullptr);
+
+    if (ioState->pendingCompletionNotifications == 0) {
+        return true;
+    }
+
+    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+        overlapped* o = &ioState->operations[i];
+
+        // Mark volatile to indicate to the compiler that it might change in the
+        // background. The kernel might update it as the I/O completes.
+        volatile io_status_block* iosb = reinterpret_cast<io_status_block*>(o);
+        if (iosb->Status == STATUS_PENDING) {
+            return false;
+        }
+    }
+
+    // Make sure that we have visibility of the results of all of the I/O
+    // operations.
+    // Assuming that the OS used a "release" memory semantic when writing
+    // to the 'Status' field here.
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+    return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_read(
+        span<std::byte> buffer) noexcept {
+    assert(context.is_running_on_io_thread());
+    assert(ioState != nullptr);
+    assert(ioState->operationCount < max_vectored_io_size);
+
+    bool allowStartingMore = false;
+
+    std::size_t offset = 0;
+    while (offset < buffer.size()) {
+        auto& op = ioState->operations[ioState->operationCount];
+        ++ioState->operationCount;
+
+        op.Internal = 0;
+        op.InternalHigh = 0;
+        op.Offset = 0;
+        op.OffsetHigh = 0;
+        op.hEvent = nullptr;
+
+        // Truncate over-large chunks to a number of bytes that will still
+        // preserve alignment requirements of the underlying device if this
+        // happens to be an unbuffered storage device.
+        // In this case we truncate to the largest multiple of 64k less than
+        // 2^32 to allow for up to 64k alignment.
+        // TODO: Ideally we'd just use the underlying alignment of the file-handle.
+        static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+        static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+        std::size_t chunkSize = buffer.size() - offset;
+        if (chunkSize > maxChunkSize) {
+            chunkSize = truncatedChunkSize;
+        }
+
+        BOOL ok = ::ReadFile(
+            fileHandle,
+            buffer.data() + offset,
+            static_cast<DWORD>(chunkSize),
+            nullptr,
+            reinterpret_cast<OVERLAPPED*>(&op));
+        if (!ok) {
+            DWORD errorCode = ::GetLastError();
+            if (errorCode == ERROR_IO_PENDING) {
+                ++ioState->pendingCompletionNotifications;
+            } else {
+                // Immediate Failure.
+                // Don't launch any more operations.
+                // TODO: Should we cancel the other operations?
+                return false;
+            }
+        } else {
+            // Succceeded synchronously
+            if (!skipNotificationOnSuccess) {
+                ++ioState->pendingCompletionNotifications;
+            }
+        }
+
+        if (ioState->operationCount == max_vectored_io_size) {
+            return false;
+        }
+
+        offset += chunkSize;
+    }
+
+    return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_write(
+        span<const std::byte> buffer) noexcept {
+    assert(context.is_running_on_io_thread());
+    assert(ioState != nullptr);
+    assert(ioState->operationCount < max_vectored_io_size);
+
+    bool allowStartingMore = false;
+
+    std::size_t offset = 0;
+    while (offset < buffer.size()) {
+        auto& op = ioState->operations[ioState->operationCount];
+        ++ioState->operationCount;
+
+        op.Internal = 0;
+        op.InternalHigh = 0;
+        op.Offset = 0;
+        op.OffsetHigh = 0;
+        op.hEvent = nullptr;
+
+        // Truncate over-large chunks to a number of bytes that will still
+        // preserve alignment requirements of the underlying device if this
+        // happens to be an unbuffered storage device.
+        // In this case we truncate to the largest multiple of 64k less than
+        // 2^32 to allow for up to 64k alignment.
+        // TODO: Ideally we'd just use the underlying alignment of the file-handle.
+        static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+        static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+        std::size_t chunkSize = buffer.size() - offset;
+        if (chunkSize > maxChunkSize) {
+            chunkSize = truncatedChunkSize;
+        }
+
+        BOOL ok = ::WriteFile(
+            fileHandle,
+            buffer.data() + offset,
+            static_cast<DWORD>(chunkSize),
+            nullptr,
+            reinterpret_cast<OVERLAPPED*>(&op));
+        if (!ok) {
+            DWORD errorCode = ::GetLastError();
+            if (errorCode == ERROR_IO_PENDING) {
+                ++ioState->pendingCompletionNotifications;
+            } else {
+                // Immediate Failure.
+                // Don't launch any more operations.
+                // TODO: Should we cancel the other operations?
+                return false;
+            }
+        } else {
+            // Succceeded synchronously
+            if (!skipNotificationOnSuccess) {
+                ++ioState->pendingCompletionNotifications;
+            }
+        }
+
+        if (ioState->operationCount == max_vectored_io_size) {
+            return false;
+        }
+
+        offset += chunkSize;
+    }
+
+    return true;
+}
+
+std::size_t low_latency_iocp_context::io_operation::get_result(std::error_code& ec) noexcept {
+    assert(context.is_running_on_io_thread());
+    assert(ioState != nullptr);
+    assert(ioState->completed);
+
+    ec = std::error_code{};
+
+    std::size_t totalBytesTransferred = 0;
+    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+        DWORD bytesTransferred = 0;
+
+        // This (hoepfully) shouldn't involve any kernel calls since it should
+        // already be complete and this can be determined by looking at the OVERLAPPED
+        // structure.
+        BOOL ok = ::GetOverlappedResultEx(
+            fileHandle,
+            reinterpret_cast<OVERLAPPED*>(&ioState->operations[i]),
+            &bytesTransferred,
+            0 /* timeout */,
+            FALSE /* bAlertable */);
+        totalBytesTransferred += bytesTransferred;
+        if (!ok) {
+            // Stop at the first error we encountered.
+            DWORD errorCode = ::GetLastError();
+            ec = std::error_code{static_cast<int>(errorCode), std::system_category()};
+            break;
+        }
+    }
+
+    return totalBytesTransferred;
+}
+
+std::tuple<low_latency_iocp_context::readable_byte_stream,
+           low_latency_iocp_context::writable_byte_stream>
+low_latency_iocp_context::scheduler::open_pipe_impl(
+    low_latency_iocp_context& context) {
+    std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
+
+    safe_handle serverHandle;
+
+    auto toHex = [](std::uint8_t value) noexcept -> char {
+        return value < 10 ? char('0' + value) : char('a' - 10 + value);
+    };
+
+    char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
+
+    // Try to create the server side of a new named pipe
+    // Use a randomly generated name to ensure uniqueness.
+
+    const DWORD pipeBufferSize = 16 * 1024;
+    const int maxAttempts = 100;
+
+    for (int attempt = 1; ; ++attempt) {
+        const std::uint64_t randomNumber = rand();
+        for (int i = 0; i < 16; ++i) {
+            pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
+        }
+        pipeName[25] = '\0';
+
+        HANDLE pipe = ::CreateNamedPipeA(
+            pipeName,
+            PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS | PIPE_WAIT,
+            1, // nMaxInstances
+            0, // nOutBufferSize
+            pipeBufferSize, // nInBufferSize
+            0, // nDefaultTimeout
+            nullptr); // lpSecurityAttributes
+        if (pipe == INVALID_HANDLE_VALUE) {
+            DWORD errorCode = ::GetLastError();
+            if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
+                // Try again with a different random name
+                continue;
+            }
+
+            throw std::system_error{
+                static_cast<int>(errorCode), std::system_category(),
+                "open_pipe: CreateNamedPipe"};
+        }
+
+        serverHandle = safe_handle{pipe};
+        break;
+    }
+
+    // Open the client-side of this named-pipe
+    safe_handle clientHandle{::CreateFileA(
+        pipeName,
+        GENERIC_WRITE,
+        0, // dwShareMode
+        nullptr, // lpSecurityAttributes
+        OPEN_EXISTING, // dwCreationDisposition
+        FILE_FLAG_OVERLAPPED,
+        nullptr)};
+    if (clientHandle == INVALID_HANDLE_VALUE) {
+        DWORD errorCode = ::GetLastError();
+        throw std::system_error{
+            static_cast<int>(errorCode), std::system_category(),
+            "open_pipe: CreateFile"};
+    }
+
+    context.associate_file_handle(serverHandle.get());
+    context.associate_file_handle(clientHandle.get());
+
+    return {
+        readable_byte_stream{context, std::move(serverHandle)},
+        writable_byte_stream{context, std::move(clientHandle)}
+        };
+}
+
+} // namespace unifex::win32

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -21,8 +21,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-namespace unifex::win32::ntapi {
-
+namespace unifex::win32::ntapi
+{
   NtCreateFile_t NtCreateFile = nullptr;
   NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
   NtReadFile_t NtReadFile = nullptr;
@@ -58,9 +58,7 @@ namespace unifex::win32::ntapi {
 
   void ensure_initialised() noexcept {
     static struct initialiser {
-      initialiser() noexcept {
-        do_initialisation();
-      }
+      initialiser() noexcept { do_initialisation(); }
     } dummy;
   }
-} // namespace unifex::win32::ntapi
+}  // namespace unifex::win32::ntapi

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/win32/detail/ntapi.hpp>
+
+#include <exception>
+#include <type_traits>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace unifex::win32::ntapi {
+
+  NtCreateFile_t NtCreateFile = nullptr;
+  NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
+  NtReadFile_t NtReadFile = nullptr;
+  NtWriteFile_t NtWriteFile = nullptr;
+  NtSetIoCompletion_t NtSetIoCompletion = nullptr;
+  NtRemoveIoCompletion_t NtRemoveIoCompletion = nullptr;
+  NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx = nullptr;
+  RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
+
+  static void do_initialisation() noexcept {
+    HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
+    if (ntdll == NULL) {
+      std::terminate();
+    }
+
+    auto init = [&](auto& fnPtr, const char* name) noexcept {
+      FARPROC p = ::GetProcAddress(ntdll, name);
+      if (p == NULL) {
+        std::terminate();
+      }
+      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(p);
+    };
+
+    init(NtCreateFile, "NtCreateFile");
+    init(NtCancelIoFileEx, "NtCancelIoFileEx");
+    init(NtReadFile, "NtReadFile");
+    init(NtWriteFile, "NtWriteFile");
+    init(NtSetIoCompletion, "NtSetIoCompletion");
+    init(NtRemoveIoCompletion, "NtRemoveIoCompletion");
+    init(NtRemoveIoCompletionEx, "NtRemoveIoCompletionEx");
+    init(RtlNtStatusToDosError, "RtlNtStatusToDosError");
+  }
+
+  void ensure_initialised() noexcept {
+    static struct initialiser {
+      initialiser() noexcept {
+        do_initialisation();
+      }
+    } dummy;
+  }
+} // namespace unifex::win32::ntapi

--- a/source/win32/safe_handle.cpp
+++ b/source/win32/safe_handle.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/win32/detail/safe_handle.hpp>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace unifex::win32 {
+
+void safe_handle::reset() noexcept {
+    handle_t h = std::exchange(handle_, nullptr);
+    if (h != nullptr && h != INVALID_HANDLE_VALUE) {
+        ::CloseHandle(h);
+    }
+}
+
+} // namespace unifex::win32

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _WIN32
+
+#include <unifex/win32/low_latency_iocp_context.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/when_all.hpp>
+#include <unifex/repeat_effect_until.hpp>
+#include <unifex/stop_when.hpp>
+#include <unifex/transform_done.hpp>
+#include <unifex/just.hpp>
+#include <unifex/inplace_stop_token.hpp>
+#include <unifex/materialize.hpp>
+#include <unifex/span.hpp>
+#include <unifex/repeat_effect_until.hpp>
+#include <unifex/trampoline_scheduler.hpp>
+#include <unifex/typed_via.hpp>
+#include <unifex/let.hpp>
+
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST(low_latency_iocp_context, construct_destruct) {
+    unifex::win32::low_latency_iocp_context context{100};
+}
+
+TEST(low_latency_iocp_context, run) {
+    unifex::win32::low_latency_iocp_context context{100};
+    unifex::inplace_stop_source stopSource;
+
+    std::thread stopperThread{[&] {
+        std::this_thread::sleep_for(10ms);
+        stopSource.request_stop();
+    }};
+
+    context.run(stopSource.get_token());
+
+    stopperThread.join();
+}
+
+TEST(low_latency_iocp_context, schedule) {
+    unifex::win32::low_latency_iocp_context context{100};
+
+    unifex::inplace_stop_source stopSource;
+
+    std::thread ioThread{[&] { context.run(stopSource.get_token()); }};
+
+    auto s = context.get_scheduler();
+
+    unifex::sync_wait(unifex::schedule(s));
+
+    stopSource.request_stop();
+    ioThread.join();
+}
+
+TEST(low_latency_iocp_context, schedule_multiple) {
+    unifex::win32::low_latency_iocp_context context{100};
+
+    unifex::inplace_stop_source stopSource;
+
+    std::thread ioThread{[&] {
+        context.run(stopSource.get_token());
+    }};
+
+    auto s = context.get_scheduler();
+
+    unifex::sync_wait(unifex::when_all(
+        unifex::schedule(s),
+        unifex::transform(
+            unifex::schedule(s),
+            [&]() {
+                assert(std::this_thread::get_id() == ioThread.get_id());
+            }),
+        unifex::schedule(s)));
+
+    stopSource.request_stop();
+    ioThread.join();
+}
+
+TEST(low_latency_iocp_context, read_write_pipe) {
+    unifex::win32::low_latency_iocp_context context{100};
+
+    unifex::inplace_stop_source stopSource;
+
+    std::thread ioThread{[&] {
+        context.run(stopSource.get_token());
+    }};
+
+    auto s = context.get_scheduler();
+
+    auto [readPipe, writePipe] = unifex::open_pipe(s);
+
+    char readBuffer[10];
+    std::memset(readBuffer, 99, sizeof(readBuffer));
+
+    const char writeBuffer[10] = { 0, 1, 2, 3, 5, 7, 11, 13, 17, 19};
+
+    auto results = unifex::sync_wait(
+        unifex::when_all(
+            unifex::async_read_some(readPipe, unifex::as_writable_bytes(unifex::span{readBuffer})),
+            unifex::async_write_some(writePipe, unifex::as_bytes(unifex::span{writeBuffer}))));
+
+    assert(results.has_value());
+
+    auto [bytesRead] = std::get<0>(std::get<0>(results.value()));
+    auto [bytesWritten] = std::get<0>(std::get<1>(results.value()));
+
+    assert(bytesRead == 10);
+    assert(bytesWritten == 10);
+
+    for (int i = 0; i < 10; ++i) {
+        assert(readBuffer[i] == writeBuffer[i]);
+    }
+
+    stopSource.request_stop();
+    ioThread.join();
+}
+
+template<typename Sender>
+auto trampoline(Sender&& sender) {
+    return unifex::typed_via((Sender&&)sender, unifex::trampoline_scheduler{});
+}
+
+template<typename Sender>
+auto repeat_n(Sender&& sender, size_t count) {
+    return unifex::repeat_effect_until(
+            trampoline((Sender&&)sender),
+            [count]() mutable {
+                if (count == 0) return true;
+                --count;
+                return false;
+            });
+}
+
+template<typename Func>
+auto defer(Func&& func) {
+    return unifex::let(
+        unifex::just(),
+        [func=(Func&&)func]() {
+            return func();
+        });
+}
+
+template<typename Sender>
+auto discard_value(Sender&& sender) {
+    return unifex::transform((Sender&&)sender, [](auto&&...) noexcept {});
+}
+
+TEST(low_latency_iocp_context, loop_read_write_pipe) {
+    unifex::win32::low_latency_iocp_context context{100};
+
+    unifex::inplace_stop_source stopSource;
+
+    std::thread ioThread{[&] {
+        context.run(stopSource.get_token());
+    }};
+
+    auto s = context.get_scheduler();
+
+    auto [readPipe, writePipe] = unifex::open_pipe(s);
+
+    std::byte readBuffer[10];
+    std::byte writeBuffer[100];
+    std::memset(writeBuffer, 77, sizeof(writeBuffer));
+
+    // Perform 10k reads of 10 bytes.
+    // and      1k writes of 100 bytes
+    // and do this asynchronously, interleaving the two loops.
+    unifex::sync_wait(
+        unifex::when_all(
+            repeat_n(
+                defer([&, &readPipe=readPipe] {
+                    return discard_value(
+                        unifex::async_read_some(readPipe, unifex::span{readBuffer}));
+                }), 10000),
+            repeat_n(
+                defer([&, &writePipe=writePipe] {
+                    return discard_value(
+                        unifex::async_write_some(writePipe, unifex::span{writeBuffer}));
+                }), 1000)));
+
+    stopSource.request_stop();
+    ioThread.join();
+}
+
+#endif // _WIN32

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -146,7 +146,7 @@ auto trampoline(Sender&& sender) {
 template<typename Sender>
 auto repeat_n(Sender&& sender, size_t count) {
     return unifex::repeat_effect_until(
-            trampoline((Sender&&)sender),
+            (Sender&&)sender,
             [count]() mutable {
                 if (count == 0) return true;
                 --count;


### PR DESCRIPTION
This adds a proof-of-concept design of a single-threaded I/O scheduler
that tries to avoid always needing two syscalls to perform an async I/O
operation (one to start it and one to receive the completion-notification)
for operations that complete quickly with low-latency by introducing
an extra polling step that polls for I/O completion of recently started
I/O operations before going back to `GetQueuedCompletionStatusEx()`.

If the operation completes as part of the polling then we can immediately
process the result and call the receiver. However, we still need to wait until
we receive the completion-notification before we can free/reuse the
OVERLAPPED structures so in this case we detach the io-state from the
operation-state and let the io-state be garbage collected and returned
to the pool of available io-states once the completion-events have been
received.

A pool of io-states are preallocated when the I/O context is created and
placed onto a free-list that allows efficient O(1) allocation of a new io-state
when launching a new operation. If the io-state pool is exhausted then
new I/O operations are delayed from starting until existing I/O operations
complete and free up an io-state.

This design was based on my understanding of ideas on low-latency I/O
patterns I saw implemented in @ned14's llfio library, although it's possible
that in translating them to libunifex and sender/receiver that I have I missed
some key aspects of that design. Feedback welcome!