### PR TITLE
Suppress vectorization warning

### DIFF
--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -65,8 +65,11 @@ public:
                 }
                 Integral chunk_end = std::min(chunk_start + static_cast<Integral>(bulk_cancellation_chunk_size), count_);
                 if constexpr (is_one_of_v<policy_t, unsequenced_policy, parallel_unsequenced_policy>) {
+UNIFEX_DIAGNOSTIC_PUSH
+
                     // Vectorisable version
 #if defined(__clang__)
+                    #pragma clang diagnostic ignored "-Wpass-failed"
                     #pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)
                     #pragma GCC ivdep
@@ -76,6 +79,8 @@ public:
                     for (Integral i(chunk_start); i < chunk_end; ++i) {
                         unifex::set_next(receiver_, Integral(i));
                     }
+
+UNIFEX_DIAGNOSTIC_POP
                 } else {
                     // Sequenced version
                     for (Integral i(chunk_start); i < chunk_end; ++i) {
@@ -85,8 +90,11 @@ public:
             }
         } else {
             if constexpr (is_one_of_v<policy_t, unsequenced_policy, parallel_unsequenced_policy>) {
+UNIFEX_DIAGNOSTIC_PUSH
+
                 // Vectorisable version
 #if defined(__clang__)
+                #pragma clang diagnostic ignored "-Wpass-failed"
                 #pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)
                 #pragma GCC ivdep
@@ -96,6 +104,8 @@ public:
                 for (Integral i(0); i < count_; ++i) {
                     unifex::set_next(receiver_, Integral(i));
                 }
+
+UNIFEX_DIAGNOSTIC_POP
             } else {
                 // Sequenced version
                 for (Integral i(0); i < count_; ++i) {

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -69,6 +69,10 @@ UNIFEX_DIAGNOSTIC_PUSH
 
                     // Vectorisable version
 #if defined(__clang__)
+                    // When optimizing for size (e.g. with -Oz), Clang will not
+                    // vectorize this loop, and will emit a warning.  There's
+                    // nothing to be done about the warning, though, so just
+                    // suppress it.
                     #pragma clang diagnostic ignored "-Wpass-failed"
                     #pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)
@@ -94,6 +98,10 @@ UNIFEX_DIAGNOSTIC_PUSH
 
                 // Vectorisable version
 #if defined(__clang__)
+                // When optimizing for size (e.g. with -Oz), Clang will not
+                // vectorize this loop, and will emit a warning.  There's
+                // nothing to be done about the warning, though, so just
+                // suppress it.
                 #pragma clang diagnostic ignored "-Wpass-failed"
                 #pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)


### PR DESCRIPTION
When building with Clang with -Oz, the compiler will not vectorize the
loops in bulk_schedule.hpp that have requested vectorization.  This
results in a warning like so:

```
In file included from libunifex/test/bulk_schedule_test.cpp:17:
libunifex/include/unifex/bulk_schedule.hpp:96:17: error: loop not
vectorized: the optimizer was unable to perform the requested
transformation; the transformation might be disabled or specified as
part of an unsupported transformation ordering
[-Werror,-Wpass-failed=transform-warning]
                for (Integral i(0); i < count_; ++i) {
                ^
1 error generated.
```

This change suppresses the warning with a Clang-specific #pragma.