### PR TITLE
Fix let_with_stop_source lifetimes

### DIFF
--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -171,7 +171,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
     UNIFEX_NO_UNIQUE_ADDRESS unifex::inplace_stop_source stop_source_;
     UNIFEX_NO_UNIQUE_ADDRESS callback_type<_stop_source_operation_callback> stop_callback_;
     connect_result_t<
-        std::invoke_result_t<SuccessorFactory&&, unifex::inplace_stop_source&>,
+        callable_result_t<SuccessorFactory, unifex::inplace_stop_source&>,
         stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver>>>
         innerOp_;
 };

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -105,7 +105,7 @@ class _stop_source_sender<SuccessorFactory>::type {
     using additional_arguments = type_list<type_list<Values...>>;
 
 public:
-    using InnerOp = std::invoke_result_t<SuccessorFactory&&, inplace_stop_source&>;
+    using InnerOp = std::invoke_result_t<SuccessorFactory, inplace_stop_source&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
     using value_types = typename InnerOp::template value_types<Variant, Tuple>;
@@ -143,8 +143,10 @@ struct _stop_source_operation_callback {
 
 template<typename SuccessorFactory, typename Receiver>
 struct _stop_source_operation<SuccessorFactory, Receiver>::type {
-    type(SuccessorFactory&& func, Receiver&& r) :
-        func_{(SuccessorFactory&&)func},
+
+    template <typename SuccessorFactory2, typename Receiver2>
+    type(SuccessorFactory2&& func, Receiver2&& r) :
+        func_{(SuccessorFactory2&&)func},
         stop_source_{},
         // Chain the stop token so that downstream cancellation also affects this
         // operation
@@ -154,9 +156,9 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
         innerOp_(
               unifex::connect(
                 ((SuccessorFactory&&)func_)(stop_source_),
-                stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver>>{
+                stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver2>>{
                     *this,
-                    static_cast<Receiver&&>(r)})) {
+                    static_cast<Receiver2&&>(r)})) {
     }
 
     void start() noexcept {

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -153,7 +153,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
             _stop_source_operation_callback(stop_source_)),
         innerOp_(
               unifex::connect(
-                func_(stop_source_),
+                std::move(func_)(stop_source_),
                 stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver>>{
                     *this,
                     static_cast<Receiver&&>(r)})) {

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -105,7 +105,7 @@ class _stop_source_sender<SuccessorFactory>::type {
     using additional_arguments = type_list<type_list<Values...>>;
 
 public:
-    using InnerOp = std::invoke_result_t<SuccessorFactory, inplace_stop_source&>;
+    using InnerOp = std::invoke_result_t<SuccessorFactory&&, inplace_stop_source&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
     using value_types = typename InnerOp::template value_types<Variant, Tuple>;
@@ -153,7 +153,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
             _stop_source_operation_callback(stop_source_)),
         innerOp_(
               unifex::connect(
-                std::move(func_)(stop_source_),
+                ((SuccessorFactory&&)func_)(stop_source_),
                 stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver>>{
                     *this,
                     static_cast<Receiver&&>(r)})) {
@@ -169,7 +169,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
     UNIFEX_NO_UNIQUE_ADDRESS unifex::inplace_stop_source stop_source_;
     UNIFEX_NO_UNIQUE_ADDRESS callback_type<_stop_source_operation_callback> stop_callback_;
     connect_result_t<
-        std::invoke_result_t<SuccessorFactory, unifex::inplace_stop_source&>,
+        std::invoke_result_t<SuccessorFactory&&, unifex::inplace_stop_source&>,
         stop_source_receiver<operation<SuccessorFactory, Receiver>, remove_cvref_t<Receiver>>>
         innerOp_;
 };

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -129,7 +129,7 @@ public:
     }
 
 private:
-    UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<SuccessorFactory> func_;
+    UNIFEX_NO_UNIQUE_ADDRESS SuccessorFactory func_;
 };
 
 struct _stop_source_operation_callback {
@@ -165,7 +165,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
 
     template<class F>
     using callback_type = typename stop_token_type_t<Receiver>::template callback_type<F>;
-    UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<SuccessorFactory> func_;
+    UNIFEX_NO_UNIQUE_ADDRESS SuccessorFactory func_;
     UNIFEX_NO_UNIQUE_ADDRESS unifex::inplace_stop_source stop_source_;
     UNIFEX_NO_UNIQUE_ADDRESS callback_type<_stop_source_operation_callback> stop_callback_;
     connect_result_t<
@@ -178,9 +178,9 @@ struct _fn {
 
     template<typename SuccessorFactory>
     auto operator()(SuccessorFactory&& factory) const
-        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<SuccessorFactory>, SuccessorFactory>)
-        -> stop_source_sender<remove_cvref_t<SuccessorFactory>> {
-        return stop_source_sender<remove_cvref_t<SuccessorFactory>>{(SuccessorFactory&&)factory};
+        noexcept(std::is_nothrow_constructible_v<std::decay_t<SuccessorFactory>, SuccessorFactory>)
+        -> stop_source_sender<std::decay_t<SuccessorFactory>> {
+        return stop_source_sender<std::decay_t<SuccessorFactory>>{(SuccessorFactory&&)factory};
     }
 };
 

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -129,7 +129,7 @@ public:
     }
 
 private:
-    UNIFEX_NO_UNIQUE_ADDRESS std::remove_cvref_t<SuccessorFactory> func_;
+    UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<SuccessorFactory> func_;
 };
 
 struct _stop_source_operation_callback {
@@ -165,7 +165,7 @@ struct _stop_source_operation<SuccessorFactory, Receiver>::type {
 
     template<class F>
     using callback_type = typename stop_token_type_t<Receiver>::template callback_type<F>;
-    UNIFEX_NO_UNIQUE_ADDRESS std::remove_cvref_t<SuccessorFactory> func_;
+    UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<SuccessorFactory> func_;
     UNIFEX_NO_UNIQUE_ADDRESS unifex::inplace_stop_source stop_source_;
     UNIFEX_NO_UNIQUE_ADDRESS callback_type<_stop_source_operation_callback> stop_callback_;
     connect_result_t<


### PR DESCRIPTION
I think this is the correct behaviour for the let variants. The expectation of the user is that the lifetime of the successor function is until the end of the async operation (so that capture state can be treated as being alive as well as parameter state).

This also changes the behaviour to call the successor function as an l-value, because that is the consistent behaviour for an object that remains alive after the function runs.