### PR TITLE
Make take until provide a scheduler

### DIFF
--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -244,6 +244,14 @@ struct _stream<SourceStream, TriggerStream>::type {
             op.source_cleanup_error(std::move(error));
           }
 
+          template(typename CPO)
+              (requires is_receiver_query_cpo_v<CPO>)
+          friend auto tag_invoke(CPO cpo, const source_receiver& r) noexcept(
+              is_nothrow_callable_v<CPO, const Receiver&>)
+              -> callable_result_t<CPO, const Receiver&> {
+            return std::move(cpo)(std::as_const(r.op_.receiver_));
+          }
+
           template <typename Func>
           friend void tag_invoke(
               tag_t<visit_continuations>,
@@ -271,6 +279,14 @@ struct _stream<SourceStream, TriggerStream>::type {
             auto& op = op_;
             op.triggerOp_.destruct();
             op.trigger_cleanup_error(std::move(error));
+          }
+
+          template(typename CPO)
+              (requires is_receiver_query_cpo_v<CPO>)
+          friend auto tag_invoke(CPO cpo, const trigger_receiver& r) noexcept(
+              is_nothrow_callable_v<CPO, const Receiver&>)
+              -> callable_result_t<CPO, const Receiver&> {
+            return std::move(cpo)(std::as_const(r.op_.receiver_));
           }
 
           template <typename Func>

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -139,6 +139,14 @@ struct _stream<SourceStream, TriggerStream>::type {
             return r.get_stop_source().get_token();
           }
 
+          template(typename CPO)
+              (requires is_receiver_query_cpo_v<CPO>)
+          friend auto tag_invoke(CPO cpo, const receiver_wrapper& r) noexcept(
+              is_nothrow_callable_v<CPO, const Receiver&>)
+              -> callable_result_t<CPO, const Receiver&> {
+            return std::move(cpo)(std::as_const(r.op_.receiver_));
+          }
+
           template <typename Func>
           friend void tag_invoke(
               tag_t<visit_continuations>,


### PR DESCRIPTION
This diff changes `take_until`'s `next_sender` to respond to receiver
queries by forwarding them to the outer receiver.  In particular, this
makes the inner receiver a `scheduler_provider`, solving a problem we
have internally.