### PR TITLE
Minor fixes for MSVC

### DIFF
--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -107,7 +107,7 @@ class context {
       static constexpr bool sends_done = true;
 
       template <typename Receiver>
-      operation<Receiver> connect(Receiver&& receiver) const& {
+      operation<Receiver> connect(Receiver&& receiver) const {
         return operation<Receiver>{(Receiver &&) receiver, loop_};
       }
 

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -144,7 +144,7 @@ namespace _timed_single_thread_context {
     static constexpr bool sends_done = true;
 
     template <typename Receiver>
-    after_operation<Duration, Receiver> connect(Receiver&& receiver) const & {
+    after_operation<Duration, Receiver> connect(Receiver&& receiver) const {
       return after_operation<Duration, Receiver>{
           *context_, duration_, (Receiver &&) receiver};
     }

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -46,25 +46,13 @@ class _receiver_wrapper<CPO, Value, Receiver>::type {
     return *r.val_;
   }
 
-  template <typename OtherCPO, typename... Args>
-  friend auto tag_invoke(OtherCPO cpo, const type &r, Args &&... args)
-      noexcept(is_nothrow_callable_v<OtherCPO, const Receiver &, Args...>)
-      -> callable_result_t<OtherCPO, const Receiver &, Args...> {
-    return ((OtherCPO &&) cpo)(std::as_const(r.receiver_), (Args &&) args...);
-  }
-
-  template <typename OtherCPO, typename... Args>
-  friend auto tag_invoke(OtherCPO cpo, type &r, Args &&... args)
-      noexcept(is_nothrow_callable_v<OtherCPO, Receiver &, Args...>)
-      -> callable_result_t<OtherCPO, Receiver &, Args...> {
-    return ((OtherCPO &&) cpo)(r.receiver_, (Args &&) args...);
-  }
-
-  template <typename OtherCPO, typename... Args>
-  friend auto tag_invoke(OtherCPO cpo, type &&r, Args &&... args)
-      noexcept(is_nothrow_callable_v<OtherCPO, Receiver, Args...>)
-      -> callable_result_t<OtherCPO, Receiver, Args...> {
-    return ((OtherCPO &&) cpo)((Receiver &&) r.receiver_, (Args &&) args...);
+  template(typename OtherCPO, typename Self, typename... Args)
+    (requires same_as<remove_cvref_t<Self>, type> AND
+              callable<OtherCPO, member_t<Self, Receiver>, Args...>)
+  friend auto tag_invoke(OtherCPO cpo, Self&& self, Args&&... args)
+      noexcept(is_nothrow_callable_v<OtherCPO, member_t<Self, Receiver>, Args...>)
+      -> callable_result_t<OtherCPO, member_t<Self, Receiver>, Args...> {
+    return static_cast<OtherCPO&&>(cpo)(static_cast<Self&&>(self).receiver_, static_cast<Args&&>(args)...);
   }
 
   Receiver receiver_;


### PR DESCRIPTION
- Remove lvalue-qualification of connect on some schedule senders.
- Simplify CPO forwarding in with_query_value() using a single tag_invoke() overload instead
  of separate overloads for lvalue/const-lvalue/rvalue receiver.

Both of these had been causing problems in recent MSVC builds which seems to
do overload resolution differently from GCC/Clang.