### PR TITLE
Fix an unused variable warning

### DIFF
--- a/test/indexed_for_test.cpp
+++ b/test/indexed_for_test.cpp
@@ -96,4 +96,8 @@ TEST(indexed_for, Pipeable) {
           x = x + idx;
         })
     | sync_wait();
+
+  // ranges::iota_view{10} produces [0, 9] so our accumulator is summing
+  // 42 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 +  9, which is 42 + 45 = 87.
+  EXPECT_EQ(87, *result);
 }


### PR DESCRIPTION
Building with `-Werror,-Wunused-variable` produces this error:

```
libunifex/test/indexed_for_test.cpp:91:8: error: unused variable 'result'
[-Werror,-Wunused-variable]
  auto result = just(42)
       ^
1 error generated.
```

This change fixes the error by using `result` to confirm that the
calculated sum is as expected.