### PR TITLE
Generalize range stream

### DIFF
--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -62,7 +62,7 @@ int main() {
 
     auto s = take_until(
         stop_immediately<int>(
-            delay(range_stream{0, 100}, context.get_scheduler(), 50ms)),
+            delay(range_stream{std::views::iota(0, 100)}, context.get_scheduler(), 50ms)),
         single(schedule_after(context.get_scheduler(), 500ms)));
 
     int sum = 0;

--- a/examples/delayed_stream_cancellation.cpp
+++ b/examples/delayed_stream_cancellation.cpp
@@ -40,7 +40,7 @@ int main() {
   sync_wait(
       stop_when(
           for_each(
-              delay(range_stream{0, 100}, context.get_scheduler(), 100ms),
+              delay(range_stream{std::views::iota(0, 100)}, context.get_scheduler(), 100ms),
               [startTime](int value) {
                 auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);
                 std::printf("[%i ms] %i\n", (int)ms.count(), value);

--- a/examples/for_each_synchronous.cpp
+++ b/examples/for_each_synchronous.cpp
@@ -27,7 +27,7 @@ int main() {
   sync_wait(transform(
       for_each(
           transform_stream(
-              range_stream{0, 10}, [](int value) { return value * value; }),
+              range_stream{std::views::iota(0, 10)}, [](int value) { return value * value; }),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));
 

--- a/examples/for_each_via_thread_scheduler.cpp
+++ b/examples/for_each_via_thread_scheduler.cpp
@@ -33,7 +33,7 @@ int main() {
           via_stream(
               context.get_scheduler(),
               transform_stream(
-                  range_stream{0, 10},
+                  range_stream{std::views::iota(0, 10)},
                   [](int value) { return value * value; })),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));

--- a/examples/for_each_via_trampoline.cpp
+++ b/examples/for_each_via_trampoline.cpp
@@ -31,7 +31,7 @@ int main() {
           typed_via_stream(
               trampoline_scheduler{},
               transform_stream(
-                  range_stream{0, 10},
+                  range_stream{std::views::iota(0, 10)},
                   [](int value) { return value * value; })),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done"); }));

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -197,7 +197,7 @@ int main() {
                       via_stream(
                           inner_delegating_ctx.get_scheduler(),
                           transform_stream(
-                              range_stream{0, 10},
+                              range_stream{std::views::iota(0, 10)},
                               [](int value) { return value + 1; })),
                           [](int value) { return value * value; })),
               [](int value) { std::printf("got %i\n", value); }),

--- a/examples/get_scheduler.cpp
+++ b/examples/get_scheduler.cpp
@@ -46,7 +46,7 @@ int main() {
   sync_wait(with_query_value(
       transform(
           for_each(via_stream(current_scheduler,
-                              transform_stream(range_stream{0, 10},
+                              transform_stream(range_stream{std::views::iota(0, 10)},
                                                [](int value) {
                                                  return value * value;
                                                })),

--- a/examples/produce_on_consume_via.cpp
+++ b/examples/produce_on_consume_via.cpp
@@ -37,7 +37,7 @@ int main() {
               on_stream(
                   context2.get_scheduler(),
                   transform_stream(
-                      range_stream{0, 10},
+                      range_stream{std::views::iota(0, 10)},
                       [](int value) { return value * value; }))),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));

--- a/examples/reduce_synchronous.cpp
+++ b/examples/reduce_synchronous.cpp
@@ -29,7 +29,7 @@ int main() {
   sync_wait(transform(
       reduce_stream(
           transform_stream(
-              range_stream{0, 10},
+              range_stream{std::views::iota(0, 10)},
               [](int value) { return value * value; }),
           0,
           [](int state, int value) { return state + value; }),

--- a/examples/reduce_with_trampoline.cpp
+++ b/examples/reduce_with_trampoline.cpp
@@ -34,7 +34,7 @@ int main() {
           typed_via_stream(
               trampoline_scheduler{},
               transform_stream(
-                  range_stream{0, 100'000},
+                  range_stream{std::views::iota(0, 100'000)},
                   [](int value) { return value * value; })),
           0,
           [](int state, int value) { return state + 10 * value; }),

--- a/examples/stop_immediately.cpp
+++ b/examples/stop_immediately.cpp
@@ -40,7 +40,7 @@ int main() {
       eventLoop.sync_wait(for_each(
           take_until(
               stop_immediately<int>(
-                  delay(range_stream{0, 100}, eventLoop.get_scheduler(), 50ms)),
+                  delay(range_stream{std::views::iota(0, 100)}, eventLoop.get_scheduler(), 50ms)),
               single(schedule_after(eventLoop.get_scheduler(), 500ms))),
           [startTime](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);

--- a/examples/stream_cancellation.cpp
+++ b/examples/stream_cancellation.cpp
@@ -37,7 +37,7 @@ int main() {
 
   auto startTime = steady_clock::now();
 
-  auto op = on_stream(current_scheduler, range_stream{0, 20})
+  auto op = on_stream(current_scheduler, range_stream{std::views::iota(0, 20)})
     | for_each([](int value) {
         // Simulate some work
         std::printf("processing %i\n", value);

--- a/examples/type_erased_stream.cpp
+++ b/examples/type_erased_stream.cpp
@@ -39,7 +39,7 @@ int main() {
                     on_stream(
                         context2.get_scheduler(),
                         transform_stream(
-                            range_stream{0, 10},
+                            range_stream{std::views::iota(0, 10)},
                             [](int value) { return value * value; })))),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -85,7 +85,7 @@ struct stream {
   sentinel_t end_;
 
   explicit stream(Range&& r) : begin_(std::begin(r)), end_(std::end(r)) {}
-  explicit stream(iterator_t begin, sentinel_t end) : begin_(begin), end_(end) {}
+  explicit stream(Range& r) : begin_(std::begin(r)), end_(std::end(r)) {}
 
   friend next_sender<Range> tag_invoke(tag_t<next>, stream<Range>& s) noexcept {
     return next_sender{s};

--- a/test/delay_test.cpp
+++ b/test/delay_test.cpp
@@ -41,7 +41,7 @@ TEST(Delay, Smoke) {
   sync_wait(
       stop_when(
           for_each(
-              delay(range_stream{0, 100}, context.get_scheduler(), 100ms),
+              delay(range_stream{std::views::iota(0, 100)}, context.get_scheduler(), 100ms),
               [startTime](int value) {
                 auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);
                 std::printf("[%i ms] %i\n", (int)ms.count(), value);
@@ -56,7 +56,7 @@ TEST(Delay, Pipeable) {
 
   auto startTime = steady_clock::now();
 
-  range_stream{0, 100}
+  range_stream{std::views::iota(0, 100)}
     | delay(context.get_scheduler(), 100ms)
     | for_each(
         [startTime](int value) {

--- a/test/for_each_test.cpp
+++ b/test/for_each_test.cpp
@@ -31,13 +31,13 @@ TEST(ForEach, Smoke) {
   sync_wait(transform(
     for_each(
       transform_stream(
-        range_stream{0, 10}, [](int value) { return value * value; }),
+        range_stream{std::views::iota(0, 10)}, [](int value) { return value * value; }),
       [](int value) { std::printf("got %i\n", value); }),
     []() { std::printf("done\n"); }));
 }
 
 TEST(ForEach, Pipeable) {
-  range_stream{0, 10}
+  range_stream{std::views::iota(0, 10)}
     | transform_stream(
         [](int value) { return value * value; })
     | for_each(

--- a/test/get_scheduler_test.cpp
+++ b/test/get_scheduler_test.cpp
@@ -56,7 +56,7 @@ TEST(get_scheduler, current_scheduler) {
   sync_wait(with_query_value(
       transform(
           for_each(via_stream(current_scheduler,
-                              transform_stream(range_stream{0, 10},
+                              transform_stream(range_stream{std::views::iota(0, 10)},
                                                [](int value) {
                                                  return value * value;
                                                })),
@@ -70,7 +70,7 @@ TEST(get_scheduler, Pipeable) {
 
   // Check that this can propagate through multiple levels of
   // composed operations.
-  range_stream{0, 10}
+  range_stream{std::views::iota(0, 10)}
     | transform_stream([](int value) {
         return value * value;
     })

--- a/test/on_stream_test.cpp
+++ b/test/on_stream_test.cpp
@@ -39,7 +39,7 @@ TEST(on_stream, Smoke) {
               on_stream(
                   context2.get_scheduler(),
                   transform_stream(
-                      range_stream{0, 10},
+                      range_stream{std::views::iota(0, 10)},
                       [](int value) { return value * value; }))),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));
@@ -49,7 +49,7 @@ TEST(on_stream, Pipeable) {
   single_thread_context context1;
   single_thread_context context2;
 
-  range_stream{0, 10}
+  range_stream{std::views::iota(0, 10)}
     | transform_stream(
         [](int value) { return value * value; })
     | on_stream(context2.get_scheduler())

--- a/test/range_stream_test.cpp
+++ b/test/range_stream_test.cpp
@@ -44,15 +44,16 @@ TEST(range_stream, iota_vector) {
   | transform([]() { std::printf("done\n"); })
   | sync_wait();
 }
+
 TEST(range_stream, rvalue_array) {
   range_stream{std::array{"foo", "bar", "baz"}}
   | for_each([](std::string_view value) { std::printf("got %s\n", value.data()); })
   | transform([]() { std::printf("done\n"); })
   | sync_wait();
 }
+
 TEST(range_stream, lvalue_array) {
   constexpr std::array words = {"foo", "bar", "baz"};
-
   range_stream{words}
   | for_each([](std::string_view value) { std::printf("got %s\n", value.data()); })
   | transform([]() { std::printf("done\n"); })

--- a/test/range_stream_test.cpp
+++ b/test/range_stream_test.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/for_each.hpp>
+#include <unifex/range_stream.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/transform.hpp>
+#include <unifex/transform_stream.hpp>
+
+#include <cstdio>
+#include <numeric>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+TEST(range_stream, iota) {
+  range_stream{std::views::iota(0, 10)}
+    | transform_stream([](int value) { return value * value; })
+    | for_each([](int value) { std::printf("got %i\n", value); })
+    | transform([]() { std::printf("done\n"); })
+    | sync_wait();
+}
+
+TEST(range_stream, iota_vector) {
+  std::vector v{10};
+  std::iota(std::begin(v), std::end(v), 0);
+
+  range_stream{v}
+  | transform_stream([](int value) { return value * value; })
+  | for_each([](int value) { std::printf("got %i\n", value); })
+  | transform([]() { std::printf("done\n"); })
+  | sync_wait();
+}
+TEST(range_stream, rvalue_array) {
+  range_stream{std::array{"foo", "bar", "baz"}}
+  | for_each([](std::string_view value) { std::printf("got %s\n", value.data()); })
+  | transform([]() { std::printf("done\n"); })
+  | sync_wait();
+}
+TEST(range_stream, lvalue_array) {
+  constexpr std::array words = {"foo", "bar", "baz"};
+
+  range_stream{words}
+  | for_each([](std::string_view value) { std::printf("got %s\n", value.data()); })
+  | transform([]() { std::printf("done\n"); })
+  | sync_wait();
+}

--- a/test/reduce_stream_test.cpp
+++ b/test/reduce_stream_test.cpp
@@ -31,7 +31,7 @@ TEST(reduce_stream, Smoke) {
   sync_wait(transform(
       reduce_stream(
           transform_stream(
-              range_stream{0, 10},
+              range_stream{std::views::iota(0, 10)},
               [](int value) { return value * value; }),
           0,
           [](int state, int value) { return state + value; }),
@@ -44,7 +44,7 @@ TEST(reduce_stream, Smoke) {
 TEST(reduce_stream, Pipeable) {
   int finalResult;
 
-  range_stream{0, 10}
+  range_stream{std::views::iota(0, 10)}
     | transform_stream(
         [](int value) { return value * value; })
     | reduce_stream(

--- a/test/single_test.cpp
+++ b/test/single_test.cpp
@@ -42,7 +42,7 @@ TEST(single, Smoke) {
       eventLoop.sync_wait(for_each(
           take_until(
               stop_immediately<int>(
-                  delay(range_stream{0, 100}, eventLoop.get_scheduler(), 50ms)),
+                  delay(range_stream{std::views::iota(0, 100)}, eventLoop.get_scheduler(), 50ms)),
               single(schedule_after(eventLoop.get_scheduler(), 500ms))),
           [startTime](int value) {
             auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);
@@ -59,7 +59,7 @@ TEST(single, Pipeable) {
 
   [[maybe_unused]] std::optional<unit> result = 
     eventLoop.sync_wait(
-      range_stream{0, 100} 
+      range_stream{std::views::iota(0, 100)}
         | delay(eventLoop.get_scheduler(), 50ms)
         | stop_immediately<int>()
         | take_until(

--- a/test/type_erase_test.cpp
+++ b/test/type_erase_test.cpp
@@ -41,7 +41,7 @@ TEST(type_erase, Smoke) {
                     on_stream(
                         context2.get_scheduler(),
                         transform_stream(
-                            range_stream{0, 10},
+                            range_stream{std::views::iota(0, 10)},
                             [](int value) { return value * value; })))),
           [](int value) { std::printf("got %i\n", value); }),
       []() { std::printf("done\n"); }));
@@ -51,7 +51,7 @@ TEST(type_erase, Pipeable) {
   single_thread_context context1;
   single_thread_context context2;
 
-  range_stream{0, 10}
+  range_stream{std::views::iota(0, 10)}
     | transform_stream(
         [](int value) { return value * value; })
     | on_stream(context2.get_scheduler())


### PR DESCRIPTION
I'm very interested in using libunifex and one of the first things I need support for is supporting ranges beyond the simple range_stream in examples. I noticed [this](https://github.com/facebookexperimental/libunifex/issues/88#issue-580245635) issue was open and decided this was worth tackling. 

So far I modified `range_stream.hpp` to take in an rvalue and lvalue range, and then we can grab the iterators from that range. It got tricky because I couldn't figure out how to support both taking in a single range as an argument as well as begin and end iterators using the same `stream`  struct, but maybe this isn't necessary. 

I'd like to improve this pull request as well because I have definitely overlooked something and would appreciate a review plus feedback on how I can improve this PR. 

Changes made:
* Updated examples to use `range_stream{std::views::iota(0, 10)}` instead of `range_stream{0, 10}` 
* Added a test using a few simple examples beyond integers
* Updated the `range_stream.hpp` header file to support streams and constrained the type using `std::ranges::range`