### PR TITLE
Remove as_const polyfill from utility

### DIFF
--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -154,7 +154,7 @@ class delegating_sender {
     auto target_op = [&receiver]() mutable {
       return unifex::connect(
         unifex::schedule(
-          unifex::get_scheduler(unifex::as_const(receiver))),
+          unifex::get_scheduler(std::as_const(receiver))),
           (Receiver&&)receiver);
     };
 

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -110,7 +110,7 @@ public:
     friend auto tag_invoke(CPO cpo, const promise_type& p)
         noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
-      return cpo(unifex::as_const(p.receiver_));
+      return cpo(std::as_const(p.receiver_));
     }
 
     Receiver& receiver_;

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -75,7 +75,7 @@ namespace _demat {
     friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r)
         noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
-      return static_cast<CPO&&>(cpo)(unifex::as_const(r.receiver_));
+      return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
     }
 
     template <typename Func>
@@ -83,7 +83,7 @@ namespace _demat {
                                   std::is_nothrow_invocable_v<
                                       Func&,
                                       const Receiver&>) {
-      std::invoke(func, unifex::as_const(r.receiver_));
+      std::invoke(func, std::as_const(r.receiver_));
     }
 
    private:

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -108,7 +108,7 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
     friend auto tag_invoke(CPO cpo, const R& r) noexcept(
         is_nothrow_callable_v<CPO, const OutputReceiver&>)
         -> callable_result_t<CPO, const OutputReceiver&> {
-      return std::move(cpo)(unifex::as_const(r.output_receiver_));
+      return std::move(cpo)(std::as_const(r.output_receiver_));
     }
   };
 
@@ -265,7 +265,7 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
   friend auto tag_invoke(CPO cpo, const R& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -101,7 +101,7 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
   friend auto tag_invoke(CPO cpo, const type& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -111,7 +111,7 @@ namespace unifex
                                            CPO,
                                            const Receiver&>)
           -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(unifex::as_const(r.receiver_));
+        return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
       }
 
       template <
@@ -124,7 +124,7 @@ namespace unifex
           Func&& func) noexcept(std::is_nothrow_invocable_v<
                                         Func&,
                                         const Receiver&>) {
-        std::invoke(func, unifex::as_const(r.receiver_));
+        std::invoke(func, std::as_const(r.receiver_));
       }
 
     private:

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -88,7 +88,7 @@ struct _error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type
   friend auto tag_invoke(CPO cpo, const type& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.op_.receiver_));
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
   friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
@@ -137,7 +137,7 @@ struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type 
   friend auto tag_invoke(CPO cpo, const type& r)
       noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.op_.receiver_));
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
   friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
@@ -174,7 +174,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
   friend auto tag_invoke(CPO cpo, const type& r)
       noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.op_.receiver_));
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
   template <typename Func>

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -214,7 +214,7 @@ struct sender {
             schedule_result_t<
                 get_scheduler_result_t<const remove_cvref_t<Receiver>&>>,
             Receiver> {
-    auto scheduler = get_scheduler(unifex::as_const(r));
+    auto scheduler = get_scheduler(std::as_const(r));
     return connect(schedule(std::move(scheduler)), (Receiver &&) r);
   }
 };
@@ -297,8 +297,8 @@ namespace _schedule_after {
                 get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
                 const Duration&>,
             Receiver> {
-      auto scheduler = get_scheduler(unifex::as_const(r));
-      return connect(schedule_after(scheduler, unifex::as_const(s.duration_)), (Receiver&&) r);
+      auto scheduler = get_scheduler(std::as_const(r));
+      return connect(schedule_after(scheduler, std::as_const(s.duration_)), (Receiver&&) r);
     }
 
     Duration duration_;
@@ -381,8 +381,8 @@ namespace _schedule_at {
                 get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
                 const TimePoint&>,
             Receiver> {
-      auto scheduler = get_scheduler(unifex::as_const(r));
-      return connect(schedule_at(scheduler, unifex::as_const(s.time_point_)), (Receiver&&) r);
+      auto scheduler = get_scheduler(std::as_const(r));
+      return connect(schedule_at(scheduler, std::as_const(s.time_point_)), (Receiver&&) r);
     }
 
     TimePoint time_point_;

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -35,7 +35,7 @@ private:
         Receiver rec_;
         void start() & noexcept {
           UNIFEX_TRY {
-            if (get_stop_token(as_const(rec_)).stop_requested()) {
+            if (get_stop_token(std::as_const(rec_)).stop_requested()) {
               unifex::set_done((Receiver&&) rec_);
             } else {
               unifex::set_value((Receiver&&) rec_);

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -92,7 +92,7 @@ class _op<Sender, Receiver>::type {
     friend auto tag_invoke(CPO cpo, const wrapped_receiver& r) noexcept(
         is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
-      return std::move(cpo)(unifex::as_const(r.get_receiver()));
+      return std::move(cpo)(std::as_const(r.get_receiver()));
     }
 
     template <typename Func>
@@ -100,7 +100,7 @@ class _op<Sender, Receiver>::type {
         tag_t<visit_continuations>,
         const wrapped_receiver& r,
         Func&& func) {
-      std::invoke(func, unifex::as_const(r.get_receiver()));
+      std::invoke(func, std::as_const(r.get_receiver()));
     }
   };
 

--- a/include/unifex/utility.hpp
+++ b/include/unifex/utility.hpp
@@ -43,17 +43,6 @@ using std::in_place;
 // using std::in_place_type;
 #endif
 
-#if defined(__cpp_lib_as_const) && __cpp_lib_as_const > 0
-using std::as_const;
-#else
-template <class T>
-constexpr std::add_const_t<T>& as_const(T& t) noexcept {
-  return t;
-}
-template <class T>
-void as_const(const T&&) = delete;
-#endif
-
 } // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -91,7 +91,7 @@ struct _value_receiver<Receiver, Values...>::type {
   friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
@@ -135,7 +135,7 @@ struct _error_receiver<Receiver, Error>::type {
   friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
@@ -178,7 +178,7 @@ struct _done_receiver<Receiver>::type {
   friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
@@ -246,7 +246,7 @@ struct _predecessor_receiver<Successor, Receiver>::type {
   friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.receiver_));
+    return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -177,7 +177,7 @@ struct _element_receiver<Index, Receiver, Senders...>::type final {
   friend auto tag_invoke(CPO cpo, const R& r) noexcept(
       is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
-    return std::move(cpo)(unifex::as_const(r.get_receiver()));
+    return std::move(cpo)(std::as_const(r.get_receiver()));
   }
 
   inplace_stop_source& get_stop_source() const {

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -112,7 +112,7 @@ struct string_const_ref_sender {
     unifex::remove_cvref_t<Receiver> receiver_;
     void start() & noexcept {
       std::string s = "hello world";
-      unifex::set_value(std::move(receiver_), unifex::as_const(s));
+      unifex::set_value(std::move(receiver_), std::as_const(s));
       s = "goodbye old value";
     }
   };


### PR DESCRIPTION
We no longer need the `as_const` polyfill in the broken-stdlib branch. Let's remove it to bring broken-stdlib closer to main