### PR TITLE
[WIP] get_completion_scheduler query for senders as of project goals

### DIFF
--- a/include/unifex/completion_channels.hpp
+++ b/include/unifex/completion_channels.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Rishabh Dwivedi <rishabhdwivedi17@gmail.com>
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+struct set_value_t {};
+struct set_error_t {};
+struct set_done_t {};
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_completion_scheduler.hpp
+++ b/include/unifex/get_completion_scheduler.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Rishabh Dwivedi <rishabhdwivedi17@gmail.com>
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/completion_channels.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _get_completion_scheduler {
+
+template <typename CPO, typename T>
+struct _fn;
+
+template <typename CPO>
+struct _fn<CPO, typename std::enable_if_t<
+            std::is_same_v<CPO, unifex::set_value_t> ||
+            std::is_same_v<CPO, unifex::set_error_t> ||
+            std::is_same_v<CPO, unifex::set_done_t>, void>> {
+  template(typename Sender)
+    (requires sender<Sender>&& is_nothrow_tag_invocable_v<_fn, Sender const&>&&
+          scheduler<tag_invoke_result_t<_fn, Sender const&>>) 
+  auto operator()(Sender const& sender) const noexcept -> tag_invoke_result_t<_fn, Sender const&> {
+    return tag_invoke(*this, sender);
+  }
+};
+
+}  // namespace _get_completion_scheduler
+
+template <typename CPO>
+constexpr _get_completion_scheduler::_fn<CPO, void> get_completion_scheduler{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>


### PR DESCRIPTION
get_completion_scheduler query is demonstrated in P2300R4 and it is also one of the project goals. We also need this for implementing unifex::bulk PR (#354). So, I am starting to implement this.

I am not an expert on this, so I would need continuous pointers on how we want to progress on this.

There are 2 phases of task of this feature I guess:
- Implementation of base get_completion_scheduler query that would just tag_invoke the call on the given sender.
- Implementing the get_completion_scheduler for each and every sender.

The latter one seems to be a lot of work to do, so based on maintainers decision we can do one of the following:
- This PR covers all the 2 phases
- This PR just covers the first one and there would be many subsequent PRs which would be implementation of get_completion_scheduler for different senders.