### PR TITLE
Introduce optional overrides for resource limits in tests

### DIFF
--- a/test/async_mutex_test.cpp
+++ b/test/async_mutex_test.cpp
@@ -30,12 +30,18 @@
 using namespace unifex;
 
 TEST(async_mutex, multiple_threads) {
+#if !defined(UNIFEX_TEST_LIMIT_ASYNC_MUTEX_ITERATIONS)
+  constexpr int iterations = 100'000;
+#else
+  constexpr int iterations = UNIFEX_TEST_LIMIT_ASYNC_MUTEX_ITERATIONS;
+#endif
+
   async_mutex mutex;
 
   int sharedState = 0;
 
   auto makeTask = [&](manual_event_loop::scheduler scheduler) -> task<int> {
-    for (int i = 0; i < 100'000; ++i) {
+    for (int i = 0; i < iterations; ++i) {
       co_await mutex.async_lock();
       co_await schedule(scheduler);
       ++sharedState;
@@ -51,7 +57,7 @@ TEST(async_mutex, multiple_threads) {
       makeTask(ctx1.get_scheduler()),
       makeTask(ctx2.get_scheduler())));
 
-  EXPECT_EQ(200'000, sharedState);
+  EXPECT_EQ(2 * iterations, sharedState);
 }
 
 #endif  // UNIFEX_NO_COROUTINES

--- a/test/async_scope_test.cpp
+++ b/test/async_scope_test.cpp
@@ -158,7 +158,11 @@ TEST_F(async_scope_test, work_spawned_in_correct_context) {
 }
 
 TEST_F(async_scope_test, lots_of_threads_works) {
+#if !defined(UNIFEX_TEST_LIMIT_ASYNC_SCOPE_THREADS)
   constexpr int maxCount = 1'000;
+#else
+  constexpr int maxCount = UNIFEX_TEST_LIMIT_ASYNC_SCOPE_THREADS;
+#endif
 
   std::array<single_thread_context, maxCount> threads;
 


### PR DESCRIPTION
The default values of number of spawned threads and mutex iterations might be too high for some runtime environments.