### PR TITLE
Fix await_transform forward declaration

### DIFF
--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -183,7 +183,7 @@ public:
 template <typename Promise, typename Sender>
 using _as_awaitable = typename _awaitable<Promise, Sender>::type;
 
-inline constexpr struct _fn {
+inline const struct _fn {
   // Call custom implementation if present.
   template(typename Promise, typename Value)
     (requires tag_invocable<_fn, Promise&, Value>)


### PR DESCRIPTION
Fixes compile error:

```
[build] unifex/await_transform.hpp(219): error C2370: 'unifex::_await_tfx::await_transform': redefinition; different storage class
[build] unifex/detail/unifex_fwd.hpp(51): note: see declaration of 'unifex::_await_tfx::await_transform'
```