### PR TITLE
Fix a couple of typos in the pre-P2300 back-compat

### DIFF
--- a/include/unifex/let.hpp
+++ b/include/unifex/let.hpp
@@ -17,6 +17,7 @@
 
 #include <unifex/config.hpp>
 #include <unifex/let_value.hpp>
+#include <unifex/then.hpp>
 
 #include <unifex/detail/prologue.hpp>
 

--- a/include/unifex/let_with_stop_source.hpp
+++ b/include/unifex/let_with_stop_source.hpp
@@ -24,7 +24,7 @@ UNIFEX_DEPRECATED_HEADER("let_with_stop_source.hpp is deprecated. Use let_value_
 
 namespace unifex {
 [[deprecated("unifex::let_with_stop_source has been renamed to unifex::let_value_with_stop_source")]]
-inline constexpr _let_v_w_stop_srce::_cpo::_fn let_with_stop_source {};
+inline constexpr _let_v_w_stop_src::_cpo::_fn let_with_stop_source {};
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>


### PR DESCRIPTION
`let.hpp` was missing an include so the compiler didn't know about
`namespace unifex::_then`, and there was a simple typo in
`let_with_stop_source.hpp`.