### PR TITLE
Avoid tail calls when compiling with the Emscripten (WebAssembly) com…

### DIFF
--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -58,10 +58,11 @@ struct _cleanup_promise_base {
 
     // Clang before clang-12 has a bug with coroutines that self-destruct in an
     // await_suspend that uses symmetric transfer. It appears that MSVC has the same
-    // bug. So instead of symmetric transfer, we accept the stack growth and resume
+    // bug, while Emscripten, the WebAssembly compiler just doesn't support tail calls yet.
+    // So instead of symmetric transfer, we accept the stack growth and resume
     // the continuation from within await_suspend.
 #if (defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 12)) || \
-    defined(_MSC_VER)
+    defined(_MSC_VER) || defined(__EMSCRIPTEN__)
     template <typename CleanupPromise>
     // Apple-clang and clang-10 and prior need for await_suspend to be noinline.
     // MSVC and clang-11 can tolerate await_suspend to be inlined, so force it.

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -185,8 +185,10 @@ struct _promise {
 
     auto final_suspend() noexcept {
       struct awaiter : _final_suspend_awaiter_base {
-#if defined(_MSC_VER) && !defined(__clang__)
-        // MSVC doesn't seem to like symmetric transfer in this final awaiter
+
+#if (defined(_MSC_VER) && !defined(__clang__)) || defined(__EMSCRIPTEN__)
+        // MSVC doesn't seem to like symmetric transfer in this final awaiter and
+        // the Emscripten (WebAssembly) compiler doesn't support tail-calls
         void await_suspend(coro::coroutine_handle<type> h) noexcept {
           return h.promise().continuation_.handle().resume();
         }


### PR DESCRIPTION
…piler

Currently, there is only experimental support for tail calls in WebAssembly (https://github.com/WebAssembly/tail-call). Chrome is the only browser that supports them, and even then it is only through a special flag. Until wider support is available, we should avoid using tail calls to allow compilation of libunifex with the WebAssembly compiler, Emscripten.

