### PR TITLE
add support for apply_target composition

### DIFF
--- a/include/unifex/bind_back.hpp
+++ b/include/unifex/bind_back.hpp
@@ -24,23 +24,22 @@
 
 namespace unifex {
 
-namespace _bind_back {
+namespace _compose {
 
-namespace detail {
-
-struct compose {
+struct _fn {
   template <typename Target, typename Other, typename Self>
-  auto operator()(Target&& target, Other&& other, Self&& self) const 
+  auto operator()(Target&& target, Other&& other, Self&& self) const
     noexcept(
       is_nothrow_callable_v<Other, Target> &&
-      is_nothrow_callable_v<Self, callable_result_t<Other, Target>>
-    ) 
+      is_nothrow_callable_v<Self, callable_result_t<Other, Target>>)
     -> callable_result_t<Self, callable_result_t<Other, Target>> {
-    return ((Self&&)self)(((Other&&)other)((Target&&)target));
+    return ((Self&&) self)(((Other&&) other)((Target&&) target));
   }
 };
 
-} // namespace detail
+} // namespace _compose
+
+namespace _bind_back {
 
 template <typename Cpo, typename Target>
 struct _apply_fn_impl {
@@ -52,19 +51,15 @@ using _apply_fn = typename _apply_fn_impl<Cpo, ArgN...>::type;
 
 template <typename Cpo, typename Target>
 struct _apply_fn_impl<Cpo, Target>::type {
-  std::remove_reference_t<Target>* target_;
-
-  template <typename... _ArgN>
-  using _result_t =
-    typename meta_quote1_<callable_result_t>::template apply<Cpo, Target, _ArgN...>;
+  Cpo&& cpo_;
+  Target&& target_;
 
   template (typename... ArgN)
     (requires callable<Cpo, Target, ArgN...>)
-  auto operator()(ArgN&&... argN) 
-    noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
-    -> _result_t<ArgN...> {
-    return Cpo{}((Target&&) *target_, (ArgN&&)argN...);
+  auto operator()(ArgN&&... argN)
+    noexcept(is_nothrow_callable_v<Cpo, Target, ArgN...>)
+    -> callable_result_t<Cpo, Target, ArgN...> {
+    return ((Cpo&&) cpo_)((Target&&) target_, (ArgN&&) argN...);
   }
 };
 
@@ -80,76 +75,61 @@ using _result = typename _result_impl<Cpo, ArgN...>::type;
 
 template <typename Cpo, typename... ArgN>
 struct _result_impl<Cpo, ArgN...>::type : _result_base {
- private:
-  std::tuple<remove_cvref_t<ArgN>...> argN_;
- public:
-  template <typename... CN>
-  explicit constexpr type(CN&&... cn) 
-    noexcept(std::is_nothrow_constructible_v<std::tuple<remove_cvref_t<ArgN>...>, CN...>) 
-    : argN_((CN&&) cn...) {}
-
-  template <typename Target, typename... _ArgN>
-  using _result_t =
-    typename meta_quote1_<callable_result_t>::template apply<Cpo, Target, _ArgN...>;
+  UNIFEX_NO_UNIQUE_ADDRESS Cpo cpo_;
+  std::tuple<ArgN...> argN_;
 
   template (typename Target)
-    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, ArgN const&...>)
-  auto operator()(Target&& target) const &
-    noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN const&...>) 
-    -> _result_t<Target, ArgN const&...> {
-    return std::apply(_apply_fn<Cpo, Target>{&target}, argN_);
+    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
+      callable<Cpo const&, Target, ArgN const&...>)
+  decltype(auto) operator()(Target&& target) const &
+    noexcept(is_nothrow_callable_v<Cpo const&, Target, ArgN const&...>) {
+    return std::apply(_apply_fn<Cpo const&, Target>{cpo_, (Target&&) target}, argN_);
   }
   template (typename Target)
-    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, remove_cvref_t<ArgN>...>)
-  auto operator()(Target&& target) &&
-    noexcept(
-      is_nothrow_callable_v<Cpo, Target, remove_cvref_t<ArgN>...>) 
-    -> _result_t<Target, remove_cvref_t<ArgN>...> {
-    return std::apply(_apply_fn<Cpo, Target>{&target}, std::move(argN_));
+    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
+      callable<Cpo, Target, ArgN...>)
+  decltype(auto) operator()(Target&& target) &&
+    noexcept(is_nothrow_callable_v<Cpo, Target, ArgN...>) {
+    return std::apply(
+        _apply_fn<Cpo, Target>{(Cpo&&) cpo_, (Target&&) target},
+        std::move(argN_));
   }
 
-  template (typename Target)
-    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, remove_cvref_t<ArgN>...>)
-  friend auto operator|(Target&& target, type&& self) 
+  template (typename Target, typename Self)
+    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
+      same_as<remove_cvref_t<Self>, type> AND
+      callable<member_t<Self, Cpo>, Target, member_t<Self, ArgN>...>)
+  friend decltype(auto) operator|(Target&& target, Self&& self)
     noexcept(
-      is_nothrow_callable_v<Cpo, Target, remove_cvref_t<ArgN>...>) 
-    -> _result_t<Target, remove_cvref_t<ArgN>...> {
-    return std::move(self)((Target&&) target);
-  }
-  template (typename Target)
-    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, ArgN const&...>)
-  friend auto operator|(Target&& target, const type& self) 
-    noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN const&...>) 
-    -> _result_t<Target, ArgN const&...> {
-    return self((Target&&) target);
+      is_nothrow_callable_v<member_t<Self, Cpo>, Target, member_t<Self, ArgN>...>) {
+    return std::apply(
+        _apply_fn<member_t<Self, Cpo>, Target>{((Self&&) self).cpo_, (Target&&) target},
+        ((Self&&) self).argN_);
   }
 
   template (typename Other, typename Self)
