### PR TITLE
Forcibly disable epoll support on old Androids

### DIFF
--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -39,7 +39,17 @@
 #cmakedefine UNIFEX_COROUTINES_HEADER <@UNIFEX_COROUTINES_HEADER@>
 #cmakedefine UNIFEX_COROUTINES_NAMESPACE @UNIFEX_COROUTINES_NAMESPACE@
 
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 19
+// Android makes timerfd_create and friend available as of API version 19;
+// before that, the epoll API exists but it's insufficient for our purposes.
+// https://android.googlesource.com/platform/bionic/+/master/libc/include/sys/timerfd.h#56
+#  define UNIFEX_NO_EPOLL 1
+#endif
+
+#if !defined(UNIFEX_NO_EPOLL)
 #cmakedefine01 UNIFEX_NO_EPOLL
+#endif
+
 #cmakedefine01 UNIFEX_NO_LIBURING
 
 // UNIFEX_DECLARE_NON_DEDUCED_TYPE(type)


### PR DESCRIPTION
Prior to API level 19, Android's epoll doesn't expose `timerfd_create`, `timerfd_settime`, or `timerfd_gettime`, which means
`linux/io_epoll_context.cpp` can't build.  This change defines `UNIFEX_NO_EPOLL` as `1` when compiling for Android with a target API level of less than 19 to avoid build errors.

This PR should be a substitute for PR #169.