### PR TITLE
adding upon_* async algorithms

### DIFF
--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <functional>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _upon_done {
+
+template <typename Receiver, std::invocable Func>
+struct _receiver {
+  struct type;
+};
+template <typename Receiver, std::invocable Func>
+using receiver_t = typename _receiver<Receiver, Func>::type;
+
+template <typename Receiver, std::invocable Func>
+struct _receiver<Receiver, Func>::type {
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+
+  template <typename... Values>
+  void set_value(Values&&... values) && noexcept {
+    unifex::set_value(std::move(receiver_), std::forward<Values>(values)...);
+  }
+
+  template <typename Error>
+  void set_error(Error&& error) && noexcept {
+    unifex::set_error(std::move(receiver_), std::forward<Error>(error));
+  }
+
+  void set_done() && noexcept {
+    if constexpr (noexcept(std::invoke(std::move(func_)))) {
+      std::invoke(std::move(func_));
+      unifex::set_done(std::move(receiver_));
+    } else {
+      UNIFEX_TRY {
+        std::invoke(std::move(func_));
+        unifex::set_value(std::move(receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
+    }
+  }
+
+  template <typename CPO, typename R>
+  requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>
+  friend auto tag_invoke(CPO cpo, const R& r) noexcept(
+      is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(std::as_const(r.receiver_));
+  }
+
+  template <typename Visit>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+    std::invoke(visit, self.receiver_);
+  }
+};
+
+template <typename Predecessor, typename Func>
+struct _sender {
+  struct type;
+};
+template <typename Predecessor, typename Func>
+using sender =
+    typename _sender<remove_cvref_t<Predecessor>, std::decay_t<Func>>::type;
+
+template <typename Predecessor, typename Func>
+struct _sender<Predecessor, Func>::type {
+  UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Predecessor, Variant, Tuple>;
+
+  template <template <typename...> class Variant>
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
+
+  template <typename Receiver>
+  using receiver_t = receiver_t<Receiver, Func>;
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type& sender) {
+    return blocking(sender.pred_);
+  }
+
+  template <typename Sender, typename Receiver>
+  requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND
+      sender_to<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>>
+  friend auto
+  tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>&&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>>&&
+              is_nothrow_connectable_v<
+                  member_t<Sender, Predecessor>,
+                  receiver_t<remove_cvref_t<Receiver>>>)
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
+    return unifex::connect(
+        static_cast<Sender&&>(s).pred_,
+        receiver_t<remove_cvref_t<Receiver>>{
+            static_cast<Sender&&>(s).func_, static_cast<Receiver&&>(r)});
+  }
+};
+
+namespace _cpo {
+struct _fn {
+private:
+  template <typename Sender, typename Func>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender, Func>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_upon_done::sender>>::template apply<Sender, Func>;
+
+public:
+  template <typename Sender, typename Func>
+  requires tag_invocable<_fn, Sender, Func>
+  auto operator()(Sender&& predecessor, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
+          -> _result_t<Sender, Func> {
+    return unifex::tag_invoke(
+        _fn{}, std::forward<Sender>(predecessor), std::forward<Func>(func));
+  }
+
+  template <typename Sender, typename Func>
+  requires(!tag_invocable<_fn, Sender, Func>) auto
+  operator()(Sender&& predecessor, Func&& func) const
+      noexcept(std::is_nothrow_constructible_v<
+               _upon_done::sender<Sender, Func>,
+               Sender,
+               Func>) -> _result_t<Sender, Func> {
+    return _upon_done::sender<Sender, Func>{
+        std::forward<Sender>(predecessor), std::forward<Func>(func)};
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, std::forward<Func>(func));
+  }
+};
+};  // namespace _cpo
+}  // namespace _upon_done
+inline constexpr _upon_done::_cpo::_fn upon_done{};
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -21,8 +21,8 @@ template <typename Result, typename = void>
 struct result_overload {
   using type = type_list<Result>;
 };
