### PR TITLE
fix non-virtual destructor warnings

### DIFF
--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -58,10 +58,12 @@ struct _stream<SourceStream, Values...>::type {
   };
 
   struct cleanup_operation_base {
+    virtual ~cleanup_operation_base() = default;
     virtual void start_cleanup() noexcept = 0;
   };
 
   struct next_receiver_base {
+    virtual ~next_receiver_base() = default;
     virtual void set_value(Values&&... values) && noexcept = 0;
     virtual void set_done() && noexcept = 0;
     virtual void set_error(std::exception_ptr ex) && noexcept = 0;

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -79,6 +79,7 @@ struct _stream<SourceStream, TriggerStream>::type {
   };
 
   struct cleanup_operation_base {
+    virtual ~cleanup_operation_base() = default;
     virtual void start_trigger_cleanup() noexcept = 0;
   };
 

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -41,6 +41,7 @@ using stream = typename _stream<Values...>::type;
 template <typename... Values>
 struct _stream<Values...>::type {
   struct next_receiver_base {
+    virtual ~next_receiver_base() = default;
     virtual void set_value(Values&&... values) noexcept = 0;
     virtual void set_done() noexcept = 0;
     virtual void set_error(std::exception_ptr ex) noexcept = 0;
@@ -60,6 +61,7 @@ struct _stream<Values...>::type {
   };
 
   struct cleanup_receiver_base {
+    virtual ~cleanup_receiver_base() = default;
     virtual void set_done() noexcept = 0;
     virtual void set_error(std::exception_ptr ex) noexcept = 0;
 
@@ -76,7 +78,7 @@ struct _stream<Values...>::type {
   };
 
   struct stream_base {
-    virtual ~stream_base() {}
+    virtual ~stream_base() = default;
     virtual void start_next(
         next_receiver_base& receiver,
         inplace_stop_token stopToken) noexcept = 0;


### PR DESCRIPTION
When compiling the coroutine_stream_consumer example with
-Werror, I observed errors such as:

```
    ... has accessible non-virtual destructor [-Werror=non-virtual-dtor]
    220 |         struct concrete_receiver final : next_receiver_base {
```

Fix these by adding default virtual destructors to all base structures
which define virtual functions.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
