### PR TITLE
Add a default for the template parameter for the inplace_stop_callback ctor

### DIFF
--- a/include/unifex/inplace_stop_token.hpp
+++ b/include/unifex/inplace_stop_token.hpp
@@ -173,7 +173,7 @@ inline inplace_stop_token inplace_stop_source::get_token() noexcept {
 template <typename F>
 class inplace_stop_callback final : private inplace_stop_callback_base {
  public:
-  template(typename T)
+  template(typename T = F)
     (requires convertible_to<T, F>)
   explicit inplace_stop_callback(inplace_stop_token token, T&& func) noexcept(
       std::is_nothrow_constructible_v<F, T>)


### PR DESCRIPTION
... in case type deduction fails (say, if you use an initializer list as an argument).