### PR TITLE
add a scheduler_provider concept

### DIFF
--- a/include/unifex/async_manual_reset_event.hpp
+++ b/include/unifex/async_manual_reset_event.hpp
@@ -58,9 +58,10 @@ struct _sender {
     : evt_(&evt) {}
 
   template (typename Receiver)
-    (requires receiver_of<Receiver>)
+    (requires receiver_of<Receiver> AND scheduler_provider<Receiver>)
   operation<remove_cvref_t<Receiver>> connect(Receiver&& r) const noexcept(
-      noexcept(operation<remove_cvref_t<Receiver>>{std::declval<async_manual_reset_event&>(), (Receiver&&)r})) {
+      noexcept(operation<remove_cvref_t<Receiver>>{
+          UNIFEX_DECLVAL(async_manual_reset_event&), (Receiver&&)r})) {
     return operation<remove_cvref_t<Receiver>>{*evt_, (Receiver&&)r};
   }
 

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -178,6 +178,27 @@ template <typename SchedulerProvider>
 using get_scheduler_result_t =
     decltype(get_scheduler(UNIFEX_DECLVAL(SchedulerProvider&&)));
 
+// Define the scheduler concept without the macros for better diagnostics
+#if UNIFEX_CXX_CONCEPTS
+template <typename SP>
+concept //
+  scheduler_provider = //
+    requires(SP&& sp) {
+      get_scheduler((SP&&) sp);
+    };
+#else
+template <typename SP>
+UNIFEX_CONCEPT_FRAGMENT( //
+  _scheduler_provider,
+    requires(SP&& sp) (
+      get_scheduler((SP&&) sp)
+    ));
+template <typename SP>
+UNIFEX_CONCEPT //
+  scheduler_provider = //
+    UNIFEX_FRAGMENT(unifex::_scheduler_provider, SP);
+#endif
+
 namespace _schedule {
 struct sender {
   template <


### PR DESCRIPTION
Use `scheduler_provider` to constrain the `connect` of `async_manual_reset_event::async_wait`'s sender.

Also, improve the diagnostic when trying to `co_await` a sender that is not actually awaitable within the current coroutine.