### PR TITLE
Add install target for library

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -417,3 +417,35 @@ jobs:
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")
         endif()
+
+    - name: Install
+      shell: cmake -P {0}
+      continue-on-error: ${{ matrix.config.experimental || false }}
+      run: |
+        set(ENV{NINJA_STATUS} "[%f/%t %o/sec] ")
+
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+
+        set(path_separator ":")
+        if ("${{ runner.os }}" STREQUAL "Windows")
+          set(path_separator ";")
+        endif()
+        set(ENV{PATH} "$ENV{GITHUB_WORKSPACE}${path_separator}$ENV{PATH}")
+
+        set(install_directory "$ENV{GITHUB_WORKSPACE}/install-target-dir")
+        message(STATUS "Install to: ${install_directory}")
+
+        execute_process(
+          COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir}}/cmake --install build --prefix "${install_directory}"
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Bad exit status")
+        endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(libunifex LANGUAGES CXX
-                  VERSION 0.1)
+                  VERSION 0.1.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -86,13 +86,13 @@ configure_file(unifex.pc.in unifex.pc @ONLY)
 
 install(TARGETS unifex EXPORT unifexTargets)
 install(FILES ${PROJECT_BINARY_DIR}/include/unifex/config.hpp
-        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/unifex/)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/unifex/)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
         TYPE INCLUDE
         PATTERN "*.in" EXCLUDE)
 install(EXPORT unifexTargets
         FILE unifexConfig.cmake
         NAMESPACE unifex::
-        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/unifex/)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unifex/)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unifex.pc
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -64,13 +64,28 @@ configure_file(
   ../include/unifex/config.hpp.in
   "${PROJECT_BINARY_DIR}/include/unifex/config.hpp")
 
+include(GNUInstallDirs)
 target_include_directories(unifex
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
-    "${PROJECT_BINARY_DIR}/include")
+    PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_features(unifex PUBLIC cxx_std_17)
 
 if(CXX_COROUTINES_HAVE_COROUTINES)
   target_link_libraries(unifex PUBLIC std::coroutines)
 endif()
+
+# install unifex with its configure file into the default paths
+
+install(TARGETS unifex EXPORT unifexTargets)
+install(FILES ${PROJECT_BINARY_DIR}/include/unifex/config.hpp
+        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/unifex/)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+        TYPE INCLUDE
+        PATTERN "*.in" EXCLUDE)
+install(EXPORT unifexTargets
+        FILE unifexConfig.cmake
+        NAMESPACE unifex::
+        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/unifex/)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -80,6 +80,8 @@ if(CXX_COROUTINES_HAVE_COROUTINES)
   target_link_libraries(unifex PUBLIC std::coroutines)
 endif()
 
+configure_file(unifex.pc.in unifex.pc @ONLY)
+
 # install unifex with its configure file into the default paths
 
 install(TARGETS unifex EXPORT unifexTargets)
@@ -92,3 +94,5 @@ install(EXPORT unifexTargets
         FILE unifexConfig.cmake
         NAMESPACE unifex::
         DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/unifex/)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unifex.pc
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,6 +4,9 @@
 # LICENSE.txt file in the root directory of this source tree.
 
 add_library(unifex "")
+set_target_properties(unifex PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_sources(unifex
   PRIVATE

--- a/source/unifex.pc.in
+++ b/source/unifex.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires:
+Libs: -L${libdir} -lunifex
+Cflags: -I${includedir}


### PR DESCRIPTION
Enable an install target for unifex and a pkgconfig file so that unifex
can be used by non-CMake based repositories.

- Add an install target for the library
- Add library versioning
- Add pkgconfig file
- ci: add install target testing
