### PR TITLE
Make unifex::async_scope::spawn return a unifex::future<>

### DIFF
--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -97,7 +97,9 @@ struct _spawn_op_base {
 
   void request_stop() noexcept {
     stopSource_.request_stop();
-    set_done();
+    if (try_set_state(op_state::done)) {
+      evt_.set();
+    }
   }
 
   void set_done() noexcept {

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -643,6 +643,10 @@ public:
   template(typename Scheduler, typename Fun)             //
       (requires scheduler<Scheduler> AND callable<Fun>)  //
       void detached_spawn_call_on(Scheduler&& scheduler, Fun&& fun) {
+    static_assert(
+        is_nothrow_callable_v<Fun>,
+        "Please annotate your callable with noexcept.");
+
     detached_spawn_on((Scheduler &&) scheduler, just_from((Fun &&) fun));
   }
 

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -260,6 +260,7 @@ struct lazy final {
     void set_value() noexcept {
       auto p = std::exchange(this->promise_, nullptr);
       p->consume(std::move(receiver_));
+      p->decref();
     }
 
     void set_error(std::exception_ptr e) noexcept {

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -361,7 +361,7 @@ struct future final {
       }
 
       explicit type(promise_holder&& p, const Receiver& r)
-          noexcept(is_nothrow_move_constructible_v<Receiver>)
+          noexcept(is_nothrow_copy_constructible_v<Receiver>)
         : promise_holder(std::move(p)),
           receiver_(r) {
       }

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -96,21 +96,8 @@ struct _spawn_op_base {
   }
 
   void request_stop() noexcept {
-    // first try to complete the receiver; we might be racing with the operation
-    // so we need to use the atomic try_set_state to maintain consistency
-    bool needsStop = try_set_state(op_state::done);
-
-    // schedule the associated future to be woken up
-    evt_.set();
-
-    // don't bother requesting stop on the stop source unless try_set_state
-    // succeeded; this should save some work if the operation was already
-    // complete
-    if (needsStop) {
-      // do this after setting the event, above, so the future can potentially
-      // complete while we run stop callbacks, etc.
-      stopSource_.request_stop();
-    }
+    stopSource_.request_stop();
+    set_done();
   }
 
   void set_done() noexcept {

--- a/test/async_scope_test.cpp
+++ b/test/async_scope_test.cpp
@@ -18,7 +18,11 @@
 
 #include <unifex/just.hpp>
 #include <unifex/just_from.hpp>
+#include <unifex/just_void_or_done.hpp>
 #include <unifex/let_value_with.hpp>
+#include <unifex/let_value_with_stop_token.hpp>
+#include <unifex/on.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/scope_guard.hpp>
 #include <unifex/sequence.hpp>
 #include <unifex/single_thread_context.hpp>
@@ -38,7 +42,11 @@ using unifex::get_scheduler;
 using unifex::get_stop_token;
 using unifex::just;
 using unifex::just_from;
+using unifex::just_void_or_done;
 using unifex::let_value_with;
+using unifex::let_value_with_stop_token;
+using unifex::on;
+using unifex::optional;
 using unifex::same_as;
 using unifex::schedule;
 using unifex::scope_guard;
@@ -100,11 +108,10 @@ struct async_scope_test : testing::Test {
   }
 
   void expect_work_to_run() {
-    future<int, int> futureInt =
-        scope.spawn_on(thread.get_scheduler(), just(42, 42));
+    future<int, int> fut = scope.spawn_on(thread.get_scheduler(), just(42, 42));
 
     // we'll hang here if the above work doesn't start
-    auto result = sync_wait(std::move(futureInt));
+    auto result = sync_wait(std::move(fut));
 
     ASSERT_TRUE(result);
     EXPECT_EQ(std::tuple(42, 42), *result);
@@ -113,12 +120,12 @@ struct async_scope_test : testing::Test {
   void expect_work_to_run_call_on() {
     async_manual_reset_event evt;
 
-    future<> lzy = scope.spawn_call_on(
+    future<> fut = scope.spawn_call_on(
         thread.get_scheduler(), [&]() noexcept { evt.set(); });
 
     // we'll hang here if the above work doesn't start
     sync_wait(evt.async_wait());
-    sync_wait(std::move(lzy));
+    sync_wait(std::move(fut));
   }
 };
 
@@ -262,6 +269,107 @@ TEST_F(async_scope_test, spawning_a_sender_producing_const_int_works) {
   EXPECT_EQ(*result, 42);
 }
 
+TEST_F(
+    async_scope_test, spawning_just_void_or_done_signals_the_future_with_done) {
+  auto fut = scope.spawn(just_void_or_done(false));
+
+  static_assert(same_as<decltype(fut), future<>>);
+
+  auto result = sync_wait(std::move(fut));
+
+  EXPECT_FALSE(result);
+}
+
+TEST_F(
+    async_scope_test,
+    spawning_just_from_throwing_function_signals_the_future_with_an_exception) {
+  auto fut = scope.spawn(just_from([]() { throw 1; }));
+
+  static_assert(same_as<decltype(fut), future<>>);
+
+  try {
+    sync_wait(std::move(fut));
+    FAIL();
+  } catch (int i) {
+    EXPECT_EQ(i, 1);
+  } catch (...) {
+    FAIL();
+  }
+}
+
+namespace {
+
+template <typename StopToken, typename Callback>
+auto make_stop_callback(StopToken stoken, Callback callback) {
+  using stop_callback_t = typename StopToken::template callback_type<Callback>;
+
+  return stop_callback_t{std::move(stoken), std::move(callback)};
+}
+
+}  // namespace
+
+TEST_F(async_scope_test, discarding_a_future_requests_cancellation) {
+  async_manual_reset_event scheduled, finished;
+
+  std::atomic<bool> wasStopped{false};
+
+  optional<future<>> optFuture = scope.spawn_on(
+      thread.get_scheduler(),
+      let_value_with_stop_token([&](auto stoken) noexcept {
+        return let_value_with(
+            [&wasStopped, stoken = std::move(stoken)]() mutable noexcept {
+              return make_stop_callback(
+                  std::move(stoken),
+                  [&wasStopped]() noexcept { wasStopped = true; });
+            },
+            [&scheduled, &finished](auto&) noexcept {
+              return sequence(
+                  just_from([&scheduled]() noexcept { scheduled.set(); }),
+                  finished.async_wait());
+            });
+      }));
+
+  // ensure the spawned work is actually spawned before...
+  sync_wait(scheduled.async_wait());
+
+  // ...dropping the future
+  optFuture.reset();
+
+  // we know that the stop callback has been registered (that happens before the
+  // spawned work sets the scheduled event) so dropping the future ought to
+  // trigger the callback and set wasStopped to true
+  EXPECT_TRUE(wasStopped.load());
+
+  // now clean up the test state; release the awaited event and block until the
+  // scope sees the work finish (skipping this last step causes a race between
+  // waking up the blocked work and destroying finished)
+
+  finished.set();
+
+  sync_wait(scope.complete());
+}
+
+TEST_F(async_scope_test, requesting_the_scope_stop_cancels_pending_futures) {
+  async_manual_reset_event evt;
+
+  auto fut = scope.spawn_on(thread.get_scheduler(), evt.async_wait());
+
+  scope.request_stop();
+
+  // with the scope cancelled, pending futures should all immediately complete
+  // with done
+  auto result = sync_wait(std::move(fut));
+
+  EXPECT_FALSE(result);
+
+  // but the scope itself won't complete until the spawned work is actually done
+  // so we need to release the event here and block on scope completion before
+  // the event is destroyed to make sure the test actually completes
+  evt.set();
+
+  sync_wait(scope.complete());
+}
+
 TEST_F(async_scope_test, spawning_after_cleaning_up_destroys_the_sender) {
   spawn_work_after_cleanup();
 }
@@ -333,10 +441,10 @@ TEST_F(async_scope_test, lots_of_threads_works) {
 
   for (auto& thread : threads) {
     // Spawn maxCount jobs that are all waiting on unique threads to spawn a
-    // job each that increments count and then waits. The last job to increment
-    // count will unblock the waiting jobs, so the group will then race to tear
-    // themselves down.  On tear-down, decrement count again so that it can be
-    // expected to be zero once everything's done.
+    // job each that increments count and then waits. The last job to
+    // increment count will unblock the waiting jobs, so the group will then
+    // race to tear themselves down.  On tear-down, decrement count again so
+    // that it can be expected to be zero once everything's done.
     //
     // This should stress-test job submission and cancellation.
     scope.detached_spawn_on(

--- a/test/create_test.cpp
+++ b/test/create_test.cpp
@@ -39,7 +39,7 @@ struct CreateTest : testing::Test {
   void anIntAPI(int a, int b, void* context, void (*completed)(void* context, int result)) {
     // Execute some work asynchronously on some other thread. When its
     // work is finished, pass the result to the callback.
-    someScope.spawn_call_on(someThread.get_scheduler(), [=]() noexcept {
+    someScope.detached_spawn_call_on(someThread.get_scheduler(), [=]() noexcept {
       auto result = a + b;
       completed(context, result);
     });
@@ -48,7 +48,7 @@ struct CreateTest : testing::Test {
   void aVoidAPI(void* context, void (*completed)(void* context)) {
     // Execute some work asynchronously on some other thread. When its
     // work is finished, pass the result to the callback.
-    someScope.spawn_call_on(someThread.get_scheduler(), [=]() noexcept {
+    someScope.detached_spawn_call_on(someThread.get_scheduler(), [=]() noexcept {
       completed(context);
     });
   }


### PR DESCRIPTION
This diff changes `unifex::async_scope::spawn(Sender auto)` to return a
new type, `unifex::future<...>`.  `future<>` is a _Sender_ that completes
with the result of the _Sender_ given to `spawn`.