### PR TITLE
fix unused var warnings

### DIFF
--- a/test/materialize_test.cpp
+++ b/test/materialize_test.cpp
@@ -65,6 +65,7 @@ TEST(Materialize, Failure) {
           | materialize()
           | dematerialize()
           | sync_wait();
+        EXPECT_FALSE(!!result); // should be unreachable - silences unused warning
       } catch(const std::runtime_error& ex) { 
         EXPECT_STREQ(ex.what(), "failure"); 
         throw;

--- a/test/tag_invoke_test.cpp
+++ b/test/tag_invoke_test.cpp
@@ -40,13 +40,13 @@ static_assert(unifex::is_nothrow_tag_invocable_v<test_cpo, X, int>);
 static_assert(!unifex::is_nothrow_tag_invocable_v<test_cpo, Y>);
 
 TEST(tag_invoke, tag_invoke_usage) {
-    unifex::tag_invoke(test_cpo{}, X{});
+    unifex::tag_invoke(test, X{});
     EXPECT_TRUE(unifex::tag_invoke(test_cpo{}, X{}, 42));
 }
 
 TEST(tag_invoke, tag_invoke_constexpr) {
-    constexpr bool result1 = unifex::tag_invoke(test_cpo{}, X{}, 42);
-    constexpr bool result2 = unifex::tag_invoke(test_cpo{}, X{}, -3);
+    constexpr bool result1 = unifex::tag_invoke(test, X{}, 42);
+    constexpr bool result2 = unifex::tag_invoke(test, X{}, -3);
     EXPECT_TRUE(result1);
     EXPECT_FALSE(result2);
 }


### PR DESCRIPTION
these were failing on a build that enables warnings as errors