### PR TITLE
Support -fno-rtti

### DIFF
--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -20,9 +20,9 @@
 #include <unifex/tag_invoke.hpp>
 #include <unifex/config.hpp>
 #include <unifex/coroutine.hpp>
+#include <unifex/type_index.hpp>
 
 #include <functional>
-#include <typeindex>
 #include <vector>
 
 #include <unifex/detail/prologue.hpp>
@@ -74,7 +74,7 @@ class continuation_info {
     return c;
   }
 
-  std::type_index type() const noexcept {
+  type_index type() const noexcept {
     return vtable_->typeIndexGetter_();
   }
 
@@ -96,7 +96,7 @@ class continuation_info {
  private:
   using callback_t = void(const continuation_info&, void*);
   using visitor_t = void(const void*, callback_t*, void*);
-  using type_index_getter_t = std::type_index() noexcept;
+  using type_index_getter_t = type_index() noexcept;
 
   struct vtable_t {
     type_index_getter_t* typeIndexGetter_;
@@ -117,8 +117,8 @@ template <typename Continuation>
 inline continuation_info continuation_info::from_continuation(
     const Continuation& r) noexcept {
   static constexpr vtable_t vtable{
-      []() noexcept -> std::type_index {
-        return typeid(remove_cvref_t<Continuation>);
+      []() noexcept -> type_index {
+        return type_id<remove_cvref_t<Continuation>>();
       },
       [](const void* address, callback_t* cb, void* data) {
         visit_continuations(

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -104,6 +104,28 @@
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
+#  if defined(_CPPRTTI)
+#    define UNIFEX_NO_RTTI 0
+#  else
+#    define UNIFEX_NO_RTTI 1
+#  endif
+#elif defined(__clang__)
+#  if __has_feature(cxx_rtti)
+#    define UNIFEX_NO_RTTI 0
+#  else
+#    define UNIFEX_NO_RTTI 1
+#  endif
+#elif defined(__GNUC__)
+#  if defined(__GXX_RTTI)
+#    define UNIFEX_NO_RTTI 0
+#  else
+#    define UNIFEX_NO_RTTI 1
+#  endif
+#else
+#  define UNIFEX_NO_RTTI 0
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
   #define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
   #define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
   #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME

--- a/include/unifex/type_index.hpp
+++ b/include/unifex/type_index.hpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/type_traits.hpp>
+
+#if UNIFEX_NO_RTTI
+#include <functional>
+#else
+#include <typeindex>
+#endif
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+#if UNIFEX_NO_RTTI
+
+struct type_index final {
+  const char* name() const noexcept {
+    return index_;
+  }
+
+  std::size_t hash_code() const noexcept {
+    return std::hash<const void*>{}(index_);
+  }
+
+ private:
+  const char* index_;
+
+  explicit type_index(const char* index) noexcept
+    : index_(index) {}
+
+  friend bool operator==(type_index lhs, type_index rhs) noexcept {
+    return lhs.index_ == rhs.index_;
+  }
+
+  friend bool operator!=(type_index lhs, type_index rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator<(type_index lhs, type_index rhs) noexcept {
+    return std::less<const void*>{}(lhs.index_, rhs.index_);
+  }
+
+  friend bool operator>(type_index lhs, type_index rhs) noexcept {
+    return rhs < lhs;
+  }
+
+  friend bool operator<=(type_index lhs, type_index rhs) noexcept {
+    return !(lhs > rhs);
+  }
+
+  friend bool operator>=(type_index lhs, type_index rhs) noexcept {
+    return !(rhs < lhs);
+  }
+
+  template <typename T>
+  friend type_index type_id() noexcept;
+
+  template <typename T>
+  static type_index make() noexcept {
+    static_assert(std::is_same_v<T, remove_cvref_t<T>>);
+
+#ifdef __FUNCSIG__
+    static constexpr auto index = __FUNCSIG__;
+#else
+    static constexpr auto index = __PRETTY_FUNCTION__;
+#endif
+
+    return type_index{index};
+  }
+};
+
+template <typename T>
+type_index type_id() noexcept {
+  return type_index::make<remove_cvref_t<T>>();
+}
+
+#else
+
+using type_index = std::type_index;
+
+template <typename T>
+type_index type_id() noexcept {
+  return typeid(T);
+}
+
+#endif
+
+} // namespace unifex
+
+#if UNIFEX_NO_RTTI
+
+namespace std {
+
+template <>
+struct hash<unifex::type_index> {
+  std::size_t operator()(unifex::type_index index) const noexcept {
+    return index.hash_code();
+  }
+};
+
+} // namespace std
+
+#endif
+
+#include <unifex/detail/epilogue.hpp>

--- a/test/bulk_schedule_test.cpp
+++ b/test/bulk_schedule_test.cpp
@@ -37,7 +37,7 @@ TEST(bulk, bulk_transform) {
             unifex::bulk_transform(
                 unifex::bulk_transform(
                     unifex::bulk_schedule(sched, count),
-                    [count](std::size_t index) noexcept {
+                    [](std::size_t index) noexcept {
                         // Reverse indices
                         return count - 1 - index;
                     }, unifex::par_unseq),


### PR DESCRIPTION
This change introduces <unifex/type_index.hpp> and unifex::type_index to
support building Unifex without RTTI.

When RTTI is enabled unifex::type_index is an alias for std::type_index.
When RTTI is disabled unifex::type_index is a struct with a work-alike
interface to std::type_index. In either mode, unifex::type_id<T>() is a
substitute for typeid(T).