### PR TITLE
.clang-format update wrt new project formatting rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,7 +36,7 @@ BraceWrapping: {
   AfterControlStatement: false,
   AfterEnum: false,
   AfterFunction: false,
-  AfterNamespace: true,
+  AfterNamespace: false,
   AfterStruct: false,
   AfterUnion: false,
   BeforeCatch: false,
@@ -76,7 +76,7 @@ IndentPPDirectives: AfterHash
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: All
+NamespaceIndentation: None
 PointerAlignment: Left
 ReflowComments: true
 SortIncludes: true


### PR DESCRIPTION
Currently every project file doesn't follow the given .clang-format file. Specifically for namespaces. Hence, this PR changes the .clang-format to specify new formatting rules.