### PR TITLE
enhance any_sender_of to permit type-erased receiver queries

### DIFF
--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -46,7 +46,7 @@ struct vtable_entry<CPO, Ret(Args...)> {
   static constexpr vtable_entry create() noexcept {
     constexpr fn_t* f =
         [](_overload::base_cpo_t<CPO> cpo,
-           replace_this_with_void_ptr_t<Args>... args) {
+           replace_this_with_void_ptr_t<Args>... args) -> Ret {
       void* thisPointer = extract_this<Args...>{}(args...);
       T& obj = *static_cast<T*>(thisPointer);
       return std::move(cpo)(
@@ -76,7 +76,7 @@ struct vtable_entry<CPO, Ret(Args...) noexcept> {
   static constexpr vtable_entry create() noexcept {
     constexpr fn_t* f = [](
         _overload::base_cpo_t<CPO> cpo,
-        replace_this_with_void_ptr_t<Args>... args) noexcept {
+        replace_this_with_void_ptr_t<Args>... args) noexcept -> Ret {
       void* thisPointer = extract_this<Args...>{}(args...);
       T& obj = *static_cast<T*>(thisPointer);
       return std::move(cpo)(replace_this<Args>::get((Args&&)args, obj)...);

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -39,7 +39,8 @@ using join_receiver = typename _join_receiver<Receiver>::type;
 template<typename Receiver>
 class _join_receiver<Receiver>::type {
 public:
-    template<typename Receiver2>
+    template(typename Receiver2)
+      (requires constructible_from<Receiver, Receiver2>)
     explicit type(Receiver2&& r) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>)
     : receiver_((Receiver2&&)r)
     {}

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -42,8 +42,9 @@ namespace _inline_sched {
 
     UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-    template <typename Receiver2>
-    explicit type(Receiver2&& r)
+    template(typename Receiver2)
+      (requires constructible_from<Receiver, Receiver2>)
+    explicit type(Receiver2&& r) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>)
       : receiver_((Receiver2 &&) r) {}
 
     void start() noexcept {

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -42,7 +42,8 @@ namespace unifex
     template <typename Receiver>
     class _receiver<Receiver>::type {
     public:
-      template <typename Receiver2>
+      template(typename Receiver2)
+        (requires constructible_from<Receiver, Receiver2>)
       explicit type(Receiver2&& receiver) noexcept(
           std::is_nothrow_constructible_v<Receiver, Receiver2>)
         : receiver_(static_cast<Receiver2&&>(receiver)) {}

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -61,8 +61,10 @@ struct _op<Receiver>::type {
           template callback_type<cancel_callback>>
     stopCallback_;
 
-  template <typename Receiver2>
-  type(Receiver2&& receiver) : receiver_((Receiver2 &&) receiver) {}
+  template(typename Receiver2)
+    (requires constructible_from<Receiver, Receiver2>)
+  type(Receiver2&& receiver)
+    : receiver_((Receiver2 &&) receiver) {}
 
   void start() noexcept {
     assert(get_stop_token(receiver_).stop_possible());

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -44,7 +44,8 @@ struct _next_op<Sender, Receiver>::type {
   };
   bool done_;
 
-  template <typename Receiver2>
+  template(typename Receiver2)
+    (requires constructible_from<Receiver, Receiver2>)
   explicit type(Receiver2&& receiver)
     : receiver_((Receiver2&&)receiver)
     , done_(true)

--- a/test/bulk_schedule_test.cpp
+++ b/test/bulk_schedule_test.cpp
@@ -103,7 +103,7 @@ TEST(bulk, Pipeable) {
         }, unifex::par_unseq)
       | unifex::bulk_transform(
         [&](std::size_t index) noexcept {
-            output[index] = index;
+            output[index] = static_cast<int>(index);
         }, unifex::par_unseq)
       | unifex::bulk_join()
       | unifex::sync_wait();


### PR DESCRIPTION
This uses the `any_ref` in #186 to type-erase a reference to a receiver together with a set of receiver queries.

The test demonstrates how to use this to type-erase a `sender` such that all receivers connected to it will be type-erased along with the receiver queries; in this case, `get_scheduler`.