### PR TITLE
Support install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ If you want to build libunifex as C++20, add:
       -DCMAKE_CXX_STANDARD:STRING=20
 ```
 
+To specify install path, add:
+
+```sh
+      -DCMAKE_INSTALL_PREFIX=/path/to/install
+```
+
+The default value for `CMAKE_INSTALL_PREFIX` is `/usr/local` in Unix-like systems.
+
 ## Building Library + Running Tests
 
 To build the library and tests.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,3 +74,10 @@ target_compile_features(unifex PUBLIC cxx_std_17)
 if(CXX_COROUTINES_HAVE_COROUTINES)
   target_link_libraries(unifex PUBLIC std::coroutines)
 endif()
+
+install(DIRECTORY ${PROJECT_BINARY_DIR}/include/unifex ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
+install(TARGETS unifex
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)


### PR DESCRIPTION
The default install destination is `/usr/local` in Unix-like systems.
User can use `-CMAKE_INSTALL_PREFIX=/path/to/install` to specify install
position.

TODO: Verify the default install destination on Windows