### PR TITLE
Minimal changes to allow compilation to succeed on gcc and clang on MSYS2

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -238,7 +238,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Debug (C++17)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: Debug,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -247,7 +247,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Optimised (C++17)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -256,7 +256,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Debug (C++20)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: Debug,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -264,7 +264,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Optimised (C++20)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",

--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -66,7 +66,7 @@ private:
 
 template <typename Scheduler, typename Allocator>
 void test(Scheduler scheduler, Allocator allocator) {
-  int value = 0;
+  [[maybe_unused]] int value = 0;
 
   auto addToValue = [&](int x) {
     // The via() is expected to allocate when it calls submit().

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -32,7 +32,7 @@
 #  define _In_
 #  define _In_opt_
 #  define _Out_
-#  define _Out_writes_to(A, B)
+#  define _Out_writes_to_(A, B)
 #endif
 
 namespace unifex::win32::ntapi

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -18,7 +18,7 @@
 #include <cstdint>
 
 // Mirror definition of NTAPI without depending on windows headers.
-#if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED)
+#if (_MSC_VER >= 800) || defined(__MINGW32__) || defined(_STDCALL_SUPPORTED)
 #  define UNIFEX_NTAPI __stdcall
 #else
 #  define _cdecl

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -31,10 +31,15 @@ namespace unifex::win32
 #  pragma warning(push)
 #  pragma warning(disable : 4201)  // non-standard anonymous struct/union
 #endif
+#if defined(__GNUC__)
+#  define UNIFEX_NAMELESS_UNION __extension__
+#else
+#  define UNIFEX_NAMELESS_UNION
+#endif
   struct overlapped {
     ulong_ptr_t Internal;
     ulong_ptr_t InternalHigh;
-    union {
+    UNIFEX_NAMELESS_UNION union {
       struct {
         dword_t Offset;
         dword_t OffsetHigh;
@@ -43,7 +48,7 @@ namespace unifex::win32
     };
     handle_t hEvent;
   };
-
+#undef UNIFEX_NAMELESS_UNION
 #if defined(_MSC_VER)
 #  pragma warning(pop)
 #endif

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -410,6 +410,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Receiver>
+    using schedule_op = schedule_op<Receiver>;
     low_latency_iocp_context& context_;
   };
 
@@ -578,6 +580,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buf, typename Receiver>
+    using read_file_op = read_file_op<Buf, Receiver>;
     low_latency_iocp_context& context_;
     handle_t fileHandle_;
     bool skipNotificationsOnSuccess_;
@@ -751,6 +755,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buf, typename Receiver>
+    using write_file_op = write_file_op<Buf, Receiver>;
     low_latency_iocp_context& context_;
     handle_t fileHandle_;
     bool skipNotificationsOnSuccess_;
@@ -772,6 +778,9 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buffer>
+    using read_file_sender = read_file_sender<Buffer>;
+
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
   };
@@ -791,6 +800,9 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buffer>
+    using write_file_sender = write_file_sender<Buffer>;
+
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
   };

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -673,7 +673,7 @@ private:
         }
     }
 
-    void set_done_impl() noexcept {
+    void set_done_impl() noexcept override {
         unifex::set_done(std::move(receiver_));
     }
 
@@ -751,7 +751,7 @@ private:
         }
     }
 
-    void set_done_impl() noexcept {
+    void set_done_impl() noexcept override {
         unifex::set_done(std::move(receiver_));
     }
 

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -151,7 +151,7 @@ public:
     {}
 
 private:
-    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(op.receiver_));
@@ -257,13 +257,13 @@ protected:
 
 private:
     static void CALLBACK unstoppable_work_callback(
-        PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
         op.set_value_impl();
     }
 
     static void CALLBACK stoppable_work_callback(
-            PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
 
         // Signal that the work callback has started executing.

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -438,7 +438,8 @@ public:
     static constexpr bool sends_done = true;
 
     template(typename Receiver)
-        (requires receiver_of<Receiver> AND is_stop_never_possible_v<Receiver>)
+        (requires receiver_of<Receiver> AND
+            is_stop_never_possible_v<stop_token_type_t<Receiver>>)
     schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
         return schedule_op<unifex::remove_cvref_t<Receiver>>{
             *pool_, (Receiver&&)r};

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -20,6 +20,7 @@
 #include <unifex/exception.hpp>
 
 #include <atomic>
+#include <cstring>
 #include <random>
 #include <system_error>
 

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -43,7 +43,8 @@ namespace unifex::win32::ntapi
       if (p == NULL) {
         std::terminate();
       }
-      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(p);
+      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
+        reinterpret_cast<void(*)()>(p));
     };
 
     init(NtCreateFile, "NtCreateFile");

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -36,6 +36,7 @@
 #include <unifex/just_from.hpp>
 
 #include <chrono>
+#include <cstring>
 #include <thread>
 
 #include <gtest/gtest.h>

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -125,8 +125,8 @@ TEST(low_latency_iocp_context, read_write_pipe) {
 
     UNIFEX_ASSERT(results.has_value());
 
-    auto [bytesRead] = std::get<0>(std::get<0>(results.value()));
-    auto [bytesWritten] = std::get<0>(std::get<1>(results.value()));
+    [[maybe_unused]] auto [bytesRead] = std::get<0>(std::get<0>(results.value()));
+    [[maybe_unused]] auto [bytesWritten] = std::get<0>(std::get<1>(results.value()));
 
     UNIFEX_ASSERT(bytesRead == 10);
     UNIFEX_ASSERT(bytesWritten == 10);


### PR DESCRIPTION
Fix typos, add missing #includes, avoid redefining macros, suppress warnings. Work around some gcc quirks.
