### PR TITLE
Fix warnings reported by strict GCC settings

### DIFF
--- a/cmake/unifex_env.cmake
+++ b/cmake/unifex_env.cmake
@@ -18,3 +18,11 @@ elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
 else()
   message(WARNING "[unifex warning]: unknown compiler ${CMAKE_CXX_COMPILER_ID} !")
 endif()
+
+if (MSVC)
+    # warning level 3 and all warnings as errors
+    add_compile_options(/W3 /WX)
+else()
+    # lots of warnings and all warnings as errors
+    add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()

--- a/examples/any_unique.cpp
+++ b/examples/any_unique.cpp
@@ -30,7 +30,7 @@ inline constexpr struct get_typeid_cpo {
       unifex::type_index(const unifex::this_&) noexcept;
 
   template <typename T>
-  friend unifex::type_index tag_invoke(get_typeid_cpo, const T& x) {
+  friend unifex::type_index tag_invoke(get_typeid_cpo, const T&) {
     return unifex::type_id<T>();
   }
 

--- a/examples/any_unique.cpp
+++ b/examples/any_unique.cpp
@@ -91,12 +91,12 @@ int main() {
   using B = unifex::any_unique_t<>;
   {
     const A a = std::string{"hello"};
-    auto id = get_typeid(a);
+    [[maybe_unused]] auto id = get_typeid(a);
     UNIFEX_ASSERT(id == unifex::type_id<std::string>());
   }
   {
     const B b = std::string{"hello"};
-    auto id = get_typeid(b);
+    [[maybe_unused]] auto id = get_typeid(b);
     UNIFEX_ASSERT(id == unifex::type_id<B>());
   }
   {

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -168,10 +168,10 @@ class delegating_scheduler {
     return delegating_sender{context_};
   }
 
-  friend bool operator==(delegating_scheduler, delegating_scheduler) noexcept {
+  [[maybe_unused]] friend bool operator==(delegating_scheduler, delegating_scheduler) noexcept {
     return true;
   }
-  friend bool operator!=(delegating_scheduler, delegating_scheduler) noexcept {
+  [[maybe_unused]] friend bool operator!=(delegating_scheduler, delegating_scheduler) noexcept {
     return false;
   }
 

--- a/examples/linux/io_epoll_test.cpp
+++ b/examples/linux/io_epoll_test.cpp
@@ -101,7 +101,7 @@ int main() {
   }
 
   auto pipe_bench = [](auto& rPipeRef, auto& buffer, auto scheduler, int seconds,
-                       auto& data, auto& reps, auto& offset) {
+                       [[maybe_unused]] auto& data, auto& reps, [[maybe_unused]] auto& offset) {
     return defer([&, scheduler, seconds] {
       return defer([&] {
         return

--- a/examples/materialize.cpp
+++ b/examples/materialize.cpp
@@ -29,7 +29,7 @@ using namespace unifex;
 int main() {
     single_thread_context ctx;
 
-    std::optional<int> result = sync_wait(
+    [[maybe_unused]] std::optional<int> result = sync_wait(
         dematerialize(
             materialize(
                 transform(

--- a/examples/schedule_with_subscheduler.cpp
+++ b/examples/schedule_with_subscheduler.cpp
@@ -22,11 +22,11 @@ using namespace unifex;
 
 int main() {
   timed_single_thread_context context;
-  auto scheduler = context.get_scheduler();
+  auto schedr = context.get_scheduler();
 
   std::optional<bool> result = sync_wait(transform(
-      schedule_with_subscheduler(scheduler),
-      [&](auto subScheduler) noexcept { return subScheduler == scheduler; }));
+      schedule_with_subscheduler(schedr),
+      [&](auto subScheduler) noexcept { return subScheduler == schedr; }));
 
   if (result.has_value() && result.value()) {
     // Success

--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -379,7 +379,7 @@ class _byval<CPOs...>::type
           (Concrete &&) concrete) {}
 
   template <typename Concrete, typename... Args>
-  explicit type(std::in_place_type_t<Concrete> tag, Args&&... args)
+  explicit type([[maybe_unused]] std::in_place_type_t<Concrete> tag, Args&&... args)
     : impl_(new Concrete((Args&&) args...))
     , vtable_(vtable_holder_t::template create<Concrete>()) {}
 

--- a/include/unifex/any_unique.hpp
+++ b/include/unifex/any_unique.hpp
@@ -480,8 +480,8 @@ class _byref<CPOs...>::type
     return self.impl_;
   }
 
-  void* impl_;
   vtable_holder_t vtable_;
+  void* impl_;
 };
 
 } // namespace _any_unique

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -236,7 +236,7 @@ public:
   }
 };
 
-};
+} // namespace _async_scope
 
 using _async_scope::async_scope;
 

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -137,8 +137,8 @@ UNIFEX_DIAGNOSTIC_POP
     }
 
 private:
-    Receiver receiver_;
     Integral count_;
+    Receiver receiver_;
 };
 
 template<typename Scheduler, typename Integral>

--- a/include/unifex/continuations.hpp
+++ b/include/unifex/continuations.hpp
@@ -236,8 +236,10 @@ private:
   friend continuation_info;
 
   inline static constexpr _continuation_handle_vtable default_vtable_ {
-    &_ci::_default_type_index_getter,
-    &_ci::_default_visit,
+    {
+        &_ci::_default_type_index_getter,
+        &_ci::_default_visit,
+    },
     &_default_done_callback
   };
 
@@ -266,8 +268,10 @@ coro::coroutine_handle<> _done_callback_for(void* address) noexcept {
 
 template <typename Promise>
 inline constexpr _continuation_handle_vtable _vtable_for {
-  &_ci::_type_index_getter_for<Promise>,
-  &_visit_for<Promise>,
+  {
+        &_ci::_type_index_getter_for<Promise>,
+        &_visit_for<Promise>,
+  },
   &_done_callback_for<Promise>
 };
 

--- a/include/unifex/detail/prologue.hpp
+++ b/include/unifex/detail/prologue.hpp
@@ -24,6 +24,12 @@
 
 #include <unifex/config.hpp>
 
+UNIFEX_DIAGNOSTIC_PUSH
+
+#if defined(__clang__)
+    #pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+
 #if UNIFEX_CXX_CONCEPTS
   #define template(...) \
     template <__VA_ARGS__> UNIFEX_PP_EXPAND \
@@ -33,5 +39,7 @@
     template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
     /**/
 #endif
+
+UNIFEX_DIAGNOSTIC_POP
 
 #define AND UNIFEX_AND

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -218,7 +218,7 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
                 unifex::transform(
                   unifex::transform_done(
                     std::move(bulk_phase),
-                    [&stopSource, &state](){
+                    [&state](){
                       if(state.found_flag == true) {
                         // If the item was found, then continue as if not cancelled
                         return just();

--- a/include/unifex/for_each.hpp
+++ b/include/unifex/for_each.hpp
@@ -37,7 +37,7 @@ namespace _for_each {
       }
     };
     struct _reduce {
-      void operator()(unit s) const noexcept {}
+      void operator()(unit) const noexcept {}
     };
   } // namespace _impl
 

--- a/include/unifex/just_done.hpp
+++ b/include/unifex/just_done.hpp
@@ -62,7 +62,7 @@ class sender {
   template(typename This, typename Receiver)
       (requires same_as<remove_cvref_t<This>, sender> AND
         receiver<Receiver>)
-  friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
+  friend auto tag_invoke(tag_t<connect>, This&&, Receiver&& r)
       noexcept
       -> operation<Receiver> {
     return {static_cast<Receiver&&>(r)};

--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -332,7 +332,7 @@ public:
   template(typename CPO, typename Sender, typename Receiver)
       (requires same_as<CPO, tag_t<unifex::connect>> AND
         same_as<remove_cvref_t<Sender>, type>)
-  friend auto tag_invoke(CPO cpo, Sender&& sender, Receiver&& receiver)
+  friend auto tag_invoke([[maybe_unused]] CPO cpo, Sender&& sender, Receiver&& receiver)
       -> operation<decltype((static_cast<Sender&&>(sender).pred_)), SuccessorFactory, Receiver> {
     return operation<decltype((static_cast<Sender&&>(sender).pred_)), SuccessorFactory, Receiver>{
         static_cast<Sender&&>(sender).pred_,

--- a/include/unifex/span.hpp
+++ b/include/unifex/span.hpp
@@ -25,7 +25,7 @@
 
 namespace unifex {
 
-inline constexpr std::size_t dynamic_extent = -1;
+inline constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
 
 template <typename T, std::size_t Extent = dynamic_extent>
 struct span {

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -152,10 +152,10 @@ public:
   schedule_sender schedule() const noexcept {
     return schedule_sender{maxRecursionDepth_};
   }
-  friend bool operator==(scheduler a, scheduler b) noexcept {
+  friend bool operator==(scheduler, scheduler) noexcept {
     return true;
   }
-  friend bool operator!=(scheduler a, scheduler b) noexcept {
+  friend bool operator!=(scheduler, scheduler) noexcept {
     return false;
   }
 };

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -309,7 +309,7 @@ class _sender<Senders...>::type {
       (requires same_as<CPO, tag_t<unifex::connect>> AND
         same_as<remove_cvref_t<Sender>, type> AND
         when_all_connectable_v<remove_cvref_t<Receiver>, member_t<Sender, Senders>...>)
-  friend auto tag_invoke(CPO cpo, Sender&& sender, Receiver&& receiver)
+  friend auto tag_invoke([[maybe_unused]] CPO cpo, Sender&& sender, Receiver&& receiver)
     -> operation<Receiver, member_t<Sender, Senders>...> {
     return std::apply([&](Senders&&... senders) {
       return operation<Receiver, member_t<Sender, Senders>...>{

--- a/source/linux/io_uring_context.cpp
+++ b/source/linux/io_uring_context.cpp
@@ -528,14 +528,12 @@ void io_uring_context::acquire_completion_queue_items() noexcept {
     UNIFEX_ASSERT(count <= cqEntryCount_);
 
     operation_base head;
-    operation_base* tail = &head;
 
     LOGX("got %u completions\n", count);
 
     operation_queue completionQueue;
 
     for (std::uint32_t i = 0; i < count; ++i) {
-      auto index = (cqHead + i) & mask;
       auto& cqe = cqEntries_[(cqHead + i) & mask];
 
       if (cqe.user_data == remote_queue_event_user_data) {

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -301,7 +301,7 @@ get_iocp_entries:
     UNIFEX_ASSERT(offset >= 0);
 
     std::ptrdiff_t index = offset / sizeof(vectored_io_state);
-    UNIFEX_ASSERT(index < ioPoolSize_);
+    UNIFEX_ASSERT(index < static_cast<std::ptrdiff_t>(ioPoolSize_));
 
     return &pool[index];
   }

--- a/test/P0443_test.cpp
+++ b/test/P0443_test.cpp
@@ -42,7 +42,7 @@ namespace {
   struct throwing_executor {
     UNIFEX_TEMPLATE(typename Fn)
       (requires invocable<Fn&>)
-    void execute(Fn fn) const {
+    void execute(Fn) const {
       throw std::runtime_error("sorry, charlie");
     }
     [[maybe_unused]] friend bool operator==(throwing_executor, throwing_executor) noexcept {

--- a/test/any_sender_of_test.cpp
+++ b/test/any_sender_of_test.cpp
@@ -115,7 +115,7 @@ using AnySenderOfTestTypes = Types<
     void(int, std::string),
     void(int, std::string) noexcept>;
 
-TYPED_TEST_SUITE(AnySenderOfTest, AnySenderOfTestTypes);
+TYPED_TEST_SUITE(AnySenderOfTest, AnySenderOfTestTypes, );
 
 template <typename SenderSig, typename ReceiverSig = SenderSig, typename... ExtraReceiverSigs>
 void testWrappingAJust() noexcept {

--- a/test/any_unique_test.cpp
+++ b/test/any_unique_test.cpp
@@ -30,7 +30,7 @@ inline constexpr struct get_typeid_cpo {
       unifex::type_index(const unifex::this_&) noexcept;
 
   template <typename T>
-  friend unifex::type_index tag_invoke(get_typeid_cpo, const T& x) {
+  friend unifex::type_index tag_invoke(get_typeid_cpo, const T&) {
     return unifex::type_id<T>();
   }
 

--- a/test/find_if_test.cpp
+++ b/test/find_if_test.cpp
@@ -43,7 +43,7 @@ TEST(find_if, find_if_sequential) {
               return v == another_parameter;
             },
             unifex::seq),
-        [](std::vector<int>::iterator v, int another_parameter) noexcept {
+        [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
           UNIFEX_ASSERT(another_parameter == 3);
           return v;
         }));
@@ -76,7 +76,7 @@ TEST(find_if, find_if_parallel) {
                 return v == another_parameter;
               },
               unifex::par),
-          [](std::vector<int>::iterator v, int another_parameter) noexcept {
+          [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
             UNIFEX_ASSERT(another_parameter == checkValue);
             return v;
           })));
@@ -120,7 +120,7 @@ TEST(find_if, Pipeable) {
           },
           unifex::seq)
       | transform(
-          [](std::vector<int>::iterator v, int another_parameter) noexcept {
+          [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
             UNIFEX_ASSERT(another_parameter == 3);
             return v;
           });


### PR DESCRIPTION
When the repository is used as a meson subproject, where the consuming top-level
project uses `warning_level=3`[1], libunifex fails to compile with many warnings
reported by GCC.  These errors are all trivially resolved so fix them and add
CMake set up to prevent future regressions.

1. https://mesonbuild.com/Builtin-options.html
