### PR TITLE
Update googletest to fix some compile errors under clang trunk

### DIFF
--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -14,7 +14,7 @@ ExternalProject_Add(googletest
   # gmock understands noexcept function qualifiers
   # and for which usage of std::result_of has been
   # discontinued.
-  GIT_TAG           61f010d703b32de9bfb20ab90ece38ab2f25977f
+  GIT_TAG           aa9b44a18678dfdf57089a5ac22c1edb69f35da5
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/include/unifex/detail/concept_macros.hpp
+++ b/include/unifex/detail/concept_macros.hpp
@@ -195,7 +195,6 @@
       decltype(&NAME ## UNIFEX_CONCEPT_FRAGMENT_impl_<As...>)); \
     char (&NAME ## UNIFEX_CONCEPT_FRAGMENT_(...))[2] \
     /**/
-  #define M(ARG) ARG,
   #if defined(_MSC_VER) && !defined(__clang__)
     #define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
       ::unifex::_concept::true_<decltype( \


### PR DESCRIPTION
Upgrade googletest to fix a warning/error under clang-trunk that was complaining
about use of an implicit copy constructor when the copy-assignment operator had
been deleted.

Also removed a spurious `#define M(ARG)` macro in `concept_macros.hpp` that was causing problems with the latest googletest which was using `M` as a template parameter.