### PR TITLE
Adding Variant Sender

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -1191,3 +1191,21 @@ namespace unifex
   };
 }
 ```
+
+### `variant_sender`
+
+Non-type erased sender that is parameterized on multiple sender types.
+Receivers must implement `set_value` for all value types produced by all
+senders.
+
+```
+defer(
+  [condition]()
+      -> variant_sender<decltype(just(42)), decltype(just(true))> {
+    if (condition) {
+      return just(42);
+    } else {
+      return just(true);
+    }
+  });
+```

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -78,9 +78,6 @@ struct _sender {
 template <typename... Senders>
 using sender = typename _sender<Senders...>::type;
 
-template<typename Sender>
-struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {};
-
 template <typename... Senders>
 class _sender<Senders...>::type {
   std::variant<Senders...> sender_variant;
@@ -103,7 +100,7 @@ class _sender<Senders...>::type {
     : sender_variant(std::forward<ConcreteSender>(concrete_sender)) {}
 
   template(typename This, typename Receiver)
-    (requires same_as<remove_cvref_t<This>, type> AND receiver<Receiver> AND std::conjunction_v<unifex::is_connectable<Senders, Receiver>...>)
+    (requires same_as<remove_cvref_t<This>, type> AND std::conjunction_v<std::bool_constant<sender_to<member_t<This, Senders>, Receiver>>...>)
   friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
     noexcept(std::conjunction_v<unifex::is_nothrow_connectable<Senders, Receiver>...>)
   {

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/std_concepts.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _variant_sender {
+
+template <typename... Ops>
+struct _op {
+  struct type;
+};
+template <typename... Ops>
+using operation = typename _op<Ops...>::type;
+
+template <typename... Ops>
+struct _op<Ops...>::type {
+  void start() & noexcept {
+    std::visit([](auto& op) noexcept(noexcept(unifex::start(op))) { unifex::start(op); }, variant_op);
+  }
+
+  std::variant<Ops...> variant_op;
+};
+
+
+template <_block::_enum First, _block::_enum... Rest>
+struct max_blocking_kind {
+  constexpr auto operator()() noexcept { return First; }
+};
+
+template <_block::_enum First, _block::_enum Second, _block::_enum... Rest>
+struct max_blocking_kind<First, Second, Rest...> {
+  constexpr auto operator()() noexcept {
+    if constexpr (First == Second) {
+      return max_blocking_kind<First, Rest...>{}();
+    } else if constexpr (
+        (First == blocking_kind::always &&
+        Second == blocking_kind::always_inline) ||
+        (Second == blocking_kind::always &&
+        First == blocking_kind::always_inline)) {
+      return max_blocking_kind<blocking_kind::always_inline, Rest...>{}();
+    } else {
+      return blocking_kind::maybe;
+    }
+  }
+};
+
+template <typename... Senders>
+struct _sender {
+  class type;
+};
+template <typename... Senders>
+using sender = typename _sender<Senders...>::type;
+
+template<typename Sender>
+struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {};
+
+template <typename... Senders>
+class _sender<Senders...>::type {
+  std::variant<Senders...> sender_variant;
+
+ public:
+
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = typename concat_type_lists_unique_t<sender_value_types_t<Senders, type_list, Tuple>...>::template apply<Variant>;
+
+  template <template <typename...> class Variant>
+  using error_types = concat_type_lists_unique_t<sender_error_types_t<Senders, Variant>...>;
+
+  static constexpr bool sends_done = std::disjunction_v<std::bool_constant<sender_traits<Senders>::sends_done>...>;
+
+  template<typename ConcreteSender>
+  type(ConcreteSender&& concrete_sender)
+    noexcept(std::is_nothrow_constructible_v<std::variant<Senders...>, decltype(concrete_sender)>)
+    : sender_variant(std::forward<ConcreteSender>(concrete_sender)) {}
+
+  template(typename This, typename Receiver)
+    (requires same_as<remove_cvref_t<This>, type> AND receiver<Receiver> AND std::conjunction_v<unifex::is_connectable<Senders, Receiver>...>)
+  friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
+    noexcept(std::conjunction_v<unifex::is_nothrow_connectable<Senders, Receiver>...>)
+  {
+    return operation<connect_result_t<Senders, Receiver>...>{
+        std::visit([r = static_cast<Receiver&&>(r)](auto&& sender) mutable noexcept(unifex::is_nothrow_connectable_v<decltype(sender), Receiver>) {
+            return std::variant<connect_result_t<Senders, Receiver>...>{unifex::connect(std::move(sender), static_cast<Receiver&&>(r))};
+        }, std::move(static_cast<This&&>(that).sender_variant))
+    };
+  }
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type&) noexcept {
+    return _variant_sender::max_blocking_kind<cblocking<Senders>...>{}();
+  }
+};
+} // namespace _variant_sender
+
+template <typename... Senders>
+using variant_sender = typename _variant_sender::_sender<Senders...>::type;
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -42,10 +42,10 @@ using operation = typename _op<Ops...>::type;
 template <typename... Ops>
 struct _op<Ops...>::type {
   void start() & noexcept {
-    std::visit([](auto& op) noexcept { unifex::start(op); }, variant_op);
+    std::visit([](auto& op) noexcept { unifex::start(op); }, variantOp_);
   }
 
-  std::variant<Ops...> variant_op;
+  std::variant<Ops...> variantOp_;
 };
 
 
@@ -64,7 +64,7 @@ struct max_blocking_kind<First, Second, Rest...> {
         Second == blocking_kind::always_inline) ||
         (Second == blocking_kind::always &&
         First == blocking_kind::always_inline)) {
-      return max_blocking_kind<blocking_kind::always_inline, Rest...>{}();
+      return max_blocking_kind<blocking_kind::always, Rest...>{}();
     } else {
       return blocking_kind::maybe;
     }
@@ -80,7 +80,7 @@ using sender = typename _sender<remove_cvref_t<Senders>...>::type;
 
 template <typename... Senders>
 class _sender<Senders...>::type {
-  std::variant<Senders...> sender_variant;
+  std::variant<Senders...> senderVariant_;
 
  public:
 
@@ -95,9 +95,9 @@ class _sender<Senders...>::type {
   static constexpr bool sends_done = std::disjunction_v<std::bool_constant<sender_traits<Senders>::sends_done>...>;
 
   template<typename ConcreteSender>
-  type(ConcreteSender&& concrete_sender)
-    noexcept(std::is_nothrow_constructible_v<std::variant<Senders...>, decltype(concrete_sender)>)
-    : sender_variant(std::forward<ConcreteSender>(concrete_sender)) {}
+  type(ConcreteSender&& concreteSender)
+    noexcept(std::is_nothrow_constructible_v<std::variant<Senders...>, decltype(concreteSender)>)
+    : senderVariant_(std::forward<ConcreteSender>(concreteSender)) {}
 
   template<typename Base, typename Matchee>
   using match_reference_t = std::conditional_t<std::is_lvalue_reference_v<Base>, std::add_lvalue_reference_t<Matchee>, Matchee>;
@@ -110,7 +110,7 @@ class _sender<Senders...>::type {
     return operation<connect_result_t<Senders, Receiver>...>{
         std::visit([&r](auto&& sender) noexcept(unifex::is_nothrow_connectable_v<decltype(sender), Receiver>) {
             return std::variant<connect_result_t<Senders, Receiver>...>{unifex::connect(std::move(sender), static_cast<Receiver&&>(r))};
-        }, std::move(static_cast<decltype(that)>(that).sender_variant))
+        }, std::move(static_cast<decltype(that)>(that).senderVariant_))
     };
   }
 

--- a/test/variant_sender_test.cpp
+++ b/test/variant_sender_test.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/defer.hpp>
+#include <unifex/dematerialize.hpp>
+#include <unifex/just.hpp>
+#include <unifex/just_error.hpp>
+#include <unifex/just_done.hpp>
+#include <unifex/materialize.hpp>
+#include <unifex/variant_sender.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/timed_single_thread_context.hpp>
+
+#include <chrono>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+struct IntAndStringReceiver {
+    void set_value(int) {
+
+    }
+
+    void set_value(std::string) {
+
+    }
+
+    void set_done() {}
+
+    void set_error(std::exception_ptr) noexcept {}
+};
+
+TEST(Variant, CombineJustAndError) {
+  auto func = [](bool v) -> variant_sender<decltype(just(5)), decltype(just_error(5))> {
+      if (v) {
+          return just(5);
+      } else {
+          return just_error(10);
+      }
+  };
+
+  auto just_variant_sender = func(true);
+  EXPECT_FALSE(just_variant_sender.sends_done);
+  auto result = sync_wait(just_variant_sender);
+
+  EXPECT_TRUE(!!result);
+  EXPECT_EQ(*result, 5);
+
+  try {
+      auto just_error_variant_sender = func(false);
+      EXPECT_FALSE(just_error_variant_sender.sends_done);
+      sync_wait(just_error_variant_sender);
+      EXPECT_FALSE(true);
+  } catch (int& v) {
+      EXPECT_EQ(v, 10);
+  }
+
+  std::cout << "variant_sender done " << *result << "\n";
+}
+
+TEST(Variant, CombineJustAndDone) {
+  auto func = [](bool v) -> variant_sender<decltype(just(5)), decltype(just_done())> {
+      if (v) {
+          return just(5);
+      } else {
+          return just_done();
+      }
+  };
+
+  auto just_variant_sender = func(true);
+  EXPECT_TRUE(just_variant_sender.sends_done);
+  auto result = sync_wait(just_variant_sender);
+
+  EXPECT_TRUE(!!result);
+  EXPECT_EQ(*result, 5);
+
+  auto just_done_variant_sender = func(false);
+  EXPECT_TRUE(just_done_variant_sender.sends_done);
+  auto result2 = sync_wait(just_done_variant_sender);
+  EXPECT_FALSE(!!result2);
+
+  std::cout << "variant_sender done " << *result << "\n";
+}
+
+TEST(Variant, CombineJustAndJust) {
+  auto func = [&](bool v) -> variant_sender<decltype(just(5)), decltype(dematerialize(materialize(just(42))))> {
+      if (v) {
+          return just(5);
+      } else {
+          return dematerialize(materialize(just(42)));
+      }
+  };
+
+  auto just_variant_sender = func(true);
+  EXPECT_FALSE(just_variant_sender.sends_done);
+  auto result = sync_wait(just_variant_sender);
+
+  EXPECT_TRUE(!!result);
+  EXPECT_EQ(*result, 5);
+
+  auto materialized_variant_sender = func(false);
+  auto result2 = sync_wait(materialized_variant_sender);
+  EXPECT_TRUE(!!result2);
+  EXPECT_EQ(*result2, 42);
+
+  std::cout << "variant_sender done " << *result << "\n";
+}
+
+TEST(Variant, CombineJustAndJust_Invalid) {
+  auto func = [](bool v) -> variant_sender<decltype(just(5)), decltype(just(std::declval<std::string>()))> {
+      if (v) {
+          return just(5);
+      } else {
+          return just(std::string("Hello World"));
+      }
+  };
+
+  IntAndStringReceiver rec;
+
+  auto just_variant_sender = func(true);
+  EXPECT_FALSE(just_variant_sender.sends_done);
+  auto op = unifex::connect(just_variant_sender, rec);
+  unifex::start(op);
+
+  auto just_string_sender = func(false);
+  EXPECT_FALSE(just_variant_sender.sends_done);
+  auto op2 = unifex::connect(just_string_sender, rec);
+  unifex::start(op2);
+}


### PR DESCRIPTION
Returning multiple senders from within a `let_value*` function requires either type erasing the results or inventing new types to represent the multiple senders. This is cumbersome since type erasure isn't always needed. 

This PR introduces the VariantSender type that wraps an underlying sender and provides an easy mechanism to create new Sender types that collapse multiple other Senders. 