### PR TITLE
Start to support -fno-exceptions

### DIFF
--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -306,10 +306,7 @@ class _make<CPOs...>::type
     allocator_type typedAllocator{std::move(alloc)};
     auto ptr = allocator_traits::allocate(typedAllocator, 1);
 
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       // TODO: Ideally we'd use allocator_traits::construct() here but
       // that makes it difficult to provide consistent behaviour across
       // std::allocator and std::pmr::polymorphic_allocator as the latter
@@ -318,13 +315,10 @@ class _make<CPOs...>::type
       // injection of the parameters.
       ::new ((void*)ptr)
           concrete_type{std::allocator_arg, typedAllocator, (Args &&) args...};
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       allocator_traits::deallocate(typedAllocator, ptr, 1);
-      throw;
+      UNIFEX_RETHROW();
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
 
     impl_ = static_cast<void*>(ptr);
   }

--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -305,7 +305,11 @@ class _make<CPOs...>::type
     using allocator_traits = std::allocator_traits<allocator_type>;
     allocator_type typedAllocator{std::move(alloc)};
     auto ptr = allocator_traits::allocate(typedAllocator, 1);
+
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       // TODO: Ideally we'd use allocator_traits::construct() here but
       // that makes it difficult to provide consistent behaviour across
       // std::allocator and std::pmr::polymorphic_allocator as the latter
@@ -314,10 +318,14 @@ class _make<CPOs...>::type
       // injection of the parameters.
       ::new ((void*)ptr)
           concrete_type{std::allocator_arg, typedAllocator, (Args &&) args...};
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       allocator_traits::deallocate(typedAllocator, ptr, 1);
       throw;
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
+
     impl_ = static_cast<void*>(ptr);
   }
 

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -176,18 +176,12 @@ namespace _async_trace {
       Receiver receiver_;
 
       void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           auto trace = async_trace(receiver_);
           unifex::set_value(std::move(receiver_), std::move(trace));
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(std::move(receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     };
   };

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -176,12 +176,18 @@ namespace _async_trace {
       Receiver receiver_;
 
       void start() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           auto trace = async_trace(receiver_);
           unifex::set_value(std::move(receiver_), std::move(trace));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(std::move(receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     };
   };

--- a/include/unifex/awaitable_sender.hpp
+++ b/include/unifex/awaitable_sender.hpp
@@ -132,8 +132,11 @@ struct _sender<Awaitable>::type {
   detail::sender_task connect(Receiver&& receiver) && {
     return [](Awaitable awaitable,
            remove_cvref_t<Receiver> receiver) -> detail::sender_task {
+#if !UNIFEX_NO_EXCEPTIONS
           std::exception_ptr ex;
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             if constexpr (std::is_void_v<result_type>) {
               co_await(Awaitable &&) awaitable;
               co_yield[&] {
@@ -155,12 +158,15 @@ struct _sender<Awaitable>::type {
                     };
                   }(co_await (Awaitable &&) awaitable);
             }
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             ex = std::current_exception();
           }
           co_yield[&] {
             unifex::set_error(std::move(receiver), std::move(ex));
           };
+#endif // !UNIFEX_NO_EXCEPTIONS
         }((Awaitable &&) awaitable_, (Receiver &&) receiver);
   }
 };

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -125,6 +125,12 @@
 #  define UNIFEX_NO_RTTI 0
 #endif
 
+#if __cpp_exceptions >= 199711
+#  define UNIFEX_NO_EXCEPTIONS 0
+#else
+#  define UNIFEX_NO_EXCEPTIONS 1
+#endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
   #define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
   #define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -127,8 +127,14 @@
 
 #if __cpp_exceptions >= 199711
 #  define UNIFEX_NO_EXCEPTIONS 0
+#  define UNIFEX_TRY try
+#  define UNIFEX_CATCH(...) catch (__VA_ARGS__)
+#  define UNIFEX_RETHROW() throw
 #else
 #  define UNIFEX_NO_EXCEPTIONS 1
+#  define UNIFEX_TRY
+#  define UNIFEX_CATCH(...) if constexpr (true) {} else
+#  define UNIFEX_RETHROW() ((void)0)
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -93,7 +93,10 @@ namespace unifex
         using completion_value_op_t = connect_result_t<CompletionSender, value_receiver>;
         unifex::deactivate_union_member<completion_value_op_t>(op->completionValueOp_);
 
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           // Move the stored values onto the stack so that we can
           // destroy the ones stored in the operation-state. This
           // prevents the need to add a big switch to the operation
@@ -115,10 +118,13 @@ namespace unifex
                     static_cast<Values&&>(values)...);
               },
               static_cast<std::tuple<Values...>&&>(values));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename Error>
