### PR TITLE
Suppress -Wunneeded-internal-declaration in P0443_test.cpp

### DIFF
--- a/test/P0443_test.cpp
+++ b/test/P0443_test.cpp
@@ -30,10 +30,10 @@ namespace {
     void execute(Fn fn) const {
       fn();
     }
-    friend bool operator==(inline_executor, inline_executor) noexcept {
+    [[maybe_unused]] friend bool operator==(inline_executor, inline_executor) noexcept {
       return true;
     }
-    friend bool operator!=(inline_executor, inline_executor) noexcept {
+    [[maybe_unused]] friend bool operator!=(inline_executor, inline_executor) noexcept {
       return false;
     }
   };
@@ -43,10 +43,10 @@ namespace {
     void execute(Fn fn) const {
       throw std::runtime_error("sorry, charlie");
     }
-    friend bool operator==(throwing_executor, throwing_executor) noexcept {
+    [[maybe_unused]] friend bool operator==(throwing_executor, throwing_executor) noexcept {
       return true;
     }
-    friend bool operator!=(throwing_executor, throwing_executor) noexcept {
+    [[maybe_unused]] friend bool operator!=(throwing_executor, throwing_executor) noexcept {
       return false;
     }
   };


### PR DESCRIPTION
Building test/P0443_test.cpp generates the following warning:

```
libunifex/test/P0443_test.cpp:34:17: error: function 'operator==' is not
needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
    friend bool operator==(inline_executor, inline_executor) noexcept {
                ^
libunifex/test/P0443_test.cpp:37:17: error: function 'operator!=' is not
needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
    friend bool operator!=(inline_executor, inline_executor) noexcept {
                ^
libunifex/test/P0443_test.cpp:47:17: error: function 'operator==' is not
needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
    friend bool operator==(throwing_executor, throwing_executor) noexcept {
                ^
libunifex/test/P0443_test.cpp:50:17: error: function 'operator!=' is not
needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
    friend bool operator!=(throwing_executor, throwing_executor) noexcept {
                ^
4 errors generated.
```

This change fixes the problem by marking the problematic operators with
`[[maybe_unused]]`.

The "unused" functions can't be simply deleted because they're required
to satisfy the Scheduler concept.