### PR TITLE
Fix missing config.hpp include on unifex_fwd

### DIFF
--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <unifex/config.hpp>
+
 namespace unifex {
   namespace detail {
     template <typename, typename = void>


### PR DESCRIPTION
unifex_fwd uses UNIFEX_NO_COROUTINES, so needs to include config.hpp.

Signed-off-by: Matheus Izvekov <mizvekov@gmail.com>