### PR TITLE
Fix compile time bug

### DIFF
--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -33,9 +33,11 @@
 #include <unifex/linux/monotonic_clock.hpp>
 #include <unifex/linux/safe_file_descriptor.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <system_error>
 #include <utility>
@@ -439,7 +441,7 @@ class io_uring_context::read_sender {
         sqe.rw_flags = 0;
         sqe.user_data = reinterpret_cast<std::uintptr_t>(
             static_cast<completion_base*>(this));
-        sqe.__pad2[0] = sqe.__pad2[1] = sqe.__pad2[2] = 0;
+        std::fill(std::begin(sqe.__pad2), std::end(sqe.__pad2), 0);
 
         this->execute_ = &operation::on_read_complete;
       };
@@ -557,7 +559,7 @@ class io_uring_context::write_sender {
         sqe.rw_flags = 0;
         sqe.user_data = reinterpret_cast<std::uintptr_t>(
             static_cast<completion_base*>(this));
-        sqe.__pad2[0] = sqe.__pad2[1] = sqe.__pad2[2] = 0;
+        std::fill(std::begin(sqe.__pad2), std::end(sqe.__pad2), 0);
 
         this->execute_ = &operation::on_write_complete;
       };

--- a/source/linux/io_uring_context.cpp
+++ b/source/linux/io_uring_context.cpp
@@ -630,7 +630,7 @@ bool io_uring_context::try_register_remote_queue_notification() noexcept {
     sqe.len = 0;
     sqe.poll_events = POLL_IN;
     sqe.user_data = remote_queue_event_user_data;
-    sqe.__pad2[0] = sqe.__pad2[1] = sqe.__pad2[2] = 0;
+    std::fill(std::begin(sqe.__pad2), std::end(sqe.__pad2), 0);
 
     return true;
   };
@@ -756,7 +756,7 @@ bool io_uring_context::try_submit_timer_io(const time_point& dueTime) noexcept {
     sqe.rw_flags =
         1; // HACK: Should be 'sqe.timeout_flags = IORING_TIMEOUT_ABS'
     sqe.user_data = timer_user_data();
-    sqe.__pad2[0] = sqe.__pad2[1] = sqe.__pad2[2] = 0;
+    std::fill(std::begin(sqe.__pad2), std::end(sqe.__pad2), 0);
 
     time_.tv_sec = dueTime.seconds_part();
     time_.tv_nsec = dueTime.nanoseconds_part();
@@ -781,7 +781,7 @@ bool io_uring_context::try_submit_timer_io_cancel() noexcept {
     sqe.len = 0;
     sqe.rw_flags = 0;
     sqe.user_data = remove_timer_user_data();
-    sqe.__pad2[0] = sqe.__pad2[1] = sqe.__pad2[2] = 0;
+    std::fill(std::begin(sqe.__pad2), std::end(sqe.__pad2), 0);
   };
 
   return try_submit_io(populateSqe);


### PR DESCRIPTION
Arch Linux
```bash
$ uname -r
5.10.67-1-lts
$ clang --version
clang version 12.0.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

https://github.com/torvalds/linux/commit/9ba6a1c06279ce499fcf755d8134d679a1f3b4ed
A bit strange, perhaps due to the fact that I also have a non-LTS kernel, its headers were used instead of the correct ones