### PR TITLE
fix on() to support current_scheduler

### DIFF
--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -42,7 +42,9 @@ namespace _on {
         (requires sender<Sender> AND scheduler<Scheduler> AND //
           (!tag_invocable<_fn, Sender, Scheduler>))
     auto operator()(Sender&& sender, Scheduler&& scheduler) const {
-      return sequence(schedule(scheduler),
+      auto sndr = schedule(scheduler);
+      return sequence(
+        std::move(sndr),
         with_query_value(
           (Sender&&)sender,
           get_scheduler,

--- a/include/unifex/on.hpp
+++ b/include/unifex/on.hpp
@@ -42,10 +42,11 @@ namespace _on {
         (requires sender<Sender> AND scheduler<Scheduler> AND //
           (!tag_invocable<_fn, Sender, Scheduler>))
     auto operator()(Sender&& sender, Scheduler&& scheduler) const {
-      return with_query_value(
-          sequence(schedule(), (Sender&&)sender),
+      return sequence(schedule(scheduler),
+        with_query_value(
+          (Sender&&)sender,
           get_scheduler,
-          (Scheduler&&)scheduler);
+          (Scheduler&&)scheduler));
     }
   } on{};
 } // namespace _on


### PR DESCRIPTION
enables current scheduler to be used with `on()`

```cpp
with_query_value(
    when_all(
            on(transform(just(x), x_to_x2), current_scheduler()),
            . . . ),
    get_scheduler,
    sched
);
```