### PR TITLE
Hoist untyped RAII containers for coroutine_handle<> out of task<> and its awaiter

### DIFF
--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -184,8 +184,8 @@ struct _promise {
 
     auto final_suspend() noexcept {
       struct awaiter : _final_suspend_awaiter_base {
-        auto await_suspend(coro::coroutine_handle<type> h) noexcept {
-          return h.promise().continuation_.handle();
+        void await_suspend(coro::coroutine_handle<type> h) noexcept {
+          return h.promise().continuation_.handle().resume();
         }
       };
       return awaiter{};

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -291,6 +291,7 @@ struct tagged_coro_holder {
   }
 
  protected:
+  // Stored as an integer so we can use the low bit as a dirty bit
   std::uintptr_t coro_;
 };
 
@@ -361,7 +362,6 @@ struct _awaiter {
     using needs_stop_token_t =
         std::bool_constant<!same_as<stop_token_t, inplace_stop_token>>;
 
-    std::uintptr_t coro_; // Stored as an integer so we can use the low bit as a dirty bit
     // Only store the scheduler and the stop_token in the awaiter if we need to type
     // erase them. Otherwise, these members are "empty" and should take up no space
     // because of the [[no_unique_address]] attribute.

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -184,9 +184,16 @@ struct _promise {
 
     auto final_suspend() noexcept {
       struct awaiter : _final_suspend_awaiter_base {
+#if defined(_MSC_VER) && !defined(__clang__)
+        // MSVC doesn't seem to like symmetric transfer in this final awaiter
         void await_suspend(coro::coroutine_handle<type> h) noexcept {
           return h.promise().continuation_.handle().resume();
         }
+#else
+        auto await_suspend(coro::coroutine_handle<type> h) noexcept {
+          return h.promise().continuation_.handle();
+        }
+#endif
       };
       return awaiter{};
     }


### PR DESCRIPTION
This PR hoists two RAII containers for `coroutine_handle<>` out of `unifex::task<>` and its awaiter.  The result is a fairly significant binary size reduction in one of our apps.