### PR TITLE
task<> scheduler affinity

### DIFF
--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -22,6 +22,7 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -103,6 +104,10 @@ namespace _alloc {
           connect_result_t<member_t<Self, Sender>, Receiver>,
           remove_cvref_t<get_allocator_t<Receiver>>>{
           static_cast<Self&&>(s).sender_, (Receiver &&) r};
+    }
+
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+      return blocking(self.sender_);
     }
 
     Sender sender_;

--- a/include/unifex/any_scheduler.hpp
+++ b/include/unifex/any_scheduler.hpp
@@ -198,6 +198,10 @@ struct _with<CPOs...>::any_scheduler {
     return _sender{this};
   }
 
+  type_index type() const noexcept {
+    return _get_type_index(impl_);
+  }
+
   friend _equal_to_fn;
   friend bool operator==(const any_scheduler& left, const any_scheduler& right) noexcept {
     return _equal_to(left.impl_, right);
@@ -211,7 +215,11 @@ private:
 };
 
 template <typename... CPOs>
-using any_scheduler_ref_impl = any_ref_t<_schedule_and_connect<CPOs...>>;
+using any_scheduler_ref_impl =
+    any_ref_t<
+        _schedule_and_connect<CPOs...>,
+        _get_type_index,
+        overload<bool(const this_&, const any_scheduler_ref<CPOs...>&) noexcept>(_equal_to)>;
 
 template <typename... CPOs>
 struct _with<CPOs...>::any_scheduler_ref {
@@ -257,6 +265,11 @@ struct _with<CPOs...>::any_scheduler_ref {
     return _sender{this};
   }
 
+  type_index type() const noexcept {
+    return _get_type_index(impl_);
+  }
+
+  // Shallow equality comparison by default, for regularity:
   friend bool operator==(const any_scheduler_ref& left, const any_scheduler_ref& right) noexcept {
     return left.impl_ == right.impl_;
   }
@@ -264,7 +277,14 @@ struct _with<CPOs...>::any_scheduler_ref {
     return !(left == right);
   }
 
+  // Deep equality comparison:
+  friend _equal_to_fn;
+  bool equal_to(const any_scheduler_ref& that) const noexcept {
+    return _equal_to(impl_, that);
+  }
+
 private:
+
   any_scheduler_ref_impl<CPOs...> impl_;
 };
 

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -103,7 +103,7 @@ namespace _async_trace {
       return operation<Receiver>{(Receiver &&) r};
     }
 
-    friend blocking_kind tag_invoke(tag_t<blocking>, const sender&) noexcept {
+    friend auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
       return blocking_kind::always_inline;
     }
   };

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -23,6 +23,7 @@
 #include <unifex/stop_token_concepts.hpp>
 #include <unifex/inline_scheduler.hpp>
 #include <unifex/any_scheduler.hpp>
+#include <unifex/blocking.hpp>
 
 #if UNIFEX_NO_COROUTINES
 # error "Coroutine support is required to use this header"
@@ -275,6 +276,10 @@ struct [[nodiscard]] _cleanup_task {
 
   std::tuple<Ts&...> await_resume() noexcept {
     return std::exchange(continuation_, {}).promise().args_;
+  }
+
+  friend auto tag_invoke(tag_t<blocking>, const _cleanup_task&) noexcept {
+    return blocking_kind::always_inline;
   }
 
 private:

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -278,7 +278,7 @@ struct [[nodiscard]] _cleanup_task {
     return std::exchange(continuation_, {}).promise().args_;
   }
 
-  friend auto tag_invoke(tag_t<blocking>, const _cleanup_task&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const _cleanup_task&) noexcept {
     return blocking_kind::always_inline;
   }
 

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -193,7 +193,7 @@ struct _die_on_done {
           _die_on_done_rec_t<Receiver>{(Receiver&&) rec});
     }
 
-    Sender sender_;
+    UNIFEX_NO_UNIQUE_ADDRESS Sender sender_;
   };
 };
 
@@ -245,7 +245,7 @@ struct _cleanup_promise : _cleanup_promise_base {
     return unifex::await_transform(*this, _die_on_done_fn{}((Value&&) value));
   }
 
-  std::tuple<Ts&...> args_;
+  UNIFEX_NO_UNIQUE_ADDRESS std::tuple<Ts&...> args_;
 };
 
 template <typename... Ts>