-    (requires derived_from<Other, _result_base> AND same_as<remove_cvref_t<Self>, type>)
-  friend _result<detail::compose, Other, Self> 
-  operator|(Other&& other, Self&& self) 
-    noexcept(
-      std::is_nothrow_constructible_v<
-        _result<detail::compose, Other, Self>,
-        Other,
-        Self
-      >) {
-    return _result<detail::compose, Other, Self>{
-      (Other&&)other, (Self&&)self};
+    (requires derived_from<remove_cvref_t<Other>, _result_base> AND
+      same_as<remove_cvref_t<Self>, type>)
+  friend decltype(auto) operator|(Other&& other, Self&& self)
+    noexcept(noexcept(
+      _result<_compose::_fn, remove_cvref_t<Other>, type>{
+          {}, // _result_base
+          {}, // _compose::_fn
+          {(Other&&) other, (Self&&) self}})) {
+    return _result<_compose::_fn, remove_cvref_t<Other>, type>{
+        {}, // _result_base
+        {}, // _compose::_fn
+        {(Other&&) other, (Self&&) self}};
   }
 };
 
 inline const struct _fn {
-public:
-
   template <typename Cpo, typename... ArgN>
-  auto operator()(Cpo&& cpo, ArgN&&... argN) const 
-      noexcept(
-          std::is_nothrow_constructible_v<_result<remove_cvref_t<Cpo>, ArgN...>, ArgN...>) 
-      -> _result<remove_cvref_t<Cpo>, ArgN...> {
-    return _result<remove_cvref_t<Cpo>, ArgN...>{(ArgN &&) argN...};
+  auto operator()(Cpo cpo, ArgN&&... argN) const
+      noexcept(noexcept(
+          _result<Cpo, std::decay_t<ArgN>...>{{}, (Cpo&&) cpo, {(ArgN &&) argN...}}))
+      -> _result<Cpo, std::decay_t<ArgN>...> {
+    return _result<Cpo, std::decay_t<ArgN>...>{{}, (Cpo&&) cpo, {(ArgN &&) argN...}};
   }
 } bind_back{};
 
@@ -158,7 +138,8 @@ public:
 using _bind_back::bind_back;
 
 template <typename Cpo, typename... ArgN>
-using bind_back_result_t = _bind_back::_result<remove_cvref_t<Cpo>, ArgN...>;
+using bind_back_result_t =
+    _bind_back::_result<std::decay_t<Cpo>, std::decay_t<ArgN>...>;
 
 } // namespace unifex
 

