### PR TITLE
Fix logic bug that determines when to disable inlining for await_susp…

### DIFF
--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -66,10 +66,10 @@ struct _cleanup_promise_base {
     template <typename CleanupPromise>
     // Apple-clang and clang-10 and prior need for await_suspend to be noinline.
     // MSVC and clang-11 can tolerate await_suspend to be inlined, so force it.
-#if defined(_MSC_VER) || !(defined(__apple_build_version__) || __clang_major__ < 11)
-    UNIFEX_ALWAYS_INLINE
-#else
+#if defined(__apple_build_version__) || (defined(__clang__) && __clang_major__ <= 10)
     UNIFEX_NO_INLINE
+#else
+    UNIFEX_ALWAYS_INLINE
 #endif
     void await_suspend(coro::coroutine_handle<CleanupPromise> h) const noexcept {
       auto continuation = h.promise().next();


### PR DESCRIPTION
…end. (#384)

* Fix logic bug that determines when to disable inlining for await_suspend.

The clang compilers on windows define _MSC_VER so will inline await_suspend which, as per the comment for the method, cannot be tolerated. The new logic enabled inlining only for MSVC and clang11+.

* Fix for inlining logic

Fix still incorrect logic to enable inlining for both visual studio compilers and clang 11 on both windows and non-windows platforms

Co-authored-by: Ian Petersen <ispeters@gmail.com>