@@ -296,7 +296,7 @@ namespace _at_coroutine_exit {
   public:
     template (typename Action, typename... Ts)
       (requires callable<std::decay_t<Action>, std::decay_t<Ts>...>)
-    _cleanup_task<Ts...> operator()(Action&& action, Ts&&... ts) const {
+    _cleanup_task<std::decay_t<Ts>...> operator()(Action&& action, Ts&&... ts) const {
       return _fn::at_coroutine_exit((Action&&) action, (Ts&&) ts...);
     }
   } at_coroutine_exit{};

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -190,6 +190,9 @@ struct _fn {
   auto operator()(Promise& promise, Value&& value) const
     noexcept(is_nothrow_tag_invocable_v<_fn, Promise&, Value>)
     -> tag_invoke_result_t<_fn, Promise&, Value> {
+    static_assert(detail::_awaitable<tag_invoke_result_t<_fn, Promise&, Value>>,
+        "The return type of a customization of unifex::await_transform() "
+        "must satisfy the awaitable concept.");
     return unifex::tag_invoke(_fn{}, promise, (Value&&)value);
   }
 

--- a/include/unifex/blocking.hpp
+++ b/include/unifex/blocking.hpp
@@ -81,7 +81,7 @@ struct blocking_kind {
   static constexpr constant<_enum::always> always {};
   static constexpr constant<_enum::always_inline> always_inline {};
 
-  _enum value;
+  _enum value{};
 };
 
 struct _fn {

--- a/include/unifex/blocking.hpp
+++ b/include/unifex/blocking.hpp
@@ -22,10 +22,11 @@
 
 namespace unifex {
 
-enum class blocking_kind {
+namespace _block {
+enum class _enum {
   // No guarantees about the timing and context on which the receiver will
   // be called.
-  maybe,
+  maybe = 0,
 
   // Always completes asynchronously.
   // Guarantees that the receiver will not be called on the current thread
@@ -44,8 +45,54 @@ enum class blocking_kind {
   always_inline
 };
 
-namespace _blocking {
-inline const struct _fn {
+struct blocking_kind {
+  blocking_kind() = default;
+
+  constexpr blocking_kind(_enum kind) noexcept
+    : value(kind)
+  {}
+
+  template <_enum Kind>
+  constexpr blocking_kind(std::integral_constant<_enum, Kind>) noexcept
+    : value(Kind)
+  {}
+
+  constexpr operator _enum() const noexcept {
+    return value;
+  }
+
+  constexpr _enum operator()() const noexcept {
+    return value;
+  }
+
+  friend constexpr bool operator==(blocking_kind a, blocking_kind b) noexcept {
+    return a.value == b.value;
+  }
+
+  friend constexpr bool operator!=(blocking_kind a, blocking_kind b) noexcept {
+    return a.value != b.value;
+  }
+
+  static constexpr struct _maybe
+    : std::integral_constant<_enum, _enum::maybe>
+  {} const maybe {};
+
+  static constexpr struct _never
+    : std::integral_constant<_enum, _enum::never>
+  {} const never {};
+
+  static constexpr struct _always
+    : std::integral_constant<_enum, _enum::always>
+  {} const always {};
+
+  static constexpr struct _always_inline
+    : std::integral_constant<_enum, _enum::always_inline>
+  {} const always_inline {};
+
+  _enum value;
+};
+
+struct _fn {
   template(typename Sender)
     (requires tag_invocable<_fn, const Sender&>)
   constexpr auto operator()(const Sender& s) const
@@ -55,12 +102,32 @@ inline const struct _fn {
   }
   template(typename Sender)
     (requires (!tag_invocable<_fn, const Sender&>))
-  constexpr blocking_kind operator()(const Sender&) const noexcept {
+  constexpr auto operator()(const Sender&) const noexcept {
     return blocking_kind::maybe;
   }
-} blocking{};
-} // namespace _blocking
-using _blocking::blocking;
+};
+
+namespace _cfn {
+  template <_enum Kind>
+  static constexpr _enum _kind(std::integral_constant<_enum, Kind>) noexcept {
+    return Kind;
+  }
+  static constexpr _enum _kind(blocking_kind) noexcept {
+    return _enum{0};
+  }
+
+  template <typename T>
+  constexpr _enum cblocking() noexcept {
+    using blocking_t = remove_cvref_t<decltype(_fn{}(UNIFEX_DECLVAL(T&)))>;
+    return _kind(blocking_t{});
+  }
+}
+
+} // namespace _block
+
+inline constexpr _block::_fn blocking {};
+using _block::_cfn::cblocking;
+using _block::blocking_kind;
 
 } // namespace unifex
 

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -232,6 +232,10 @@ namespace _as_sender {
       friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
         return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
       }
+
+      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
+        return unifex::blocking(t.awaitable_);
+      }
     private:
       Awaitable awaitable_;
     };

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -93,17 +93,13 @@ public:
 
     template <typename Value>
     auto await_transform(Value&& value) -> decltype(auto) {
-      if constexpr (callable<decltype(unifex::await_transform), promise_type&, Value>) {
-        return unifex::await_transform(*this, (Value&&)value);
-      } else {
-        return Value((Value &&) value);
-      }
+      return unifex::await_transform(*this, (Value&&) value);
     }
 
     template <typename Func>
     friend void
     tag_invoke(tag_t<visit_continuations>, const promise_type& p, Func&& func) {
-      visit_continuations(p.receiver_, (Func&&)func);
+      visit_continuations(p.receiver_, (Func&&) func);
     }
 
     template(typename CPO)
@@ -140,21 +136,12 @@ public:
 } // namespace _await
 
 namespace _await_cpo {
-  template<typename... Ts>
-  using count_types = std::integral_constant<std::size_t, sizeof...(Ts)>;
-
-  template<typename Receiver>
-  struct set_value_applicator {
-    Receiver& receiver_;
-
-    template<typename... Values>
-    void operator()(Values&&... values) {
-      unifex::set_value(std::move(receiver_), (Values&&)values...);
-    }
-  };
-
   inline const struct _fn {
   private:
+    template <typename Awaitable>
+    using awaitable_single_value_result_t =
+        non_void_t<wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>>;
+
     struct _comma_hack {
       template <typename T>
       friend T&& operator,(T&& t, _comma_hack) noexcept {
@@ -162,6 +149,7 @@ namespace _await_cpo {
       }
       operator unit() const noexcept { return {}; }
     };
+
     template <typename Awaitable, typename Receiver>
     static auto connect_impl(Awaitable awaitable, Receiver receiver)
         -> _await::sender_task<Receiver> {
@@ -170,7 +158,13 @@ namespace _await_cpo {
       try {
 #endif // !UNIFEX_NO_EXCEPTIONS
 
-        using result_type = sender_single_value_result_t<Awaitable>;
+        // The _sender_task's promise type has an await_transform that passes the
+        // awaitable through unifex::await_transform. So take that into consideration
+        // when computing the result type:
+        using promise_type = typename _await::sender_task<Receiver>::promise_type;
+        using awaitable_type =
+            callable_result_t<tag_t<unifex::await_transform>, promise_type&, Awaitable>;
+        using result_type = awaitable_single_value_result_t<awaitable_type>;
 
         // This is a bit mind bending control-flow wise.
         // We are first evaluating the co_await expression.
@@ -182,31 +176,17 @@ namespace _await_cpo {
         // for the receiver to destroy the coroutine.
         co_yield [&](result_type&& result) {
               return [&] {
-                constexpr size_t valueOverloadCount =
-                    sender_value_types_t<Awaitable, count_types, single_value_type>::value;
-                static_assert(valueOverloadCount <= 1);
-
-                if constexpr (valueOverloadCount == 1) {
-                  constexpr size_t valueCount =
-                      sender_value_types_t<Awaitable, type_identity_t, count_types>::value;
-                  if constexpr (valueCount == 0) {
-                    unifex::set_value(std::move(receiver));
-                  } else if constexpr (valueCount == 1) {
-                    unifex::set_value(std::move(receiver), static_cast<result_type&&>(result));
-                  } else {
-                    std::apply(set_value_applicator<Receiver>{receiver}, (result_type&&)result);
-                  }
+                if constexpr (std::is_void_v<await_result_t<awaitable_type>>) {
+                  unifex::set_value(std::move(receiver));
                 } else {
-                  // Shouldn't complete with a value if there are no value_types
-                  // specified.
-                  std::terminate();
+                  unifex::set_value(std::move(receiver), static_cast<result_type&&>(result));
                 }
               };
             // The _comma_hack here makes this well-formed when the co_await
             // expression has type void. This could potentially run into trouble
             // if the type of the co_await expression itself overloads operator
             // comma, but that's pretty unlikely.
-            }((co_await (Awaitable &&)awaitable, _comma_hack{}));
+            }((co_await (Awaitable &&) awaitable, _comma_hack{}));
 #if !UNIFEX_NO_EXCEPTIONS
       } catch (...) {
         ex = std::current_exception();
@@ -221,12 +201,84 @@ namespace _await_cpo {
     template <typename Awaitable, typename Receiver>
     auto operator()(Awaitable&& awaitable, Receiver&& receiver) const
       -> _await::sender_task<remove_cvref_t<Receiver>> {
-      return connect_impl((Awaitable&&)awaitable, (Receiver&&)receiver);
+      return connect_impl((Awaitable&&) awaitable, (Receiver&&) receiver);
     }
   } connect_awaitable{};
 } // namespace _await_cpo
 
 using _await_cpo::connect_awaitable;
+
+// as_sender, for adapting an awaitable to be a typed sender
+namespace _as_sender {
+  template <typename Awaitable, typename Result = await_result_t<Awaitable>>
+  struct _sndr {
+    struct type {
+      template <
+          template <typename...> class Variant,
+          template <typename...> class Tuple>
+      using value_types = Variant<Tuple<await_result_t<Awaitable>>>;
+
+      template <template <typename...> class Variant>
+      using error_types = Variant<std::exception_ptr>;
+
+      static constexpr bool sends_done = true;
+
+      type(Awaitable awaitable)
+        : awaitable_((Awaitable&&) awaitable)
+      {}
+
+      template (typename Receiver)
+        (requires receiver_of<Receiver, await_result_t<Awaitable>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
+        return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
+      }
+    private:
+      Awaitable awaitable_;
+    };
+  };
+
+  template <typename Awaitable>
+  struct _sndr<Awaitable, void> {
+    struct type {
+      template <
+          template <typename...> class Variant,
+          template <typename...> class Tuple>
+      using value_types = Variant<Tuple<>>;
+
+      template <template <typename...> class Variant>
+      using error_types = Variant<std::exception_ptr>;
+
+      static constexpr bool sends_done = true;
+
+      explicit type(Awaitable awaitable)
+          noexcept(std::is_nothrow_move_constructible_v<Awaitable>)
+        : awaitable_((Awaitable&&) awaitable)
+      {}
+
+      template (typename Receiver)
+        (requires receiver_of<Receiver>)
+      friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
+        return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
+      }
+    private:
+      Awaitable awaitable_;
+    };
+  };
+
+  template <typename Awaitable>
+  using _sender = typename _sndr<Awaitable>::type;
+
+  struct _fn {
+    template (typename Awaitable)
+      (requires detail::_awaitable<Awaitable>)
+    _sender<remove_cvref_t<Awaitable>> operator()(Awaitable&& awaitable) const {
+      return _sender<remove_cvref_t<Awaitable>>{(Awaitable&&) awaitable};
+    }
+  };
+} // namespace _as_sender
+
+// Transforms an awaitable into a typed sender:
+inline constexpr _as_sender::_fn as_sender {};
 
 } // namespace unifex
 

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -216,7 +216,7 @@ namespace _as_sender {
       template <
           template <typename...> class Variant,
           template <typename...> class Tuple>
-      using value_types = Variant<Tuple<await_result_t<Awaitable>>>;
+      using value_types = Variant<Tuple<Result>>;
 
       template <template <typename...> class Variant>
       using error_types = Variant<std::exception_ptr>;
@@ -228,7 +228,7 @@ namespace _as_sender {
       {}
 
       template (typename Receiver)
-        (requires receiver_of<Receiver, await_result_t<Awaitable>>)
+        (requires receiver_of<Receiver, Result>)
       friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
         return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
       }
@@ -263,6 +263,10 @@ namespace _as_sender {
         (requires receiver_of<Receiver>)
       friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
         return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
+      }
+
+      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
+        return unifex::blocking(t.awaitable_);
       }
     private:
       Awaitable awaitable_;

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -59,7 +59,8 @@ struct await_result_impl<
 
 } // namespace detail
 
-inline const struct _get_awaiter_fn {
+namespace _get_awaiter {
+struct _fn {
   template <typename Awaitable>
   constexpr decltype(auto) operator()(Awaitable&& awaitable) const noexcept {
     if constexpr (detail::has_member_operator_co_await_v<Awaitable>) {
@@ -70,10 +71,13 @@ inline const struct _get_awaiter_fn {
       return static_cast<Awaitable&&>(awaitable);
     }
   }
-} get_awaiter {};
+};
+} // namespace _get_awaiter
+
+inline constexpr _get_awaiter::_fn get_awaiter {};
 
 template <typename Awaitable>
-using awaiter_type_t = decltype(get_awaiter(std::declval<Awaitable>()));
+using awaiter_type_t = remove_cvref_t<decltype(get_awaiter(std::declval<Awaitable>()))>;
 
 template <typename Awaitable>
 using await_result_t =

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -24,6 +24,7 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/std_concepts.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 
 #include <type_traits>
 
@@ -177,6 +178,9 @@ namespace _demat {
           receiver_t<Receiver>{static_cast<Receiver&&>(r)});
     }
 
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+      return blocking(self.source_);
+    }
   private:
     Source source_;
   };

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -37,6 +37,21 @@ namespace unifex {
 
   using detail::_ignore;
 
+  namespace _kv
+  {
+    template <typename Key, typename Value>
+    struct _kv {
+      struct type {
+        using key_type = Key;
+        using value_type = Value;
+        UNIFEX_NO_UNIQUE_ADDRESS Key key;
+        Value value;
+      };
+    };
+  } // namespace _kv
+  template <typename Key, typename Value>
+  using kv = typename _kv::_kv<Key, Value>::type;
+
   namespace _execute_cpo {
     extern const struct _fn execute;
   } // namespace _execute_cpo
@@ -58,5 +73,22 @@ namespace unifex {
   } // namespace _await_tfx
   extern const _await_tfx::_fn await_transform;
 #endif
+
+  namespace _schedule {
+    struct _fn;
+  } // namespace _schedule
+  extern const _schedule::_fn schedule;
+
+  namespace _sf {
+    template <const auto&, typename, typename>
+    struct sender_for;
+  } // namespace _sf
+  using _sf::sender_for;
+
+  template <typename>
+  struct sender_traits;
+
+  template <const auto& CPO, typename Sender, typename Context>
+  struct sender_traits<sender_for<CPO, Sender, Context>>;
 
 } // namespace unifex

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -33,9 +33,10 @@ namespace unifex {
       template <typename T>
       /*implicit*/ _ignore(T&&) noexcept {}
     };
-  } // namespace detail
 
-  using detail::_ignore;
+    template <int=0>
+    struct _empty {};
+  } // namespace detail
 
   namespace _kv
   {

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -54,9 +54,9 @@ namespace unifex {
 
 #if !UNIFEX_NO_COROUTINES
   namespace _await_tfx {
-    extern const struct _fn await_transform;
-  }
-  using _await_tfx::await_transform;
+    struct _fn;
+  } // namespace _await_tfx
+  extern const _await_tfx::_fn await_transform;
 #endif
 
 } // namespace unifex

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -718,6 +718,10 @@ namespace unifex
 
       friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
         if constexpr (
+            blocking_kind::never == cblocking<SourceSender>() ||
+            blocking_kind::never == cblocking<CompletionSender>()) {
+          return blocking_kind::never;
+        } else if constexpr (
             blocking_kind::maybe != cblocking<SourceSender>() &&
             blocking_kind::maybe != cblocking<CompletionSender>()) {
           return blocking_kind::constant<

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -72,6 +72,26 @@ namespace unifex
         Receiver,
         std::decay_t<Values>...>::type;
 
+    constexpr blocking_kind _blocking_kind(
+        blocking_kind source,
+        blocking_kind completion) noexcept {
+      if (source == blocking_kind::never || completion == blocking_kind::never) {
+        return blocking_kind::never;
+      } else if (
+          source == blocking_kind::always_inline &&
+          completion == blocking_kind::always_inline) {
+        return blocking_kind::always_inline;
+      } else if (
+          (source == blocking_kind::always_inline ||
+          source == blocking_kind::always) &&
+          (completion == blocking_kind::always_inline ||
+          completion == blocking_kind::always)) {
+        return blocking_kind::always;
+      } else {
+        return blocking_kind::maybe;
+      }
+    }
+
     template <
         typename SourceSender,
         typename CompletionSender,
@@ -85,7 +105,7 @@ namespace unifex
       explicit type(operation_type* op) noexcept : op_(op) {}
 
       type(type&& other) noexcept
-      : op_(std::exchange(other.op_, nullptr)) {}
+        : op_(std::exchange(other.op_, nullptr)) {}
 
       void set_value() && noexcept {
         auto* const op = op_;
@@ -696,36 +716,50 @@ namespace unifex
                 static_cast<Receiver&&>(r)};
       }
 
+      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+        if constexpr (
+            blocking_kind::maybe != cblocking<SourceSender>() &&
+            blocking_kind::maybe != cblocking<CompletionSender>()) {
+          return blocking_kind::constant<
+              _final::_blocking_kind(
+                  cblocking<SourceSender>(),
+                  cblocking<CompletionSender>())>{};
+        } else {
+          return _final::_blocking_kind(
+              blocking(self.source_),
+              blocking(self.completion_));
+        }
+      }
+
       SourceSender source_;
       CompletionSender completion_;
     };