--- a/include/unifex/bind_back.hpp
+++ b/include/unifex/bind_back.hpp
@@ -26,18 +26,60 @@ namespace unifex {
 
 namespace _bind_back {
 
-struct instance_of_apply_target {};
+namespace detail {
 
-template <typename Cpo, typename... ArgN>
-struct _apply_target {
+struct compose {
+  template <typename Target, typename Other, typename Self>
+  auto operator()(Target&& target, Other&& other, Self&& self) const 
+    noexcept(
+      is_nothrow_callable_v<Other, Target> &&
+      is_nothrow_callable_v<Self, callable_result_t<Other, Target>>
+    ) 
+    -> callable_result_t<Self, callable_result_t<Other, Target>> {
+    return ((Self&&)self)(((Other&&)other)((Target&&)target));
+  }
+};
+
+} // namespace detail
+
+template <typename Cpo, typename Target>
+struct _apply_fn_impl {
   struct type;
 };
 
 template <typename Cpo, typename... ArgN>
-using apply_target = typename _apply_target<Cpo, ArgN...>::type;
+using _apply_fn = typename _apply_fn_impl<Cpo, ArgN...>::type;
+
+template <typename Cpo, typename Target>
+struct _apply_fn_impl<Cpo, Target>::type {
+  std::remove_reference_t<Target>* target_;
+
+  template <typename... _ArgN>
+  using _result_t =
+    typename meta_quote1_<callable_result_t>::template apply<Cpo, Target, _ArgN...>;
+
+  template (typename... ArgN)
+    (requires callable<Cpo, Target, ArgN...>)
+  auto operator()(ArgN&&... argN) 
+    noexcept(
+      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
+    -> _result_t<ArgN...> {
+    return Cpo{}((Target&&) *target_, (ArgN&&)argN...);
+  }
+};
+
+struct _result_base {};
 
 template <typename Cpo, typename... ArgN>
-struct _apply_target<Cpo, ArgN...>::type : public instance_of_apply_target {
+struct _result_impl {
+  struct type;
+};
+
+template <typename Cpo, typename... ArgN>
+using _result = typename _result_impl<Cpo, ArgN...>::type;
+
+template <typename Cpo, typename... ArgN>
+struct _result_impl<Cpo, ArgN...>::type : _result_base {
  private:
   std::tuple<remove_cvref_t<ArgN>...> argN_;
  public:
@@ -46,71 +88,55 @@ struct _apply_target<Cpo, ArgN...>::type : public instance_of_apply_target {
     noexcept(std::is_nothrow_constructible_v<std::tuple<remove_cvref_t<ArgN>...>, CN...>) 
     : argN_((CN&&) cn...) {}
 
+  template <typename Target, typename... _ArgN>
+  using _result_t =
+    typename meta_quote1_<callable_result_t>::template apply<Cpo, Target, _ArgN...>;
+
   template (typename Target)
-    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, ArgN const&...>)
   auto operator()(Target&& target) const &
     noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
-    -> callable_result_t<Cpo, Target, ArgN...> {
-    return std::apply([&](auto&&... argN){
-      return Cpo{}((Target&&) target, argN...);
-    }, argN_);
+      is_nothrow_callable_v<Cpo, Target, ArgN const&...>) 
+    -> _result_t<Target, ArgN const&...> {
+    return std::apply(_apply_fn<Cpo, Target>{&target}, argN_);
   }
   template (typename Target)
-    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, remove_cvref_t<ArgN>...>)
   auto operator()(Target&& target) &&
     noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
-    -> callable_result_t<Cpo, Target, ArgN...> {
-    return std::apply([&](auto&&... argN){
-      return Cpo{}((Target&&) target, (ArgN&&) argN...);
-    }, std::move(argN_));
+      is_nothrow_callable_v<Cpo, Target, remove_cvref_t<ArgN>...>) 
+    -> _result_t<Target, remove_cvref_t<ArgN>...> {
+    return std::apply(_apply_fn<Cpo, Target>{&target}, std::move(argN_));
   }
 
   template (typename Target)
-    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, remove_cvref_t<ArgN>...>)
   friend auto operator|(Target&& target, type&& self) 
     noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
-    -> callable_result_t<Cpo, Target, ArgN...> {
+      is_nothrow_callable_v<Cpo, Target, remove_cvref_t<ArgN>...>) 
+    -> _result_t<Target, remove_cvref_t<ArgN>...> {
     return std::move(self)((Target&&) target);
   }
   template (typename Target)
-    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+    (requires (!derived_from<Target, _result_base>) AND callable<Cpo, Target, ArgN const&...>)
   friend auto operator|(Target&& target, const type& self) 
     noexcept(
-      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
-    -> callable_result_t<Cpo, Target, ArgN...> {
+      is_nothrow_callable_v<Cpo, Target, ArgN const&...>) 
+    -> _result_t<Target, ArgN const&...> {
     return self((Target&&) target);
   }
 
-  struct compose {
-    template (typename Target, typename Other, typename Self)
-    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>) AND
-        std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Other>> AND
-        std::is_same_v<remove_cvref_t<Self>, type>)
-    auto operator()(Target&& target, Other&& other, Self&& self) const 
-      noexcept(
-        is_nothrow_callable_v<Other, Target> &&
-        is_nothrow_callable_v<Self, callable_result_t<Other, Target>>
-      ) 
-      -> callable_result_t<Self, callable_result_t<Other, Target>> {
-      return ((Self&&)self)(((Other&&)other)((Target&&)target));
-    }
-  };
-
   template (typename Other, typename Self)
-    (requires std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Other>> AND
-      std::is_same_v<remove_cvref_t<Self>, type>)
-  friend apply_target<compose, Other, Self> 
+    (requires derived_from<Other, _result_base> AND same_as<remove_cvref_t<Self>, type>)
+  friend _result<detail::compose, Other, Self> 
   operator|(Other&& other, Self&& self) 
     noexcept(
       std::is_nothrow_constructible_v<
-        apply_target<compose, Other, Self>,
+        _result<detail::compose, Other, Self>,
         Other,
         Self
       >) {
-    return apply_target<compose, Other, Self>{
+    return _result<detail::compose, Other, Self>{
       (Other&&)other, (Self&&)self};
   }
 };
@@ -121,9 +147,9 @@ public:
   template <typename Cpo, typename... ArgN>
   auto operator()(Cpo&& cpo, ArgN&&... argN) const 
       noexcept(
-          std::is_nothrow_constructible_v<apply_target<remove_cvref_t<Cpo>, ArgN...>, ArgN...>) 
-      -> apply_target<remove_cvref_t<Cpo>, ArgN...> {
-    return apply_target<remove_cvref_t<Cpo>, ArgN...>{(ArgN &&) argN...};
+          std::is_nothrow_constructible_v<_result<remove_cvref_t<Cpo>, ArgN...>, ArgN...>) 
+      -> _result<remove_cvref_t<Cpo>, ArgN...> {
+    return _result<remove_cvref_t<Cpo>, ArgN...>{(ArgN &&) argN...};
   }
 } bind_back{};
 
@@ -132,7 +158,7 @@ public:
 using _bind_back::bind_back;
 
 template <typename Cpo, typename... ArgN>
-using bind_back_result_t = _bind_back::apply_target<remove_cvref_t<Cpo>, ArgN...>;
+using bind_back_result_t = _bind_back::_result<remove_cvref_t<Cpo>, ArgN...>;
 
 } // namespace unifex
 

--- a/include/unifex/bind_back.hpp
+++ b/include/unifex/bind_back.hpp
@@ -26,6 +26,8 @@ namespace unifex {
 
 namespace _bind_back {
 
+struct instance_of_apply_target {};
+
 template <typename Cpo, typename... ArgN>
 struct _apply_target {
   struct type;
@@ -35,7 +37,7 @@ template <typename Cpo, typename... ArgN>
 using apply_target = typename _apply_target<Cpo, ArgN...>::type;
 
 template <typename Cpo, typename... ArgN>
-struct _apply_target<Cpo, ArgN...>::type {
+struct _apply_target<Cpo, ArgN...>::type : public instance_of_apply_target {
  private:
   std::tuple<remove_cvref_t<ArgN>...> argN_;
  public:
@@ -44,7 +46,18 @@ struct _apply_target<Cpo, ArgN...>::type {
     noexcept(std::is_nothrow_constructible_v<std::tuple<remove_cvref_t<ArgN>...>, CN...>) 
     : argN_((CN&&) cn...) {}
 
-  template <typename Target>
+  template (typename Target)
+    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+  auto operator()(Target&& target) const &
+    noexcept(
+      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
+    -> callable_result_t<Cpo, Target, ArgN...> {
+    return std::apply([&](auto&&... argN){
+      return Cpo{}((Target&&) target, argN...);
+    }, argN_);
+  }
+  template (typename Target)
+    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
   auto operator()(Target&& target) &&
     noexcept(
       is_nothrow_callable_v<Cpo, Target, ArgN...>) 
@@ -54,12 +67,51 @@ struct _apply_target<Cpo, ArgN...>::type {
     }, std::move(argN_));
   }
 
-  template <typename Target>
+  template (typename Target)
+    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
   friend auto operator|(Target&& target, type&& self) 
     noexcept(
       is_nothrow_callable_v<Cpo, Target, ArgN...>) 
     -> callable_result_t<Cpo, Target, ArgN...> {
     return std::move(self)((Target&&) target);
+  }
+  template (typename Target)
+    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>))
+  friend auto operator|(Target&& target, const type& self) 
+    noexcept(
+      is_nothrow_callable_v<Cpo, Target, ArgN...>) 
+    -> callable_result_t<Cpo, Target, ArgN...> {
+    return self((Target&&) target);
+  }
+
+  struct compose {
+    template (typename Target, typename Other, typename Self)
+    (requires (!std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Target>>) AND
+        std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Other>> AND
+        std::is_same_v<remove_cvref_t<Self>, type>)
+    auto operator()(Target&& target, Other&& other, Self&& self) const 
+      noexcept(
+        is_nothrow_callable_v<Other, Target> &&
+        is_nothrow_callable_v<Self, callable_result_t<Other, Target>>
+      ) 
+      -> callable_result_t<Self, callable_result_t<Other, Target>> {
+      return ((Self&&)self)(((Other&&)other)((Target&&)target));
+    }
+  };
+
+  template (typename Other, typename Self)
+    (requires std::is_base_of_v<instance_of_apply_target, remove_cvref_t<Other>> AND
+      std::is_same_v<remove_cvref_t<Self>, type>)
+  friend apply_target<compose, Other, Self> 
+  operator|(Other&& other, Self&& self) 
+    noexcept(
+      std::is_nothrow_constructible_v<
+        apply_target<compose, Other, Self>,
+        Other,
+        Self
+      >) {
+    return apply_target<compose, Other, Self>{
+      (Other&&)other, (Self&&)self};
   }
 };
 

--- a/test/transform_test.cpp
+++ b/test/transform_test.cpp
@@ -58,5 +58,12 @@ TEST(Pipeable, Transform) {
     | transform([&]{ ++count; })
     | sync_wait();
 
-  EXPECT_EQ(count, 1);
+  auto twocount = transform([&]{ ++count; }) | transform([&]{ ++count; });
+
+  just()
+    | transform([&]{ ++count; })
+    | twocount
+    | sync_wait();
+
+  EXPECT_EQ(count, 4);
 }


### PR DESCRIPTION
allows subexpressions

```cpp
auto two = transform([&]{ ++count; }) | transform([&]{ ++count; });

  just()
    | transform([&]{ ++count; })
    | two
    | sync_wait();
```