### PR TITLE
Minimal changes to allow compilation to succeed on gcc and clang on M…

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -222,7 +222,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Debug (C++17)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: Debug,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -231,7 +231,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Optimised (C++17)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -240,7 +240,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Debug (C++20)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: Debug,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
@@ -248,7 +248,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2019 Optimised (C++20)", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            os: windows-2019,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",

--- a/examples/submit_allocator_customisation.cpp
+++ b/examples/submit_allocator_customisation.cpp
@@ -67,7 +67,7 @@ private:
 
 template <typename Scheduler, typename Allocator>
 void test(Scheduler scheduler, Allocator allocator) {
-  int value = 0;
+  [[maybe_unused]] int value = 0;
 
   auto addToValue = [&](int x) {
     // The via() is expected to allocate when it calls submit().

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -18,7 +18,7 @@
 #include <cstdint>
 
 // Mirror definition of NTAPI without depending on windows headers.
-#if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED)
+#if (_MSC_VER >= 800) || defined(__MINGW32__) || defined(_STDCALL_SUPPORTED)
 #  define UNIFEX_NTAPI __stdcall
 #else
 #  define _cdecl
@@ -32,7 +32,7 @@
 #  define _In_
 #  define _In_opt_
 #  define _Out_
-#  define _Out_writes_to(A, B)
+#  define _Out_writes_to_(A, B)
 #endif
 
 namespace unifex::win32::ntapi

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -31,10 +31,15 @@ namespace unifex::win32
 #  pragma warning(push)
 #  pragma warning(disable : 4201)  // non-standard anonymous struct/union
 #endif
+#if defined(__GNUC__)
+#  define UNIFEX_NAMELESS_UNION __extension__
+#else
+#  define UNIFEX_NAMELESS_UNION
+#endif
   struct overlapped {
     ulong_ptr_t Internal;
     ulong_ptr_t InternalHigh;
-    union {
+    UNIFEX_NAMELESS_UNION union {
       struct {
         dword_t Offset;
         dword_t OffsetHigh;
@@ -43,7 +48,7 @@ namespace unifex::win32
     };
     handle_t hEvent;
   };
-
+#undef UNIFEX_NAMELESS_UNION
 #if defined(_MSC_VER)
 #  pragma warning(pop)
 #endif

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -411,6 +411,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Receiver>
+    using schedule_op = schedule_op<Receiver>;
     low_latency_iocp_context& context_;
   };
 
@@ -579,6 +581,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buf, typename Receiver>
+    using read_file_op = read_file_op<Buf, Receiver>;
     low_latency_iocp_context& context_;
     handle_t fileHandle_;
     bool skipNotificationsOnSuccess_;
@@ -752,6 +756,8 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buf, typename Receiver>
+    using write_file_op = write_file_op<Buf, Receiver>;
     low_latency_iocp_context& context_;
     handle_t fileHandle_;
     bool skipNotificationsOnSuccess_;
@@ -773,6 +779,9 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buffer>
+    using read_file_sender = read_file_sender<Buffer>;
+
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
   };
@@ -792,6 +801,9 @@ namespace unifex::win32
     }
 
   private:
+    template <typename Buffer>
+    using write_file_sender = write_file_sender<Buffer>;
+
     low_latency_iocp_context& context_;
     safe_handle fileHandle_;
   };

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -151,7 +151,7 @@ public:
     {}
 
 private:
-    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
         if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
             unifex::set_value(std::move(op.receiver_));
@@ -257,13 +257,13 @@ protected:
 
 private:
     static void CALLBACK unstoppable_work_callback(
-        PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
         op.set_value_impl();
     }
 
     static void CALLBACK stoppable_work_callback(
-            PTP_CALLBACK_INSTANCE instance, void* workContext, PTP_WORK work) noexcept {
+            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
         auto& op = *static_cast<type*>(workContext);
 
         // Signal that the work callback has started executing.
@@ -438,7 +438,8 @@ public:
     static constexpr bool sends_done = true;
 
     template(typename Receiver)
-        (requires receiver_of<Receiver> AND is_stop_never_possible_v<Receiver>)
+        (requires receiver_of<Receiver> AND
+            is_stop_never_possible_v<stop_token_type_t<Receiver>>)
     schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
         return schedule_op<unifex::remove_cvref_t<Receiver>>{
             *pool_, (Receiver&&)r};
@@ -673,7 +674,7 @@ private:
         }
     }
 
-    void set_done_impl() noexcept {
+    void set_done_impl() noexcept override {
         unifex::set_done(std::move(receiver_));
     }
 
@@ -751,7 +752,7 @@ private:
         }
     }
 
-    void set_done_impl() noexcept {
+    void set_done_impl() noexcept override {
         unifex::set_done(std::move(receiver_));
     }
 

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -21,6 +21,7 @@
 #include <unifex/cstddef.hpp>
 
 #include <atomic>
+#include <cstring>
 #include <random>
 #include <system_error>
 

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -43,7 +43,8 @@ namespace unifex::win32::ntapi
       if (p == NULL) {
         std::terminate();
       }
-      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(p);
+      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
+        reinterpret_cast<void(*)()>(p));
     };
 
     init(NtCreateFile, "NtCreateFile");

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -37,6 +37,7 @@
 #include <unifex/cstddef.hpp>
 
 #include <chrono>
+#include <cstring>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -125,8 +126,8 @@ TEST(low_latency_iocp_context, read_write_pipe) {
 
     UNIFEX_ASSERT(results.has_value());
 
-    auto [bytesRead] = std::get<0>(unifex::var::get<0>(results.value()));
-    auto [bytesWritten] = std::get<0>(unifex::var::get<1>(results.value()));
+    [[maybe_unused]] auto [bytesRead] = std::get<0>(unifex::var::get<0>(results.value()));
+    [[maybe_unused]] auto [bytesWritten] = std::get<0>(unifex::var::get<1>(results.value()));
 
     UNIFEX_ASSERT(bytesRead == 10);
     UNIFEX_ASSERT(bytesWritten == 10);


### PR DESCRIPTION
…SYS2 (#391)

* Typo fix (_Out_writes_to -> _Out_writes_to_)

* Include <cstring> for std::memcpy

* Avoid redefining _cdecl and __cdecl on MinGW

* Mark nameless union as an extension on g++

This avoids a warning under -pedantic.

* Avoid 'unused' errors on g++

Mark variables/bindings as "maybe unused" and delete parameter names.

* Cast function pointer from FARPROC via void(*)()

This suppresses the -Wcast-function-type warning, as mentioned in the
documentation for that option.

* Add missing override directives to suppress warnings

* Add nested class aliases to private types in enclosing class

On g++ a function that is a friend of a nested class cannot access private
member types of the enclosing class (!)

* windows_thread_pool::schedule_sender::connect constraints: fix typo

"is_stop_never_possible_v<Receiver>"
should be
"is_stop_never_possible_v<stop_token_type_t<Receiver>>".

* CI: Pin MSVC version to 2019

Co-authored-by: Richard Copley <buster@buster.me.uk>