### PR TITLE
Add sends_done to sender_traits, sender concept and define it in all senders

### DIFF
--- a/doc/concepts.md
+++ b/doc/concepts.md
@@ -266,6 +266,9 @@ a type that is an instantiation of `Variant`, with a template argument for each
 overload of `set_error` that may be called, with each template argument being
 the type of the error argument for the call to `set_error`.
 
+A nested `static constexpr bool sends_done` is defined, which indicates whether
+the sender might complete with `set_done`.
+
 For example:
 ```c++
 struct some_typed_sender {
@@ -277,6 +280,8 @@ struct some_typed_sender {
 
  template<template<typename...> class Variant>
  using error_types = Variant<std::exception_ptr>;
+
+ static constexpr bool sends_done = true;
  ...
 };
 ```
@@ -287,14 +292,13 @@ the receiver:
 - `set_value(R&&, std::string, int)`
 - `set_value(R&&)`
 - `set_error(R&&, std::exception_ptr)`
+- `set_done(R&&)`
 
-TODO: Add support for querying whether `set_done()` may be called.
-Often this will not be known in general until a receiver is available.
-Maybe we need to also put this query on the operation-state type?
+When querying the `value_types/error_types/sends_done` properties of
+a sender you should look them up in the `sender_traits<Sender>` class rather
+than on the sender type directly.
 
-TODO: Do we need to indirect these through a `sender_traits` type to
-allow these queries to be customised externally. e.g. so that we can
-allow third-party library types to implement the typed-sender concept.
+e.g. `typename unifex::sender_traits<Sender>::template value_types<std::variant, std::tuple>`
 
 ## OperationState Concept
 

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -112,6 +112,8 @@ class delegating_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<>;
 
+  static constexpr bool sends_done = true;
+
   template<typename OpType>
   struct LocalContextType {
     OpType op_;

--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -84,46 +84,24 @@ namespace _alloc {
     template <
         template <typename...> class Variant,
         template <typename...> class Tuple>
-    using value_types = typename Sender::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
-    using error_types = typename Sender::template error_types<Variant>;
+    using error_types = typename sender_traits<Sender>::template error_types<Variant>;
 
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, sender&& s, Receiver&& r)
+    static constexpr bool sends_done = sender_traits<Sender>::sends_done;
+
+    template(typename Self, typename Receiver)
+      (requires same_as<remove_cvref_t<Self>, type> AND
+                receiver<Receiver>)
+    friend auto tag_invoke(tag_t<connect>, Self&& s, Receiver&& r)
         -> operation<
-            connect_result_t<Sender, Receiver>,
+            connect_result_t<member_t<Self, Sender>, Receiver>,
             remove_cvref_t<get_allocator_t<Receiver>>> {
       return operation<
-          connect_result_t<Sender, Receiver>,
+          connect_result_t<member_t<Self, Sender>, Receiver>,
           remove_cvref_t<get_allocator_t<Receiver>>>{
-          (Sender &&) s.sender_, (Receiver &&) r};
-    }
-
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, sender& s, Receiver&& r)
-        -> operation<
-            connect_result_t<Sender&, Receiver>,
-            remove_cvref_t<get_allocator_t<Receiver>>> {
-      return operation<
-          connect_result_t<Sender&, Receiver>,
-          remove_cvref_t<get_allocator_t<Receiver>>>{
-          s.sender_, (Receiver &&) r};
-    }
-
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend auto
-    tag_invoke(tag_t<connect>, const sender& s, Receiver&& r)
-        -> operation<
-            connect_result_t<const Sender&, Receiver>,
-            remove_cvref_t<get_allocator_t<Receiver>>> {
-      return operation<
-          connect_result_t<const Sender&, Receiver>,
-          remove_cvref_t<get_allocator_t<Receiver>>>{
-          std::as_const(s.sender_), (Receiver &&) r};
+          static_cast<Self&&>(s).sender_, (Receiver &&) r};
     }
 
     Sender sender_;

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -58,6 +58,8 @@ private:
     template <template <typename...> class Variant>
     using error_types = Variant<>;
 
