### PR TITLE
Implement at_coroutine_exit for registering an async cleanup action to run automatically at coroutine exit

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -71,6 +71,9 @@
 * Synchronisation Primitives
   * `async_manual_reset_event`
   * `async_mutex`
+* Coroutine support
+  * `task`
+  * `at_coroutine_exit`
 * Other
   * `async_scope`
 
@@ -997,6 +1000,48 @@ namespace unifex
   };
 };
 ```
+
+## Coroutine support
+
+### `task`
+
+TODO
+
+### `at_coroutine_exit`
+
+`at_coroutine_exit` schedules an asynchronous task to execute when the coroutine exits,
+before resuming its parent. The action is guaranteed to execute no matter how the
+coroutine exits -- success, failure, or cancel -- like a destructor.
+
+**Usage:**
+```c++
+auto&& [state...] =
+    co_await unifex::at_coroutine_exit(
+      [](auto&&... state) -> task<void> {
+        // ... async cleanup action here...
+      },
+      state...
+    );
+```
+
+**Arguments:**
+The first argument to `at_coroutine_exit` is a coroutine lambda. The other arguments are
+optional state that may be needed by the cleanup action. The state passed to
+`at_coroutine_exit` is the same state that will be passed to the lambda.
+
+**Returns:**
+A tuple of references to the state owned by the cleanup action.
+
+If you capture references to the state returned by `at_coroutine_exit` (e.g.,
+`auto&& [state...] = ...`), then any mutation made to that state will be visible to the
+cleanup action when it runs.
+
+***Caution:***
+By the time the cleanup action runs, the coroutine that has scheduled the cleanup action
+has already been destroyed, along with any of the coroutine's local variables. Do not
+capture references to locals in the cleanup action; those references will dangle. Any
+state the cleanup action needs should be passed to `at_coroutine_exit`, which then owns
+their lifetime.
 
 ## Other
 

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -54,6 +54,8 @@ inline constexpr struct _fn {
 } // _run_at_coroutine_exit
 using _run_at_coroutine_exit::run_at_coroutine_exit;
 
+template <unsigned> struct undef;
+
 template <typename... Ts>
 struct [[nodiscard]] _cleanup_task {
   struct promise_type;
@@ -62,14 +64,15 @@ struct [[nodiscard]] _cleanup_task {
     bool await_ready() const noexcept {
       return false;
     }
-#if 1 //defined(__clang__) && \
-    ((!defined(__apple_build_version__) && __clang_major__ < 12) || \
-       defined(__apple_build_version__) && __apple_build_version__ < 12000032)
-//#if defined(__apple_build_version__) || __clang_major__ < 11)
+#if (defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 12)) || \
+    defined(_MSC_VER)
+#if defined(_MSC_VER) 
+    UNIFEX_ALWAYS_INLINE
+#elif defined(__apple_build_version__) || __clang_major__ < 11
     UNIFEX_NO_INLINE
-// #else
-//     UNIFEX_ALWAYS_INLINE
-// #endif
+#else
+    UNIFEX_ALWAYS_INLINE
+#endif
     bool await_suspend(coro::coroutine_handle<promise_type> h) const noexcept {
       // printfl("%s", "_cleanup_task::final_suspend::await_suspend");
       auto continuation = h.promise().continuation_;

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/coroutine.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/await_transform.hpp>
+
+#if UNIFEX_NO_COROUTINES
+# error "Coroutine support is required to use this header"
+#endif
+
+#include <tuple>
+#include <utility>
+
+#include <unifex/detail/prologue.hpp>
+
+// // BUGBUG
+// #include <cstdio>
+// void printfl(char const *format, ...) {
+//   va_list va;
+//   va_start(va, format);
+//   std::vprintf(format, va);
+//   va_end(va);
+//   std::putc('\n', stdout);
+//   std::fflush(stdout);
+// }
+
+namespace unifex {
+
+namespace _run_at_coroutine_exit {
+inline constexpr struct _fn {
+  template (typename Promise)
+    (requires tag_invocable<_fn, Promise&, coro::coroutine_handle<>>)
+  coro::coroutine_handle<> operator()(
+      Promise& promise, coro::coroutine_handle<> action) const noexcept {
+    return tag_invoke(*this, promise, (coro::coroutine_handle<>&&) action);
+  }
+} run_at_coroutine_exit {};
+} // _run_at_coroutine_exit
+using _run_at_coroutine_exit::run_at_coroutine_exit;
+
+template <typename... Ts>
+struct [[nodiscard]] _cleanup_task {
+  struct promise_type;
+
+  struct final_awaitable {
+    bool await_ready() const noexcept {
+      return false;
+    }
+    coro::coroutine_handle<> await_suspend(coro::coroutine_handle<promise_type> h) const noexcept {
+      //printfl("%s", "_cleanup_task::final_suspend::await_suspend");
+      auto continuation = h.promise().continuation_;
+      h.destroy();
+      return continuation;
+    }
+    void await_resume() const noexcept {
+    }
+  };
+
+  struct promise_type {
+    template <typename Action>
+    promise_type(Action&&, Ts&... ts) noexcept
+      : args_(ts...) {}
+    _cleanup_task get_return_object() noexcept {
+      return _cleanup_task(coro::coroutine_handle<promise_type>::from_promise(*this));
+    }
+    coro::suspend_always initial_suspend() noexcept {
+      return {};
+    }
+    final_awaitable final_suspend() noexcept {
+      return {};
+    }
+    [[noreturn]] void unhandled_exception() noexcept {
+      std::terminate();
+    }
+    // BUGBUG TODO
+    [[noreturn]] coro::coroutine_handle<> unhandled_done() noexcept {
+      std::terminate();
+    }
+    void return_void() noexcept {
+    }
+    template(typename Value)
+      (requires callable<tag_t<unifex::await_transform>, promise_type&, Value>)
+    auto await_transform(Value&& value)
+        noexcept(is_nothrow_callable_v<tag_t<unifex::await_transform>, promise_type&, Value>)
+        -> callable_result_t<tag_t<unifex::await_transform>, promise_type&, Value> {
+      return unifex::await_transform(*this, (Value&&)value);
+    }
+    coro::coroutine_handle<> continuation_{};
+    std::tuple<Ts&...> args_;
+  };
+
+  _cleanup_task(coro::coroutine_handle<promise_type> coro) noexcept
+    : coro_(coro) {}
+  _cleanup_task(_cleanup_task&& that) noexcept
+    : coro_(std::exchange(that.coro_, {})) {} 
+  ~_cleanup_task() {
+    assert(coro_ == nullptr);
+  }
+
+  bool await_ready() const noexcept {
+    //printfl("%s", "_cleanup_task::await_ready");
+    return false;
+  }
+  template <typename Promise>
+  bool await_suspend(coro::coroutine_handle<Promise> parent) noexcept {
+    //printfl("%s", "_cleanup_task::await_suspend");
+    coro_.promise().continuation_ = run_at_coroutine_exit(parent.promise(), coro_);
+    return false;
+  }
+  std::tuple<Ts&...> await_resume() noexcept {
+    //printfl("%s %d", "_cleanup_task::await_resume", std::get<0>(coro_.promise().args_));
+    return std::exchange(coro_, {}).promise().args_;
+  }
+
+private:
+  coro::coroutine_handle<promise_type> coro_;
+};
+
+namespace _at_coroutine_exit {
+  inline constexpr struct _fn {
+  private:
+    template (typename Action, typename... Ts)
+      (requires callable<Action, Ts&...>)
+    static _cleanup_task<Ts...> at_coroutine_exit(Action action, Ts... ts) {
+      //printfl("%s", "at_coroutine_exit(), before cleanup action");
+      co_await std::move(action)(std::move(ts)...);
+      //printfl("%s", "at_coroutine_exit(), after cleanup action");
+    }
+  public:
+    template (typename Action, typename... Ts)
+      (requires callable<std::decay_t<Action>, std::decay_t<Ts>&...>)
+    _cleanup_task<Ts...> operator()(Action&& action, Ts&&... ts) const {
+      return _fn::at_coroutine_exit((Action&&) action, (Ts&&) ts...);
+    }
+  } at_coroutine_exit{};
+} // namespace _at_coroutine_exit
+
+using _at_coroutine_exit::at_coroutine_exit;
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -97,8 +97,9 @@ struct continuation {
     return self_;
   }
 
-  coro::coroutine_handle<> handle() const noexcept {
-    return self_.handle_;
+  coro::coroutine_handle<Promise> handle() const noexcept {
+    return coro::coroutine_handle<Promise>::from_address(
+        self_.handle().address());
   }
 
   void resume() {
@@ -106,8 +107,7 @@ struct continuation {
   }
 
   Promise& promise() const noexcept {
-    return coro::coroutine_handle<Promise>::from_address(
-        self_.handle().address()).promise();
+    return handle().promise();
   }
 
   coro::coroutine_handle<> done() const noexcept {

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -62,14 +62,14 @@ struct [[nodiscard]] _cleanup_task {
     bool await_ready() const noexcept {
       return false;
     }
-#if defined(__clang__) && \
+#if 1 //defined(__clang__) && \
     ((!defined(__apple_build_version__) && __clang_major__ < 12) || \
        defined(__apple_build_version__) && __apple_build_version__ < 12000032)
-#if defined(__apple_build_version__) || __clang_major__ < 11)
+//#if defined(__apple_build_version__) || __clang_major__ < 11)
     UNIFEX_NO_INLINE
-#else
-    UNIFEX_ALWAYS_INLINE
-#endif
+// #else
+//     UNIFEX_ALWAYS_INLINE
+// #endif
     bool await_suspend(coro::coroutine_handle<promise_type> h) const noexcept {
       // printfl("%s", "_cleanup_task::final_suspend::await_suspend");
       auto continuation = h.promise().continuation_;

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -92,7 +92,7 @@ struct _cleanup_promise_base {
   }
 
   [[noreturn]] void unhandled_exception() noexcept {
-    UNIFEX_ASSERT(!"An exception happened in an async cleanup action. Terminating...");
+    UNIFEX_ASSERT(!"An exception happened in an async cleanup action. Calling terminate...");
     std::terminate();
   }
 
@@ -137,7 +137,7 @@ struct _die_on_done_rec {
       unifex::set_error((Receiver&&) rec_, (E&&) e);
     }
     [[noreturn]] void set_done() && noexcept {
-      UNIFEX_ASSERT(!"A cleanup action tried to cancel. Terminating...");
+      UNIFEX_ASSERT(!"A cleanup action tried to cancel. Calling terminate...");
       std::terminate();
     }
   };

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -61,6 +61,7 @@ struct [[nodiscard]] _cleanup_task {
     bool await_ready() const noexcept {
       return false;
     }
+    UNIFEX_NO_INLINE
     coro::coroutine_handle<> await_suspend(coro::coroutine_handle<promise_type> h) const noexcept {
       //printfl("%s", "_cleanup_task::final_suspend::await_suspend");
       auto continuation = h.promise().continuation_;
@@ -117,7 +118,7 @@ struct [[nodiscard]] _cleanup_task {
     return false;
   }
   template <typename Promise>
-  bool await_suspend(coro::coroutine_handle<Promise> parent) noexcept {
+  UNIFEX_NO_INLINE bool await_suspend(coro::coroutine_handle<Promise> parent) noexcept {
     //printfl("%s", "_cleanup_task::await_suspend");
     coro_.promise().continuation_ = run_at_coroutine_exit(parent.promise(), coro_);
     return false;

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -204,6 +204,14 @@
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
+  #define UNIFEX_NO_INLINE __attribute__((__noinline__))
+#elif defined(_MSC_VER)
+  #define UNIFEX_NO_INLINE __declspec(noinline)
+#else
+  #define UNIFEX_NO_INLINE
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
   #define UNIFEX_ASSUME_UNREACHABLE __builtin_unreachable()
 #elif defined(_MSC_VER)
   #define UNIFEX_ASSUME_UNREACHABLE __assume(0)

--- a/include/unifex/continuations.hpp
+++ b/include/unifex/continuations.hpp
@@ -100,8 +100,7 @@ class continuation_info {
   template <typename Continuation>
   static continuation_info from_continuation(const Continuation& c) noexcept;
 
-  static continuation_info from_continuation(
-      const continuation_info& c) noexcept {
+  static continuation_info from_continuation(const continuation_info& c) noexcept {
     return c;
   }
 
@@ -124,6 +123,8 @@ class continuation_info {
   template <typename F>
   friend void
   tag_invoke(tag_t<visit_continuations>, const continuation_info& c, F&& f) {
+    // Any const that gets stripped by the const_cast below gets reapplied by the
+    // static_cast in _invoke_visitor.
     c.vtable_->visit_(
         c.address_,
         &_invoke_visitor<F>,
@@ -219,6 +220,8 @@ struct continuation_handle<void> {
   template <typename F>
   friend void
   tag_invoke(tag_t<visit_continuations>, const continuation_handle<>& c, F&& f) {
+    // Any const that gets stripped by the const_cast below gets reapplied by the
+    // static_cast in _invoke_visitor.
     c.vtable_->visit_(
         c.handle_.address(),
         &_ci::_invoke_visitor<F>,

--- a/include/unifex/continuations.hpp
+++ b/include/unifex/continuations.hpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/coroutine.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/type_traits.hpp>
+#include <unifex/tag_invoke.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+namespace _visit_continuations_cpo {
+  inline const struct _fn {
+#if !UNIFEX_NO_COROUTINES
+    template(typename Promise, typename Func)
+        (requires (!same_as<Promise, void>))
+    friend void tag_invoke(
+        _fn cpo,
+        coro::coroutine_handle<Promise> h,
+        Func&& func) {
+      cpo(h.promise(), (Func &&) func);
+    }
+#endif // UNIFEX_NO_COROUTINES
+
+    template(typename Continuation, typename Func)
+      (requires tag_invocable<_fn, const Continuation&, Func>)
+    void operator()(const Continuation& c, Func&& func) const
+        noexcept(is_nothrow_tag_invocable_v<
+                _fn,
+                const Continuation&,
+                Func&&>) {
+      static_assert(
+          std::is_void_v<tag_invoke_result_t<
+              _fn,
+              const Continuation&,
+              Func&&>>,
+          "tag_invoke() overload for visit_continuations() must return void");
+      return tag_invoke(_fn{}, c, (Func &&) func);
+    }
+
+    template(typename Continuation, typename Func)
+      (requires (!tag_invocable<_fn, const Continuation&, Func>))
+    void operator()(const Continuation&, Func&&) const noexcept {}
+  } visit_continuations {};
+} // namespace _visit_continuations_cpo
+using _visit_continuations_cpo::visit_continuations;
+
+class continuation_info {
+ public:
+  template <typename Continuation>
+  static continuation_info from_continuation(const Continuation& c) noexcept;
+
+  static continuation_info from_continuation(
+      const continuation_info& c) noexcept {
+    return c;
+  }
+
+  type_index type() const noexcept {
+    return vtable_->typeIndexGetter_();
+  }
+
+  const void* address() const noexcept {
+    return address_;
+  }
+
+  template <typename F>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const continuation_info& c, F&& f) {
+    c.vtable_->visit_(
+        c.address_,
+        [](const continuation_info& info, void* data) {
+          std::invoke(*static_cast<std::add_pointer_t<F>>(data), info);
+        },
+        static_cast<void*>(std::addressof(f)));
+  }
+
+ private:
+  using callback_t = void(const continuation_info&, void*);
+  using visitor_t = void(const void*, callback_t*, void*);
+  using type_index_getter_t = type_index() noexcept;
+
+  struct vtable_t {
+    type_index_getter_t* typeIndexGetter_;
+    visitor_t* visit_;
+  };
+
+  explicit continuation_info(
+      const void* address,
+      const vtable_t* vtable) noexcept
+    : address_(address)
+    , vtable_(vtable) {}
+
+  const void* address_;
+  const vtable_t* vtable_;
+};
+
+template <typename Continuation>
+inline continuation_info continuation_info::from_continuation(
+    const Continuation& r) noexcept {
+  static constexpr vtable_t vtable{
+      []() noexcept -> type_index {
+        return type_id<remove_cvref_t<Continuation>>();
+      },
+      [](const void* address, callback_t* cb, void* data) {
+        visit_continuations(
+            *static_cast<const Continuation*>(address),
+            [cb, data](const auto& continuation) {
+              cb(continuation_info::from_continuation(continuation), data);
+            });
+      }};
+  return continuation_info{static_cast<const void*>(std::addressof(r)),
+                           &vtable};
+}
+
+#if !UNIFEX_NO_COROUTINES
+// BUGBUG "inherit" this from continuation_info
+template <typename Promise = void>
+struct continuation_handle;
+
+template <>
+struct continuation_handle<void> {
+private:
+  [[noreturn]] static coro::coroutine_handle<> default_done_callback(void*) noexcept {
+    std::terminate();
+  }
+
+  template <typename Promise>
+  static coro::coroutine_handle<> forward_unhandled_done_callback(void* p) noexcept {
+    return coro::coroutine_handle<Promise>::from_address(p).promise().unhandled_done();
+  }
+
+  using done_callback_t = coro::coroutine_handle<>(*)(void*) noexcept;
+
+  coro::coroutine_handle<> handle_{};
+  done_callback_t doneCallback_ = &default_done_callback;
+
+public:
+  continuation_handle() = default;
+
+  template (typename Promise)
+    (requires (!same_as<Promise, void>))
+  /*implicit*/ continuation_handle(coro::coroutine_handle<Promise> continuation) noexcept
+    : handle_((coro::coroutine_handle<Promise>&&) continuation)
+    , doneCallback_(&forward_unhandled_done_callback<Promise>)
+  {}
+
+  explicit operator bool() const noexcept {
+    return handle_ != nullptr;
+  }
+
+  coro::coroutine_handle<> handle() const noexcept {
+    return handle_;
+  }
+
+  void resume() {
+    handle_.resume();
+  }
+
+  coro::coroutine_handle<> done() const noexcept {
+    return doneCallback_(handle_.address());
+  }
+};
+
+template <typename Promise>
+struct continuation_handle {
+  continuation_handle() = default;
+
+  /*implicit*/ continuation_handle(coro::coroutine_handle<Promise> continuation) noexcept
+    : self_((coro::coroutine_handle<Promise>&&) continuation)
+  {}
+
+  explicit operator bool() const noexcept {
+    return !!self_;
+  }
+
+  /*implicit*/ operator continuation_handle<>() const noexcept {
+    return self_;
+  }
+
+  coro::coroutine_handle<Promise> handle() const noexcept {
+    return coro::coroutine_handle<Promise>::from_address(
+        self_.handle().address());
+  }
+
+  void resume() {
+    self_.resume();
+  }
+
+  Promise& promise() const noexcept {
+    return handle().promise();
+  }
+
+  coro::coroutine_handle<> done() const noexcept {
+    return self_.done();
+  }
+
+private:
+  continuation_handle<> self_;
+};
+#endif
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -28,6 +28,7 @@
 #include <unifex/type_list.hpp>
 #include <unifex/invoke.hpp>
 #include <unifex/at_coroutine_exit.hpp>
+#include <unifex/continuations.hpp>
 
 #if UNIFEX_NO_COROUTINES
 # error "Coroutine support is required to use this header"

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -27,6 +27,7 @@
 #include <unifex/scope_guard.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/invoke.hpp>
+#include <unifex/at_coroutine_exit.hpp>
 
 #if UNIFEX_NO_COROUTINES
 # error "Coroutine support is required to use this header"
@@ -102,6 +103,11 @@ struct _promise_base {
 
   friend inplace_stop_token tag_invoke(tag_t<get_stop_token>, const _promise_base& p) noexcept {
     return p.stoken_;
+  }
+
+  friend coro::coroutine_handle<> tag_invoke(
+    tag_t<run_at_coroutine_exit>, _promise_base& p, coro::coroutine_handle<> action) noexcept {
+    return std::exchange(p.continuation_, action);
   }
 
   using done_callback = coro::coroutine_handle<>(void*) noexcept;

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -96,12 +96,12 @@ struct _promise_base {
     return p.stoken_;
   }
 
-  friend continuation tag_invoke(
-      tag_t<exchange_continuation>, _promise_base& p, continuation action) noexcept {
-    return std::exchange(p.continuation_, (continuation&&) action);
+  friend continuation<> tag_invoke(
+      tag_t<exchange_continuation>, _promise_base& p, continuation<> action) noexcept {
+    return std::exchange(p.continuation_, (continuation<>&&) action);
   }
 
-  continuation continuation_;
+  continuation<> continuation_;
   std::optional<continuation_info> info_;
   inplace_stop_token stoken_;
 };

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -96,12 +96,12 @@ struct _promise_base {
     return p.stoken_;
   }
 
-  friend continuation<> tag_invoke(
-      tag_t<exchange_continuation>, _promise_base& p, continuation<> action) noexcept {
-    return std::exchange(p.continuation_, (continuation<>&&) action);
+  friend continuation_handle<> tag_invoke(
+      tag_t<exchange_continuation>, _promise_base& p, continuation_handle<> action) noexcept {
+    return std::exchange(p.continuation_, (continuation_handle<>&&) action);
   }
 
-  continuation<> continuation_;
+  continuation_handle<> continuation_;
   std::optional<continuation_info> info_;
   inplace_stop_token stoken_;
 };

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -88,9 +88,7 @@ struct _promise_base {
   template <typename Func>
   friend void
   tag_invoke(tag_t<visit_continuations>, const _promise_base& p, Func&& func) {
-    if (p.info_) {
-      visit_continuations(*p.info_, (Func &&) func);
-    }
+    visit_continuations(p.continuation_, (Func &&) func);
   }
 
   friend inplace_stop_token tag_invoke(tag_t<get_stop_token>, const _promise_base& p) noexcept {
@@ -103,7 +101,6 @@ struct _promise_base {
   }
 
   continuation_handle<> continuation_;
-  std::optional<continuation_info> info_;
   inplace_stop_token stoken_;
 };
 
@@ -202,7 +199,6 @@ struct _awaiter {
       UNIFEX_ASSERT(coro_);
       auto& promise = coro_.promise();
       promise.continuation_ = h;
-      promise.info_.emplace(continuation_info::from_continuation(h.promise()));
       promise.stoken_ = stopTokenAdapter_.subscribe(get_stop_token(h.promise()));
       return coro_;
     }

--- a/test/at_coroutine_exit_test.cpp
+++ b/test/at_coroutine_exit_test.cpp
@@ -203,37 +203,37 @@ TEST_F(AtCoroutineExit, MutableStatefulCleanupAction) {
 TEST_F(AtCoroutineExit, CancelInCleanupActionCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_in_cleanup_action_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 TEST_F(AtCoroutineExit, CancelDuringCancellationUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_during_cancellation_unwind_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionDuringExceptionUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_during_exception_unwind_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 TEST_F(AtCoroutineExit, CancelInCleanupActionDuringExceptionUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_in_cleanup_action_during_exception_unwind_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionDuringCancellationUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_during_cancellation_unwind_causes_death(),
-    "[Tt]erminat");
+    "terminate");
 }
 
 #endif // !UNIFEX_NO_COROUTINES

--- a/test/at_coroutine_exit_test.cpp
+++ b/test/at_coroutine_exit_test.cpp
@@ -203,37 +203,37 @@ TEST_F(AtCoroutineExit, MutableStatefulCleanupAction) {
 TEST_F(AtCoroutineExit, CancelInCleanupActionCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_in_cleanup_action_causes_death(),
-    "terminate");
+    "");
 }
 
 TEST_F(AtCoroutineExit, CancelDuringCancellationUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_during_cancellation_unwind_causes_death(),
-    "terminate");
+    "");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_causes_death(),
-    "terminate");
+    "");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionDuringExceptionUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_during_exception_unwind_causes_death(),
-    "terminate");
+    "");
 }
 
 TEST_F(AtCoroutineExit, CancelInCleanupActionDuringExceptionUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_cancel_in_cleanup_action_during_exception_unwind_causes_death(),
-    "terminate");
+    "");
 }
 
 TEST_F(AtCoroutineExit, ThrowInCleanupActionDuringCancellationUnwindCallsTerminate) {
   ASSERT_DEATH_IF_SUPPORTED(
     test_throw_in_cleanup_action_during_cancellation_unwind_causes_death(),
-    "terminate");
+    "");
 }
 
 #endif // !UNIFEX_NO_COROUTINES

--- a/test/at_coroutine_exit_test.cpp
+++ b/test/at_coroutine_exit_test.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <unifex/at_coroutine_exit.hpp>
+
+#include <unifex/task.hpp>
+#include <unifex/sync_wait.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+namespace {
+int global = 0;
+task<void> test1() {
+  global = 2;
+  co_await at_coroutine_exit([]() -> task<void> { global *= 2; co_return; });
+}
+}
+
+TEST(AtCoroutineExit, SimpleAction) {
+  sync_wait(test1());
+  EXPECT_EQ(global, 4);
+}
+
+#endif // !UNIFEX_NO_COROUTINES


### PR DESCRIPTION
Still TODO:
- [x] Implement unhandled done
- [x] Merge types `continuation_handle` and `continuation_info`.
- [x] Documentation
- [x] More tests
