### PR TITLE
Let with variadic

### DIFF
--- a/examples/let.cpp
+++ b/examples/let.cpp
@@ -101,18 +101,20 @@ int main() {
 
   std::cout << "let_with done " << *let_with_result << "\n";
 
-   // let_with example showing use with a non-moveable type and
-   // in-place construction.
+   // let_with example showing use with a non-moveable type,
+   // in-place construction and variadic state factories.
   std::optional<int> let_with_atomic_result =
-      sync_wait(let_with([] { return std::atomic<int>{42}; },
-        [&](std::atomic<int>& x) {
+      sync_wait(let_with(
+        [] { return 42; },
+        [] { return std::atomic<int>{42}; },
+        [&](int& val, std::atomic<int>& x) {
           ++x;
           printf("addressof x = %p, val = %i\n", (void*)&x, x.load());
           return async([&]() -> int {
             ++x;
             printf("successor tranform\n");
             printf("addressof x = %p, val = %i\n", (void*)&x, x.load());
-            return x.load();
+            return x.load() + val;
           });
       }));
 


### PR DESCRIPTION
This is a variadic generalisation of let_with such that rather than one in-place initialising function, we can take a list of them.

eg:
```
let_with(
        [] { return 42; },
        [] { return std::atomic<int>{42}; },
        [&](int& val, std::atomic<int>& x) {
          ++x;
          printf("addressof x = %p, val = %i\n", (void*)&x, x.load());
          return async([&]() -> int {
            ++x;
            printf("successor tranform\n");
            printf("addressof x = %p, val = %i\n", (void*)&x, x.load());
            return x.load() + val;
          });
```

I also used it to update find_if to avoid a nesting of a let_with and a let.

let_with_stop_source is still separate because it relies on not only allocating a stop source but hooking the callback in, so it has custom logic.