### PR TITLE
add async_scope::spawn_call_on to simplify usage

### DIFF
--- a/examples/stream_cancellation.cpp
+++ b/examples/stream_cancellation.cpp
@@ -37,15 +37,14 @@ int main() {
 
   auto start = steady_clock::now();
 
-  on_stream(current_scheduler, range_stream{0, 20})
+  auto op = on_stream(current_scheduler, range_stream{0, 20})
     | for_each([](int value) {
         // Simulate some work
         std::printf("processing %i\n", value);
         std::this_thread::sleep_for(10ms);
       })
-    | stop_when(schedule_after(100ms))
-    | on(context.get_scheduler())
-    | sync_wait();
+    | stop_when(schedule_after(100ms));
+  sync_wait(on(context.get_scheduler(), std::move(op)));
 
   auto end = steady_clock::now();
 

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -157,7 +157,7 @@ public:
   }
 
   template (typename Fun, typename Scheduler)
-    (requires callable<Fun> && scheduler<Scheduler>)
+    (requires callable<Fun> AND scheduler<Scheduler>)
   void spawn_call_on(Fun&& fun, Scheduler&& scheduler) {
     static_assert(
       is_nothrow_callable_v<Fun>,

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -156,6 +156,17 @@ public:
     spawn(on((Sender&&) sender, (Scheduler&&) scheduler));
   }
 
+  template (typename Fun, typename Scheduler)
+    (requires callable<Fun> && scheduler<Scheduler>)
+  void spawn_call_on(Fun&& fun, Scheduler&& scheduler) {
+    static_assert(
+      is_nothrow_callable_v<Fun>,
+      "Please annotate your callable with noexcept.");
+    spawn_on(
+      transform(just(), (Fun&&) fun),
+      (Scheduler&&) scheduler);
+  }
+
   [[nodiscard]] auto cleanup() noexcept {
     return sequence(
         transform(just(), [this]() noexcept {

--- a/include/unifex/on_stream.hpp
+++ b/include/unifex/on_stream.hpp
@@ -31,7 +31,7 @@ namespace _on_stream {
       return adapt_stream(
           (StreamSender &&) stream,
           [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return on((decltype(sender))sender, s);
+            return on(s, (decltype(sender)) sender);
           });
     }
     template (typename StreamSender, typename Scheduler)
@@ -40,7 +40,7 @@ namespace _on_stream {
       return adapt_stream(
           (StreamSender &&) stream,
           [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return on((decltype(sender))sender, s);
+            return on(s, (decltype(sender)) sender);
           });
     }
     template(typename Scheduler)

--- a/test/async_scope_test.cpp
+++ b/test/async_scope_test.cpp
@@ -97,6 +97,17 @@ struct async_scope_test : testing::Test {
     // we'll hang here if the above work doesn't start
     sync_wait(evt.async_wait());
   }
+
+  void expect_work_to_run_with() {
+    async_manual_reset_event evt;
+
+    scope.spawn_call_on(
+      [&]() noexcept { evt.set(); },
+      thread.get_scheduler());
+
+    // we'll hang here if the above work doesn't start
+    sync_wait(evt.async_wait());
+  }
 };
 
 TEST_F(async_scope_test, spawning_after_cleaning_up_destroys_the_sender) {
@@ -111,6 +122,12 @@ TEST_F(async_scope_test, cleanup_is_idempotent) {
 
 TEST_F(async_scope_test, spawning_work_makes_it_run) {
   expect_work_to_run();
+
+  sync_wait(scope.cleanup());
+}
+
+TEST_F(async_scope_test, spawning_work_makes_it_run_with_lambda) {
+  expect_work_to_run_with();
 
   sync_wait(scope.cleanup());
 }

--- a/test/async_scope_test.cpp
+++ b/test/async_scope_test.cpp
@@ -98,7 +98,7 @@ struct async_scope_test : testing::Test {
     sync_wait(evt.async_wait());
   }
 
-  void expect_work_to_run_with() {
+  void expect_work_to_run_call_on() {
     async_manual_reset_event evt;
 
     scope.spawn_call_on(
@@ -127,7 +127,7 @@ TEST_F(async_scope_test, spawning_work_makes_it_run) {
 }
 
 TEST_F(async_scope_test, spawning_work_makes_it_run_with_lambda) {
-  expect_work_to_run_with();
+  expect_work_to_run_call_on();
 
   sync_wait(scope.cleanup());
 }

--- a/test/static_thread_pool_test.cpp
+++ b/test/static_thread_pool_test.cpp
@@ -58,8 +58,7 @@ TEST(StaticThreadPool, Smoke) {
         std::printf("task 3\n");
       })));
 
-  sync_wait(
-    on(just(), tp));
+  sync_wait(on(tp, just()));
 
   EXPECT_EQ(x, 3);
 }

--- a/test/transform_done_test.cpp
+++ b/test/transform_done_test.cpp
@@ -60,13 +60,10 @@ TEST(TransformDone, StayDone) {
 
   int count = 0;
 
-  sequence(
-    just_done()
-      | transform_done(
-          []{ return just(); }) 
-      | on(scheduler),
-    just_with([&]{ ++count; }))
-    | sync_wait();
+  auto op = sequence(
+    on(scheduler, just_done() | transform_done([]{ return just(); })),
+    just_with([&]{ ++count; }));
+  sync_wait(std::move(op));
 
   EXPECT_EQ(count, 1);
 }

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -200,6 +200,7 @@ TEST(low_latency_iocp_context, loop_read_write_pipe) {
     unifex::sync_wait(
         measure_time(
             unifex::on(
+                s,
                 unifex::when_all(
                     repeat_n(
                         unifex::defer([&, &readPipe=readPipe] {
@@ -210,8 +211,7 @@ TEST(low_latency_iocp_context, loop_read_write_pipe) {
                         unifex::defer([&, &writePipe=writePipe] {
                             return discard_value(
                                 unifex::async_write_some(writePipe, unifex::span{writeBuffer}));
-                        }), 1'000)),
-                s),
+                        }), 1'000))),
             "read + write"));
 
     stopSource.request_stop();


### PR DESCRIPTION
Also, swap the argument order to `unifex::on` (take the scheduler first), and disable pipe syntax for `on`.