### PR TITLE
Fix build error in bulk_schedule_test.cpp

### DIFF
--- a/test/bulk_schedule_test.cpp
+++ b/test/bulk_schedule_test.cpp
@@ -37,7 +37,7 @@ TEST(bulk, bulk_transform) {
             unifex::bulk_transform(
                 unifex::bulk_transform(
                     unifex::bulk_schedule(sched, count),
-                    [count](std::size_t index) noexcept {
+                    [](std::size_t index) noexcept {
                         // Reverse indices
                         return count - 1 - index;
                     }, unifex::par_unseq),


### PR DESCRIPTION
Building bulk_schedule_test.cpp with Clang generated this warning:

    lambda capture 'count' is not required to be captured for this use
    [-Werror,-Wunused-lambda-capture]

This change removes 'count' from the lambda's capture list to silence
the warning.