### PR TITLE
Fix detach_on_cancel error_types propagation

### DIFF
--- a/include/unifex/detach_on_cancel.hpp
+++ b/include/unifex/detach_on_cancel.hpp
@@ -151,14 +151,11 @@ struct _sender<Sender>::type {
       class Variant,
       template <typename...>
       class Tuple>
-  using value_types =
-      typename sender_traits<Sender>::template value_types<Variant, Tuple>;
+  using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      sender_error_types_t<
-          typename sender_traits<Sender>::template error_types<Variant>,
-          type_list>,
+      sender_error_types_t<Sender, type_list>,
       type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = true;

--- a/test/detach_on_cancel_test.cpp
+++ b/test/detach_on_cancel_test.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <memory>
 #include <stdexcept>
+#include <variant>
 
 #include <unifex/inline_scheduler.hpp>
 #include <unifex/inplace_stop_token.hpp>
@@ -161,4 +162,13 @@ TEST_F(detach_on_cancel_test, cancellation_and_completion_race) {
   }
 
   EXPECT_EQ(max_iterations, count.load());
+}
+
+TEST_F(detach_on_cancel_test, error_types_propagate) {
+  using namespace unifex;
+  using error_types =
+    sender_error_types_t<decltype(detach_on_cancel(just())), type_list>;
+  using v = typename error_types::template apply<std::variant>;
+
+  EXPECT_GE(std::variant_size_v<v>, 1);
 }

--- a/test/detach_on_cancel_test.cpp
+++ b/test/detach_on_cancel_test.cpp
@@ -6,7 +6,6 @@
 #include <atomic>
 #include <memory>
 #include <stdexcept>
-#include <variant>
 
 #include <unifex/inline_scheduler.hpp>
 #include <unifex/inplace_stop_token.hpp>
@@ -20,6 +19,7 @@
 #include <unifex/sequence.hpp>
 #include <unifex/single_thread_context.hpp>
 #include <unifex/sync_wait.hpp>
+#include <unifex/variant.hpp>
 #include <unifex/with_query_value.hpp>
 #include <gtest/gtest.h>
 
@@ -168,7 +168,7 @@ TEST_F(detach_on_cancel_test, error_types_propagate) {
   using namespace unifex;
   using error_types =
     sender_error_types_t<decltype(detach_on_cancel(just())), type_list>;
-  using v = typename error_types::template apply<std::variant>;
+  using v = typename error_types::template apply<unifex::variant>;
 
-  EXPECT_GE(std::variant_size_v<v>, 1);
+  EXPECT_GE(unifex::variant_size<v>::value, 1);
 }


### PR DESCRIPTION
`detach_on_cancel:: _sender<Sender>::type::error_types` was producing an invalid variant type causing composition of other algorithms on top to fail. This is a fix + unit test to ensure the issue doesn't recur moving forward. 