### PR TITLE
add missing noexcept on final_suspend's awaiter's await_ready member

### DIFF
--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -196,7 +196,7 @@ struct _task<T>::type {
 
     auto final_suspend() noexcept {
       struct awaiter {
-        bool await_ready() {
+        bool await_ready() noexcept {
           return false;
         }
         auto await_suspend(


### PR DESCRIPTION
Latest clang trunk complains about final suspend not being noexcept.