### PR TITLE
Make the when_all sender multiply-connectable

### DIFF
--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -206,9 +206,10 @@ struct _op<Receiver, Senders...>::type {
   template <std::size_t Index, typename Receiver2, typename... Senders2>
   friend struct _element_receiver;
 
-  explicit type(Receiver&& receiver, Senders&&... senders)
-    : receiver_((Receiver &&) receiver),
-      ops_(*this, (Senders &&) senders...) {}
+  template <typename Receiver2, typename... Senders2>
+  explicit type(Receiver2&& receiver, Senders2&&... senders)
+    : receiver_((Receiver2 &&) receiver),
+      ops_(*this, (Senders2 &&) senders...) {}
 
   void start() noexcept {
     stopCallback_.construct(
@@ -312,9 +313,9 @@ class _sender<Senders...>::type {
         when_all_connectable_v<remove_cvref_t<Receiver>, member_t<Sender, Senders>...>)
   friend auto tag_invoke([[maybe_unused]] CPO cpo, Sender&& sender, Receiver&& receiver)
     -> operation<Receiver, member_t<Sender, Senders>...> {
-    return std::apply([&](Senders&&... senders) {
+    return std::apply([&](auto&&... senders) {
       return operation<Receiver, member_t<Sender, Senders>...>{
-          (Receiver &&) receiver, (Senders &&) senders...};
+          (Receiver &&) receiver, static_cast<decltype(senders)>(senders)...};
     }, static_cast<Sender &&>(sender).senders_);
   }
 

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <unifex/just.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
@@ -134,4 +135,10 @@ TEST(WhenAll2, ResultsAreDecayCopied) {
       "hello world", std::get<0>(var::get<0>(std::get<0>(result.value()))));
   EXPECT_EQ(
       "hello world", std::get<0>(var::get<0>(std::get<1>(result.value()))));
+}
+
+TEST(WhenAll2, SenderIsLvalueConnectable) {
+  auto test = unifex::when_all(unifex::just(), unifex::just());
+
+  unifex::sync_wait(test);
 }


### PR DESCRIPTION
I discovered that `when_all` doesn't compose with `repeat_effect_until`
because the `when_all` *Sender* can only be connected as an rvalue.
This change introduces a regression test and a fix.