-template <typename Result>
-struct result_overload<Result, std::enable_if_t<std::is_void_v<Result>>> {
+template <>
+struct result_overload<void> {
   using type = type_list<>;
 };
 
@@ -43,12 +43,14 @@ struct _receiver<Receiver, Func>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  template <typename... Values>
-  void set_value(Values&&... values) && noexcept {
+  template(typename... Values)
+    (requires receiver_of< Receiver, Values...>) 
+  void set_value(Values&&... values) && {
     unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
   }
 
-  template <typename Error>
+  template(typename Error)
+    (requires receiver<Receiver, Error>) 
   void set_error(Error&& error) && noexcept {
     unifex::set_error((Receiver &&)(receiver_), (Error &&)(error));
   }
@@ -84,15 +86,16 @@ struct _receiver<Receiver, Func>::type {
     }
   }
 
-  template(typename CPO, typename R)(requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>) friend auto tag_invoke(
-      CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)
+    (requires is_receiver_query_cpo_v<CPO>) 
+  friend auto tag_invoke( CPO cpo, const type& r) noexcept(
+      is_nothrow_callable_v<CPO, const Receiver&>) 
       -> callable_result_t<CPO, const Receiver&> {
     return (CPO &&)(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void
-  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+  friend void tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
     std::invoke(visit, self.receiver_);
   }
 };
@@ -165,23 +168,16 @@ public:
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
-      tag_t<unifex::connect>,
-      Sender&& s,
-      Receiver&&
-          r) noexcept(std::
-                          is_nothrow_constructible_v<
-                              remove_cvref_t<Receiver>,
-                              Receiver>&&
-                              std::is_nothrow_constructible_v<
-                                  Func,
-                                  member_t<Sender, Func>>&&
-                                  is_nothrow_connectable_v<
-                                      member_t<Sender, Predecessor>,
+  template(typename Sender, typename Receiver)
+    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND 
+     sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) 
+    friend auto tag_invoke( tag_t<unifex::connect>, Sender&& s, Receiver&& r) 
+    noexcept(
+        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>&&
+        std::is_nothrow_constructible_v<Func, member_t<Sender, Func>>&&
+        is_nothrow_connectable_v<member_t<Sender, Predecessor>,
                                       receiver_t<remove_cvref_t<Receiver>>>)
