### PR TITLE
Add support of custom file permissions when opening/creating file for…

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -950,8 +950,8 @@ CPOs.
 You can also call one of the following CPOs, passing the scheduler obtained from
 a given `io_uring_context`, to open a file:
 * `open_file_read_only(scheduler, path) -> AsyncReadFile`
-* `open_file_write_only(scheduler, path) -> AsyncWriteFile`
-* `open_file_read_write(scheduler, path) -> AsyncReadWriteFile`
+* `open_file_write_only(scheduler, path, [perms]) -> AsyncWriteFile`
+* `open_file_read_write(scheduler, path, [perms]) -> AsyncReadWriteFile`
 
 You can then use the following CPOs to read from and/or write to that file.
 * `async_read_some_at(AsyncReadFile& file, AsyncReadFile::offset_t offset, span<std::byte> buffer)`

--- a/include/unifex/file_concepts.hpp
+++ b/include/unifex/file_concepts.hpp
@@ -25,6 +25,10 @@
 
 namespace unifex {
 namespace _filesystem {
+inline constexpr filesystem::perms kDefaultPerms =
+    filesystem::perms::owner_write | filesystem::perms::owner_read |
+    filesystem::perms::group_read | filesystem::perms::others_read;
+
 inline const struct open_file_read_only_cpo {
   template <typename Executor>
   auto operator()(Executor&& executor, const filesystem::path& path) const
@@ -42,38 +46,48 @@ inline const struct open_file_read_only_cpo {
 
 inline const struct open_file_write_only_cpo {
   template <typename Executor>
-  auto operator()(Executor&& executor, const filesystem::path& path) const
+  auto operator()(
+      Executor&& executor,
+      const filesystem::path& path,
+      filesystem::perms perms = kDefaultPerms) const
       noexcept(is_nothrow_tag_invocable_v<
                open_file_write_only_cpo,
                Executor,
-               const filesystem::path&>)
+               const filesystem::path&,
+               filesystem::perms>)
           -> tag_invoke_result_t<
               open_file_write_only_cpo,
               Executor,
-              const filesystem::path&> {
-    return unifex::tag_invoke(*this, (Executor &&) executor, path);
+              const filesystem::path&,
+              filesystem::perms> {
+    return unifex::tag_invoke(*this, (Executor &&) executor, path, perms);
   }
 } open_file_write_only{};
 
 inline const struct open_file_read_write_cpo {
   template <typename Executor>
-  auto operator()(Executor&& executor, const filesystem::path& path) const
+  auto operator()(
+      Executor&& executor,
+      const filesystem::path& path,
+      filesystem::perms perms = kDefaultPerms) const
       noexcept(is_nothrow_tag_invocable_v<
                open_file_read_write_cpo,
                Executor,
-               const filesystem::path&>)
+               const filesystem::path&,
+               filesystem::perms>)
           -> tag_invoke_result_t<
               open_file_read_write_cpo,
               Executor,
-              const filesystem::path&> {
-    return unifex::tag_invoke(*this, (Executor &&) executor, path);
+              const filesystem::path&,
+              filesystem::perms> {
+    return unifex::tag_invoke(*this, (Executor &&) executor, path, perms);
   }
 } open_file_read_write{};
-} // namespace _filesystem
+}  // namespace _filesystem
 
 using _filesystem::open_file_read_only;
-using _filesystem::open_file_write_only;
 using _filesystem::open_file_read_write;
-} // namespace unifex
+using _filesystem::open_file_write_only;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/filesystem.hpp
+++ b/include/unifex/filesystem.hpp
@@ -28,6 +28,7 @@ namespace unifex
     namespace filesystem
     {
         using std::filesystem::path;
+        using std::filesystem::perms;
     }
 }
 #   endif
@@ -42,6 +43,7 @@ namespace unifex
     namespace filesystem
     {
         using std::experimental::filesystem::path;
+        using std::experimental::filesystem::perms;
     }
 }
 #   endif

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -924,11 +924,13 @@ class io_uring_context::scheduler {
   friend async_read_write_file tag_invoke(
       tag_t<open_file_read_write>,
       scheduler s,
-      const filesystem::path& path);
+      const filesystem::path& path,
+      filesystem::perms perms);
   friend async_write_only_file tag_invoke(
       tag_t<open_file_write_only>,
       scheduler s,
-      const filesystem::path& path);
+      const filesystem::path& path,
+      filesystem::perms perms);
 
   friend bool operator==(scheduler a, scheduler b) noexcept {
     return a.context_ == b.context_;


### PR DESCRIPTION
Add a possibility to pass custom file permissions when opening/creating file with write access, in this case file will be created with expected mode and we don't need to execute an extra syscall to change permissions.