@@ -374,17 +380,27 @@ namespace unifex
           (requires receiver_of<Receiver, Values...>)
       void set_value(Values&&... values) && noexcept {
         auto* const op = op_;
+
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::activate_union_member<std::tuple<std::decay_t<Values>...>>(
             op->value_, static_cast<Values&&>(values)...);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           std::move(*this).set_error(std::current_exception());
           return;
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
 
         unifex::deactivate_union_member(op->sourceOp_);
 
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           using value_receiver = value_receiver<
               SourceSender,
               CompletionSender,
@@ -401,12 +417,15 @@ namespace unifex
                         value_receiver{op});
                   });
           unifex::start(completionOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           using decayed_tuple_t = std::tuple<std::decay_t<Values>...>;
           unifex::deactivate_union_member<decayed_tuple_t>(op->value_);
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename Error>
@@ -420,7 +439,10 @@ namespace unifex
 
         unifex::deactivate_union_member(op->sourceOp_);
 
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           using error_receiver_t = error_receiver<
               SourceSender,
               CompletionSender,
@@ -437,11 +459,14 @@ namespace unifex
                         error_receiver_t{op});
                   });
           unifex::start(completionOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::deactivate_union_member<std::decay_t<Error>>(op->error_);
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       void set_done() && noexcept {
@@ -449,7 +474,10 @@ namespace unifex
 
         unifex::deactivate_union_member(op->sourceOp_);
 
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           using done_receiver =
               done_receiver<SourceSender, CompletionSender, Receiver>;
           auto& completionOp = unifex::activate_union_member_from(
@@ -460,10 +488,13 @@ namespace unifex
                   done_receiver{op});
             });
           unifex::start(completionOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template(typename CPO, typename R)

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -93,10 +93,7 @@ namespace unifex
         using completion_value_op_t = connect_result_t<CompletionSender, value_receiver>;
         unifex::deactivate_union_member<completion_value_op_t>(op->completionValueOp_);
 
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           // Move the stored values onto the stack so that we can
           // destroy the ones stored in the operation-state. This
           // prevents the need to add a big switch to the operation
@@ -119,12 +116,10 @@ namespace unifex
               },
               static_cast<std::tuple<Values...>&&>(values));
 
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename Error>
@@ -381,26 +376,17 @@ namespace unifex
       void set_value(Values&&... values) && noexcept {
         auto* const op = op_;
 
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::activate_union_member<std::tuple<std::decay_t<Values>...>>(
             op->value_, static_cast<Values&&>(values)...);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           std::move(*this).set_error(std::current_exception());
           return;
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
 
         unifex::deactivate_union_member(op->sourceOp_);
 
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           using value_receiver = value_receiver<
               SourceSender,
               CompletionSender,
@@ -417,15 +403,12 @@ namespace unifex
                         value_receiver{op});
                   });
           unifex::start(completionOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           using decayed_tuple_t = std::tuple<std::decay_t<Values>...>;
           unifex::deactivate_union_member<decayed_tuple_t>(op->value_);
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename Error>
@@ -439,10 +422,7 @@ namespace unifex
 
         unifex::deactivate_union_member(op->sourceOp_);
 
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           using error_receiver_t = error_receiver<
               SourceSender,
               CompletionSender,
@@ -459,14 +439,11 @@ namespace unifex
                         error_receiver_t{op});
                   });
           unifex::start(completionOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::deactivate_union_member<std::decay_t<Error>>(op->error_);
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       void set_done() && noexcept {
@@ -474,10 +451,7 @@ namespace unifex
 
         unifex::deactivate_union_member(op->sourceOp_);
 
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           using done_receiver =
               done_receiver<SourceSender, CompletionSender, Receiver>;
           auto& completionOp = unifex::activate_union_member_from(
@@ -488,13 +462,10 @@ namespace unifex
                   done_receiver{op});
             });
           unifex::start(completionOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op->receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template(typename CPO, typename R)

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -79,20 +79,14 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
     template <typename Iterator, typename... Values>
     void set_value(std::tuple<Iterator, Values...>&& packedResult) && noexcept {
       operation_state_.cleanup();
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         unpack_helper(
           (OutputReceiver&&) output_receiver_,
           std::move(packedResult),
           std::make_index_sequence<std::tuple_size_v<std::tuple<Iterator, Values...>>>{});
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch(...) {
+      } UNIFEX_CATCH(...) {
         unifex::set_error((OutputReceiver&&)output_receiver_, std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
     template <typename Error>
@@ -329,10 +323,7 @@ void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     Iterator begin_it, Iterator end_it, Values&&... values) && noexcept {
   auto sched = unifex::get_scheduler(receiver_);
   unpack_receiver<Receiver> unpack{(Receiver &&) receiver_, operation_state_};
-#if !UNIFEX_NO_EXCEPTIONS
-  try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+  UNIFEX_TRY {
     auto find_if_implementation_sender = find_if_helper{std::move(func_)}(
         std::move(sched), funcPolicy_, begin_it, end_it, (Values&&) values...);
     // Store nested operation state inside find_if's operation state
@@ -341,12 +332,9 @@ void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     });
 
     operation_state_.startInner();
-
-#if !UNIFEX_NO_EXCEPTIONS
-  } catch(...) {
+  } UNIFEX_CATCH(...) {
     unifex::set_error(std::move(unpack), std::current_exception());
   }
-#endif // !UNIFEX_NO_EXCEPTIONS
 }
 
 template <typename Predecessor, typename Func, typename FuncPolicy>

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -79,14 +79,20 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
     template <typename Iterator, typename... Values>
     void set_value(std::tuple<Iterator, Values...>&& packedResult) && noexcept {
       operation_state_.cleanup();
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         unpack_helper(
           (OutputReceiver&&) output_receiver_,
           std::move(packedResult),
           std::make_index_sequence<std::tuple_size_v<std::tuple<Iterator, Values...>>>{});
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch(...) {
         unifex::set_error((OutputReceiver&&)output_receiver_, std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
     template <typename Error>
@@ -323,7 +329,10 @@ void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     Iterator begin_it, Iterator end_it, Values&&... values) && noexcept {
   auto sched = unifex::get_scheduler(receiver_);
   unpack_receiver<Receiver> unpack{(Receiver &&) receiver_, operation_state_};
+#if !UNIFEX_NO_EXCEPTIONS
   try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
     auto find_if_implementation_sender = find_if_helper{std::move(func_)}(
         std::move(sched), funcPolicy_, begin_it, end_it, (Values&&) values...);
     // Store nested operation state inside find_if's operation state
@@ -332,9 +341,12 @@ void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     });
 
     operation_state_.startInner();
+
+#if !UNIFEX_NO_EXCEPTIONS
   } catch(...) {
     unifex::set_error(std::move(unpack), std::current_exception());
   }
+#endif // !UNIFEX_NO_EXCEPTIONS
 }
 
 template <typename Predecessor, typename Func, typename FuncPolicy>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -77,18 +77,12 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
       apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
       unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
     } else {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error((Receiver &&) receiver_, std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -77,12 +77,18 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
       apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
       unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
     } else {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error((Receiver &&) receiver_, std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -44,21 +44,15 @@ struct _op<Receiver, Values...>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
   void start() & noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       std::apply(
           [&](Values&&... values) {
             unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
           },
           std::move(values_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error((Receiver &&) receiver_, std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 };
 

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -44,15 +44,21 @@ struct _op<Receiver, Values...>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
   void start() & noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       std::apply(
           [&](Values&&... values) {
             unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
           },
           std::move(values_));
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error((Receiver &&) receiver_, std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 };
 

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -56,18 +56,12 @@ struct _successor_receiver<Operation, Values...>::type {
   template <typename... SuccessorValues>
   void set_value(SuccessorValues&&... values) && noexcept {
     cleanup();
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       unifex::set_value(
           std::move(op_.receiver_), (SuccessorValues &&) values...);
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(std::move(op_.receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {
@@ -131,10 +125,7 @@ struct _predecessor_receiver<Operation>::type {
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
     auto& op = op_;
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       scope_guard destroyPredOp =
         [&]() noexcept { unifex::deactivate_union_member(op.predOp_); };
       auto& valueTuple =
@@ -153,12 +144,9 @@ struct _predecessor_receiver<Operation>::type {
             });
       unifex::start(succOp);
       destroyValues.release();
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(std::move(op.receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -56,12 +56,18 @@ struct _successor_receiver<Operation, Values...>::type {
   template <typename... SuccessorValues>
   void set_value(SuccessorValues&&... values) && noexcept {
     cleanup();
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       unifex::set_value(
           std::move(op_.receiver_), (SuccessorValues &&) values...);
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(std::move(op_.receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {
@@ -125,7 +131,10 @@ struct _predecessor_receiver<Operation>::type {
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
     auto& op = op_;
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       scope_guard destroyPredOp =
         [&]() noexcept { unifex::deactivate_union_member(op.predOp_); };
       auto& valueTuple =
@@ -144,9 +153,12 @@ struct _predecessor_receiver<Operation>::type {
             });
       unifex::start(succOp);
       destroyValues.release();
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(std::move(op.receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {

--- a/include/unifex/linux/io_epoll_context.hpp
+++ b/include/unifex/linux/io_epoll_context.hpp
@@ -211,12 +211,18 @@ class io_epoll_context::schedule_sender {
   class operation : private operation_base {
    public:
     void start() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         context_.schedule_impl(this);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
    private:
@@ -239,12 +245,18 @@ class io_epoll_context::schedule_sender {
       if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::set_value(static_cast<Receiver&&>(op.receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op.receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -332,11 +344,17 @@ class io_epoll_context::schedule_at_sender {
       if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(std::move(timerOp).receiver_);
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::set_value(std::move(timerOp).receiver_);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(std::move(timerOp).receiver_, std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -578,11 +596,17 @@ class io_epoll_context::read_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(receiver_), ssize_t(result));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -619,11 +643,17 @@ class io_epoll_context::read_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(self).receiver_, ssize_t(result));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(self).receiver_, std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -789,11 +819,17 @@ class io_epoll_context::write_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(receiver_), ssize_t(result));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -830,11 +866,17 @@ class io_epoll_context::write_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(self).receiver_, ssize_t(result));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(self).receiver_, std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(

--- a/include/unifex/linux/io_epoll_context.hpp
+++ b/include/unifex/linux/io_epoll_context.hpp
@@ -211,18 +211,12 @@ class io_epoll_context::schedule_sender {
   class operation : private operation_base {
    public:
     void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         context_.schedule_impl(this);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
    private:
@@ -245,18 +239,12 @@ class io_epoll_context::schedule_sender {
       if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::set_value(static_cast<Receiver&&>(op.receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(
               static_cast<Receiver&&>(op.receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -344,17 +332,11 @@ class io_epoll_context::schedule_at_sender {
       if constexpr (is_nothrow_receiver_of_v<Receiver>) {
         unifex::set_value(std::move(timerOp).receiver_);
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::set_value(std::move(timerOp).receiver_);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(std::move(timerOp).receiver_, std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -596,17 +578,11 @@ class io_epoll_context::read_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(receiver_), ssize_t(result));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -643,17 +619,11 @@ class io_epoll_context::read_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(self).receiver_, ssize_t(result));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(self).receiver_, std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -819,17 +789,11 @@ class io_epoll_context::write_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(receiver_), ssize_t(result));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(receiver_), ssize_t(result));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(
@@ -866,17 +830,11 @@ class io_epoll_context::write_sender {
         if constexpr (is_nothrow_receiver_of_v<Receiver, ssize_t>) {
           unifex::set_value(std::move(self).receiver_, ssize_t(result));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(self).receiver_, ssize_t(result));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(self).receiver_, std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else {
         unifex::set_error(

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <unifex/config.hpp>
 #if !UNIFEX_NO_LIBURING
 
 #include <unifex/detail/atomic_intrusive_queue.hpp>
@@ -325,12 +326,18 @@ class io_uring_context::schedule_sender {
   class operation : private operation_base {
    public:
     void start() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         context_.schedule_impl(this);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
    private:
@@ -354,11 +361,17 @@ class io_uring_context::schedule_sender {
       if constexpr (noexcept(unifex::set_value(static_cast<Receiver&&>(op.receiver_)))) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::set_value(static_cast<Receiver&&>(op.receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -453,11 +466,17 @@ class io_uring_context::read_sender {
         if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(self.receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else if (self.result_ == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
@@ -569,11 +588,17 @@ class io_uring_context::write_sender {
         if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(std::move(self.receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else if (self.result_ == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
@@ -752,11 +777,17 @@ class io_uring_context::schedule_at_sender {
       if constexpr (noexcept(unifex::set_value(std::move(timerOp).receiver_))) {
         unifex::set_value(std::move(timerOp).receiver_);
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::set_value(std::move(timerOp).receiver_);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(std::move(timerOp).receiver_, std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -326,18 +326,12 @@ class io_uring_context::schedule_sender {
   class operation : private operation_base {
    public:
     void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         context_.schedule_impl(this);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
 
    private:
@@ -361,17 +355,11 @@ class io_uring_context::schedule_sender {
       if constexpr (noexcept(unifex::set_value(static_cast<Receiver&&>(op.receiver_)))) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::set_value(static_cast<Receiver&&>(op.receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 
@@ -466,17 +454,11 @@ class io_uring_context::read_sender {
         if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(self.receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else if (self.result_ == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
@@ -588,17 +570,11 @@ class io_uring_context::write_sender {
         if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(std::move(self.receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       } else if (self.result_ == -ECANCELED) {
         unifex::set_done(std::move(self.receiver_));
@@ -777,17 +753,11 @@ class io_uring_context::schedule_at_sender {
       if constexpr (noexcept(unifex::set_value(std::move(timerOp).receiver_))) {
         unifex::set_value(std::move(timerOp).receiver_);
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::set_value(std::move(timerOp).receiver_);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(std::move(timerOp).receiver_, std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
 

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -69,21 +69,15 @@ namespace unifex
               unifex::set_error,
               static_cast<Error&&>(error));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(
                 static_cast<Receiver&&>(receiver_),
                 unifex::set_error,
                 static_cast<Error&&>(error));
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 
@@ -94,19 +88,13 @@ namespace unifex
           unifex::set_value(
               static_cast<Receiver&&>(receiver_), unifex::set_done);
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::set_value(
                 static_cast<Receiver&&>(receiver_), unifex::set_done);
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(receiver_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -69,15 +69,21 @@ namespace unifex
               unifex::set_error,
               static_cast<Error&&>(error));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(
                 static_cast<Receiver&&>(receiver_),
                 unifex::set_error,
                 static_cast<Error&&>(error));
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 
@@ -88,13 +94,19 @@ namespace unifex
           unifex::set_value(
               static_cast<Receiver&&>(receiver_), unifex::set_done);
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::set_value(
                 static_cast<Receiver&&>(receiver_), unifex::set_done);
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(receiver_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 

--- a/include/unifex/new_thread_context.hpp
+++ b/include/unifex/new_thread_context.hpp
@@ -153,10 +153,7 @@ private:
 
 template <typename Receiver>
 inline void _op<Receiver>::type::start() & noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-  try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+  UNIFEX_TRY {
     // Acquire the lock before launching the thread.
     // This prevents the run() method from trying to read the thread_ variable
     // until after we have finished assigning it.
@@ -172,12 +169,9 @@ inline void _op<Receiver>::type::start() & noexcept {
     // we ensure the count increment happens before the count decrement that
     // is performed when the thread is being retired.
     ctx_->activeThreadCount_.fetch_add(1, std::memory_order_relaxed);
-
-#if !UNIFEX_NO_EXCEPTIONS
-  } catch (...) {
+  } UNIFEX_CATCH (...) {
     unifex::set_error(std::move(receiver_), std::current_exception());
   }
-#endif // !UNIFEX_NO_EXCEPTIONS
 }
 
 template <typename Receiver>
@@ -205,17 +199,11 @@ inline void _op<Receiver>::type::run() noexcept {
   if (get_stop_token(receiver_).stop_requested()) {
     unifex::set_done(std::move(receiver_));
   } else {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       unifex::set_value(std::move(receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(std::move(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   ctx->retire_thread(std::move(thisThread));

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -175,10 +175,7 @@ struct _next_receiver<Operation>::type {
   void set_value(Values... values) && noexcept {
     auto& op = op_;
     unifex::deactivate_union_member(op.next_);
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       op.state_ = std::invoke(
           op.reducer_,
           std::forward<state_type>(op.state_),
@@ -187,9 +184,7 @@ struct _next_receiver<Operation>::type {
         return unifex::connect(next(op.stream_), _reduce::next_receiver<Operation>{op});
       });
       unifex::start(op.next_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::activate_union_member_from(op.errorCleanup_, [&] {
         return unifex::connect(
             cleanup(op.stream_),
@@ -197,7 +192,6 @@ struct _next_receiver<Operation>::type {
       });
       unifex::start(op.errorCleanup_.get());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {
@@ -268,21 +262,15 @@ struct _op<StreamSender, State, ReducerFunc, Receiver>::type {
   ~type() {} // Due to the union member, this is load-bearing. DO NOT DELETE.
 
   void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       unifex::activate_union_member_from(next_, [&] {
         return unifex::connect(next(stream_), next_receiver<operation>{*this});
       });
       unifex::start(next_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 };
 

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -84,10 +84,7 @@ public:
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         // call predicate and complete with void if it returns true
         if(op->predicate_()) {
           unifex::set_value(std::move(op->receiver_));
@@ -98,12 +95,9 @@ public:
           });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -84,7 +84,10 @@ public:
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         // call predicate and complete with void if it returns true
         if(op->predicate_()) {
           unifex::set_value(std::move(op->receiver_));
@@ -95,9 +98,12 @@ public:
           });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -84,15 +84,21 @@ public:
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         auto& sourceOp = unifex::activate_union_member_from(op->sourceOp_, [&] {
             return unifex::connect(op->source_, source_receiver_t{op});
           });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 
@@ -201,17 +207,23 @@ public:
         });
       unifex::start(triggerOp);
     } else {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
-      auto& triggerOp = unifex::activate_union_member_from<trigger_op_t>(
-        op->triggerOps_,
-          [&]() {
-            return unifex::connect(
-              std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
-          });
-        unifex::start(triggerOp);
+#endif // !UNIFEX_NO_EXCEPTIONS
+
+        auto& triggerOp = unifex::activate_union_member_from<trigger_op_t>(
+          op->triggerOps_,
+            [&]() {
+              return unifex::connect(
+                std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
+            });
+          unifex::start(triggerOp);
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -84,21 +84,15 @@ public:
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         auto& sourceOp = unifex::activate_union_member_from(op->sourceOp_, [&] {
             return unifex::connect(op->source_, source_receiver_t{op});
           });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 
@@ -207,10 +201,7 @@ public:
         });
       unifex::start(triggerOp);
     } else {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         auto& triggerOp = unifex::activate_union_member_from<trigger_op_t>(
           op->triggerOps_,
             [&]() {
@@ -218,12 +209,9 @@ public:
                 std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
             });
           unifex::start(triggerOp);
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -52,19 +52,13 @@ struct _sender_awaiter<Sender, Value>::type {
         unifex::activate_union_member(awaiter_.value_, (Values&&)values...);
         awaiter_.state_ = state::value;
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
             unifex::activate_union_member(awaiter_.value_, (Values&&)values...);
             awaiter_.state_ = state::value;
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
             unifex::activate_union_member(awaiter_.ex_, std::current_exception());
             awaiter_.state_ = state::error;
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
       awaiter_.continuation_.resume();
     }

--- a/include/unifex/sender_awaitable.hpp
+++ b/include/unifex/sender_awaitable.hpp
@@ -52,13 +52,19 @@ struct _sender_awaiter<Sender, Value>::type {
         unifex::activate_union_member(awaiter_.value_, (Values&&)values...);
         awaiter_.state_ = state::value;
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::activate_union_member(awaiter_.value_, (Values&&)values...);
             awaiter_.state_ = state::value;
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
             unifex::activate_union_member(awaiter_.ex_, std::current_exception());
             awaiter_.state_ = state::error;
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
       awaiter_.continuation_.resume();
     }

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -57,14 +57,21 @@ namespace detail {
       if(r_)
         unifex::set_done((R&&) *r_);
     }
+
     void operator()() & noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         unifex::set_value((R&&) *r_);
         r_ = nullptr;
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch(...) {
         unifex::set_error((R&&) *r_, std::current_exception());
         r_ = nullptr;
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   };
 
@@ -240,15 +247,22 @@ namespace _connect_cpo {
       struct type {
         remove_cvref_t<Executor> e_;
         remove_cvref_t<Receiver> r_;
+
         void start() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             using _as_invocable =
               detail::_as_invocable<remove_cvref_t<Receiver>, Executor>;
             unifex::execute(std::move(e_), _as_invocable{r_});
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch(...) {
             // BUGBUG: see https://github.com/executors/executors/issues/463
             // unifex::set_error(std::move(r_), std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       };
     };

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -59,19 +59,13 @@ namespace detail {
     }
 
     void operator()() & noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         unifex::set_value((R&&) *r_);
         r_ = nullptr;
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch(...) {
+      } UNIFEX_CATCH(...) {
         unifex::set_error((R&&) *r_, std::current_exception());
         r_ = nullptr;
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   };
 
@@ -249,20 +243,14 @@ namespace _connect_cpo {
         remove_cvref_t<Receiver> r_;
 
         void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             using _as_invocable =
               detail::_as_invocable<remove_cvref_t<Receiver>, Executor>;
             unifex::execute(std::move(e_), _as_invocable{r_});
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch(...) {
+          } UNIFEX_CATCH(...) {
             // BUGBUG: see https://github.com/executors/executors/issues/463
             // unifex::set_error(std::move(r_), std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       };
     };

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -57,12 +57,14 @@ namespace detail {
       if(r_)
         unifex::set_done((R&&) *r_);
     }
-    void operator()() & noexcept try {
-      unifex::set_value((R&&) *r_);
-      r_ = nullptr;
-    } catch(...) {
-      unifex::set_error((R&&) *r_, std::current_exception());
-      r_ = nullptr;
+    void operator()() & noexcept {
+      try {
+        unifex::set_value((R&&) *r_);
+        r_ = nullptr;
+      } catch(...) {
+        unifex::set_error((R&&) *r_, std::current_exception());
+        r_ = nullptr;
+      }
     }
   };
 
@@ -238,13 +240,15 @@ namespace _connect_cpo {
       struct type {
         remove_cvref_t<Executor> e_;
         remove_cvref_t<Receiver> r_;
-        void start() noexcept try {
-          using _as_invocable =
-            detail::_as_invocable<remove_cvref_t<Receiver>, Executor>;
-          unifex::execute(std::move(e_), _as_invocable{r_});
-        } catch(...) {
-          // BUGBUG: see https://github.com/executors/executors/issues/463
-          // unifex::set_error(std::move(r_), std::current_exception());
+        void start() noexcept {
+          try {
+            using _as_invocable =
+              detail::_as_invocable<remove_cvref_t<Receiver>, Executor>;
+            unifex::execute(std::move(e_), _as_invocable{r_});
+          } catch(...) {
+            // BUGBUG: see https://github.com/executors/executors/issues/463
+            // unifex::set_error(std::move(r_), std::current_exception());
+          }
         }
       };
     };

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -161,18 +161,24 @@ namespace unifex
           op->status_ = operation_type::status::successor_operation_constructed;
           unifex::start(op->succOp_.get());
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             unifex::activate_union_member_from(op->succOp_, [&] {
               return unifex::connect(
                   static_cast<Successor&&>(op->successor_), successor_receiver_t{op});
             });
             op->status_ = operation_type::status::successor_operation_constructed;
             unifex::start(op->succOp_.get());
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(op->receiver_),
                 std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -161,24 +161,18 @@ namespace unifex
           op->status_ = operation_type::status::successor_operation_constructed;
           unifex::start(op->succOp_.get());
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             unifex::activate_union_member_from(op->succOp_, [&] {
               return unifex::connect(
                   static_cast<Successor&&>(op->successor_), successor_receiver_t{op});
             });
             op->status_ = operation_type::status::successor_operation_constructed;
             unifex::start(op->succOp_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             unifex::set_error(
                 static_cast<Receiver&&>(op->receiver_),
                 std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
       }
 

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -232,7 +232,10 @@ namespace unifex
       }
 
       void deliver_result() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           std::visit(
               [this](auto&& tuple) {
                 if constexpr (
@@ -251,9 +254,12 @@ namespace unifex
                 }
               },
               std::move(result_));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error(std::move(receiver_), std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename... Values>

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -232,10 +232,7 @@ namespace unifex
       }
 
       void deliver_result() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           std::visit(
               [this](auto&& tuple) {
                 if constexpr (
@@ -254,12 +251,9 @@ namespace unifex
                 }
               },
               std::move(result_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error(std::move(receiver_), std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       template <typename... Values>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -63,20 +63,14 @@ struct _receiver {
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         unifex::activate_union_member(promise_.value_, (Values&&)values...);
         promise_.state_ = promise<T>::state::value;
-
-#if !UNIFEX_NO_EXCEPTIONS
       }
-      catch (...) {
+      UNIFEX_CATCH (...) {
         unifex::activate_union_member(promise_.exception_, std::current_exception());
         promise_.state_ = promise<T>::state::error;
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
 
       signal_complete();
     }

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -63,14 +63,21 @@ struct _receiver {
 
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         unifex::activate_union_member(promise_.value_, (Values&&)values...);
         promise_.state_ = promise<T>::state::value;
+
+#if !UNIFEX_NO_EXCEPTIONS
       }
       catch (...) {
         unifex::activate_union_member(promise_.exception_, std::current_exception());
         promise_.state_ = promise<T>::state::error;
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       signal_complete();
     }
 

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -165,22 +165,16 @@ struct _stream<SourceStream, TriggerStream>::type {
           if (!stream_.triggerNextStarted_) {
             stream_.triggerNextStarted_ = true;
 
-#if !UNIFEX_NO_EXCEPTIONS
-            try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+            UNIFEX_TRY {
               stream_.triggerNextOp_.construct_from([&] {
                 return unifex::connect(
                   next(stream_.trigger_),
                   trigger_next_receiver{stream_});
               });
               unifex::start(stream_.triggerNextOp_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-            } catch (...) {
+            } UNIFEX_CATCH (...) {
               stream_.trigger_next_done();
             }
-#endif // !UNIFEX_NO_EXCEPTIONS
           }
 
           stopCallback_.construct(
@@ -293,22 +287,16 @@ struct _stream<SourceStream, TriggerStream>::type {
         {}
 
         void start() noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             sourceOp_.construct_from([&] {
               return unifex::connect(
                 cleanup(stream_.source_),
                 source_receiver{*this});
             });
             unifex::start(sourceOp_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             source_cleanup_error(std::current_exception());
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
 
           if (!stream_.cleanupReady_.load(std::memory_order_acquire)) {
             stream_.cleanupOperation_ = this;
@@ -325,23 +313,17 @@ struct _stream<SourceStream, TriggerStream>::type {
         }
 
         void start_trigger_cleanup() noexcept final {
-#if !UNIFEX_NO_EXCEPTIONS
-          try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+          UNIFEX_TRY {
             triggerOp_.construct_from([&] {
               return unifex::connect(
                 cleanup(stream_.trigger_),
                 trigger_receiver{*this});
             });
             unifex::start(triggerOp_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-          } catch (...) {
+          } UNIFEX_CATCH (...) {
             trigger_cleanup_error(std::current_exception());
             return;
           }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
 
         void source_cleanup_done() noexcept {

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -164,16 +164,23 @@ struct _stream<SourceStream, TriggerStream>::type {
         void start() noexcept {
           if (!stream_.triggerNextStarted_) {
             stream_.triggerNextStarted_ = true;
+
+#if !UNIFEX_NO_EXCEPTIONS
             try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
               stream_.triggerNextOp_.construct_from([&] {
                 return unifex::connect(
                   next(stream_.trigger_),
                   trigger_next_receiver{stream_});
               });
               unifex::start(stream_.triggerNextOp_.get());
+
+#if !UNIFEX_NO_EXCEPTIONS
             } catch (...) {
               stream_.trigger_next_done();
             }
+#endif // !UNIFEX_NO_EXCEPTIONS
           }
 
           stopCallback_.construct(
@@ -286,16 +293,22 @@ struct _stream<SourceStream, TriggerStream>::type {
         {}
 
         void start() noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             sourceOp_.construct_from([&] {
               return unifex::connect(
                 cleanup(stream_.source_),
                 source_receiver{*this});
             });
             unifex::start(sourceOp_.get());
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             source_cleanup_error(std::current_exception());
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
 
           if (!stream_.cleanupReady_.load(std::memory_order_acquire)) {
             stream_.cleanupOperation_ = this;
@@ -312,17 +325,23 @@ struct _stream<SourceStream, TriggerStream>::type {
         }
 
         void start_trigger_cleanup() noexcept final {
+#if !UNIFEX_NO_EXCEPTIONS
           try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
             triggerOp_.construct_from([&] {
               return unifex::connect(
                 cleanup(stream_.trigger_),
                 trigger_receiver{*this});
             });
             unifex::start(triggerOp_.get());
+
+#if !UNIFEX_NO_EXCEPTIONS
           } catch (...) {
             trigger_cleanup_error(std::current_exception());
             return;
           }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
 
         void source_cleanup_done() noexcept {

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -286,13 +286,19 @@ namespace _thread_unsafe_event_loop {
      public:
       template <typename... Values>
       void set_value(Values&&... values) && noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::activate_union_member(promise_.value_, (Values &&) values...);
           promise_.state_ = state::value;
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::activate_union_member(promise_.exception_, std::current_exception());
           promise_.state_ = state::error;
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       void set_error(std::exception_ptr ex) && noexcept {

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -286,19 +286,13 @@ namespace _thread_unsafe_event_loop {
      public:
       template <typename... Values>
       void set_value(Values&&... values) && noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::activate_union_member(promise_.value_, (Values &&) values...);
           promise_.state_ = state::value;
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::activate_union_member(promise_.exception_, std::current_exception());
           promise_.state_ = state::error;
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
 
       void set_error(std::exception_ptr ex) && noexcept {

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -67,12 +67,18 @@ struct _receiver<Receiver, Func>::type {
         std::invoke((Func &&) func_, (Values &&) values...);
         unifex::set_value((Receiver &&) receiver_);
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           std::invoke((Func &&) func_, (Values &&) values...);
           unifex::set_value((Receiver &&) receiver_);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     } else {
       if constexpr (noexcept(std::invoke(
@@ -81,13 +87,19 @@ struct _receiver<Receiver, Func>::type {
             (Receiver &&) receiver_,
             std::invoke((Func &&) func_, (Values &&) values...));
       } else {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           unifex::set_value(
               (Receiver &&) receiver_,
               std::invoke((Func &&) func_, (Values &&) values...));
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
   }

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -67,18 +67,12 @@ struct _receiver<Receiver, Func>::type {
         std::invoke((Func &&) func_, (Values &&) values...);
         unifex::set_value((Receiver &&) receiver_);
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           std::invoke((Func &&) func_, (Values &&) values...);
           unifex::set_value((Receiver &&) receiver_);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     } else {
       if constexpr (noexcept(std::invoke(
@@ -87,19 +81,13 @@ struct _receiver<Receiver, Func>::type {
             (Receiver &&) receiver_,
             std::invoke((Func &&) func_, (Values &&) values...));
       } else {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           unifex::set_value(
               (Receiver &&) receiver_,
               std::invoke((Func &&) func_, (Values &&) values...));
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch (...) {
+        } UNIFEX_CATCH (...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     }
   }

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -95,7 +95,10 @@ public:
       op->startedOp_ = 0 - 1;
       unifex::start(op->finalOp_.get());
     } else {
+#if !UNIFEX_NO_EXCEPTIONS
       try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
         op->startedOp_ = 0;
         unifex::deactivate_union_member(op->sourceOp_);
         unifex::activate_union_member_from(op->finalOp_, [&] {
@@ -103,9 +106,12 @@ public:
         });
         op->startedOp_ = 0 - 1;
         unifex::start(op->finalOp_.get());
+
+#if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
+#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -95,10 +95,7 @@ public:
       op->startedOp_ = 0 - 1;
       unifex::start(op->finalOp_.get());
     } else {
-#if !UNIFEX_NO_EXCEPTIONS
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+      UNIFEX_TRY {
         op->startedOp_ = 0;
         unifex::deactivate_union_member(op->sourceOp_);
         unifex::activate_union_member_from(op->finalOp_, [&] {
@@ -106,12 +103,9 @@ public:
         });
         op->startedOp_ = 0 - 1;
         unifex::start(op->finalOp_.get());
-
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
+      } UNIFEX_CATCH (...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
-#endif // !UNIFEX_NO_EXCEPTIONS
     }
   }
 

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -187,57 +187,39 @@ struct _predecessor_receiver<Successor, Receiver>::type {
 
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       submit(
           (Successor &&) successor_,
           value_receiver<Receiver, Values...>{
               {(Values &&) values...}, (Receiver &&) receiver_});
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       submit(
           (Successor &&) successor_,
           error_receiver<Receiver, Error>{
               (Error &&) error, (Receiver &&) receiver_});
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       submit(
           (Successor &&) successor_,
           done_receiver<Receiver>{(Receiver &&) receiver_});
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template(typename CPO)

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -187,39 +187,57 @@ struct _predecessor_receiver<Successor, Receiver>::type {
 
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       submit(
           (Successor &&) successor_,
           value_receiver<Receiver, Values...>{
               {(Values &&) values...}, (Receiver &&) receiver_});
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       submit(
           (Successor &&) successor_,
           error_receiver<Receiver, Error>{
               (Error &&) error, (Receiver &&) receiver_});
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   void set_done() && noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       submit(
           (Successor &&) successor_,
           done_receiver<Receiver>{(Receiver &&) receiver_});
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template(typename CPO)

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -138,15 +138,21 @@ struct _element_receiver<Index, Receiver, Senders...>::type final {
 
   template <typename... Values>
   void set_value(Values&&... values) noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       std::get<Index>(op_.values_)
           .emplace(
               std::in_place_type<std::tuple<std::decay_t<Values>...>>,
               (Values &&) values...);
       op_.element_complete();
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       this->set_error(std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template <typename Error>
@@ -242,13 +248,19 @@ struct _op<Receiver, Senders...>::type {
 
   template <std::size_t... Indices>
   void deliver_value(std::index_sequence<Indices...>) noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       unifex::set_value(
           std::move(receiver_),
           std::get<Indices>(std::move(values_)).value()...);
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       unifex::set_error(std::move(receiver_), std::current_exception());
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   std::tuple<std::optional<value_variant_for_sender<remove_cvref_t<Senders>>>...> values_;

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -138,21 +138,15 @@ struct _element_receiver<Index, Receiver, Senders...>::type final {
 
   template <typename... Values>
   void set_value(Values&&... values) noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       std::get<Index>(op_.values_)
           .emplace(
               std::in_place_type<std::tuple<std::decay_t<Values>...>>,
               (Values &&) values...);
       op_.element_complete();
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       this->set_error(std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   template <typename Error>
@@ -248,19 +242,13 @@ struct _op<Receiver, Senders...>::type {
 
   template <std::size_t... Indices>
   void deliver_value(std::index_sequence<Indices...>) noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       unifex::set_value(
           std::move(receiver_),
           std::get<Indices>(std::move(values_)).value()...);
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       unifex::set_error(std::move(receiver_), std::current_exception());
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   std::tuple<std::optional<value_variant_for_sender<remove_cvref_t<Senders>>>...> values_;

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -156,17 +156,11 @@ private:
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(op.receiver_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-            try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+            UNIFEX_TRY {
                 unifex::set_value(std::move(op.receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-            } catch (...) {
+            } UNIFEX_CATCH (...) {
                 unifex::set_error(std::move(op.receiver_), std::current_exception());
             }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -410,17 +404,11 @@ private:
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-            try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+            UNIFEX_TRY {
                 unifex::set_value(std::move(receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-            } catch (...) {
+            } UNIFEX_CATCH (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -675,17 +663,11 @@ private:
         if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-            try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+            UNIFEX_TRY {
                 unifex::set_value(std::move(receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-            } catch (...) {
+            } UNIFEX_CATCH (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -759,17 +741,11 @@ private:
         if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
-#if !UNIFEX_NO_EXCEPTIONS
-            try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+            UNIFEX_TRY {
                 unifex::set_value(std::move(receiver_));
-
-#if !UNIFEX_NO_EXCEPTIONS
-            } catch (...) {
+            } UNIFEX_CATCH (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
-#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -156,11 +156,17 @@ private:
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(op.receiver_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
             try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
                 unifex::set_value(std::move(op.receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
             } catch (...) {
                 unifex::set_error(std::move(op.receiver_), std::current_exception());
             }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -404,11 +410,17 @@ private:
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
             try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
                 unifex::set_value(std::move(receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
             } catch (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -663,11 +675,17 @@ private:
         if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
             try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
                 unifex::set_value(std::move(receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
             } catch (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 
@@ -741,11 +759,17 @@ private:
         if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(receiver_));
         } else {
+#if !UNIFEX_NO_EXCEPTIONS
             try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
                 unifex::set_value(std::move(receiver_));
+
+#if !UNIFEX_NO_EXCEPTIONS
             } catch (...) {
                 unifex::set_error(std::move(receiver_), std::current_exception());
             }
+#endif // !UNIFEX_NO_EXCEPTIONS
         }
     }
 

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -28,21 +28,15 @@ namespace _static_thread_pool {
 
     threads_.reserve(threadCount);
 
-#if !UNIFEX_NO_EXCEPTIONS
-    try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+    UNIFEX_TRY {
       for (std::uint32_t i = 0; i < threadCount; ++i) {
         threads_.emplace_back([this, i] { run(i); });
       }
-
-#if !UNIFEX_NO_EXCEPTIONS
-    } catch (...) {
+    } UNIFEX_CATCH (...) {
       request_stop();
       join();
-      throw;
+      UNIFEX_RETHROW();
     }
-#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   context::~context() {

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -27,15 +27,22 @@ namespace _static_thread_pool {
     assert(threadCount > 0);
 
     threads_.reserve(threadCount);
+
+#if !UNIFEX_NO_EXCEPTIONS
     try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
       for (std::uint32_t i = 0; i < threadCount; ++i) {
         threads_.emplace_back([this, i] { run(i); });
       }
+
+#if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       request_stop();
       join();
       throw;
     }
+#endif // !UNIFEX_NO_EXCEPTIONS
   }
 
   context::~context() {

--- a/test/P0443_test.cpp
+++ b/test/P0443_test.cpp
@@ -59,17 +59,11 @@ namespace {
     struct _op {
       Receiver r_;
       void start() & noexcept {
-#if !UNIFEX_NO_EXCEPTIONS
-        try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
+        UNIFEX_TRY {
           set_value((Receiver&&) r_);
-
-#if !UNIFEX_NO_EXCEPTIONS
-        } catch(...) {
+        } UNIFEX_CATCH(...) {
           set_error((Receiver&&) r_, std::current_exception());
         }
-#endif // !UNIFEX_NO_EXCEPTIONS
       }
     };
   public:

--- a/test/P0443_test.cpp
+++ b/test/P0443_test.cpp
@@ -37,6 +37,8 @@ namespace {
       return false;
     }
   };
+
+#if !UNIFEX_NO_EXCEPTIONS
   struct throwing_executor {
     UNIFEX_TEMPLATE(typename Fn)
       (requires invocable<Fn&>)
@@ -50,16 +52,24 @@ namespace {
       return false;
     }
   };
+#endif // !UNIFEX_NO_EXCEPTIONS
+
   class inline_sender : sender_base {
     template <typename Receiver>
     struct _op {
       Receiver r_;
       void start() & noexcept {
+#if !UNIFEX_NO_EXCEPTIONS
         try {
+#endif // !UNIFEX_NO_EXCEPTIONS
+
           set_value((Receiver&&) r_);
+
+#if !UNIFEX_NO_EXCEPTIONS
         } catch(...) {
           set_error((Receiver&&) r_, std::current_exception());
         }
+#endif // !UNIFEX_NO_EXCEPTIONS
       }
     };
   public:
@@ -98,6 +108,7 @@ TEST(P0443, connect_with_executor) {
   EXPECT_EQ(1, i);
 }
 
+#if !UNIFEX_NO_EXCEPTIONS
 TEST(P0443, connect_with_throwing_executor) {
   int i = 0;
   struct _receiver {
@@ -118,6 +129,7 @@ TEST(P0443, connect_with_throwing_executor) {
   } catch (...) {}
   EXPECT_EQ(4, i);
 }
+#endif // !UNIFEX_NO_EXCEPTIONS
 
 TEST(P0443, schedule_with_executor) {
   int i = 0;

--- a/test/P0443_test.cpp
+++ b/test/P0443_test.cpp
@@ -54,10 +54,12 @@ namespace {
     template <typename Receiver>
     struct _op {
       Receiver r_;
-      void start() & noexcept try {
-        set_value((Receiver&&) r_);
-      } catch(...) {
-        set_error((Receiver&&) r_, std::current_exception());
+      void start() & noexcept {
+        try {
+          set_value((Receiver&&) r_);
+        } catch(...) {
+          set_error((Receiver&&) r_, std::current_exception());
+        }
       }
     };
   public:

--- a/test/retry_when_test.cpp
+++ b/test/retry_when_test.cpp
@@ -25,6 +25,8 @@
 #include <cstdio>
 #include <chrono>
 
+#include <gtest/gtest.h>
+
 using namespace std::chrono_literals;
 
 class some_error : public std::exception {
@@ -33,7 +35,7 @@ class some_error : public std::exception {
     }
 };
 
-int main() {
+TEST(retry_when, WorksAsExpected) {
   unifex::timed_single_thread_context ctx;
   auto scheduler = ctx.get_scheduler();
 
@@ -46,7 +48,7 @@ int main() {
 
   int operationCount = 0;
 
-  try {
+  EXPECT_THROW(
     unifex::sync_wait(
       unifex::retry_when(
         unifex::transform(unifex::schedule_after(scheduler, 10ms), [&] {
@@ -62,33 +64,20 @@ int main() {
 
           // Simulate some back-off strategy that increases the timeout.
           return unifex::schedule_after(scheduler, count * 100ms);
-        }));
+        })), some_error);
 
-    // Should have thrown an exception.
-    std::printf("error: operation should have failed with an exception\n");
-    return 1;
-  } catch (const some_error&) {
-    std::printf("[%d] caught some_error in main()\n", (int)timeSinceStartInMs());
-  }
-
-  const int expectedDurationInMs = 
+  const int expectedDurationInMs =
     10 +
     (100 + 10) +
     (200 + 10) +
     (300 + 10) +
-    (400 + 10) + 
+    (400 + 10) +
     (500 + 10);
 
   const auto elapsedDurationInMs = timeSinceStartInMs();
-  if (elapsedDurationInMs < expectedDurationInMs) {
-      std::printf("error: operation completed sooner than expected\n");
-      return 2;
-  }
+  EXPECT_GE(elapsedDurationInMs, expectedDurationInMs)
+      << "error: operation completed sooner than expected";
 
-  if (operationCount != 6) {
-      std::printf("error: operation should have executed 6 times\n");
-      return 3;
-  }
-
-  return 0;
+  EXPECT_EQ(operationCount, 6)
+      << "error: operation should have executed 6 times";
 }

--- a/test/retry_when_test.cpp
+++ b/test/retry_when_test.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <unifex/config.hpp>
+
+#if !UNIFEX_NO_EXCEPTIONS
+
 #include <unifex/retry_when.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/transform.hpp>
@@ -81,3 +85,5 @@ TEST(retry_when, WorksAsExpected) {
   EXPECT_EQ(operationCount, 6)
       << "error: operation should have executed 6 times";
 }
+
+#endif // !UNIFEX_NO_EXCEPTIONS

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -31,6 +31,8 @@ using namespace std::chrono_literals;
 
 struct my_error {};
 
+#if !UNIFEX_NO_EXCEPTIONS
+
 TEST(WhenAll2, Smoke) {
   timed_single_thread_context context;
 
@@ -85,6 +87,8 @@ TEST(WhenAll2, Smoke) {
   EXPECT_FALSE(ranPart2Callback);
   EXPECT_FALSE(ranFinalCallback);
 }
+
+#endif // !UNIFEX_NO_EXCEPTIONS
 
 struct string_const_ref_sender {
   template <


### PR DESCRIPTION
This change conditionally compiles out any `try` or `catch` keywords when compiled without exception support.  It does not deal with `throw` statements where Unifex throws an exception to report failure itself, such as in `windows_thread_pool`.