-      -> connect_result_t<
-          member_t<Sender, Predecessor>,
-          receiver_t<remove_cvref_t<Receiver>>> {
+      -> connect_result_t<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>> {
     return unifex::connect(
         static_cast<Sender&&>(s).pred_,
         receiver_t<remove_cvref_t<Receiver>>{
@@ -199,30 +195,28 @@ private:
       meta_quote2<_upon_done::sender>>::template apply<Sender, Func>;
 
 public:
-  template(typename Sender, typename Func)(
-      requires std::is_invocable_v<Func> AND
-          tag_invocable<_fn, Sender, Func>) auto
-  operator()(Sender&& predecessor, Func&& func) const
+  template(typename Sender, typename Func)
+    (requires invocable<Func> AND tag_invocable<_fn, Sender, Func>) 
+  auto operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
-          -> _result_t<Sender, Func> {
+      -> _result_t<Sender, Func> {
     return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
   }
 
-  template(typename Sender, typename Func)(
-      requires std::is_invocable_v<Func> AND(
-          !tag_invocable<_fn, Sender, Func>)) auto
-  operator()(Sender&& predecessor, Func&& func) const
+  template(typename Sender, typename Func)
+    (requires(!tag_invocable<_fn, Sender, Func>) AND invocable<Func>)
+  auto operator()(Sender&& predecessor, Func&& func) const
       noexcept(std::is_nothrow_constructible_v<
-               _upon_done::sender<Sender, Func>,
-               Sender,
-               Func>) -> _result_t<Sender, Func> {
+               _upon_done::sender<Sender, Func>, Sender, Func>) 
+      -> _result_t<Sender, Func> {
     return _upon_done::sender<Sender, Func>{
         (Sender &&)(predecessor), (Func &&)(func)};
   }
-  template(typename Func)(requires std::is_invocable_v<Func>) constexpr auto
-  operator()(Func&& func) const
+  template(typename Func)
+    (requires invocable<Func>) 
+  constexpr auto operator()(Func&& func) const
       noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
-          -> bind_back_result_t<_fn, Func> {
+      -> bind_back_result_t<_fn, Func> {
     return bind_back(*this, (Func &&)(func));
   }
 };

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -161,7 +161,7 @@ public:
     return bind_back(*this, (Func &&)(func));
   }
 };
-};  // namespace _cpo
+}  // namespace _cpo
 }  // namespace _upon_done
 inline constexpr _upon_done::_cpo::_fn upon_done{};
 }  // namespace unifex

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <functional>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _upon_error {
+
+template <typename Receiver, typename Func>
+struct _receiver {
+  struct type;
+};
+template <typename Receiver, typename Func>
+using receiver_t = typename _receiver<Receiver, Func>::type;
+
+template <typename Receiver, typename Func>
+struct _receiver<Receiver, Func>::type {
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+
+  template <typename... Values>
+  void set_value(Values&&... values) && noexcept {
+    unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
+  }
+
+  template <typename Error>
+  void set_error(Error&&) && noexcept {
+    if constexpr (noexcept(std::invoke((Func &&) func_))) {
+      unifex::set_error((Receiver &&) receiver_, std::invoke((Func &&) func_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_error(
+            (Receiver &&) receiver_, std::invoke((Func &&) func_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error((Receiver &&) receiver_, std::current_exception());
+      }
+    }
+  }
+
+  void set_done() && noexcept { unifex::set_done((Receiver &&)(receiver_)); }
+
+  template(typename CPO, typename R)(requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>) friend auto tag_invoke(
+      CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return (CPO &&)(cpo)(std::as_const(r.receiver_));
+  }
+
+  template <typename Visit>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+    std::invoke(visit, self.receiver_);
+  }
+};
+
+template <typename Predecessor, typename Func>
+struct _sender {
+  struct type;
+};
+template <typename Predecessor, typename Func>
+using sender =
+    typename _sender<remove_cvref_t<Predecessor>, std::decay_t<Func>>::type;
+
+template <typename Predecessor, typename Func>
+struct _sender<Predecessor, Func>::type {
+  UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Predecessor, Variant, Tuple>;
+
+  template <template <typename...> class Variant>
+  using error_types = typename concat_type_lists_unique_t<
+      type_list<std::invoke_result_t<Func>>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
+
+  template <typename Receiver>
+  using receiver_t = receiver_t<Receiver, Func>;
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type& sender) {
+    return blocking(sender.pred_);
+  }
+
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>&&
+                              std::is_nothrow_constructible_v<
+                                  Func,
+                                  member_t<Sender, Func>>&&
+                                  is_nothrow_connectable_v<
+                                      member_t<Sender, Predecessor>,
+                                      receiver_t<remove_cvref_t<Receiver>>>)
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
+    return unifex::connect(
+        static_cast<Sender&&>(s).pred_,
+        receiver_t<remove_cvref_t<Receiver>>{
+            static_cast<Sender&&>(s).func_, static_cast<Receiver&&>(r)});
+  }
+};
+
+namespace _cpo {
+struct _fn {
+private:
+  template <typename Sender, typename Func>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender, Func>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_upon_error::sender>>::template apply<Sender, Func>;
+
+public:
+  template(typename Sender, typename Func)(
+      requires std::is_invocable_v<Func> AND(
+          !std::is_same_v<std::invoke_result_t<Func>, void>)
+          AND tag_invocable<_fn, Sender, Func>
+
+      ) auto
+  operator()(Sender&& predecessor, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
+          -> _result_t<Sender, Func> {
+    return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
+  }
+
+  template(typename Sender, typename Func)(
+      requires std::is_invocable_v<Func> AND(
+          !std::is_same_v<std::invoke_result_t<Func>, void>)
+          AND(!tag_invocable<_fn, Sender, Func>)) auto
+  operator()(Sender&& predecessor, Func&& func) const
+      noexcept(std::is_nothrow_constructible_v<
+               _upon_error::sender<Sender, Func>,
+               Sender,
+               Func>) -> _result_t<Sender, Func> {
+    return _upon_error::sender<Sender, Func>{
+        (Sender &&)(predecessor), (Func &&)(func)};
+  }
+
+  template(typename Func)(requires std::is_invocable_v<Func> AND(
+      !std::is_same_v<std::invoke_result_t<Func>, void>)) constexpr auto
+  operator()(Func&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&)(func));
+  }
+};
+}  // namespace _cpo
+}  // namespace _upon_error
+inline constexpr _upon_error::_cpo::_fn upon_error{};
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -113,12 +113,12 @@ struct _sender<Predecessor, Func>::type {
 
 private:
   /*
-   * This helper returns type_list<Result> if invoking func returns Result
-   * else if func returns void then helper returns type_list<>
+   * This helper returns type_list<type_list<Result>> if invoking func returns
+   * Result else if func returns void then helper returns type_list<type_list<>>
    */
   template <typename Error>
   using invoked_result_t =
-      detail::result_overload_t<std::invoke_result_t<Func, Error>>;
+      type_list<detail::result_overload_t<std::invoke_result_t<Func, Error>>>;
 
 public:
   template <
@@ -127,12 +127,9 @@ public:
       template <typename...>
       class Tuple>
   using value_types = type_list_nested_apply_t<
-      type_list<concat_type_lists_unique_t<
-          sender_value_types_t<
-              Predecessor,
-              concat_type_lists_unique_t,
-              type_list>,
-          sender_error_types_t<Predecessor, invoked_result_t>>>,
+      concat_type_lists_unique_t<
+          sender_value_types_t<Predecessor, type_list, type_list>,
+          sender_error_types_t<Predecessor, invoked_result_t>>,
       Variant,
       Tuple>;
 

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 #include <type_traits>
+#include <variant>
 
 using namespace unifex;
 

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,11 +1,50 @@
+#include <unifex/then.hpp>
 #include <unifex/just.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/upon_done.hpp>
 
 #include <gtest/gtest.h>
+#include <type_traits>
 
 using namespace unifex;
+
+TEST(UponDone, StaticTypeCheck) {
+  auto res1 = just(42)
+    | upon_done([]{
+        return 2;
+      });
+  static_assert(std::is_same_v<decltype(res1)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+
+  auto res2 = just()
+    | upon_done([]{
+        return 2;
+      });
+  static_assert(std::is_same_v<decltype(res2)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<>>>);
+
+  auto res3 = just(42)
+    | upon_done([]{
+        return;
+      });
+  static_assert(std::is_same_v<decltype(res3)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+
+  auto res4 = just(42)
+    | upon_done([]{
+        return 2.0;
+      });
+  static_assert(std::is_same_v<decltype(res4)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+
+  auto res5 = just_done()
+    | upon_done([]{
+        return 2;
+      });
+  static_assert(std::is_same_v<decltype(res5)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+}
 
 TEST(UponDone, Working) {
   int count = 0;
@@ -31,7 +70,7 @@ TEST(UponDone, NotCalled){
   int count = 0;
 
   auto x = just(42)
-    | upon_done([&]{count++;})
+    | upon_done([&]{count++; return 2;})
     | sync_wait();
 
   EXPECT_EQ(count, 0);
@@ -44,19 +83,20 @@ TEST(UponDone, ReturningValue) {
     | upon_done([&]{
         count++;
         return 42;
-        })
+      })
     | sync_wait();
   EXPECT_EQ(count, 1);
   EXPECT_EQ(res.value(), 42);
 }
 
-TEST(UponDone, VoidReturnCallback) {
+TEST(UponDone, NotCalledWithDifferentReturnType){
   int count = 0;
-  auto res = just(32)
+  auto res = just(42)
     | upon_done([&]{
         count++;
+        return 2.0;
       })
     | sync_wait();
   EXPECT_EQ(count, 0);
-  EXPECT_EQ(res.value(), 32);
+  EXPECT_EQ(res.value(), 42);
 }

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,0 +1,32 @@
+#include <unifex/sync_wait.hpp>
+#include <unifex/just_done.hpp>
+#include <unifex/upon_done.hpp>
+
+#include <chrono>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+TEST(UponDone, Working) {
+  int count = 0;
+  sync_wait(upon_done(just_done(), [&] { ++count; }));
+  EXPECT_EQ(count, 1);
+}
+
+TEST(Pipeable, UponDone){
+  int count = 0;
+
+  just_done()
+    | upon_done([&]{count++;})
+    | sync_wait();
+
+  just_done()
+    | upon_done([&]{count++;})
+    | sync_wait();
+
+  EXPECT_EQ(count, 2);
+}

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,3 +1,4 @@
+#include <unifex/just.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/upon_done.hpp>
@@ -29,4 +30,15 @@ TEST(Pipeable, UponDone){
     | sync_wait();
 
   EXPECT_EQ(count, 2);
+}
+
+TEST(NotCalled, UponDone){
+  int count = 0;
+
+  auto x = just(42)
+    | upon_done([&]{count++;})
+    | sync_wait();
+
+  EXPECT_EQ(count, 0);
+  EXPECT_EQ(x.value(), 42);
 }

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -3,14 +3,9 @@
 #include <unifex/just_done.hpp>
 #include <unifex/upon_done.hpp>
 
-#include <chrono>
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 using namespace unifex;
-using namespace std::chrono;
-using namespace std::chrono_literals;
 
 TEST(UponDone, Working) {
   int count = 0;
@@ -18,7 +13,7 @@ TEST(UponDone, Working) {
   EXPECT_EQ(count, 1);
 }
 
-TEST(Pipeable, UponDone){
+TEST(UponDone, Pipeable){
   int count = 0;
 
   just_done()
@@ -32,7 +27,7 @@ TEST(Pipeable, UponDone){
   EXPECT_EQ(count, 2);
 }
 
-TEST(NotCalled, UponDone){
+TEST(UponDone, NotCalled){
   int count = 0;
 
   auto x = just(42)
@@ -41,4 +36,27 @@ TEST(NotCalled, UponDone){
 
   EXPECT_EQ(count, 0);
   EXPECT_EQ(x.value(), 42);
+}
+
+TEST(UponDone, ReturningValue) {
+  int count = 0;
+  auto res = just_done()
+    | upon_done([&]{
+        count++;
+        return 42;
+        })
+    | sync_wait();
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(res.value(), 42);
+}
+
+TEST(UponDone, VoidReturnCallback) {
+  int count = 0;
+  auto res = just(32)
+    | upon_done([&]{
+        count++;
+      })
+    | sync_wait();
+  EXPECT_EQ(count, 0);
+  EXPECT_EQ(res.value(), 32);
 }

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,14 +1,20 @@
+#include <unifex/when_all.hpp>
 #include <unifex/then.hpp>
 #include <unifex/just.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/upon_done.hpp>
+#include "unifex/let_done.hpp"
+#include "unifex/timed_single_thread_context.hpp"
 
 #include <gtest/gtest.h>
 #include <type_traits>
 #include <variant>
+#include <chrono>
 
 using namespace unifex;
+using namespace std::chrono;
+using namespace std::chrono_literals;
 
 TEST(UponDone, StaticTypeCheck) {
   auto res1 = just(42)
@@ -45,6 +51,29 @@ TEST(UponDone, StaticTypeCheck) {
       });
   static_assert(std::is_same_v<decltype(res5)::value_types<std::variant, std::tuple>,
       std::variant<std::tuple<int>>>);
+
+  auto res6 = just_done()
+    | upon_done([]{
+      });
+  static_assert(std::is_same_v<decltype(res6)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<>>>);
+
+  timed_single_thread_context context;
+  auto scheduler = context.get_scheduler();
+  auto sch_then_sender = schedule_after(scheduler, 200ms)
+    | then([]{return 2;});
+  static_assert(std::is_same_v<decltype(sch_then_sender)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+
+  auto res7 = sch_then_sender
+    | upon_done([]{});
+  static_assert(std::is_same_v<decltype(res7)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>, std::tuple<>>>);
+
+  auto res8 = std::move(sch_then_sender)
+    | upon_done([]{ return 1.2; });
+  static_assert(std::is_same_v<decltype(res8)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>, std::tuple<double>>>);
 }
 
 TEST(UponDone, Working) {

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -4,6 +4,8 @@
 #include <unifex/upon_error.hpp>
 
 #include <gtest/gtest.h>
+#include <type_traits>
+#include <variant>
 
 using namespace unifex;
 

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -7,6 +7,34 @@
 
 using namespace unifex;
 
+TEST(UponError, StaticTypeCheck) {
+  auto res1 = just(42)
+    | upon_error([](auto){return 42;});
+  static_assert(std::is_same_v<decltype(res1)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>>>);
+
+  auto res2 = just()
+    | upon_error([](auto){
+        return 2;
+      });
+  static_assert(std::is_same_v<decltype(res2)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<>, std::tuple<int>>>);
+
+  auto res3 = just(42)
+    | upon_error([](auto){
+        return;
+      });
+  static_assert(std::is_same_v<decltype(res3)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>, std::tuple<>>>);
+
+  auto res4 = just(42)
+    | upon_error([](auto){
+        return 2.0;
+      });
+  static_assert(std::is_same_v<decltype(res4)::value_types<std::variant, std::tuple>,
+      std::variant<std::tuple<int>, std::tuple<double>>>);
+}
+
 TEST(UponError, Working) {
   int val = 0;
   auto res = sync_wait(upon_error(just_error(42), [&](auto err_val) {
@@ -48,21 +76,11 @@ TEST(UponError, ExceptionHandling) {
       | upon_error([&](auto) {
         val = 1;
         throw 2;
+        return 2;
       })
       | sync_wait();
   } catch(int err){
     EXPECT_EQ(err, 2);
   }
   EXPECT_EQ(val, 0);
-}
-
-TEST(UponError, VoidReturnCallback) {
-  int val = 0;
-  auto res = just(42) 
-    | upon_error([&](auto){
-        val = 2;
-      })
-    | sync_wait();
-  EXPECT_EQ(val, 0);
-  EXPECT_EQ(res.value(), 42);
 }

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -1,0 +1,49 @@
+#include <unifex/just.hpp>
+#include <unifex/just_error.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/upon_error.hpp>
+#include <iostream>
+
+#include <chrono>
+#include <iostream>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+TEST(UponError, Working) {
+  int err_code = 0;
+  try {
+    sync_wait(upon_error(just_error(42), [] { return 2; }));
+  } catch (int err) {
+    err_code = err;
+  }
+  EXPECT_EQ(err_code, 2);
+}
+
+TEST(Pipeable, UponError) {
+  int err_code = 0;
+  try {
+    just_error(42)
+      | upon_error([]{ return 2; })
+      | sync_wait();
+  } catch (int err) {
+    err_code = err;
+  }
+  EXPECT_EQ(err_code, 2);
+}
+
+TEST(NotCalled, UponError) {
+  int err_code = 0;
+  try {
+    just(42)
+      | upon_error([]{ return 2; })
+      | sync_wait();
+  } catch (int err) {
+    err_code = err;
+  }
+  EXPECT_EQ(err_code, 0);
+}

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -3,8 +3,6 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/upon_error.hpp>
 
-#include <type_traits>
-
 #include <gtest/gtest.h>
 
 using namespace unifex;
@@ -19,7 +17,7 @@ TEST(UponError, Working) {
   EXPECT_EQ(res.value(), 2);
 }
 
-TEST(Pipeable, UponError) {
+TEST(UponError, Pipeable) {
   int val = 0;
   auto res = just_error(42) 
     | upon_error([&](auto err_val) {
@@ -31,11 +29,11 @@ TEST(Pipeable, UponError) {
   EXPECT_EQ(res.value(), 2);
 }
 
-TEST(NotCalled, UponError) {
+TEST(UponError, NotCalled) {
   int val = 0;
   auto res = just(42)
     | upon_error([&](auto) {
-      val = 1;
+      val++;
       return 2;
     })
     | sync_wait();
@@ -43,14 +41,13 @@ TEST(NotCalled, UponError) {
   EXPECT_EQ(res.value(), 42);
 }
 
-TEST(ExceptionHandling, UponError) {
+TEST(UponError, ExceptionHandling) {
   int val = 0;
   try{
     just(42)
       | upon_error([&](auto) {
         val = 1;
         throw 2;
-        return 2;
       })
       | sync_wait();
   } catch(int err){
@@ -59,12 +56,13 @@ TEST(ExceptionHandling, UponError) {
   EXPECT_EQ(val, 0);
 }
 
-TEST(VoidReturn, UponError) {
+TEST(UponError, VoidReturnCallback) {
   int val = 0;
-  just_error(42) 
+  auto res = just(42) 
     | upon_error([&](auto){
         val = 2;
       })
     | sync_wait();
-  EXPECT_EQ(val, 2);
+  EXPECT_EQ(val, 0);
+  EXPECT_EQ(res.value(), 42);
 }


### PR DESCRIPTION
[P2300](https://wg21.link/P2300) proposes two algorithms similar to ``unifex::then``, ``upon_done`` and ``upon_error``. This PR intends to add those algorithms to libunifex with names: ``unifex::upon_done`` and ``unifex::upon_error``. I am trying to make coding conventions similar to already existing modules in libunifex and would be happy to change if some coding conventions doesn't match coding conventions of project.

Current Progress:
- upon_done implementation and test added and tests are passing. Tests are kept similar to unifex::then tests.
- upon_error implementation and tests added and tests are passing.