-  }  // namespace _final
 
-  namespace _final_cpo
-  {
-    inline const struct _fn {
-      template <typename SourceSender, typename CompletionSender>
-      auto operator()(SourceSender&& source, CompletionSender&& completion) const
-          noexcept(std::is_nothrow_constructible_v<
-                  _final::sender<SourceSender, CompletionSender>,
-                  SourceSender,
-                  CompletionSender>) -> _final::sender<SourceSender, CompletionSender> {
-        return _final::sender<SourceSender, CompletionSender>{
-            static_cast<SourceSender&&>(source),
-            static_cast<CompletionSender&&>(completion)};
-      }
-      template <typename CompletionSender>
-      constexpr auto operator()(CompletionSender&& completion) const
-          noexcept(is_nothrow_callable_v<
-            tag_t<bind_back>, _fn, CompletionSender>)
-          -> bind_back_result_t<_fn, CompletionSender> {
-        return bind_back(*this, (CompletionSender&&)completion);
-      }
-    } finally{};
-  } // namespace _final_cpo
+    namespace _cpo
+    {
+      struct _fn {
+        template <typename SourceSender, typename CompletionSender>
+        auto operator()(SourceSender&& source, CompletionSender&& completion) const
+            noexcept(std::is_nothrow_constructible_v<
+                    _final::sender<SourceSender, CompletionSender>,
+                    SourceSender,
+                    CompletionSender>) -> _final::sender<SourceSender, CompletionSender> {
+          return _final::sender<SourceSender, CompletionSender>{
+              static_cast<SourceSender&&>(source),
+              static_cast<CompletionSender&&>(completion)};
+        }
+        template <typename CompletionSender>
+        constexpr auto operator()(CompletionSender&& completion) const
+            noexcept(is_nothrow_callable_v<
+              tag_t<bind_back>, _fn, CompletionSender>)
+            -> bind_back_result_t<_fn, CompletionSender> {
+          return bind_back(*this, (CompletionSender&&)completion);
+        }
+      };
+    } // namespace _cpo
+  } // namespace _final
 
