### PR TITLE
Respect blocking_kind in `let_value()`

### DIFF
--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -273,6 +273,51 @@ struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {
 template <typename... Successors>
 using any_sends_done = std::disjunction<sends_done_impl<Successors>...>;
 
+template <typename Sender, typename... Rest>
+struct max_blocking_kind {
+  constexpr auto operator()() noexcept { return cblocking<Sender>(); }
+};
+
+template <typename First, typename Second, typename... Rest>
+struct max_blocking_kind<First, Second, Rest...> {
+  constexpr auto operator()() noexcept {
+    constexpr blocking_kind first = cblocking<First>();
+    constexpr blocking_kind second = cblocking<Second>();
+
+    if constexpr (first == second) {
+      return max_blocking_kind<First, Rest...>{}();
+    } else if constexpr (
+        first == blocking_kind::always &&
+        second == blocking_kind::always_inline) {
+      return max_blocking_kind<First, Rest...>{}();
+    } else if constexpr (
+        first == blocking_kind::always_inline &&
+        second == blocking_kind::always) {
+      return max_blocking_kind<Second, Rest...>{}();
+    } else {
+      return blocking_kind::maybe;
+    }
+  }
+};
+
+constexpr blocking_kind _blocking_kind(blocking_kind source, blocking_kind completion) noexcept {
+  if (source == blocking_kind::never || completion == blocking_kind::never) {
+    return blocking_kind::never;
+  } else if (
+      source == blocking_kind::always_inline &&
+      completion == blocking_kind::always_inline) {
+    return blocking_kind::always_inline;
+  } else if (
+      (source == blocking_kind::always_inline ||
+       source == blocking_kind::always) &&
+      (completion == blocking_kind::always_inline ||
+       completion == blocking_kind::always)) {
+    return blocking_kind::always;
+  } else {
+    return blocking_kind::maybe;
+  }
+}
+
 template <typename Predecessor, typename SuccessorFactory>
 class _sender<Predecessor, SuccessorFactory>::type {
   using sender = type;
@@ -349,6 +394,19 @@ public:
         static_cast<Sender&&>(sender).pred_,
         static_cast<Sender&&>(sender).func_,
         static_cast<Receiver&&>(receiver)};
+  }
+
+  friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type&) noexcept {
+    constexpr blocking_kind succ = successor_types<_let_v::max_blocking_kind>{}();
+    if constexpr (
+        blocking_kind::never == cblocking<Predecessor>() || blocking_kind::never == succ) {
+      return blocking_kind::never;
+    } else if constexpr (
+        blocking_kind::maybe != cblocking<Predecessor>() && blocking_kind::maybe != succ) {
+      return blocking_kind::constant<_let_v::_blocking_kind(cblocking<Predecessor>(), succ)>{};
+    } else {
+      return _let_v::_blocking_kind(cblocking<Predecessor>(), succ);
+    }
   }
 };
 

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -45,6 +45,55 @@ constexpr auto asyncVector = [](auto& context) {
         return std::vector<int>{1, 2, 3, 4};
     });
 };
+
+namespace _never_block {
+template <typename... Values>
+struct sender {
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = Variant<Tuple<Values...>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = false;
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
+    return blocking_kind::never;
+  }
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&... values) const noexcept {
+    return _never_block::sender{(Values&&)values...};
+  }
+
+} never_block{};
+} // namespace _never_block
+
+using _never_block::never_block;
+
+namespace _multi {
+struct _multi_sender {
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = Variant<Tuple<int>, Tuple<double>>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+  static constexpr bool sends_done = false;
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&...) const noexcept {
+    return _multi::_multi_sender{};
+  }
+} multi_sender{};
+} // namespace _multi
+using _multi::multi_sender;
 } // anonymous namespace
 
 TEST(Let, Simple) {
@@ -121,4 +170,68 @@ TEST(Let, Pipeable) {
   EXPECT_TRUE(!!result);
   EXPECT_EQ(*result, 42);
   std::cout << "let_value done " << *result << "\n";
+}
+
+TEST(Let, InlineBlockingKind) {
+  auto snd = let_value(just(), just);
+  using Snd = decltype(snd);
+  static_assert(blocking_kind::always_inline == cblocking<Snd>());
+}
+
+TEST(Let, PipeInlineBlockingKind) {
+  auto snd = just() | let_value(just);
+  using Snd = decltype(snd);
+  static_assert(blocking_kind::always_inline == cblocking<Snd>());
+}
+
+TEST(Let, MaybeBlockingKind) {
+  timed_single_thread_context context;
+
+  auto snd1 = let_value(schedule(context.get_scheduler()), just);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::maybe == cblocking<Snd1>());
+
+  auto snd2 = let_value(multi_sender(), just);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}
+
+TEST(Let, PipeMaybeBlockingKind) {
+  timed_single_thread_context context;
+
+  auto snd1 = just() | let_value([&] {
+    return schedule(context.get_scheduler());
+  });
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::maybe == cblocking<Snd1>());
+
+  auto snd2 = just() | let_value(multi_sender);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}
+
+TEST(Let, NeverBlockingKind) {
+  auto snd1 = let_value(never_block(), never_block);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::never == cblocking<Snd1>());
+
+  timed_single_thread_context context;
+
+  auto snd2 = let_value(schedule(context.get_scheduler()), never_block);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::never == cblocking<Snd2>());
+
+  auto snd3 = let_value(never_block(), multi_sender);
+  using Snd3 = decltype(snd3);
+  static_assert(blocking_kind::never == cblocking<Snd3>());
+}
+
+TEST(Let, PipeNeverBlockingKind) {
+  auto snd1 = never_block() | let_value(never_block);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::never == cblocking<Snd1>());
+
+  auto snd2 = never_block() | let_value(multi_sender);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::never == cblocking<Snd2>());
 }


### PR DESCRIPTION
* `let_value()` would always assume `blocking_kind::maybe`, which
  results in potentially unnecessary reschedule on resumption (#297)
* replicate `blocking_kind` customization from `finally()`