### PR TITLE
Fix asan error for let_value with coroutines

### DIFF
--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -72,8 +72,9 @@ struct _successor_receiver<Operation, Values...>::type {
   }
 
   void set_done() && noexcept {
+    auto& op = op_;
     cleanup();
-    unifex::set_done(std::move(op_.receiver_));
+    unifex::set_done(std::move(op.receiver_));
   }
 
   // Taking by value here to force a copy on the offchance the error
@@ -81,8 +82,9 @@ struct _successor_receiver<Operation, Values...>::type {
   // case the call to cleanup() would invalidate it.
   template <typename Error>
   void set_error(Error error) && noexcept {
+    auto& op = op_;
     cleanup();
-    unifex::set_error(std::move(op_.receiver_), (Error &&) error);
+    unifex::set_error(std::move(op.receiver_), (Error &&) error);
   }
 
 private:

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -245,6 +245,13 @@ unifex::task<int> someTask(int num) {
   co_return num;
 }
 
+unifex::task<void> someDoneTask(int num) {
+  if (num == 1) {
+    throw std::invalid_argument("Throwing for testing purposes");
+  }
+  co_return;
+}
+
 TEST(Let, SimpleLetValueWithCoroutine) {
   optional<int> result =
       sync_wait(let_value(unifex::just(42), [](int num) {
@@ -254,5 +261,17 @@ TEST(Let, SimpleLetValueWithCoroutine) {
   EXPECT_TRUE(!!result);
   EXPECT_EQ(*result, 42);
   std::cout << "let_value with simple coroutine done " << *result << "\n";
+}
+
+TEST(Let, SimpleLetValueVoidWithCoroutine) {
+  EXPECT_NO_THROW(sync_wait(let_value(unifex::just(), []() {
+    return someDoneTask(5);
+  })));
+}
+
+TEST(Let, SimpleLetValueErrorWithCoroutine) {
+  EXPECT_THROW(sync_wait(let_value(unifex::just(1), [](int num) {
+    return someDoneTask(num);
+  })), std::invalid_argument);
 }
 #endif // !UNIFEX_NO_COROUTINES

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -264,8 +264,8 @@ TEST(Let, SimpleLetValueWithCoroutine) {
 }
 
 TEST(Let, SimpleLetValueVoidWithCoroutine) {
-  EXPECT_NO_THROW(sync_wait(let_value(unifex::just(), []() {
-    return someDoneTask(5);
+  EXPECT_NO_THROW(sync_wait(let_value(unifex::just(5), [](int num) {
+    return someDoneTask(num);
   })));
 }
 

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -26,6 +26,10 @@
 #include <iostream>
 #include <unifex/variant.hpp>
 
+#if !UNIFEX_NO_COROUTINES
+#include <unifex/task.hpp>
+#endif // !UNIFEX_NO_COROUTINES
+
 #include <gtest/gtest.h>
 
 using namespace unifex;
@@ -235,3 +239,20 @@ TEST(Let, PipeNeverBlockingKind) {
   using Snd2 = decltype(snd2);
   static_assert(blocking_kind::never == cblocking<Snd2>());
 }
+
+#if !UNIFEX_NO_COROUTINES
+unifex::task<int> someTask(int num) {
+  co_return num;
+}
+
+TEST(Let, SimpleLetValueWithCoroutine) {
+  optional<int> result =
+      sync_wait(let_value(unifex::just(42), [](int num) {
+        return someTask(num);
+    }));
+
+  EXPECT_TRUE(!!result);
+  EXPECT_EQ(*result, 42);
+  std::cout << "let_value with simple coroutine done " << *result << "\n";
+}
+#endif // !UNIFEX_NO_COROUTINES


### PR DESCRIPTION
There's an ASAN issue in let_value that only repros when a coroutine is being used to evaluate the value. This diff adds the test that will repro without the fix, and will show that the fix causes this test to pass.

This was tested by enabling coroutines and asan in unifex tests.