+    static constexpr bool sends_done = false;
+
     lock_sender(const lock_sender &) = delete;
     lock_sender(lock_sender &&) = default;
 

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -198,6 +198,8 @@ namespace _async_trace {
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
+    static constexpr bool sends_done = false;
+
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& r) const& {
       return operation<Receiver>{(Receiver &&) r};

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -74,8 +74,7 @@ class _as_awaitable {
     }
     
     void set_done() && noexcept {
-      // TODO: Enable this once sender_traits support 'sends_done'
-      //static_assert(sender_traits<remove_cvref_t<Sender>>::sends_done);
+      static_assert(sender_traits<remove_cvref_t<Sender>>::sends_done);
       op_->state_ = state::done;
       continuation_.promise().unhandled_done().resume();
     }

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -41,8 +41,9 @@ namespace _await_transform {
 
 template <typename Promise, typename Sender>
 class _as_awaitable {
-  using value_t = typename remove_cvref_t<Sender>::
+  using value_t = typename sender_traits<remove_cvref_t<Sender>>::
         template value_types<single_overload, single_value_type>::type::type;
+  
   enum class state { empty, value, exception, done };
 
   class receiver {
@@ -73,6 +74,8 @@ class _as_awaitable {
     }
     
     void set_done() && noexcept {
+      // TODO: Enable this once sender_traits support 'sends_done'
+      //static_assert(sender_traits<remove_cvref_t<Sender>>::sends_done);
       op_->state_ = state::done;
       continuation_.promise().unhandled_done().resume();
     }

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -94,12 +94,12 @@ template<typename Source>
 class _join_sender<Source>::type {
 public:
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename Source::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<Source>::template value_types<Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename Source::template error_types<Variant>;
+    using error_types = typename sender_traits<Source>::template error_types<Variant>;
 
-    static constexpr bool sends_done = Source::sends_done;
+    static constexpr bool sends_done = sender_traits<Source>::sends_done;
 
     template<typename Source2>
     explicit type(Source2&& s)

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -163,9 +163,9 @@ public:
     using next_types = Variant<Tuple<Integral>>;
 
     template<template<typename...> class Variant>
-    using error_types = typename schedule_sender_t::template error_types<Variant>;
+    using error_types = typename sender_traits<schedule_sender_t>::template error_types<Variant>;
 
-    static constexpr bool sends_done = schedule_sender_t::sends_done;
+    static constexpr bool sends_done = true;
 
     template<typename Scheduler2>
     explicit type(Scheduler2&& s, Integral count)

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -151,17 +151,17 @@ public:
         template<typename...> class Variant,
         template<typename...> class Tuple>
     using next_types = type_list_nested_apply_t<
-        typename Source::template next_types<concat_type_lists_unique_t, result>,
+        typename sender_traits<Source>::template next_types<concat_type_lists_unique_t, result>,
         Variant,
         Tuple>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename Source::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<Source>::template value_types<Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename Source::template error_types<Variant>;
+    using error_types = typename sender_traits<Source>::template error_types<Variant>;
 
-    static constexpr bool sends_done = Source::sends_done;
+    static constexpr bool sends_done = sender_traits<Source>::sends_done;
 
     template<typename Source2, typename Func2>
     explicit type(Source2&& source, Func2&& func, Policy policy)

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -144,14 +144,16 @@ namespace _demat {
     template <
         template <typename...> class Variant,
         template <typename...> class Tuple>
-    using value_types = typename Source::template value_types<
+    using value_types = typename sender_traits<Source>::template value_types<
         variant<Variant>::template apply,
         tuple<tag_t<set_value>, Tuple>::template apply>;
 
     template <template <typename...> class Variant>
-    using error_types = typename Source::template value_types<
+    using error_types = typename sender_traits<Source>::template value_types<
         variant<append_error_types<Variant>::template apply>::template apply,
         tuple<tag_t<set_error>, single_type_t>::template apply>;
+
+    static constexpr bool sends_done = sender_traits<Source>::sends_done;
 
     template <typename Source2>
     explicit type(Source2&& source)

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -580,7 +580,7 @@ namespace unifex
             error_;
 
         // Storage for value-types that might be produced by SourceSender.
-        UNIFEX_NO_UNIQUE_ADDRESS typename remove_cvref_t<SourceSender>::template value_types<
+        UNIFEX_NO_UNIQUE_ADDRESS typename sender_traits<remove_cvref_t<SourceSender>>::template value_types<
             manual_lifetime_union,
             decayed_tuple<std::tuple>::template apply>
             value_;
@@ -632,7 +632,7 @@ namespace unifex
       template <
           template <typename...> class Variant,
           template <typename...> class Tuple>
-      using value_types = typename SourceSender::
+      using value_types = typename sender_traits<SourceSender>::
           template value_types<Variant, decayed_tuple<Tuple>::template apply>;
 
       // This can produce any of the error_types of SourceSender, or of
@@ -642,11 +642,15 @@ namespace unifex
       // connect() operation and move/copy of values
       template <template <typename...> class Variant>
       using error_types = typename concat_type_lists_unique_t<
-          typename SourceSender::template error_types<
+          typename sender_traits<SourceSender>::template error_types<
               decayed_tuple<type_list>::template apply>,
-          typename CompletionSender::template error_types<
+          typename sender_traits<CompletionSender>::template error_types<
               decayed_tuple<type_list>::template apply>,
           type_list<std::exception_ptr>>::template apply<Variant>;
+
+      static constexpr bool sends_done =
+          sender_traits<SourceSender>::sends_done ||
+          sender_traits<CompletionSender>::sends_done;
 
       template <typename SourceSender2, typename CompletionSender2>
       explicit type(

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -286,7 +286,7 @@ struct _operation_state {
       typename receiver_type::template unpack_receiver<Receiver>>;
   };
   using operation_state_t =
-      typename Predecessor::template value_types<concat_type_lists_unique_t, find_if_apply>::type;
+      typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, find_if_apply>::type;
 
   template<typename Sender>
   _operation_state(Sender&& s, Receiver&& r) :
@@ -362,15 +362,16 @@ struct _sender<Predecessor, Func, FuncPolicy>::type {
       template <typename...> class Variant,
       template <typename...> class Tuple>
   using value_types = type_list_nested_apply_t<
-    typename Predecessor::template value_types<concat_type_lists_unique_t, result>,
+    typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, result>,
     Variant,
     Tuple>;
 
-
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-    typename Predecessor::template error_types<type_list>,
+    typename sender_traits<Predecessor>::template error_types<type_list>,
     type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = true;
 
   template <typename Receiver>
   using receiver_type = receiver_t<Predecessor, Receiver, Func, FuncPolicy>;
@@ -389,8 +390,6 @@ struct _sender<Predecessor, Func, FuncPolicy>::type {
         decltype((static_cast<Sender&&>(s).pred_)),
         receiver_type<remove_cvref_t<Receiver>>>)
       -> _operation_state<Predecessor, Receiver, Func, FuncPolicy> {
-
-
     return _operation_state<Predecessor, Receiver, Func, FuncPolicy>{
       static_cast<Sender&&>(s), static_cast<Receiver&&>(r)};
   }

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -134,12 +134,14 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
   template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
-  using value_types = typename Predecessor::template value_types<Variant, Tuple>;
+  using value_types = typename sender_traits<Predecessor>::template value_types<Variant, Tuple>;
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      typename Predecessor::template error_types<type_list>,
+      typename sender_traits<Predecessor>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 
   friend constexpr auto tag_invoke(
       tag_t<blocking>,

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -69,6 +69,8 @@ namespace _inline_sched {
       template <template <typename...> class Variant>
       using error_types = Variant<>;
 
+      static constexpr bool sends_done = true;
+
       friend constexpr blocking_kind tag_invoke(
           tag_t<blocking>,
           const schedule_task&) noexcept {

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -76,6 +76,8 @@ class _sender<Values...>::type {
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
+  static constexpr bool sends_done = false;
+
   template(typename... Values2)
     (requires (sizeof...(Values2) == sizeof...(Values)))
   explicit type(std::in_place_t, Values2&&... values)

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -255,6 +255,12 @@ using sender = typename _sender<
     remove_cvref_t<Predecessor>,
     remove_cvref_t<SuccessorFactory>>::type;
 
+template<typename Sender>
+struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {};
+
+template <typename... Successors>
+using any_sends_done = std::disjunction<sends_done_impl<Successors>...>;
+
 template <typename Predecessor, typename SuccessorFactory>
 class _sender<Predecessor, SuccessorFactory>::type {
   using sender = type;
@@ -266,7 +272,7 @@ class _sender<Predecessor, SuccessorFactory>::type {
 
   template <template <typename...> class List>
   using successor_types =
-      typename Predecessor::template value_types<List, successor_type>;
+      typename sender_traits<Predecessor>::template value_types<List, successor_type>;
 
   template <
       template <typename...> class Variant,
@@ -275,7 +281,7 @@ class _sender<Predecessor, SuccessorFactory>::type {
    public:
     template <typename... Senders>
     using apply = typename concat_type_lists_unique_t<
-        typename Senders::template value_types<type_list, Tuple>...
+        typename sender_traits<Senders>::template value_types<type_list, Tuple>...
         >::template apply<Variant>;
   };
 
@@ -296,7 +302,7 @@ class _sender<Predecessor, SuccessorFactory>::type {
   struct error_types_impl {
     template <typename... Senders>
     using apply = typename concat_type_lists_unique_t<
-        typename Senders::template error_types<type_list>...,
+        typename sender_traits<Senders>::template error_types<type_list>...,
         type_list<std::exception_ptr>>::template apply<Variant>;
   };
 
@@ -310,6 +316,10 @@ public:
   template <template <typename...> class Variant>
   using error_types =
       successor_types<error_types_impl<Variant>::template apply>;
+
+  static constexpr bool sends_done =
+    sender_traits<Predecessor>::sends_done ||
+    successor_types<any_sends_done>::value;
 
  public:
   template <typename Predecessor2, typename SuccessorFactory2>

--- a/include/unifex/let_with.hpp
+++ b/include/unifex/let_with.hpp
@@ -52,10 +52,12 @@ public:
     using InnerOp = std::invoke_result_t<SuccessorFactory, callable_result_t<StateFactory>&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename InnerOp::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<InnerOp>::template value_types<Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename InnerOp::template error_types<Variant>;
+    using error_types = typename sender_traits<InnerOp>::template error_types<Variant>;
+
+    static constexpr bool sends_done = sender_traits<InnerOp>::sends_done;
 
     template<typename StateFactory2, typename SuccessorFactory2>
     explicit type(StateFactory2&& stateFactory, SuccessorFactory2&& func) :

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -108,10 +108,12 @@ public:
     using InnerOp = std::invoke_result_t<SuccessorFactory, inplace_stop_source&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename InnerOp::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<InnerOp>::template value_types<Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename InnerOp::template error_types<Variant>;
+    using error_types = typename sender_traits<InnerOp>::template error_types<Variant>;
+
+    static constexpr bool sends_done = sender_traits<InnerOp>::sends_done;
 
     template<typename SuccessorFactory2>
     explicit type(SuccessorFactory2&& func) : func_((SuccessorFactory2&&)func)

--- a/include/unifex/linux/io_epoll_context.hpp
+++ b/include/unifex/linux/io_epoll_context.hpp
@@ -261,6 +261,8 @@ class io_epoll_context::schedule_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
+  static constexpr bool sends_done = true;
+
   template <typename Receiver>
   operation<std::remove_reference_t<Receiver>> connect(Receiver&& r) && {
     return operation<std::remove_reference_t<Receiver>>{context_,
@@ -448,6 +450,8 @@ class io_epoll_context::schedule_at_sender {
 
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
 
   explicit schedule_at_sender(
       io_epoll_context& context,
@@ -700,6 +704,8 @@ class io_epoll_context::read_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<std::error_code, std::exception_ptr>;
 
+  static constexpr bool sends_done = true;
+
   explicit read_sender(
       io_epoll_context& context,
       int fd,
@@ -910,6 +916,8 @@ class io_epoll_context::write_sender {
 
   template <template <typename...> class Variant>
   using error_types = Variant<std::error_code, std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
 
   explicit write_sender(
       io_epoll_context& context,

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -376,6 +376,8 @@ class io_uring_context::schedule_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
+  static constexpr bool sends_done = true;
+
   template <typename Receiver>
   operation<std::remove_reference_t<Receiver>> connect(Receiver&& r) {
     return operation<std::remove_reference_t<Receiver>>{context_,
@@ -487,6 +489,8 @@ class io_uring_context::read_sender {
   // receiver's set_value() exits with an exception.
   template <template <typename...> class Variant>
   using error_types = Variant<std::error_code, std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
 
   explicit read_sender(
       io_uring_context& context,
@@ -603,6 +607,8 @@ class io_uring_context::write_sender {
   // receiver's set_value() exits with an exception.
   template <template <typename...> class Variant>
   using error_types = Variant<std::error_code, std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
 
   explicit write_sender(
       io_uring_context& context,
@@ -871,6 +877,8 @@ class io_uring_context::schedule_at_sender {
   // receiver's set_value() exits with an exception.
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
 
   explicit schedule_at_sender(
       io_uring_context& context,

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -153,7 +153,7 @@ namespace unifex
               template apply>;
 
       using type =
-          typename Source::template value_types<value_variant, value_tuple>;
+          typename sender_traits<Source>::template value_types<value_variant, value_tuple>;
     };
 
     template <typename Source>
@@ -177,6 +177,8 @@ namespace unifex
 
       template <template <typename...> class Variant>
       using error_types = Variant<std::exception_ptr>;
+
+      static constexpr bool sends_done = false;
 
       template(typename Source2)
           (requires constructible_from<Source, Source2>)

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -80,6 +80,8 @@ struct sender {
   template <template <typename...> class Variant>
   using error_types = Variant<>;
 
+  static constexpr bool sends_done = true;
+
   template <typename Receiver>
   operation<Receiver> connect(Receiver&& receiver) {
     return operation<Receiver>{(Receiver &&) receiver};

--- a/include/unifex/new_thread_context.hpp
+++ b/include/unifex/new_thread_context.hpp
@@ -75,6 +75,8 @@ private:
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
+    static constexpr bool sends_done = true;
+
     explicit schedule_sender(context* ctx) noexcept
       : context_(ctx) {}
 

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -55,6 +55,8 @@ struct next_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<>;
 
+  static constexpr bool sends_done = true;
+
   friend constexpr blocking_kind tag_invoke(
       tag_t<blocking>,
       const stream&) noexcept {

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -50,6 +50,8 @@ namespace _ready_done {
     template <template <typename...> class Variant>
     using error_types = Variant<>;
 
+    static constexpr bool sends_done = true;
+
     friend constexpr blocking_kind tag_invoke(
         tag_t<blocking>,
         const sender&) {

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -298,9 +298,11 @@ struct _sender<StreamSender, State, ReducerFunc>::type {
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      typename next_sender_t<StreamSender>::template error_types<type_list>,
-      typename cleanup_sender_t<StreamSender>::template error_types<type_list>,
+      typename sender_traits<next_sender_t<StreamSender>>::template error_types<type_list>,
+      typename sender_traits<cleanup_sender_t<StreamSender>>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = false;
 
   template <typename Receiver>
   using operation = operation<StreamSender, State, ReducerFunc, Receiver>;

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -194,8 +194,10 @@ public:
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      typename Source::template error_types<type_list>,
+      typename sender_traits<Source>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = true;
 
   template <typename Source2, typename Predicate2>
   explicit type(Source2&& source, Predicate2&& predicate)

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -178,6 +178,8 @@ struct _schedule::sender {
   template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
+  static constexpr bool sends_done = true;
+
   template(
     typename Receiver,
     typename Scheduler =
@@ -246,6 +248,8 @@ namespace _schedule_after {
 
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = true;
 
     explicit type(Duration d)
       : duration_(d)
@@ -323,6 +327,8 @@ namespace _schedule_at {
 
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = true;
 
     explicit type(TimePoint tp)
       : time_point_(tp)

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -73,8 +73,7 @@ namespace detail {
   UNIFEX_CONCEPT_FRAGMENT(  //
     _has_sender_types_impl, //
       requires() (          //
-        // BUGBUG TODO:
-        // typename (std::bool_constant<S::sends_done>),
+        typename (std::bool_constant<S::sends_done>),
         typename (_has_value_types<S::template value_types>),
         typename (_has_error_types<S::template error_types>)
       ));
@@ -87,8 +86,7 @@ namespace detail {
   UNIFEX_CONCEPT_FRAGMENT(  //
     _has_bulk_sender_types_impl, //
       requires() (          //
-        // BUGBUG TODO:
-        // typename (std::bool_constant<S::sends_done>),
+        typename (std::bool_constant<S::sends_done>),
         typename (_has_value_types<S::template value_types>),
         typename (_has_value_types<S::template next_types>),
         typename (_has_error_types<S::template error_types>)
@@ -131,8 +129,7 @@ namespace detail {
     template <template <typename...> class Variant>
     using error_types = typename S::template error_types<Variant>;
 
-    // TODO
-    // static constexpr bool sends_done = S::sends_done;
+    static constexpr bool sends_done = S::sends_done;
   };
 
   template <typename S>
@@ -378,14 +375,14 @@ namespace detail {
 
 template <typename Sender, typename Adaptor>
 using adapt_error_types_t =
-    typename Sender::template error_types<Adaptor::template apply>;
+    typename sender_traits<Sender>::template error_types<Adaptor::template apply>;
 
 template <
     typename Sender,
     template <typename...> class Variant,
     typename Adaptor>
 using adapt_value_types_t =
-    typename Sender::template value_types<Variant, typename Adaptor::apply>;
+    typename sender_traits<Sender>::template value_types<Variant, typename Adaptor::apply>;
 
 template <typename... Types>
 struct single_value_type {

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -300,13 +300,17 @@ namespace unifex
           template <typename...> class Variant,
           template <typename...> class Tuple>
       using value_types =
-          typename Successor::template value_types<Variant, Tuple>;
+          typename sender_traits<Successor>::template value_types<Variant, Tuple>;
 
       template <template <typename...> class Variant>
       using error_types = typename concat_type_lists_unique_t<
-          typename Predecessor::template error_types<type_list>,
-          typename Successor::template error_types<type_list>,
+          typename sender_traits<Predecessor>::template error_types<type_list>,
+          typename sender_traits<Successor>::template error_types<type_list>,
           type_list<std::exception_ptr>>::template apply<Variant>;
+
+      static constexpr bool sends_done =
+        sender_traits<Predecessor>::sends_done ||
+        sender_traits<Successor>::sends_done;
 
       template(typename Predecessor2, typename Successor2)
           (requires constructible_from<Predecessor, Predecessor2> AND

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -92,10 +92,12 @@ struct _stream<Sender>::type {
 
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
-    using value_types = typename Sender::template value_types<Variant, Tuple>;
+    using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
-    using error_types = typename Sender::template error_types<Variant>;
+    using error_types = typename sender_traits<Sender>::template error_types<Variant>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     auto connect(Receiver&& receiver) {

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -204,11 +204,13 @@ struct _stream<SourceStream, Values...>::type {
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
     using value_types =
-      typename next_sender_t<SourceStream>::template value_types<Variant, Tuple>;
+      typename sender_traits<next_sender_t<SourceStream>>::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      typename next_sender_t<SourceStream>::template error_types<Variant>;
+      typename sender_traits<next_sender_t<SourceStream>>::template error_types<Variant>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     struct _op {
@@ -311,8 +313,10 @@ struct _stream<SourceStream, Values...>::type {
 
     template <template <typename...> class Variant>
     using error_types = typename concat_type_lists_unique_t<
-      typename cleanup_sender_t<SourceStream>::template error_types<type_list>,
+      typename sender_traits<cleanup_sender_t<SourceStream>>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     struct _op {

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -262,9 +262,9 @@ namespace unifex
 
       using result_variant = typename concat_type_lists_t<
           type_list<std::tuple<>, std::tuple<tag_t<unifex::set_done>>>,
-          typename std::remove_reference_t<
-              Source>::template value_types<type_list, value_decayed_tuple>,
-          typename std::remove_reference_t<Source>::template error_types<
+          typename sender_traits<std::remove_reference_t<
+              Source>>::template value_types<type_list, value_decayed_tuple>,
+          typename sender_traits<std::remove_reference_t<Source>>::template error_types<
               error_tuples>>::template apply<std::variant>;
 
       UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
@@ -310,15 +310,17 @@ namespace unifex
           class Variant,
           template <typename...>
           class Tuple>
-      using value_types = typename Source::
+      using value_types = typename sender_traits<Source>::
           template value_types<concat_type_lists_unique_t, decayed_type_list>::
               template apply<compose_nested<Variant, Tuple>::template apply>;
 
       template <template <typename...> class Variant>
       using error_types = typename concat_type_lists_unique_t<
-          typename Source::template error_types<
+          typename sender_traits<Source>::template error_types<
               decayed_tuple<type_list>::template apply>,
           type_list<std::exception_ptr>>::template apply<Variant>;
+
+      static constexpr bool sends_done = true;
 
       template <typename Source2, typename Trigger2>
       explicit type(Source2&& source, Trigger2&& trigger) noexcept(

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -95,12 +95,14 @@ struct _stream<SourceStream, TriggerStream>::type {
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
     using value_types =
-      typename next_sender_t<SourceStream>::
+      typename sender_traits<next_sender_t<SourceStream>>::
         template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      typename next_sender_t<SourceStream>::template error_types<Variant>;
+      typename sender_traits<next_sender_t<SourceStream>>::template error_types<Variant>;
+
+    static constexpr bool sends_done = sender_traits<next_sender_t<SourceStream>>::sends_done;
 
     template <typename Receiver>
     struct _op {
@@ -201,12 +203,14 @@ struct _stream<SourceStream, TriggerStream>::type {
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
     using value_types =
-      typename cleanup_sender_t<SourceStream>::
+      typename sender_traits<cleanup_sender_t<SourceStream>>::
         template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      typename cleanup_sender_t<SourceStream>::template error_types<Variant>;
+      typename sender_traits<cleanup_sender_t<SourceStream>>::template error_types<Variant>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     struct _op {

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -146,6 +146,8 @@ namespace _thread_unsafe_event_loop {
     template <template <typename...> class Variant>
     using error_types = Variant<>;
 
+    static constexpr bool sends_done = true;
+
     template <typename Receiver>
     after_operation<Duration, remove_cvref_t<Receiver>> connect(Receiver&& r) const& {
       return after_operation<Duration, remove_cvref_t<Receiver>>{
@@ -221,6 +223,8 @@ namespace _thread_unsafe_event_loop {
 
     template <template <typename...> class Variant>
     using error_types = Variant<>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     at_operation<remove_cvref_t<Receiver>> connect(Receiver&& r) const& {

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -135,6 +135,8 @@ namespace _timed_single_thread_context {
     template <template <typename...> class Variant>
     using error_types = Variant<>;
 
+    static constexpr bool sends_done = true;
+
     template <typename Receiver>
     after_operation<Duration, Receiver> connect(Receiver&& receiver) const & {
       return after_operation<Duration, Receiver>{
@@ -202,6 +204,8 @@ namespace _timed_single_thread_context {
 
     template <template <typename...> class Variant>
     using error_types = Variant<>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     at_operation<remove_cvref_t<Receiver>> connect(Receiver&& receiver) {

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -121,6 +121,8 @@ class scheduler {
     template <template <typename...> class Variant>
     using error_types = Variant<>;
 
+    static constexpr bool sends_done = true;
+
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) const& {
       return operation<Receiver>{(Receiver &&) receiver, maxRecursionDepth_};

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -143,14 +143,16 @@ public:
       template <typename...> class Variant,
       template <typename...> class Tuple>
   using value_types = type_list_nested_apply_t<
-    typename Predecessor::template value_types<concat_type_lists_unique_t, result>,
+    typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, result>,
     Variant,
     Tuple>;
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-    typename Predecessor::template error_types<type_list>,
+    typename sender_traits<Predecessor>::template error_types<type_list>,
     type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, Func>;

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -265,15 +265,17 @@ public:
   template <template <typename...> class Variant,
            template <typename...> class Tuple>
   using value_types = typename concat_type_lists_unique_t<
-        typename Source::template value_types<type_list, Tuple>,
-        typename decltype(std::declval<Done>()())::template value_types<type_list, Tuple>
+        typename sender_traits<Source>::template value_types<type_list, Tuple>,
+        typename sender_traits<final_sender_t>::template value_types<type_list, Tuple>
       >::template apply<Variant>;
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      typename Source::template error_types<type_list>,
-      typename decltype(std::declval<Done>()())::template error_types<type_list>,
+      typename sender_traits<Source>::template error_types<type_list>,
+      typename sender_traits<final_sender_t>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<final_sender_t>::sends_done;
 
   template <typename Source2, typename Done2>
   explicit type(Source2&& source, Done2&& done)

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -280,6 +280,8 @@ struct _stream<Values...>::type {
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
+    static constexpr bool sends_done = true;
+
     template <typename Receiver>
     struct _op {
       struct type {
@@ -334,6 +336,8 @@ struct _stream<Values...>::type {
 
     template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = true;
 
     template <typename Receiver>
     struct _op {

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -261,14 +261,18 @@ struct _sender<Predecessor, Successor>::type {
       template <typename...> class Variant,
       template <typename...> class Tuple>
   using value_types = type_list_nested_apply_t<
-      typename Predecessor::template value_types<concat_type_lists_unique_t, overload_list>,
+      typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, overload_list>,
       Variant, Tuple>;
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      typename Predecessor::template error_types<type_list>,
-      typename Successor::template error_types<type_list>,
+      typename sender_traits<Predecessor>::template error_types<type_list>,
+      typename sender_traits<Successor>::template error_types<type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done =
+    sender_traits<Predecessor>::sends_done ||
+    sender_traits<Successor>::sends_done;
 
   friend constexpr blocking_kind tag_invoke(
       tag_t<blocking>,

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -113,7 +113,7 @@ using unique_decayed_error_types = concat_type_lists_unique_t<
 
 template <template <typename...> class Variant, typename... Senders>
 using error_types = typename concat_type_lists_unique_t<
-    typename Senders::template error_types<unique_decayed_error_types>...,
+    typename sender_traits<Senders>::template error_types<unique_decayed_error_types>...,
     type_list<std::exception_ptr>>::template apply<Variant>;
 
 template <typename... Values>
@@ -121,7 +121,7 @@ using decayed_value_tuple = type_list<std::tuple<std::decay_t<Values>...>>;
 
 template <typename Sender>
 using value_variant_for_sender =
-  typename Sender::template value_types<concat_type_lists_unique_t, decayed_value_tuple>::template apply<std::variant>;
+  typename sender_traits<Sender>::template value_types<concat_type_lists_unique_t, decayed_value_tuple>::template apply<std::variant>;
 
 template <size_t Index, typename Receiver, typename... Senders>
 struct _element_receiver {
@@ -296,6 +296,8 @@ class _sender<Senders...>::type {
 
   template <template <typename...> class Variant>
   using error_types = error_types<Variant, Senders...>;
+
+  static constexpr bool sends_done = true;
 
   template <typename... Senders2>
   explicit type(Senders2&&... senders)

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -111,10 +111,12 @@ class _sender<CPO, Value, Sender>::type {
 public:
   template <template <typename...> class Variant,
             template <typename...> class Tuple>
-  using value_types = typename Sender::template value_types<Variant, Tuple>;
+  using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename Sender::template error_types<Variant>;
+  using error_types = typename sender_traits<Sender>::template error_types<Variant>;
+
+  static constexpr bool sends_done = sender_traits<Sender>::sends_done;
 
   template <typename Sender2, typename Value2>
   explicit type(Sender2 &&sender, Value2 &&value)

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -101,6 +101,8 @@ struct string_const_ref_sender {
   template <template <typename...> class Variant>
   using error_types = Variant<const std::exception_ptr&>;
 
+  static constexpr bool sends_done = false;
+
   template <typename Receiver>
   struct operation {
     unifex::remove_cvref_t<Receiver> receiver_;


### PR DESCRIPTION
Also update all lookups of `value_types/error_types/sends_done`
on other senders to go through `sender_traits` instead of looking
for them directly on the sender.
