### PR TITLE
ADL-isolate task<T>::awaiter<U> and _await_transform::_as_awaiter<T>

### DIFF
--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -38,7 +38,7 @@ using namespace unifex;
 
 template<typename Sender>
 auto done_as_optional(Sender&& sender) {
-  using value_type = unifex::single_value_result_t<unifex::remove_cvref_t<Sender>>;
+  using value_type = unifex::sender_single_value_result_t<unifex::remove_cvref_t<Sender>>;
   return unifex::transform_done(
     unifex::transform((Sender&&)sender, [](auto&&... values) {
       return std::optional<value_type>{std::in_place, static_cast<decltype(values)>(values)...};

--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -85,10 +85,10 @@ namespace _alloc {
     template <
         template <typename...> class Variant,
         template <typename...> class Tuple>
-    using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
     template <template <typename...> class Variant>
-    using error_types = typename sender_traits<Sender>::template error_types<Variant>;
+    using error_types = sender_error_types_t<Sender, Variant>;
 
     static constexpr bool sends_done = sender_traits<Sender>::sends_done;
 

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -92,7 +92,8 @@ protected:
       (requires (constructible_from<Value, Us...> ||
           (std::is_void_v<Value> && sizeof...(Us) == 0)))
     void set_value(Us&&... us) &&
-        noexcept(std::is_nothrow_constructible_v<Value, Us...>) {
+        noexcept(std::is_nothrow_constructible_v<Value, Us...> ||
+            std::is_void_v<Value>) {
       unifex::activate_union_member(result_->value_, (Us&&) us...);
       result_->state_ = state::value;
       continuation_.resume();

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -41,8 +41,7 @@ namespace _await_transform {
 
 template <typename Promise, typename Sender>
 class _as_awaitable {
-  using value_t = typename sender_traits<remove_cvref_t<Sender>>::
-        template value_types<single_overload, single_value_type>::type::type;
+  using value_t = sender_single_value_return_type_t<remove_cvref_t<Sender>>;
   
   enum class state { empty, value, exception, done };
 

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -37,74 +37,24 @@
 
 namespace unifex {
 
-namespace _await_transform {
+namespace _await_tfx {
+
+template <typename Promise, typename Value>
+struct _awaitable_base {
+  struct type;
+};
 
 template <typename Promise, typename Sender>
-class _as_awaitable {
-  using value_t = sender_single_value_return_type_t<remove_cvref_t<Sender>>;
-  
-  enum class state { empty, value, exception, done };
+struct _awaitable {
+  struct type;
+};
 
-  class receiver {
-  public:
-    explicit receiver(_as_awaitable* op, coro::coroutine_handle<Promise> continuation) noexcept
-    : op_(op)
-    , continuation_(continuation)
-    {}
+enum class state { empty, value, exception, done };
 
-    receiver(receiver&& r) noexcept
-    : op_(std::exchange(r.op_, nullptr))
-    , continuation_(std::exchange(r.continuation_, nullptr))
-    {}
-
-    template(class... Us)
-      (requires (constructible_from<value_t, Us...> || (std::is_void_v<value_t> && sizeof...(Us) == 0)))
-    void set_value(Us&&... us) &&
-        noexcept(std::is_nothrow_constructible_v<value_t, Us...>) {
-      unifex::activate_union_member(op_->value_, (Us&&) us...);
-      op_->state_ = state::value;
-      continuation_.resume();
-    }
-
-    void set_error(std::exception_ptr eptr) && noexcept {
-      unifex::activate_union_member(op_->exception_, std::move(eptr));
-      op_->state_ = state::exception;
-      continuation_.resume();
-    }
-    
-    void set_done() && noexcept {
-      static_assert(sender_traits<remove_cvref_t<Sender>>::sends_done);
-      op_->state_ = state::done;
-      continuation_.promise().unhandled_done().resume();
-    }
-
-    template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Promise&>)
-    friend auto tag_invoke(CPO cpo, const receiver& r)
-        noexcept(is_nothrow_callable_v<CPO, const Promise&>)
-        -> callable_result_t<CPO, const Promise&> {
-      const Promise& p = r.continuation_.promise();
-      return std::move(cpo)(p);
-    }
-
-    template <typename Func>
-    friend void
-    tag_invoke(tag_t<visit_continuations>, const receiver& r, Func&& func) {
-      visit_continuations(r.continuation_.promise(), (Func&&)func);
-    }
-
-  private:
-    _as_awaitable* op_;
-    coro::coroutine_handle<Promise> continuation_;
-  };
-
-public:
-  explicit _as_awaitable(Sender&& sender, coro::coroutine_handle<Promise> h)
-    noexcept(is_nothrow_connectable_v<Sender, receiver>)
-  : op_(unifex::connect((Sender&&)sender, receiver{this, h}))
-  {}
-
-  ~_as_awaitable() {
+template <typename Value>
+struct _expected {
+  _expected() noexcept {}
+  ~_expected() {
     switch(state_) {
     case state::value:
       unifex::deactivate_union_member(value_);
@@ -116,32 +66,108 @@ public:
     }
   }
 
+  state state_ = state::empty;
+  union {
+    manual_lifetime<Value> value_;
+    manual_lifetime<std::exception_ptr> exception_;
+  };
+};
+
+template <typename Promise, typename Value>
+struct _awaitable_base<Promise, Value>::type {
+protected:
+  struct _rec {
+  public:
+    explicit _rec(_expected<Value>* result, coro::coroutine_handle<Promise> continuation) noexcept
+    : result_(result)
+    , continuation_(continuation)
+    {}
+
+    _rec(_rec&& r) noexcept
+    : result_(std::exchange(r.result_, nullptr))
+    , continuation_(std::exchange(r.continuation_, nullptr))
+    {}
+
+    template(class... Us)
+      (requires (constructible_from<Value, Us...> ||
+          (std::is_void_v<Value> && sizeof...(Us) == 0)))
+    void set_value(Us&&... us) &&
+        noexcept(std::is_nothrow_constructible_v<Value, Us...>) {
+      unifex::activate_union_member(result_->value_, (Us&&) us...);
+      result_->state_ = state::value;
+      continuation_.resume();
+    }
+
+    void set_error(std::exception_ptr eptr) && noexcept {
+      unifex::activate_union_member(result_->exception_, std::move(eptr));
+      result_->state_ = state::exception;
+      continuation_.resume();
+    }
+    
+    void set_done() && noexcept {
+      result_->state_ = state::done;
+      continuation_.promise().unhandled_done().resume();
+    }
+
+    template(typename CPO)
+      (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Promise&>)
+    friend auto tag_invoke(CPO cpo, const _rec& r)
+        noexcept(is_nothrow_callable_v<CPO, const Promise&>)
+        -> callable_result_t<CPO, const Promise&> {
+      const Promise& p = r.continuation_.promise();
+      return std::move(cpo)(p);
+    }
+
+    template <typename Func>
+    friend void
+    tag_invoke(tag_t<visit_continuations>, const _rec& r, Func&& func) {
+      visit_continuations(r.continuation_.promise(), (Func&&)func);
+    }
+
+  private:
+    _expected<Value>* result_;
+    coro::coroutine_handle<Promise> continuation_;
+  };
+
+  _expected<Value> result_;
+
+public:
   bool await_ready() const noexcept {
     return false;
   }
 
+  Value await_resume() {
+    switch (result_.state_) {
+    case state::value:
+      return std::move(result_.value_).get();
+    default:
+      assert(result_.state_ == state::exception);
+      std::rethrow_exception(result_.exception_.get());
+    }
+  }
+};
+
+template <typename Promise, typename Sender>
+struct _awaitable<Promise, Sender>::type
+  : _awaitable_base<Promise, sender_single_value_return_type_t<Sender>>::type {
+private:
+  using _base =
+      typename _awaitable_base<Promise, sender_single_value_return_type_t<Sender>>::type;
+  using _rec = typename _base::_rec;
+  connect_result_t<Sender, _rec> op_;
+public:
+  explicit type(Sender&& sender, coro::coroutine_handle<Promise> h)
+    noexcept(is_nothrow_connectable_v<Sender, _rec>)
+  : op_(unifex::connect((Sender&&)sender, _rec{&this->result_, h}))
+  {}
+
   void await_suspend(coro::coroutine_handle<Promise>) noexcept {
     unifex::start(op_);
   }
-
-  value_t await_resume() {
-    switch (state_) {
-    case state::value:
-      return std::move(value_).get();
-    default:
-      assert(state_ == state::exception);
-      std::rethrow_exception(exception_.get());
-    }
-  }
-
-private:
-  state state_ = state::empty;
-  union {
-    manual_lifetime<value_t> value_;
-    manual_lifetime<std::exception_ptr> exception_;
-  };
-  connect_result_t<Sender, receiver> op_;
 };
+
+template <typename Promise, typename Sender>
+using _as_awaitable = typename _awaitable<Promise, Sender>::type;
 
 struct _fn {
   // Call custom implementation if present.
@@ -171,7 +197,7 @@ struct _fn {
   }
 };
 
-} // namespace _await_transform
+} // namespace _await_tfx
 
 // The await_transform() customisation point allows value-types to customise
 // what kind of awaitable object should be used for this type when it is used
@@ -182,7 +208,7 @@ struct _fn {
 //
 // Coroutine promise_types can implement their .await_transform() methods to
 // forward to this customisation point to enable use of type customisations.
-inline constexpr _await_transform::_fn await_transform;
+inline constexpr _await_tfx::_fn await_transform;
 
 } // namespace unifex
 

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -95,10 +95,10 @@ template<typename Source>
 class _join_sender<Source>::type {
 public:
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename sender_traits<Source>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename sender_traits<Source>::template error_types<Variant>;
+    using error_types = sender_error_types_t<Source, Variant>;
 
     static constexpr bool sends_done = sender_traits<Source>::sends_done;
 

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -164,7 +164,7 @@ public:
     using next_types = Variant<Tuple<Integral>>;
 
     template<template<typename...> class Variant>
-    using error_types = typename sender_traits<schedule_sender_t>::template error_types<Variant>;
+    using error_types = sender_error_types_t<schedule_sender_t, Variant>;
 
     static constexpr bool sends_done = true;
 

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -156,10 +156,10 @@ public:
         Tuple>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename sender_traits<Source>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename sender_traits<Source>::template error_types<Variant>;
+    using error_types = sender_error_types_t<Source, Variant>;
 
     static constexpr bool sends_done = sender_traits<Source>::sends_done;
 

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -145,14 +145,18 @@ namespace _demat {
     template <
         template <typename...> class Variant,
         template <typename...> class Tuple>
-    using value_types = typename sender_traits<Source>::template value_types<
-        variant<Variant>::template apply,
-        tuple<tag_t<set_value>, Tuple>::template apply>;
+    using value_types =
+        sender_value_types_t<
+            Source,
+            variant<Variant>::template apply,
+            tuple<tag_t<set_value>, Tuple>::template apply>;
 
     template <template <typename...> class Variant>
-    using error_types = typename sender_traits<Source>::template value_types<
-        variant<append_error_types<Variant>::template apply>::template apply,
-        tuple<tag_t<set_error>, single_type_t>::template apply>;
+    using error_types =
+        sender_value_types_t<
+            Source,
+            variant<append_error_types<Variant>::template apply>::template apply,
+            tuple<tag_t<set_error>, single_type_t>::template apply>;
 
     static constexpr bool sends_done = sender_traits<Source>::sends_done;
 

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -577,14 +577,16 @@ namespace unifex
       union {
         // Storage for error-types that might be produced by SourceSender.
         UNIFEX_NO_UNIQUE_ADDRESS
-        typename remove_cvref_t<SourceSender>::template error_types<error_result_union>
+        sender_error_types_t<remove_cvref_t<SourceSender>, error_result_union>
             error_;
 
         // Storage for value-types that might be produced by SourceSender.
-        UNIFEX_NO_UNIQUE_ADDRESS typename sender_traits<remove_cvref_t<SourceSender>>::template value_types<
+        UNIFEX_NO_UNIQUE_ADDRESS
+        sender_value_types_t<
+            remove_cvref_t<SourceSender>,
             manual_lifetime_union,
             decayed_tuple<std::tuple>::template apply>
-            value_;
+                value_;
       };
 
       using source_operation_t =
@@ -592,11 +594,14 @@ namespace unifex
             SourceSender,
             receiver_t<SourceSender, CompletionSender, Receiver>>>;
 
-      using completion_value_union_t = typename remove_cvref_t<SourceSender>::
-          template value_types<manual_lifetime_union, value_operation>;
+      using completion_value_union_t =
+          sender_value_types_t<
+              remove_cvref_t<SourceSender>,
+              manual_lifetime_union,
+              value_operation>;
 
-      using completion_error_union_t = typename remove_cvref_t<SourceSender>::
-          template error_types<error_operation_union>;
+      using completion_error_union_t =
+          sender_error_types_t<remove_cvref_t<SourceSender>, error_operation_union>;
 
       // Operation storage.
       union {
@@ -642,12 +647,11 @@ namespace unifex
       // TODO: In theory we could eliminate exception_ptr in the case that the
       // connect() operation and move/copy of values
       template <template <typename...> class Variant>
-      using error_types = typename concat_type_lists_unique_t<
-          typename sender_traits<SourceSender>::template error_types<
-              decayed_tuple<type_list>::template apply>,
-          typename sender_traits<CompletionSender>::template error_types<
-              decayed_tuple<type_list>::template apply>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+      using error_types =
+          typename concat_type_lists_unique_t<
+              sender_error_types_t<SourceSender, decayed_tuple<type_list>::template apply>,
+              sender_error_types_t<CompletionSender, decayed_tuple<type_list>::template apply>,
+              type_list<std::exception_ptr>>::template apply<Variant>;
 
       static constexpr bool sends_done =
           sender_traits<SourceSender>::sends_done ||

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -134,12 +134,13 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
   template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
-  using value_types = typename sender_traits<Predecessor>::template value_types<Variant, Tuple>;
+  using value_types = sender_value_types_t<Predecessor, Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<Predecessor>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<Predecessor, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -273,17 +273,16 @@ class _sender<Predecessor, SuccessorFactory>::type {
 
   template <template <typename...> class List>
   using successor_types =
-      typename sender_traits<Predecessor>::template value_types<List, successor_type>;
+      sender_value_types_t<Predecessor, List, successor_type>;
 
   template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
   struct value_types_impl {
-   public:
     template <typename... Senders>
-    using apply = typename concat_type_lists_unique_t<
-        typename sender_traits<Senders>::template value_types<type_list, Tuple>...
-        >::template apply<Variant>;
+    using apply =
+        typename concat_type_lists_unique_t<
+            sender_value_types_t<Senders, type_list, Tuple>...>::template apply<Variant>;
   };
 
   // TODO: Ideally we'd only conditionally add the std::exception_ptr type
@@ -302,9 +301,10 @@ class _sender<Predecessor, SuccessorFactory>::type {
   template <template <typename...> class Variant>
   struct error_types_impl {
     template <typename... Senders>
-    using apply = typename concat_type_lists_unique_t<
-        typename sender_traits<Senders>::template error_types<type_list>...,
-        type_list<std::exception_ptr>>::template apply<Variant>;
+    using apply =
+        typename concat_type_lists_unique_t<
+            sender_error_types_t<Senders, type_list>...,
+            type_list<std::exception_ptr>>::template apply<Variant>;
   };
 
 public:

--- a/include/unifex/let_with.hpp
+++ b/include/unifex/let_with.hpp
@@ -52,10 +52,10 @@ public:
     using InnerOp = std::invoke_result_t<SuccessorFactory, callable_result_t<StateFactory>&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename sender_traits<InnerOp>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<InnerOp, Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename sender_traits<InnerOp>::template error_types<Variant>;
+    using error_types = sender_error_types_t<InnerOp, Variant>;
 
     static constexpr bool sends_done = sender_traits<InnerOp>::sends_done;
 

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -108,10 +108,10 @@ public:
     using InnerOp = std::invoke_result_t<SuccessorFactory, inplace_stop_source&>;
 
     template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = typename sender_traits<InnerOp>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<InnerOp, Variant, Tuple>;
 
     template<template<typename...> class Variant>
-    using error_types = typename sender_traits<InnerOp>::template error_types<Variant>;
+    using error_types = sender_error_types_t<InnerOp, Variant>;
 
     static constexpr bool sends_done = sender_traits<InnerOp>::sends_done;
 

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -154,7 +154,7 @@ namespace unifex
               template apply>;
 
       using type =
-          typename sender_traits<Source>::template value_types<value_variant, value_tuple>;
+          sender_value_types_t<Source, value_variant, value_tuple>;
     };
 
     template <typename Source>

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -298,10 +298,11 @@ struct _sender<StreamSender, State, ReducerFunc>::type {
   using value_types = Variant<Tuple<State>>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<next_sender_t<StreamSender>>::template error_types<type_list>,
-      typename sender_traits<cleanup_sender_t<StreamSender>>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<next_sender_t<StreamSender>, type_list>,
+          sender_error_types_t<cleanup_sender_t<StreamSender>, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = false;
 

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -194,9 +194,10 @@ public:
   using value_types = Variant<Tuple<>>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<Source>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<Source, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = true;
 

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -326,23 +326,26 @@ class _sender<Source, Func>::type {
   using trigger_sender = std::invoke_result_t<Func&, remove_cvref_t<Error>>;
 
   template <typename... Errors>
-  using make_error_type_list = typename concat_type_lists_unique<
-      typename sender_traits<trigger_sender<Errors>>::template error_types<type_list>...,
-      type_list<std::exception_ptr>>::type;
+  using make_error_type_list =
+      typename concat_type_lists_unique<
+          sender_error_types_t<trigger_sender<Errors>, type_list>...,
+          type_list<std::exception_ptr>>::type;
 
   template <typename... Errors>
   using sends_done_impl = any_sends_done<Source, trigger_sender<Errors>...>;
 
 public:
   template <template <typename...> class Variant,
-           template <typename...> class Tuple>
-  using value_types = typename sender_traits<Source>::template value_types<Variant, Tuple>;
+            template <typename...> class Tuple>
+  using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename sender_traits<Source>::template error_types<make_error_type_list>::template apply<Variant>;
+  using error_types =
+      typename sender_error_types_t<Source, make_error_type_list>::template
+          apply<Variant>;
 
   static constexpr bool sends_done =
-    sender_traits<Source>::template error_types<sends_done_impl>::value;
+    sender_error_types_t<Source, sends_done_impl>::value;
 
   template <typename Source2, typename Func2>
   explicit type(Source2&& source, Func2&& func)

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -373,16 +373,18 @@ namespace detail {
 } // namespace detail
 /// \endcond
 
-template <typename Sender, typename Adaptor>
-using adapt_error_types_t =
-    typename sender_traits<Sender>::template error_types<Adaptor::template apply>;
-
 template <
     typename Sender,
     template <typename...> class Variant,
-    typename Adaptor>
-using adapt_value_types_t =
-    typename sender_traits<Sender>::template value_types<Variant, typename Adaptor::apply>;
+    template <typename...> class Tuple>
+using sender_value_types_t =
+    typename sender_traits<Sender>::template value_types<Variant, Tuple>;
+
+template <
+    typename Sender,
+    template <typename...> class Variant>
+using sender_error_types_t =
+    typename sender_traits<Sender>::template error_types<Variant>;
 
 template <typename... Types>
 struct single_value_type {
@@ -418,13 +420,16 @@ public:
 };
 
 template <typename Sender>
-using single_value_result_t = non_void_t<wrap_reference_t<decay_rvalue_t<
-    typename Sender::template value_types<single_overload, single_value_type>::
-        type::type>>>;
+using sender_single_value_return_type_t =
+    typename sender_value_types_t<Sender, single_overload, single_value_type>::type::type;
+
+template <typename Sender>
+using sender_single_value_result_t =
+    non_void_t<wrap_reference_t<decay_rvalue_t<sender_single_value_return_type_t<Sender>>>>;
 
 template <typename Sender>
 constexpr bool is_sender_nofail_v =
-    Sender::template error_types<is_empty_list>::value;
+    sender_error_types_t<Sender, is_empty_list>::value;
 
 } // namespace unifex
 

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -300,13 +300,14 @@ namespace unifex
           template <typename...> class Variant,
           template <typename...> class Tuple>
       using value_types =
-          typename sender_traits<Successor>::template value_types<Variant, Tuple>;
+          sender_value_types_t<Successor, Variant, Tuple>;
 
       template <template <typename...> class Variant>
-      using error_types = typename concat_type_lists_unique_t<
-          typename sender_traits<Predecessor>::template error_types<type_list>,
-          typename sender_traits<Successor>::template error_types<type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+      using error_types =
+          typename concat_type_lists_unique_t<
+              sender_error_types_t<Predecessor, type_list>,
+              sender_error_types_t<Successor, type_list>,
+              type_list<std::exception_ptr>>::template apply<Variant>;
 
       static constexpr bool sends_done =
         sender_traits<Predecessor>::sends_done ||

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -92,10 +92,10 @@ struct _stream<Sender>::type {
 
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
-    using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
+    using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
     template <template <typename...> class Variant>
-    using error_types = typename sender_traits<Sender>::template error_types<Variant>;
+    using error_types = sender_error_types_t<Sender, Variant>;
 
     static constexpr bool sends_done = true;
 

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -205,11 +205,11 @@ struct _stream<SourceStream, Values...>::type {
     template <template <typename...> class Variant,
              template <typename...> class Tuple>
     using value_types =
-      typename sender_traits<next_sender_t<SourceStream>>::template value_types<Variant, Tuple>;
+      sender_value_types_t<next_sender_t<SourceStream>, Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      typename sender_traits<next_sender_t<SourceStream>>::template error_types<Variant>;
+      sender_error_types_t<next_sender_t<SourceStream>, Variant>;
 
     static constexpr bool sends_done = true;
 
@@ -313,9 +313,10 @@ struct _stream<SourceStream, Values...>::type {
     using value_types = Variant<>;
 
     template <template <typename...> class Variant>
-    using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<cleanup_sender_t<SourceStream>>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+    using error_types =
+        typename concat_type_lists_unique_t<
+            sender_error_types_t<cleanup_sender_t<SourceStream>, type_list>,
+            type_list<std::exception_ptr>>::template apply<Variant>;
 
     static constexpr bool sends_done = true;
 

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -261,12 +261,12 @@ namespace unifex
       using error_tuples = type_list<
           std::tuple<tag_t<unifex::set_error>, std::decay_t<Errors>>...>;
 
-      using result_variant = typename concat_type_lists_t<
-          type_list<std::tuple<>, std::tuple<tag_t<unifex::set_done>>>,
-          typename sender_traits<std::remove_reference_t<
-              Source>>::template value_types<type_list, value_decayed_tuple>,
-          typename sender_traits<std::remove_reference_t<Source>>::template error_types<
-              error_tuples>>::template apply<std::variant>;
+      using result_variant =
+          typename concat_type_lists_t<
+              type_list<std::tuple<>, std::tuple<tag_t<unifex::set_done>>>,
+              sender_value_types_t<remove_cvref_t<Source>, type_list, value_decayed_tuple>,
+              sender_error_types_t<remove_cvref_t<Source>, error_tuples>>::template
+                  apply<std::variant>;
 
       UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
       std::atomic<int> activeOpCount_ = 2;
@@ -276,8 +276,8 @@ namespace unifex
           stopCallback_;
       UNIFEX_NO_UNIQUE_ADDRESS result_variant result_;
       UNIFEX_NO_UNIQUE_ADDRESS connect_result_t<Source, source_receiver> sourceOp_;
-      UNIFEX_NO_UNIQUE_ADDRESS connect_result_t<Trigger, trigger_receiver>
-          triggerOp_;
+      UNIFEX_NO_UNIQUE_ADDRESS
+      connect_result_t<Trigger, trigger_receiver> triggerOp_;
     };
 
     template <typename Source, typename Trigger>
@@ -316,10 +316,10 @@ namespace unifex
               template apply<compose_nested<Variant, Tuple>::template apply>;
 
       template <template <typename...> class Variant>
-      using error_types = typename concat_type_lists_unique_t<
-          typename sender_traits<Source>::template error_types<
-              decayed_tuple<type_list>::template apply>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+      using error_types =
+          typename concat_type_lists_unique_t<
+              sender_error_types_t<Source, decayed_tuple<type_list>::template apply>,
+              type_list<std::exception_ptr>>::template apply<Variant>;
 
       static constexpr bool sends_done = true;
 

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -144,8 +144,8 @@ namespace _sync_wait_cpo {
     template(typename Sender)
       (requires typed_sender<Sender>)
     auto operator()(Sender&& sender) const
-        -> std::optional<single_value_result_t<remove_cvref_t<Sender>>> {
-      using Result = single_value_result_t<remove_cvref_t<Sender>>;
+        -> std::optional<sender_single_value_result_t<remove_cvref_t<Sender>>> {
+      using Result = sender_single_value_result_t<remove_cvref_t<Sender>>;
       return _sync_wait::_impl<Result>((Sender&&) sender);
     }
     constexpr auto operator()() const

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -101,7 +101,7 @@ struct _stream<SourceStream, TriggerStream>::type {
 
     template <template <typename...> class Variant>
     using error_types =
-      typename sender_traits<next_sender_t<SourceStream>>::template error_types<Variant>;
+      sender_error_types_t<next_sender_t<SourceStream>, Variant>;
 
     static constexpr bool sends_done = sender_traits<next_sender_t<SourceStream>>::sends_done;
 
@@ -209,7 +209,7 @@ struct _stream<SourceStream, TriggerStream>::type {
 
     template <template <typename...> class Variant>
     using error_types =
-      typename sender_traits<cleanup_sender_t<SourceStream>>::template error_types<Variant>;
+      sender_error_types_t<cleanup_sender_t<SourceStream>, Variant>;
 
     static constexpr bool sends_done = true;
 

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -385,7 +385,7 @@ class thread_unsafe_event_loop {
 
   template <
       typename Sender,
-      typename Result = single_value_result_t<remove_cvref_t<Sender>>>
+      typename Result = sender_single_value_result_t<remove_cvref_t<Sender>>>
   std::optional<Result> sync_wait(Sender&& sender) {
     using promise_t = _thread_unsafe_event_loop::sync_wait_promise<Result>;
     promise_t promise;

--- a/include/unifex/transform.hpp
+++ b/include/unifex/transform.hpp
@@ -142,15 +142,17 @@ public:
   template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
-  using value_types = type_list_nested_apply_t<
-    typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, result>,
-    Variant,
-    Tuple>;
+  using value_types =
+      type_list_nested_apply_t<
+          sender_value_types_t<Predecessor, concat_type_lists_unique_t, result>,
+          Variant,
+          Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-    typename sender_traits<Predecessor>::template error_types<type_list>,
-    type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<Predecessor, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 

--- a/include/unifex/transform_done.hpp
+++ b/include/unifex/transform_done.hpp
@@ -264,17 +264,19 @@ class _sndr<Source, Done>::type {
 
 public:
   template <template <typename...> class Variant,
-           template <typename...> class Tuple>
-  using value_types = typename concat_type_lists_unique_t<
-        typename sender_traits<Source>::template value_types<type_list, Tuple>,
-        typename sender_traits<final_sender_t>::template value_types<type_list, Tuple>
-      >::template apply<Variant>;
+            template <typename...> class Tuple>
+  using value_types =
+      typename concat_type_lists_unique_t<
+          sender_value_types_t<Source, type_list, Tuple>,
+          sender_value_types_t<final_sender_t, type_list, Tuple>>::template
+              apply<Variant>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<Source>::template error_types<type_list>,
-      typename sender_traits<final_sender_t>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<Source, type_list>,
+          sender_error_types_t<final_sender_t, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<final_sender_t>::sends_done;
 

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -260,15 +260,17 @@ struct _sender<Predecessor, Successor>::type {
   template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
-  using value_types = type_list_nested_apply_t<
-      typename sender_traits<Predecessor>::template value_types<concat_type_lists_unique_t, overload_list>,
-      Variant, Tuple>;
+  using value_types =
+      type_list_nested_apply_t<
+          sender_value_types_t<Predecessor, concat_type_lists_unique_t, overload_list>,
+          Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename concat_type_lists_unique_t<
-      typename sender_traits<Predecessor>::template error_types<type_list>,
-      typename sender_traits<Successor>::template error_types<type_list>,
-      type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types =
+      typename concat_type_lists_unique_t<
+          sender_error_types_t<Predecessor, type_list>,
+          sender_error_types_t<Successor, type_list>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done =
     sender_traits<Predecessor>::sends_done ||

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -112,16 +112,18 @@ using unique_decayed_error_types = concat_type_lists_unique_t<
   type_list<std::decay_t<Errors>>...>;
 
 template <template <typename...> class Variant, typename... Senders>
-using error_types = typename concat_type_lists_unique_t<
-    typename sender_traits<Senders>::template error_types<unique_decayed_error_types>...,
-    type_list<std::exception_ptr>>::template apply<Variant>;
+using error_types =
+    typename concat_type_lists_unique_t<
+        sender_error_types_t<Senders, unique_decayed_error_types>...,
+        type_list<std::exception_ptr>>::template apply<Variant>;
 
 template <typename... Values>
 using decayed_value_tuple = type_list<std::tuple<std::decay_t<Values>...>>;
 
 template <typename Sender>
 using value_variant_for_sender =
-  typename sender_traits<Sender>::template value_types<concat_type_lists_unique_t, decayed_value_tuple>::template apply<std::variant>;
+  typename sender_value_types_t<Sender, concat_type_lists_unique_t, decayed_value_tuple>
+      ::template apply<std::variant>;
 
 template <size_t Index, typename Receiver, typename... Senders>
 struct _element_receiver {

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -112,10 +112,10 @@ class _sender<CPO, Value, Sender>::type {
 public:
   template <template <typename...> class Variant,
             template <typename...> class Tuple>
-  using value_types = typename sender_traits<Sender>::template value_types<Variant, Tuple>;
+  using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types = typename sender_traits<Sender>::template error_types<Variant>;
+  using error_types = sender_error_types_t<Sender, Variant>;
 
   static constexpr bool sends_done = sender_traits<Sender>::sends_done;
 


### PR DESCRIPTION
Also, refactor `_task` for slightly shorter type names and refactor `_await_transform::_as_awaiter` so that all senders of the same value type share most of the implementation.