### PR TITLE
CMake: add 'noexcept' to final_suspend in test code

### DIFF
--- a/cmake/FindCoroutines.cmake
+++ b/cmake/FindCoroutines.cmake
@@ -188,7 +188,7 @@ if(CXX_COROUTINES_HAVE_COROUTINES)
             int result;
             present get_return_object() { return present{*this}; }
             @CXX_COROUTINES_NAMESPACE@::suspend_never initial_suspend() { return {}; }
-            @CXX_COROUTINES_NAMESPACE@::suspend_always final_suspend() { return {}; }
+            @CXX_COROUTINES_NAMESPACE@::suspend_always final_suspend() noexcept { return {}; }
             void return_value(int i) { result = i; }
             void unhandled_exception() {}
           };


### PR DESCRIPTION
Newer compilers require final_suspend to be noexcept. This patch
adapts the detection code to that.