-using _final_cpo::finally;
-
+  inline constexpr _final::_cpo::_fn finally {};
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -22,6 +22,7 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/unstoppable_token.hpp>
+#include <unifex/blocking.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -50,6 +51,10 @@ namespace _get_stop_token {
         (requires same_as<Tag, tag_t<await_transform>>)
       friend auto tag_invoke(Tag, Promise& promise, _awaitable) noexcept {
         return _awaiter{_fn{}(promise)};
+      }
+
+      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaitable&) noexcept {
+        return blocking_kind::always_inline;
       }
     };
 

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -43,6 +43,10 @@ namespace _get_stop_token {
         StopToken await_resume() noexcept {
           return (StopToken&&) stoken_;
         }
+
+        friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
+          return blocking_kind::always_inline;
+        }
       };
       template <typename StopToken>
       _awaiter(StopToken) -> _awaiter<StopToken>;
@@ -51,10 +55,6 @@ namespace _get_stop_token {
         (requires same_as<Tag, tag_t<await_transform>>)
       friend auto tag_invoke(Tag, Promise& promise, _awaitable) noexcept {
         return _awaiter{_fn{}(promise)};
-      }
-
-      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaitable&) noexcept {
-        return blocking_kind::always_inline;
       }
     };
 

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -76,7 +76,7 @@ namespace _inline_sched {
 
       static constexpr bool sends_done = true;
 
-      friend constexpr blocking_kind tag_invoke(
+      friend constexpr auto tag_invoke(
           tag_t<blocking>,
           const schedule_task&) noexcept {
         return blocking_kind::always_inline;

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -95,7 +95,7 @@ class _sender<Values...>::type {
     return {static_cast<This&&>(that).values_, static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const type&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/just_done.hpp
+++ b/include/unifex/just_done.hpp
@@ -68,7 +68,7 @@ class sender {
     return {static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const sender&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/just_error.hpp
+++ b/include/unifex/just_error.hpp
@@ -85,7 +85,7 @@ class _sender<Error>::type {
     return {static_cast<This&&>(that).error_, static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const type&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -89,7 +89,7 @@ class context {
  public:
   class scheduler {
     class schedule_task {
-      friend constexpr blocking_kind tag_invoke(
+      friend constexpr auto tag_invoke(
           tag_t<blocking>,
           const schedule_task&) noexcept {
         return blocking_kind::never;

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -57,7 +57,7 @@ struct next_sender {
 
   static constexpr bool sends_done = true;
 
-  friend constexpr blocking_kind tag_invoke(
+  friend constexpr auto tag_invoke(
       tag_t<blocking>,
       const stream&) noexcept {
     return blocking_kind::always_inline;

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -52,7 +52,7 @@ namespace _ready_done {
 
     static constexpr bool sends_done = true;
 
-    friend constexpr blocking_kind tag_invoke(
+    friend constexpr auto tag_invoke(
         tag_t<blocking>,
         const sender&) {
       return blocking_kind::always_inline;

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -461,7 +461,37 @@ namespace _now {
 using _now::now;
 
 namespace _current {
-  inline const struct _scheduler {
+  struct _scheduler {
+#if !UNIFEX_NO_COROUTINES
+  private:
+    template <typename Scheduler>
+    struct _awaiter {
+      Scheduler sched_;
+
+      static constexpr bool await_ready() noexcept {
+        return true;
+      }
+      void await_suspend(coro::coroutine_handle<>) const noexcept {
+      }
+      Scheduler await_resume() {
+        return (Scheduler&&) sched_;
+      }
+      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
+        return blocking_kind::always_inline;
+      }
+    };
+    template <typename Scheduler>
+    _awaiter(Scheduler) -> _awaiter<Scheduler>;
+
+    // `co_await current_scheduler()` to fetch a coroutine's current scheduler.
+    template (typename Tag, typename Promise)
+      (requires same_as<Tag, tag_t<await_transform>> AND scheduler_provider<Promise&>)
+    friend auto tag_invoke(Tag, Promise& promise, _scheduler) noexcept {
+      return _awaiter{get_scheduler(promise)};
+    }
+#endif
+
+  public:
     auto schedule() const noexcept {
         return unifex::schedule();
     }
@@ -479,9 +509,12 @@ namespace _current {
     friend constexpr bool operator!=(_scheduler, _scheduler) noexcept {
         return false;
     }
-  } current_scheduler{};
-}
-using _current::current_scheduler;
+    constexpr _scheduler operator()() const noexcept {
+      return {};
+    }
+  };
+} // namespace _current
+inline constexpr _current::_scheduler current_scheduler {};
 
 } // namespace unifex
 

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -132,7 +132,7 @@ namespace _schedule {
   template <typename S>
   using _schedule_result_t = decltype(impl(UNIFEX_DECLVAL(S&&)));
 
-  inline const struct _fn {
+  struct _fn {
     template (typename Scheduler)
       (requires callable<_impl, Scheduler>)
     auto operator()(Scheduler&& sched) const
@@ -142,7 +142,7 @@ namespace _schedule {
     }
 
     constexpr sender operator()() const noexcept;
-  } schedule{};
+  };
 } // namespace _schedule
 inline const _schedule::_fn schedule {};
 

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -134,7 +134,17 @@ namespace detail {
   };
 
 // Workaround for unknown MSVC (19.28.29333) bug
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+  template <typename S>
+  inline constexpr bool _has_sender_traits =
+      !std::is_base_of_v<_no_sender_traits, sender_traits<S>>;
+#elif UNIFEX_CXX_CONCEPTS
+  template <typename S>
+  concept _has_sender_traits =
+      !requires {
+        typename sender_traits<S>::_unspecialized;
+      };
+#else
   template <typename S>
   UNIFEX_CONCEPT_FRAGMENT(  //
     _not_has_sender_traits, //
@@ -145,10 +155,6 @@ namespace detail {
   UNIFEX_CONCEPT         //
     _has_sender_traits = //
       (!UNIFEX_FRAGMENT(detail::_not_has_sender_traits, S));
-#else
-  template <typename S>
-  inline constexpr bool _has_sender_traits =
-      !std::is_base_of_v<_no_sender_traits, sender_traits<S>>; 
 #endif
 
   template <typename S>

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -133,21 +133,6 @@ namespace detail {
     using next_types = typename S::template next_types<Variant, Tuple>;
   };
 
-// #if !UNIFEX_NO_COROUTINES
-//   template <typename A>
-//   struct _awaitable_sender_traits {
-//     template <
-//         template <typename...> class Variant,
-//         template <typename...> class Tuple>
-//     using value_types = Variant<Tuple<await_result_t<A>>>;
-
-//     template <template <typename...> class Variant>
-//     using error_types = Variant<std::exception_ptr>;
-
-//     static constexpr bool sends_done = true;
-//   };
-// #endif
-
   struct _no_sender_traits {
     using _unspecialized = void;
   };
@@ -186,10 +171,6 @@ namespace detail {
       return _void_sender_traits{};
     } else if constexpr (std::is_base_of_v<sender_base, S>) {
       return sender_base{};
-// #if !UNIFEX_NO_COROUTINES
-//     } else if constexpr (detail::_awaitable<S>) {
-//       return _awaitable_sender_traits<S>{};
-// #endif
     } else {
       return _no_sender_traits{};
     }

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -21,6 +21,10 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/receiver_concepts.hpp>
 
+#if !UNIFEX_NO_COROUTINES
+#include <unifex/coroutine_concepts.hpp>
+#endif
+
 #include <exception>
 #include <tuple>
 #include <type_traits>
@@ -129,6 +133,21 @@ namespace detail {
     using next_types = typename S::template next_types<Variant, Tuple>;
   };
 
+// #if !UNIFEX_NO_COROUTINES
+//   template <typename A>
+//   struct _awaitable_sender_traits {
+//     template <
+//         template <typename...> class Variant,
+//         template <typename...> class Tuple>
+//     using value_types = Variant<Tuple<await_result_t<A>>>;
+
+//     template <template <typename...> class Variant>
+//     using error_types = Variant<std::exception_ptr>;
+
+//     static constexpr bool sends_done = true;
+//   };
+// #endif
+
   struct _no_sender_traits {
     using _unspecialized = void;
   };
@@ -167,6 +186,10 @@ namespace detail {
       return _void_sender_traits{};
     } else if constexpr (std::is_base_of_v<sender_base, S>) {
       return sender_base{};
+// #if !UNIFEX_NO_COROUTINES
+//     } else if constexpr (detail::_awaitable<S>) {
+//       return _awaitable_sender_traits<S>{};
+// #endif
     } else {
       return _no_sender_traits{};
     }

--- a/include/unifex/sender_for.hpp
+++ b/include/unifex/sender_for.hpp
@@ -50,6 +50,7 @@ namespace unifex
               std::is_nothrow_move_constructible_v<Context>)
         : snd_((Sender&&) snd), ctx_{(Context&&) ctx} {}
 
+      // Forward all tag_invokes:
       template (typename CPO, typename Self, typename... Args)
         (requires same_as<sender_for, remove_cvref_t<Self>> AND
             (!callable<const Context&, CPO>) AND
@@ -60,7 +61,7 @@ namespace unifex
         return ((CPO&&) cpo)(((Self&&) self).snd_, (Args&&) args...);
       }
 
-      // Handle property queries:
+      // Handle custom property queries by consulting the context:
       template (typename CPO)
         (requires callable<const Context&, CPO>)
       UNIFEX_ALWAYS_INLINE
@@ -99,6 +100,12 @@ namespace unifex
 
   template <const auto& CPO>
   inline constexpr _sf::_make_sender_for<CPO> make_sender_for {};
+
+  template <typename T, const auto& CPO>
+  inline constexpr bool is_sender_for_v = false;
+
+  template <typename Sender, typename Context, const auto& CPO>
+  inline constexpr bool is_sender_for_v<sender_for<CPO, Sender, Context>, CPO> = true;
 
   template <const auto& CPO, typename Sender, typename Context>
   struct sender_traits<sender_for<CPO, Sender, Context>>

--- a/include/unifex/sender_for.hpp
+++ b/include/unifex/sender_for.hpp
@@ -36,9 +36,8 @@ namespace unifex
         (requires same_as<sender_for, remove_cvref_t<Self>> AND
             callable<CPO, member_t<Self, Sender>, Args...>)
       UNIFEX_ALWAYS_INLINE
-      friend auto tag_invoke(CPO cpo, Self&& self, Args&&... args)
-          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>)
-          -> callable_result_t<CPO, member_t<Self, Sender>, Args...> {
+      friend decltype(auto) tag_invoke(CPO cpo, Self&& self, Args&&... args)
+          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>) {
         return ((CPO&&) cpo)(((Self&&) self).snd_, (Args&&) args...);
       }
 

--- a/include/unifex/sender_for.hpp
+++ b/include/unifex/sender_for.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex
+{
+  namespace _sf
+  {
+    template <const auto& C, typename Sender>
+    struct sender_for {
+      explicit sender_for(Sender snd)
+          noexcept(std::is_nothrow_move_constructible_v<Sender>)
+        : snd_((Sender&&) snd) {}
+
+      template (typename CPO, typename Self, typename... Args)
+        (requires same_as<sender_for, remove_cvref_t<Self>> AND
+            callable<CPO, member_t<Self, Sender>, Args...>)
+      UNIFEX_ALWAYS_INLINE
+      friend decltype(auto) tag_invoke(CPO cpo, Self&& self, Args&&... args)
+          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>) {
+        return ((CPO&&) cpo)(((Self&&) self).snd_, (Args&&) args...);
+      }
+
+      const Sender& base() const & noexcept {
+        return snd_;
+      }
+
+      Sender&& base() && noexcept {
+        return (Sender&&) snd_;
+      }
+     private:
+      Sender snd_;
+    };
+
+    template <auto& CPO>
+    struct _make_sender_for {
+      template (typename Sender)
+        (requires sender<Sender>)
+      sender_for<CPO, remove_cvref_t<Sender>> operator()(Sender&& snd) const
+          noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>) {
+        return sender_for<CPO, remove_cvref_t<Sender>>{(Sender&&) snd};
+      }
+    };
+  } // namespace _sf
+
+  using _sf::sender_for;
+
+  template <const auto& CPO>
+  inline constexpr _sf::_make_sender_for<CPO> make_sender_for {};
+
+  template <const auto& CPO, typename Sender>
+  struct sender_traits<sender_for<CPO, Sender>>
+    : sender_traits<Sender>
+  {};
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sender_for.hpp
+++ b/include/unifex/sender_for.hpp
@@ -36,8 +36,9 @@ namespace unifex
         (requires same_as<sender_for, remove_cvref_t<Self>> AND
             callable<CPO, member_t<Self, Sender>, Args...>)
       UNIFEX_ALWAYS_INLINE
-      friend decltype(auto) tag_invoke(CPO cpo, Self&& self, Args&&... args)
-          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>) {
+      friend auto tag_invoke(CPO cpo, Self&& self, Args&&... args)
+          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>)
+          -> callable_result_t<CPO, member_t<Self, Sender>, Args...> {
         return ((CPO&&) cpo)(((Self&&) self).snd_, (Args&&) args...);
       }
 

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -37,6 +37,25 @@ namespace unifex
 {
   namespace _seq
   {
+    constexpr blocking_kind _blocking_kind(
+        blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
+      if (predBlocking == blocking_kind::never) {
+        return blocking_kind::never;
+      } else if (
+          predBlocking == blocking_kind::always_inline &&
+          succBlocking == blocking_kind::always_inline) {
+        return blocking_kind::always_inline;
+      } else if (
+          (predBlocking == blocking_kind::always_inline ||
+          predBlocking == blocking_kind::always) &&
+          (succBlocking == blocking_kind::always_inline ||
+          succBlocking == blocking_kind::always)) {
+        return blocking_kind::always;
+      } else {
+        return blocking_kind::maybe;
+      }
+    }
+
     template <typename Predecessor, typename Successor, typename Receiver>
     struct _op {
       class type;
@@ -283,18 +302,16 @@ namespace unifex
     };
 
     template <typename Predecessor, typename Successor>
-    struct _sender {
-      class type;
+    struct _sndr {
+      struct type;
     };
     template <typename Predecessor, typename Successor>
-    using sender = typename _sender<
+    using _sender = typename _sndr<
         remove_cvref_t<Predecessor>,
         remove_cvref_t<Successor>>::type;
 
     template <typename Predecessor, typename Successor>
-    class _sender<Predecessor, Successor>::type {
-      using sender = type;
-    public:
+    struct _sndr<Predecessor, Successor>::type {
       template <
           template <typename...> class Variant,
           template <typename...> class Tuple>
@@ -321,25 +338,16 @@ namespace unifex
         : predecessor_(static_cast<Predecessor&&>(predecessor))
         , successor_(static_cast<Successor&&>(successor)) {}
 
-      // TODO: give this a compile-time blocking when possible.
-      friend blocking_kind
-      tag_invoke(tag_t<blocking>, const sender& sender) {
-        const auto predBlocking = blocking(sender.predecessor_);
-        const auto succBlocking = blocking(sender.successor_);
-        if (predBlocking == blocking_kind::never) {
-          return blocking_kind::never;
-        } else if (
-            predBlocking == blocking_kind::always_inline &&
-            succBlocking == blocking_kind::always_inline) {
-          return blocking_kind::always_inline;
-        } else if (
-            (predBlocking == blocking_kind::always_inline ||
-            predBlocking == blocking_kind::always) &&
-            (succBlocking == blocking_kind::always_inline ||
-            succBlocking == blocking_kind::always)) {
-          return blocking_kind::always;
+      friend auto tag_invoke(tag_t<blocking>, const type& self) {
+        if constexpr (
+            blocking_kind::maybe != cblocking<Predecessor>() &&
+            blocking_kind::maybe != cblocking<Successor>()) {
+          return blocking_kind::constant<
+              _seq::_blocking_kind(cblocking<Predecessor>(), cblocking<Successor>())>();
         } else {
-          return blocking_kind::maybe;
+          return _seq::_blocking_kind(
+              blocking(self.predecessor_),
+              blocking(self.successor_));
         }
       }
 
@@ -364,81 +372,81 @@ namespace unifex
       UNIFEX_NO_UNIQUE_ADDRESS Predecessor predecessor_;
       UNIFEX_NO_UNIQUE_ADDRESS Successor successor_;
     };
-  }  // namespace _seq
 
-  namespace _seq_cpo {
-    inline const struct _fn {
-      // Sequencing a single sender is just the same as returning the sender
-      // itself.
-      template <typename First>
-      remove_cvref_t<First> operator()(First&& first) const
-          noexcept(std::is_nothrow_constructible_v<remove_cvref_t<First>, First>) {
-        return static_cast<First&&>(first);
-      }
+    namespace _cpo {
+      struct _fn {
+        // Sequencing a single sender is just the same as returning the sender
+        // itself.
+        template <typename First>
+        remove_cvref_t<First> operator()(First&& first) const
+            noexcept(std::is_nothrow_constructible_v<remove_cvref_t<First>, First>) {
+          return static_cast<First&&>(first);
+        }
 
-      template(typename First, typename Second)
-        (requires sender<First> AND sender<Second> AND //
-          tag_invocable<_fn, First, Second>)
-      auto operator()(First&& first, Second&& second) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, First, Second>)
-          -> tag_invoke_result_t<_fn, First, Second> {
-        return unifex::tag_invoke(
-            _fn{}, static_cast<First&&>(first), static_cast<Second&&>(second));
-      }
+        template(typename First, typename Second)
+          (requires sender<First> AND sender<Second> AND //
+            tag_invocable<_fn, First, Second>)
+        auto operator()(First&& first, Second&& second) const
+            noexcept(is_nothrow_tag_invocable_v<_fn, First, Second>)
+            -> tag_invoke_result_t<_fn, First, Second> {
+          return unifex::tag_invoke(
+              _fn{}, static_cast<First&&>(first), static_cast<Second&&>(second));
+        }
 
-      template(typename First, typename Second)
-        (requires sender<First> AND sender<Second> AND //
-          (!tag_invocable<_fn, First, Second>))
-      auto operator()(First&& first, Second&& second) const
-          noexcept(std::is_nothrow_constructible_v<
-                  _seq::sender<First, Second>,
-                  First,
-                  Second>)
-              -> _seq::sender<First, Second> {
-        return _seq::sender<First, Second>{
-            static_cast<First&&>(first),
-            static_cast<Second&&>(second)};
-      }
+        template(typename First, typename Second)
+          (requires sender<First> AND sender<Second> AND //
+            (!tag_invocable<_fn, First, Second>))
+        auto operator()(First&& first, Second&& second) const
+            noexcept(std::is_nothrow_constructible_v<
+                    _seq::_sender<First, Second>,
+                    First,
+                    Second>)
+                -> _seq::_sender<First, Second> {
+          return _seq::_sender<First, Second>{
+              static_cast<First&&>(first),
+              static_cast<Second&&>(second)};
+        }
 
-      template(typename First, typename Second, typename Third, typename... Rest)
-        (requires sender<First> AND sender<Second> AND sender<Third> AND
-          (sender<Rest> &&...) AND tag_invocable<_fn, First, Second, Third, Rest...>)
-      auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Third, Rest...>)
-          -> tag_invoke_result_t<_fn, First, Second, Third, Rest...> {
-        return unifex::tag_invoke(
-            _fn{},
-            static_cast<First&&>(first),
-            static_cast<Second&&>(second),
-            static_cast<Third&&>(third),
-            static_cast<Rest&&>(rest)...);
-      }
+        template(typename First, typename Second, typename Third, typename... Rest)
+          (requires sender<First> AND sender<Second> AND sender<Third> AND
+            (sender<Rest> &&...) AND tag_invocable<_fn, First, Second, Third, Rest...>)
+        auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
+            noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Third, Rest...>)
+            -> tag_invoke_result_t<_fn, First, Second, Third, Rest...> {
+          return unifex::tag_invoke(
+              _fn{},
+              static_cast<First&&>(first),
+              static_cast<Second&&>(second),
+              static_cast<Third&&>(third),
+              static_cast<Rest&&>(rest)...);
+        }
 
-      template(typename First, typename Second, typename Third, typename... Rest)
-        (requires sender<First> AND sender<Second> AND sender<Third> AND
-          (sender<Rest> &&...) AND (!tag_invocable<_fn, First, Second, Third, Rest...>))
-      auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
-          noexcept(is_nothrow_callable_v<_fn, First, Second> &&
-              is_nothrow_callable_v<
-                  _fn,
-                  callable_result_t<_fn, First, Second>,
-                  Third,
-                  Rest...>)
-          -> callable_result_t<
-              _fn,
-              callable_result_t<_fn, First, Second>,
-              Third,
-              Rest...> {
-        // Fall-back to pair-wise invocation of the sequence() CPO.
-        return (*this)(
-            (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
-            static_cast<Third&&>(third),
-            static_cast<Rest&&>(rest)...);
-      }
-    } sequence{};
-  } // _seq_cpo
+        template(typename First, typename Second, typename Third, typename... Rest)
+          (requires sender<First> AND sender<Second> AND sender<Third> AND
+            (sender<Rest> &&...) AND (!tag_invocable<_fn, First, Second, Third, Rest...>))
+        auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
+            noexcept(is_nothrow_callable_v<_fn, First, Second> &&
+                is_nothrow_callable_v<
+                    _fn,
+                    callable_result_t<_fn, First, Second>,
+                    Third,
+                    Rest...>)
+            -> callable_result_t<
+                _fn,
+                callable_result_t<_fn, First, Second>,
+                Third,
+                Rest...> {
+          // Fall-back to pair-wise invocation of the sequence() CPO.
+          return (*this)(
+              (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
+              static_cast<Third&&>(third),
+              static_cast<Rest&&>(rest)...);
+        }
+      };
+    } // _cpo
+  } // namespace _seq
 
-  using _seq_cpo::sequence;
+  inline constexpr _seq::_cpo::_fn sequence {};
 
 } // namespace unifex
 

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -321,6 +321,7 @@ namespace unifex
         : predecessor_(static_cast<Predecessor&&>(predecessor))
         , successor_(static_cast<Successor&&>(successor)) {}
 
+      // TODO: give this a compile-time blocking when possible.
       friend blocking_kind
       tag_invoke(tag_t<blocking>, const sender& sender) {
         const auto predBlocking = blocking(sender.predecessor_);

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -19,6 +19,7 @@
 #include <unifex/coroutine.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/blocking.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -81,6 +82,10 @@ private:
     auto connect(Receiver&& rec) const
       -> typename _op<remove_cvref_t<Receiver>>::type {
       return typename _op<remove_cvref_t<Receiver>>::type{(Receiver&&) rec};
+    }
+
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _sender&) noexcept {
+      return blocking_kind::always_inline;
     }
   };
 

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/detail/concept_macros.hpp>
 
@@ -56,8 +57,6 @@ namespace unifex {
       using type = T<Args...>;
     };
 
-    struct empty {};
-
     namespace _cpo {
       inline constexpr _fn tag_invoke{};
     }
@@ -85,7 +84,7 @@ namespace unifex {
     : conditional_t<
           is_tag_invocable_v<CPO, Args...>,
           _tag_invoke::defer<tag_invoke_result_t, CPO, Args...>,
-          _tag_invoke::empty> 
+          detail::_empty<>>
   {};
 
   template <typename CPO, typename... Args>

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -57,12 +57,12 @@ namespace unifex {
     };
 
     struct empty {};
-  }  // namespace _tag_invoke
 
-  namespace _tag_invoke_cpo {
-    inline constexpr _tag_invoke::_fn tag_invoke{};
-  }
-  using namespace _tag_invoke_cpo;
+    namespace _cpo {
+      inline constexpr _fn tag_invoke{};
+    }
+  } // namespace _tag_invoke
+  using namespace _tag_invoke::_cpo;
 
   template <auto& CPO>
   using tag_t = remove_cvref_t<decltype(CPO)>;

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -195,8 +195,7 @@ struct _awaiter {
 
     ~type() {
       if (coro_ & 1u) {
-        --coro_;
-        auto thisCoro = coro::coroutine_handle<>::from_address((void*) coro_);
+        auto thisCoro = coro::coroutine_handle<>::from_address((void*) --coro_);
         thisCoro.destroy();
         stopTokenAdapter_.unsubscribe();
         sched_.destruct();

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -177,8 +177,8 @@ struct _promise {
     template <typename Value>
     decltype(auto) await_transform(Value&& value) {
       if constexpr (derived_from<remove_cvref_t<Value>, _task_base>) {
-        // We are co_await-ing a unifex::task or something that completes inline. We don't
-        // need an additional transition.
+        // We are co_await-ing a unifex::task, which completes inline because of task
+        // scheduler affinity. We don't need an additional transition.
         return unifex::await_transform(*this, (Value&&) value);
       } else if constexpr (tag_invocable<tag_t<unifex::await_transform>, type&, Value>
           || detail::_awaitable<Value>) {
@@ -198,7 +198,7 @@ struct _promise {
     template <typename Awaitable>
     decltype(auto) transform_awaitable_(Awaitable&& awaitable) {
       if constexpr (blocking_kind::always_inline == cblocking<Awaitable>()) {
-        return (Awaitable&&) awaitable;
+        return Awaitable{(Awaitable&&) awaitable};
       } else {
         return unifex::await_transform(
             *this,

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -79,6 +79,10 @@ struct _promise_base {
       return false;
     }
     static void await_resume() noexcept {}
+
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _final_suspend_awaiter_base&) noexcept {
+      return blocking_kind::always_inline;
+    }
   };
 
   coro::suspend_always initial_suspend() noexcept {

--- a/include/unifex/this.hpp
+++ b/include/unifex/this.hpp
@@ -49,7 +49,7 @@ struct _replace_this<void> {
   using apply = Arg;
 
   template <typename Arg>
-  static Arg&& get(Arg&& arg, _ignore) noexcept {
+  static Arg&& get(Arg&& arg, detail::_ignore) noexcept {
     return (Arg &&) arg;
   }
 };
@@ -60,7 +60,7 @@ struct _replace_this<this_> {
   using apply = T;
 
   template <typename T>
-  static T&& get(_ignore, T& obj) noexcept {
+  static T&& get(detail::_ignore, T& obj) noexcept {
     return (T &&) obj;
   }
 };
@@ -71,7 +71,7 @@ struct _replace_this<this_&> {
   using apply = T&;
 
   template <typename T>
-  static T& get(_ignore, T& obj) noexcept {
+  static T& get(detail::_ignore, T& obj) noexcept {
     return obj;
   }
 };
@@ -82,7 +82,7 @@ struct _replace_this<this_&&> {
   using apply = T&&;
 
   template <typename T>
-  static T&& get(_ignore, T& obj) noexcept {
+  static T&& get(detail::_ignore, T& obj) noexcept {
     return (T &&) obj;
   }
 };
@@ -93,7 +93,7 @@ struct _replace_this<const this_&> {
   using apply = const T&;
 
   template <typename T>
-  static const T& get(_ignore, T& obj) noexcept {
+  static const T& get(detail::_ignore, T& obj) noexcept {
     return obj;
   }
 };
@@ -104,7 +104,7 @@ struct _replace_this<const this_&&> {
   using type = const T&&;
 
   template <typename T>
-  static const T&& get(_ignore, T& obj) noexcept {
+  static const T&& get(detail::_ignore, T& obj) noexcept {
     return (const T&&) obj;
   }
 };
@@ -132,7 +132,7 @@ struct _extract_this {
 template <bool... IsThis>
 struct _extract_this<false, IsThis...> {
   template <typename... TRest>
-  decltype(auto) operator()(_ignore, TRest&&... rest) const noexcept {
+  decltype(auto) operator()(detail::_ignore, TRest&&... rest) const noexcept {
     static_assert(sizeof...(IsThis) > 0, "Arguments to extract_this");
     return _extract_this<IsThis...>{}((TRest &&) rest...);
   }

--- a/include/unifex/transform_error.hpp
+++ b/include/unifex/transform_error.hpp
@@ -91,7 +91,7 @@ public:
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  void set_error(_ignore) noexcept {
+  void set_error(detail::_ignore) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
     auto op = op_; // preserve pointer value.
     if constexpr (

--- a/include/unifex/transform_error.hpp
+++ b/include/unifex/transform_error.hpp
@@ -72,10 +72,10 @@ class _rcvr<Source, Error, Receiver>::type final {
 
 public:
   explicit type(operation* op) noexcept
-  : op_(op) {}
+    : op_(op) {}
 
   type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
+    : op_(std::exchange(other.op_, {}))
   {}
  
   template(typename... Values)
@@ -154,10 +154,10 @@ class _frcvr<Source, Error, Receiver>::type {
 
 public:
   explicit type(operation* op) noexcept
-  : op_(op) {}
+    : op_(op) {}
 
   type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
+    : op_(std::exchange(other.op_, {}))
   {}
  
   template(typename... Values)
@@ -269,6 +269,12 @@ template <typename Source, typename Error>
 class _sndr<Source, Error>::type {
   using final_sender_t = callable_result_t<Error>;
 
+  template <typename Sender, typename Receiver>
+  using source_receiver_t = receiver_type<member_t<Sender, Source>, Error, Receiver>;
+
+  template <typename Sender, typename Receiver>
+  using final_receiver_t = final_receiver_type<member_t<Sender, Source>, Error, Receiver>;
+
 public:
   template <template <typename...> class Variant,
             template <typename...> class Tuple>
@@ -296,20 +302,16 @@ public:
     , error_((Error2&&)error)
   {}
 
-  template(
-    typename Sender,
-    typename Receiver,
-    typename...,
-    typename SourceReceiver = receiver_type<member_t<Sender, Source>, Error, Receiver>,
-    typename FinalReceiver = final_receiver_type<member_t<Sender, Source>, Error, Receiver>)
+  template(typename Sender, typename Receiver)
       (requires same_as<remove_cvref_t<Sender>, type> AND
           constructible_from<Error, member_t<Sender, Error>> AND
           constructible_from<remove_cvref_t<Receiver>, Receiver> AND
-          sender_to<member_t<Sender, Source>, SourceReceiver> AND
-          sender_to<final_sender_t, FinalReceiver>)
+          receiver<Receiver> AND
+          sender_to<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>> AND
+          sender_to<final_sender_t, final_receiver_t<Sender, Receiver>>)
   friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-       noexcept(
-        is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver> &&
+      noexcept(
+        is_nothrow_connectable_v<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>> &&
         std::is_nothrow_constructible_v<Error, member_t<Sender, Error>> &&
         std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
       -> operation_type<member_t<Sender, Source>, Error, Receiver> {

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -63,6 +63,11 @@ namespace _typed_via {
 } // namespace _typed_via
 
 inline constexpr _typed_via::_fn typed_via {};
+
+template <typename Source, typename Scheduler>
+using typed_via_result_t =
+    decltype(typed_via(UNIFEX_DECLVAL(Source&&), UNIFEX_DECLVAL(Scheduler&&)));
+
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -34,6 +34,25 @@
 namespace unifex {
 namespace _via {
 
+constexpr blocking_kind _blocking_kind(blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
+  if (predBlocking == blocking_kind::never &&
+      succBlocking == blocking_kind::never) {
+    return blocking_kind::never;
+  } else if (
+      predBlocking == blocking_kind::always_inline &&
+      succBlocking == blocking_kind::always_inline) {
+    return blocking_kind::always_inline;
+  } else if (
+      (predBlocking == blocking_kind::always_inline ||
+        predBlocking == blocking_kind::always) &&
+      (succBlocking == blocking_kind::always_inline ||
+        succBlocking == blocking_kind::always)) {
+    return blocking_kind::always;
+  } else {
+    return blocking_kind::maybe;
+  }
+}
+
 template <typename Receiver, typename... Values>
 struct _value_receiver {
   struct type;
@@ -276,27 +295,14 @@ struct _sender<Predecessor, Successor>::type {
     sender_traits<Predecessor>::sends_done ||
     sender_traits<Successor>::sends_done;
 
-  // TODO: give this a compile-time blocking when possible.
-  friend constexpr blocking_kind tag_invoke(
-      tag_t<blocking>,
-      const sender& sender) {
-    const auto predBlocking = blocking(sender.pred_);
-    const auto succBlocking = blocking(sender.succ_);
-    if (predBlocking == blocking_kind::never &&
-        succBlocking == blocking_kind::never) {
-      return blocking_kind::never;
-    } else if (
-        predBlocking == blocking_kind::always_inline &&
-        succBlocking == blocking_kind::always_inline) {
-      return blocking_kind::always_inline;
-    } else if (
-        (predBlocking == blocking_kind::always_inline ||
-         predBlocking == blocking_kind::always) &&
-        (succBlocking == blocking_kind::always_inline ||
-         succBlocking == blocking_kind::always)) {
-      return blocking_kind::always;
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender& self) noexcept {
+    if constexpr (
+        blocking_kind::maybe != cblocking<Predecessor>() &&
+        blocking_kind::maybe != cblocking<Successor>()) {
+      return blocking_kind::constant<
+          _via::_blocking_kind(cblocking<Predecessor>(), cblocking<Successor>())>();
     } else {
-      return blocking_kind::maybe;
+      return _via::_blocking_kind(blocking(self.pred_), blocking(self.succ_));
     }
   }
 

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -276,6 +276,7 @@ struct _sender<Predecessor, Successor>::type {
     sender_traits<Predecessor>::sends_done ||
     sender_traits<Successor>::sends_done;
 
+  // TODO: give this a compile-time blocking when possible.
   friend constexpr blocking_kind tag_invoke(
       tag_t<blocking>,
       const sender& sender) {

--- a/test/finally_test.cpp
+++ b/test/finally_test.cpp
@@ -68,3 +68,15 @@ TEST(Finally, Error) {
   ASSERT_TRUE(res.has_value());
   EXPECT_EQ(*res, context.get_thread_id());
 }
+
+TEST(Finally, BlockingKind) {
+  auto snd1 = finally(just(), just());
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::always_inline == cblocking<Snd1>());
+
+  timed_single_thread_context context;
+  
+  auto snd2 = finally(just(), schedule(context.get_scheduler()));
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}

--- a/test/task_scheduler_affinity_test.cpp
+++ b/test/task_scheduler_affinity_test.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <thread>
+
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/single_thread_context.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+namespace {
+struct TaskSchedulerAffinityTest : testing::Test {
+  single_thread_context thread_ctx;
+};
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<std::thread::id, std::thread::id>> child(Scheduler s) {
+  auto that_id =
+      co_await transform(schedule(s), []{ return std::this_thread::get_id(); });
+  // Should have automatically transitioned back to the original thread:
+  auto this_id = std::this_thread::get_id();
+  co_return std::make_pair(this_id, that_id);
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> inner(Scheduler s) {
+  // Transition to the scheduler's context:
+  co_await schedule(s);
+  // Should return the new context
+  co_return std::this_thread::get_id();
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
+  // Call a nested coroutine that transitions context:
+  auto that_id = co_await inner(s);
+  // Should have automatically transitioned back to the correct context
+  auto this_id = std::this_thread::get_id();
+  co_return std::make_pair(this_id, that_id);
+}
+} // anonymous namespace
+
+TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
+  if(auto opt = sync_wait(child(thread_ctx.get_scheduler()))) {
+    auto [this_id, that_id] = *opt;
+    ASSERT_EQ(this_id, std::this_thread::get_id());    
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());    
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, InlineThreadHopInCoroutine) {
+  if(auto opt = sync_wait(outer(thread_ctx.get_scheduler()))) {
+    auto [this_id, that_id] = *opt;
+    ASSERT_EQ(this_id, std::this_thread::get_id());    
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());    
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+#endif // !UNIFEX_NO_COROUTINES

--- a/test/task_scheduler_affinity_test.cpp
+++ b/test/task_scheduler_affinity_test.cpp
@@ -23,7 +23,11 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/task.hpp>
 #include <unifex/transform.hpp>
+#include <unifex/stop_if_requested.hpp>
 #include <unifex/single_thread_context.hpp>
+#include <unifex/just.hpp>
+#include <unifex/transform_done.hpp>
+#include <unifex/transform_error.hpp>
 
 #include <gtest/gtest.h>
 
@@ -62,13 +66,81 @@ task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
   auto this_id = std::this_thread::get_id();
   co_return std::make_pair(this_id, that_id);
 }
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler has changed:
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<bool> test_current_scheduler(Scheduler s) {
+  auto before = co_await current_scheduler();
+  co_await schedule(s);
+  auto after = co_await current_scheduler();
+  co_return before != after;
+}
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler is inherited by child tasks:
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited_impl(Scheduler s) {
+  bool sameScheduler = (co_await current_scheduler()).equal_to(s);
+  co_return std::make_pair(sameScheduler, std::this_thread::get_id());
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Scheduler s) {
+  co_await schedule(s);
+  co_return co_await test_current_scheduler_is_inherited_impl(s);
+}
+
+// Test that we properly transition back to the right context when
+// the task is cancelled.
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<void> test_context_restored_on_cancel_2(Scheduler s) {
+  co_await schedule(s);
+  co_await stop();
+  ADD_FAILURE() << "Coroutine did not stop!";
+  co_return;
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> test_context_restored_on_cancel(Scheduler s) {
+  // swallow the cancellation signal:
+  (void) co_await transform_done(
+      test_context_restored_on_cancel_2(s),
+      []() noexcept { return just(); });
+  co_return std::this_thread::get_id();
+}
+
+// Test that we properly transition back to the right context when
+// the task fails.
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<void> test_context_restored_on_error_2(Scheduler s) {
+  co_await schedule(s);
+  throw std::runtime_error("whoops");
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> test_context_restored_on_error(Scheduler s) {
+  std::thread::id id;
+  // swallow the cancellation signal:
+  try {
+    co_await test_context_restored_on_error_2(s);
+    ADD_FAILURE() << "Was expecting a throw";
+  } catch(...) {
+    id = std::this_thread::get_id();
+  }
+  co_return id;
+}
 } // anonymous namespace
 
 TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
   if(auto opt = sync_wait(child(thread_ctx.get_scheduler()))) {
     auto [this_id, that_id] = *opt;
-    ASSERT_EQ(this_id, std::this_thread::get_id());    
-    ASSERT_EQ(that_id, thread_ctx.get_thread_id());    
+    ASSERT_EQ(this_id, std::this_thread::get_id());
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());
   } else {
     ADD_FAILURE() << "child coroutine completed unexpectedly";
   }
@@ -77,8 +149,46 @@ TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
 TEST_F(TaskSchedulerAffinityTest, InlineThreadHopInCoroutine) {
   if(auto opt = sync_wait(outer(thread_ctx.get_scheduler()))) {
     auto [this_id, that_id] = *opt;
-    ASSERT_EQ(this_id, std::this_thread::get_id());    
-    ASSERT_EQ(that_id, thread_ctx.get_thread_id());    
+    ASSERT_EQ(this_id, std::this_thread::get_id());
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerTest) {
+  if(auto opt = sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_TRUE(*opt);
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerIsInheritedTest) {
+  if(auto opt = sync_wait(test_current_scheduler_is_inherited(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    auto [success, thread_id] = *opt;
+    EXPECT_TRUE(success);
+    EXPECT_EQ(thread_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnCancelTest) {
+  if(auto opt = sync_wait(test_context_restored_on_cancel(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ(*opt, std::this_thread::get_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnErrrorTest) {
+  if(auto opt = sync_wait(test_context_restored_on_error(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ(*opt, std::this_thread::get_id());
   } else {
     ADD_FAILURE() << "child coroutine completed unexpectedly";
   }


### PR DESCRIPTION
This PR makes `unifex::task<>` scheduler-aware. It inherits and propagates the current scheduler just as it does with stop tokens. When awaiting arbitrary awaitables and senders, it wraps the awaitable/sender in `typed_via` to thunk back onto the current scheduler; that is, unless the awaitable/scheduler responds to a `blocking` query with a compile-time `blocking_kind::always_inline`.

`co_await schedule(sched)` is magical. It transitions the coroutine onto the execution context of `sched` and registers a cleanup action to put the coroutine back onto the original scheduler before resuming the parent coroutine. When awaiting another `task<>`, we assume that we will be resumed on the correct context and do not insert an additional thunk.

Still TODO:
- [x] Lots of tests
- [x] Fix MSVC build
- [ ] Docs

Incidentally, I am aware of a situation that breaks `task<>` scheduler affinity: if you register an async cleanup action with `at_coroutine_exit` that changes execution context, the original context is not automatically restored. For now, my recommendation is: don't do that.