### PR TITLE
Clangformat broken stdlib branch

### DIFF
--- a/include/unifex/adapt_stream.hpp
+++ b/include/unifex/adapt_stream.hpp
@@ -28,7 +28,10 @@ template <typename Stream, typename NextAdaptFunc, typename CleanupAdaptFunc>
 struct _adapted {
   struct type;
 };
-template <typename Stream, typename NextAdaptFunc, typename CleanupAdaptFunc = void>
+template <
+    typename Stream,
+    typename NextAdaptFunc,
+    typename CleanupAdaptFunc = void>
 using adapted = typename _adapted<
     remove_cvref_t<Stream>,
     std::decay_t<NextAdaptFunc>,
@@ -70,33 +73,33 @@ struct _adapted<Stream, AdaptFunc, void>::type {
     return std::invoke(s.adapter_, cleanup(s.innerStream_));
   }
 };
-} // namespace _adapt_stream
+}  // namespace _adapt_stream
 
 namespace _adapt_stream_cpo {
-  inline const struct _fn {
-    template <typename Stream, typename AdapterFunc>
-    auto operator()(Stream&& stream, AdapterFunc&& adapt) const
-        -> _adapt_stream::adapted<Stream, AdapterFunc> {
-      return {(Stream &&) stream, (AdapterFunc &&) adapt};
-    }
+inline const struct _fn {
+  template <typename Stream, typename AdapterFunc>
+  auto operator()(Stream&& stream, AdapterFunc&& adapt) const
+      -> _adapt_stream::adapted<Stream, AdapterFunc> {
+    return {(Stream &&) stream, (AdapterFunc &&) adapt};
+  }
 
-    template <
-        typename Stream,
-        typename NextAdapterFunc,
-        typename CleanupAdapterFunc>
-    auto operator()(
-        Stream&& stream,
-        NextAdapterFunc&& adaptNext,
-        CleanupAdapterFunc&& adaptCleanup) const
-        -> _adapt_stream::adapted<Stream, NextAdapterFunc, CleanupAdapterFunc> {
-      return {
-          (Stream &&) stream,
-          (NextAdapterFunc &&) adaptNext,
-          (CleanupAdapterFunc &&) adaptCleanup};
-    }
-  } adapt_stream {};
-} // namespace _adapt_stream_cpo
+  template <
+      typename Stream,
+      typename NextAdapterFunc,
+      typename CleanupAdapterFunc>
+  auto operator()(
+      Stream&& stream,
+      NextAdapterFunc&& adaptNext,
+      CleanupAdapterFunc&& adaptCleanup) const
+      -> _adapt_stream::adapted<Stream, NextAdapterFunc, CleanupAdapterFunc> {
+    return {
+        (Stream &&) stream,
+        (NextAdapterFunc &&) adaptNext,
+        (CleanupAdapterFunc &&) adaptCleanup};
+  }
+} adapt_stream{};
+}  // namespace _adapt_stream_cpo
 using _adapt_stream_cpo::adapt_stream;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/get_allocator.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/scope_guard.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/bind_back.hpp>
-#include <unifex/blocking.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -31,123 +31,121 @@
 
 namespace unifex {
 namespace _alloc {
-  template <typename Operation, typename Allocator>
-  struct _op {
-    class type;
-  };
-  template <typename Operation, typename Allocator>
-  using operation = typename _op<Operation, Allocator>::type;
+template <typename Operation, typename Allocator>
+struct _op {
+  class type;
+};
+template <typename Operation, typename Allocator>
+using operation = typename _op<Operation, Allocator>::type;
 
-  template <typename Operation, typename Allocator>
-  class _op<Operation, Allocator>::type {
-    using operation = type;
-    using allocator_t = typename std::allocator_traits<
-        Allocator>::template rebind_alloc<Operation>;
+template <typename Operation, typename Allocator>
+class _op<Operation, Allocator>::type {
+  using operation = type;
+  using allocator_t = typename std::allocator_traits<
+      Allocator>::template rebind_alloc<Operation>;
 
-  public:
-    template <typename Sender, typename Receiver>
-    explicit type(Sender&& s, Receiver&& r)
-      : allocator_(get_allocator(r)) {
-      using allocator_traits = std::allocator_traits<allocator_t>;
-      Operation* op = allocator_traits::allocate(allocator_, 1);
-      scope_guard freeOnError = [&]() noexcept {
-        allocator_traits::deallocate(allocator_, op, 1);
-      };
-      op_ = ::new (static_cast<void*>(op))
-          Operation(connect((Sender &&) s, (Receiver &&) r));
-      freeOnError.release();
-    }
+public:
+  template <typename Sender, typename Receiver>
+  explicit type(Sender&& s, Receiver&& r) : allocator_(get_allocator(r)) {
+    using allocator_traits = std::allocator_traits<allocator_t>;
+    Operation* op = allocator_traits::allocate(allocator_, 1);
+    scope_guard freeOnError = [&]() noexcept {
+      allocator_traits::deallocate(allocator_, op, 1);
+    };
+    op_ = ::new (static_cast<void*>(op))
+        Operation(connect((Sender &&) s, (Receiver &&) r));
+    freeOnError.release();
+  }
 
-    ~type() {
-      op_->~Operation();
-      std::allocator_traits<allocator_t>::deallocate(allocator_, op_, 1);
-    }
+  ~type() {
+    op_->~Operation();
+    std::allocator_traits<allocator_t>::deallocate(allocator_, op_, 1);
+  }
 
-    friend void tag_invoke(tag_t<start>, operation& op) noexcept {
-      start(*op.op_);
-    }
+  friend void tag_invoke(tag_t<start>, operation& op) noexcept {
+    start(*op.op_);
+  }
 
-  private:
-    Operation* op_;
-    UNIFEX_NO_UNIQUE_ADDRESS allocator_t allocator_;
-  };
+private:
+  Operation* op_;
+  UNIFEX_NO_UNIQUE_ADDRESS allocator_t allocator_;
+};
 
-  template <typename Sender>
-  struct _sender {
-    class type;
-  };
-  template <typename Sender>
-  using sender = typename _sender<remove_cvref_t<Sender>>::type;
+template <typename Sender>
+struct _sender {
+  class type;
+};
+template <typename Sender>
+using sender = typename _sender<remove_cvref_t<Sender>>::type;
 
-  template <typename Sender>
-  class _sender<Sender>::type {
-    using sender = type;
-  public:
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = sender_value_types_t<Sender, Variant, Tuple>;
+template <typename Sender>
+class _sender<Sender>::type {
+  using sender = type;
 
-    template <template <typename...> class Variant>
-    using error_types = sender_error_types_t<Sender, Variant>;
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
-    static constexpr bool sends_done = sender_traits<Sender>::sends_done;
+  template <template <typename...> class Variant>
+  using error_types = sender_error_types_t<Sender, Variant>;
 
-    template(typename Self, typename Receiver)
-      (requires same_as<remove_cvref_t<Self>, type> AND
-                receiver<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, Self&& s, Receiver&& r)
-        -> operation<
-            connect_result_t<member_t<Self, Sender>, Receiver>,
-            remove_cvref_t<get_allocator_t<Receiver>>> {
-      return operation<
+  static constexpr bool sends_done = sender_traits<Sender>::sends_done;
+
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND receiver<
+          Receiver>) friend auto tag_invoke(tag_t<connect>, Self&& s, Receiver&& r)
+      -> operation<
           connect_result_t<member_t<Self, Sender>, Receiver>,
-          remove_cvref_t<get_allocator_t<Receiver>>>{
-          static_cast<Self&&>(s).sender_, (Receiver &&) r};
-    }
+          remove_cvref_t<get_allocator_t<Receiver>>> {
+    return operation<
+        connect_result_t<member_t<Self, Sender>, Receiver>,
+        remove_cvref_t<get_allocator_t<Receiver>>>{
+        static_cast<Self&&>(s).sender_, (Receiver &&) r};
+  }
 
-    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
-      return blocking(self.sender_);
-    }
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+    return blocking(self.sender_);
+  }
 
-    Sender sender_;
-  };
-} // namespace _alloc
+  Sender sender_;
+};
+}  // namespace _alloc
 
 namespace _alloc_cpo {
-  inline const struct _fn {
-  private:
-    template <typename Sender>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Sender>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote1<_alloc::sender>>::template apply<Sender>;
-  public:
-    template(typename Sender)
-      (requires tag_invocable<_fn, Sender>)
-    auto operator()(Sender&& predecessor) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Sender>)
-        -> _result_t<Sender> {
-      return unifex::tag_invoke(_fn{}, (Sender&&) predecessor);
-    }
-    template(typename Sender)
-      (requires (!tag_invocable<_fn, Sender>))
-    auto operator()(Sender&& predecessor) const
-        noexcept(std::is_nothrow_constructible_v<_alloc::sender<Sender>, Sender>)
-        -> _result_t<Sender> {
-      return _alloc::sender<Sender>{(Sender &&) predecessor};
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
-  } allocate{};
-} // namespace _alloc_cpo
+inline const struct _fn {
+private:
+  template <typename Sender>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_alloc::sender>>::template apply<Sender>;
+
+public:
+  template(typename Sender)(requires tag_invocable<_fn, Sender>) auto
+  operator()(Sender&& predecessor) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender>) -> _result_t<Sender> {
+    return unifex::tag_invoke(_fn{}, (Sender &&) predecessor);
+  }
+  template(typename Sender)(requires(!tag_invocable<_fn, Sender>)) auto
+  operator()(Sender&& predecessor) const
+      noexcept(std::is_nothrow_constructible_v<_alloc::sender<Sender>, Sender>)
+          -> _result_t<Sender> {
+    return _alloc::sender<Sender>{(Sender &&) predecessor};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
+} allocate{};
+}  // namespace _alloc_cpo
 using _alloc_cpo::allocate;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/any_scheduler.hpp
+++ b/include/unifex/any_scheduler.hpp
@@ -15,15 +15,14 @@
  */
 #pragma once
 
+#include <unifex/any_sender_of.hpp>
 #include <unifex/any_unique.hpp>
 #include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
-#include <unifex/any_unique.hpp>
-#include <unifex/any_sender_of.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/type_index.hpp>
 #include <unifex/tag_invoke.hpp>
+#include <unifex/type_index.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -34,15 +33,14 @@ template <typename Ret>
 struct _copy_as_fn {
   using type_erased_signature_t = Ret(const this_&);
 
-  template (typename T)
-    (requires tag_invocable<_copy_as_fn, const T&>)
-  Ret operator()(const T& t) const {
+  template(typename T)(requires tag_invocable<_copy_as_fn, const T&>) Ret
+  operator()(const T& t) const {
     return tag_invoke(*this, t);
   }
 
-  template (typename T)
-    (requires (!tag_invocable<_copy_as_fn, const T&>) AND copy_constructible<T>)
-  Ret operator()(const T& t) const {
+  template(typename T)(requires(!tag_invocable<_copy_as_fn, const T&>)
+                           AND copy_constructible<T>) Ret
+  operator()(const T& t) const {
     return Ret{t};
   }
 };
@@ -63,18 +61,19 @@ inline constexpr struct _get_type_index_fn {
 } _get_type_index{};
 
 inline constexpr struct _equal_to_fn {
-  template (typename T, typename U)
-    (requires tag_invocable<_equal_to_fn, const T&, const U&>)
-  bool operator()(const T& t, const U& u) const noexcept {
+  template(typename T, typename U)(
+      requires tag_invocable<_equal_to_fn, const T&, const U&>) bool
+  operator()(const T& t, const U& u) const noexcept {
     static_assert(is_nothrow_tag_invocable_v<_equal_to_fn, const T&, const U&>);
     return tag_invoke(*this, t, u);
   }
 
-  template (typename T, typename U)
-    (requires (!tag_invocable<_equal_to_fn, const T&, const U&>) AND
-      equality_comparable<T>)
-  bool operator()(const T& t, const U& u) const noexcept {
-    static_assert(noexcept(t == t),
+  template(typename T, typename U)(
+      requires(!tag_invocable<_equal_to_fn, const T&, const U&>)
+          AND equality_comparable<T>) bool
+  operator()(const T& t, const U& u) const noexcept {
+    static_assert(
+        noexcept(t == t),
         "Equality comparison of schedulers ought to be noexcept");
     return type_id<T>() == _get_type_index(u.impl_) &&
         t == *static_cast<const T*>(get_object_address(u.impl_));
@@ -88,7 +87,8 @@ template <typename... CPOs>
 struct _schedule_and_connect_fn {
   struct type {
     using _rec_ref_t = _void_receiver_ref<CPOs...>;
-    using type_erased_signature_t = _any::_operation_state(const this_&, _rec_ref_t);
+    using type_erased_signature_t =
+        _any::_operation_state(const this_&, _rec_ref_t);
 
 #ifdef _MSC_VER
     // MSVC (_MSC_VER == 1927) doesn't seem to like the requires
@@ -98,7 +98,7 @@ struct _schedule_and_connect_fn {
         is_tag_invocable_v<type, const Scheduler&, _rec_ref_t>,
         _any::_operation_state>
     operator()(const Scheduler& sched, _rec_ref_t rec) const {
-      return tag_invoke(*this, sched, (_rec_ref_t&&) rec);
+      return tag_invoke(*this, sched, (_rec_ref_t &&) rec);
     }
 
     template <typename Scheduler>
@@ -106,46 +106,50 @@ struct _schedule_and_connect_fn {
         !is_tag_invocable_v<type, const Scheduler&, _rec_ref_t>,
         _any::_operation_state>
     operator()(const Scheduler& sched, _rec_ref_t rec) const {
-      return _any::_connect<type_list<CPOs...>>(schedule(sched), (_rec_ref_t&&) rec);
+      return _any::_connect<type_list<CPOs...>>(
+          schedule(sched), (_rec_ref_t &&) rec);
     }
 #else
-    template (typename Scheduler)
-      (requires tag_invocable<type, const Scheduler&, _rec_ref_t>)
-    _any::_operation_state operator()(const Scheduler& sched, _rec_ref_t rec) const {
-      return tag_invoke(*this, sched, (_rec_ref_t&&) rec);
+    template(typename Scheduler)(
+        requires tag_invocable<type, const Scheduler&, _rec_ref_t>)
+        _any::_operation_state
+        operator()(const Scheduler& sched, _rec_ref_t rec) const {
+      return tag_invoke(*this, sched, (_rec_ref_t &&) rec);
     }
 
-    template (typename Scheduler)
-      (requires (!tag_invocable<type, const Scheduler&, _rec_ref_t>) AND
-        scheduler<Scheduler>)
-    _any::_operation_state operator()(const Scheduler& sched, _rec_ref_t rec) const {
-      return _any::_connect<type_list<CPOs...>>(schedule(sched), (_rec_ref_t&&) rec);
+    template(typename Scheduler)(
+        requires(!tag_invocable<type, const Scheduler&, _rec_ref_t>)
+            AND scheduler<Scheduler>) _any::_operation_state
+    operator()(const Scheduler& sched, _rec_ref_t rec) const {
+      return _any::_connect<type_list<CPOs...>>(
+          schedule(sched), (_rec_ref_t &&) rec);
     }
 #endif
   };
 };
 
 template <typename... CPOs>
-inline constexpr typename _schedule_and_connect_fn<CPOs...>::type _schedule_and_connect{};
+inline constexpr
+    typename _schedule_and_connect_fn<CPOs...>::type _schedule_and_connect{};
 
 template <typename... CPOs>
 using _any_void_sender_of =
-  typename _any::_with<CPOs...>::template any_sender_of<>;
+    typename _any::_with<CPOs...>::template any_sender_of<>;
 
 template <typename... CPOs>
-using any_scheduler_impl =
-  any_unique_t<
+using any_scheduler_impl = any_unique_t<
     _schedule_and_connect<CPOs...>,
     _copy_as<any_scheduler<CPOs...>>,
     _get_type_index,
-    overload<bool(const this_&, const any_scheduler<CPOs...>&) noexcept>(_equal_to)>;
+    overload<bool(const this_&, const any_scheduler<CPOs...>&) noexcept>(
+        _equal_to)>;
 
 template <typename... CPOs>
 struct _with<CPOs...>::any_scheduler {
-  template (typename Scheduler)
-    (requires (!same_as<Scheduler, any_scheduler>) AND scheduler<Scheduler>)
-  /* implicit */ any_scheduler(Scheduler sched)
-    : impl_((Scheduler&&) sched) {}
+  template(typename Scheduler)(requires(!same_as<Scheduler, any_scheduler>)
+                                   AND scheduler<Scheduler>)
+      /* implicit */ any_scheduler(Scheduler sched)
+    : impl_((Scheduler &&) sched) {}
 
   any_scheduler(any_scheduler&&) noexcept = default;
   any_scheduler(const any_scheduler& that)
@@ -158,7 +162,11 @@ struct _with<CPOs...>::any_scheduler {
   }
 
   struct _sender {
-    template <template <class...> class Variant, template <class...> class Tuple>
+    template <
+        template <class...>
+        class Variant,
+        template <class...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <class...> class Variant>
@@ -168,25 +176,20 @@ struct _with<CPOs...>::any_scheduler {
 
     _sender(_sender&&) noexcept = default;
 
-    template (typename Receiver)
-      (requires receiver_of<Receiver> AND
-        (invocable<CPOs, const Receiver&> &&...))
-    any_operation_state_for<Receiver> connect(Receiver rec) && {
+    template(typename Receiver)(requires receiver_of<Receiver> AND(
+        invocable<CPOs, const Receiver&>&&...))
+        any_operation_state_for<Receiver> connect(Receiver rec) && {
       any_scheduler_impl<CPOs...> const& impl = sched_.impl_;
       return any_operation_state_for<Receiver>{
-          (Receiver&&) rec,
-          [&impl](_void_receiver_ref<CPOs...> rec2) {
+          (Receiver &&) rec, [&impl](_void_receiver_ref<CPOs...> rec2) {
             return _schedule_and_connect<CPOs...>(
-                impl, (_void_receiver_ref<CPOs...>&&) rec2);
-          }
-        };
+                impl, (_void_receiver_ref<CPOs...> &&) rec2);
+          }};
     }
 
   private:
     friend any_scheduler;
-    _sender(const any_scheduler* sched)
-      : sched_(*sched)
-    {}
+    _sender(const any_scheduler* sched) : sched_(*sched) {}
     // TODO This does a dynamic allocation. Fix this by:
     // 1. Implementing the small-object optimization in any_unique, and
     // 2. Provide hooks so that _sender can take a strong reference on
@@ -194,19 +197,17 @@ struct _with<CPOs...>::any_scheduler {
     any_scheduler sched_;
   };
 
-  _sender schedule() const {
-    return _sender{this};
-  }
+  _sender schedule() const { return _sender{this}; }
 
-  type_index type() const noexcept {
-    return _get_type_index(impl_);
-  }
+  type_index type() const noexcept { return _get_type_index(impl_); }
 
   friend _equal_to_fn;
-  friend bool operator==(const any_scheduler& left, const any_scheduler& right) noexcept {
+  friend bool
+  operator==(const any_scheduler& left, const any_scheduler& right) noexcept {
     return _equal_to(left.impl_, right);
   }
-  friend bool operator!=(const any_scheduler& left, const any_scheduler& right) noexcept {
+  friend bool
+  operator!=(const any_scheduler& left, const any_scheduler& right) noexcept {
     return !(left == right);
   }
 
@@ -215,11 +216,11 @@ private:
 };
 
 template <typename... CPOs>
-using any_scheduler_ref_impl =
-    any_ref_t<
-        _schedule_and_connect<CPOs...>,
-        _get_type_index,
-        overload<bool(const this_&, const any_scheduler_ref<CPOs...>&) noexcept>(_equal_to)>;
+using any_scheduler_ref_impl = any_ref_t<
+    _schedule_and_connect<CPOs...>,
+    _get_type_index,
+    overload<bool(const this_&, const any_scheduler_ref<CPOs...>&) noexcept>(
+        _equal_to)>;
 
 #if defined(__GLIBCXX__)
 template <typename>
@@ -235,26 +236,32 @@ inline constexpr bool _is_tuple<std::tuple<Ts...> const> = true;
 template <typename... CPOs>
 struct _with<CPOs...>::any_scheduler_ref {
 #if !defined(__GLIBCXX__)
-  template (typename Scheduler)
-    (requires (!same_as<const Scheduler, const any_scheduler_ref>) AND
-      scheduler<Scheduler>)
-  /* implicit */ any_scheduler_ref(Scheduler& sched) noexcept
-    : impl_(sched) {}
+  template(typename Scheduler)(
+      requires(!same_as<const Scheduler, const any_scheduler_ref>)
+          AND scheduler<Scheduler>)
+      /* implicit */ any_scheduler_ref(Scheduler& sched) noexcept
+    : impl_(sched) {
+  }
 #else
   // Under-constrained implicit tuple converting constructor from a
   // single argument doesn't exclude instances of the tuple type
   // itself, so it is considered for copy/move constructors, leading
   // to constraint recursion with the any_scheduler_ref constructor
   // below.
-  template (typename Scheduler)
-    (requires (!same_as<const Scheduler, const any_scheduler_ref>) AND
-      (!_is_tuple<Scheduler>) AND scheduler<Scheduler>)
-  /* implicit */ any_scheduler_ref(Scheduler& sched) noexcept
-    : impl_(sched) {}
+  template(typename Scheduler)(
+      requires(!same_as<const Scheduler, const any_scheduler_ref>)
+          AND(!_is_tuple<Scheduler>) AND scheduler<Scheduler>)
+      /* implicit */ any_scheduler_ref(Scheduler& sched) noexcept
+    : impl_(sched) {
+  }
 #endif
 
   struct _sender {
-    template <template <class...> class Variant, template <class...> class Tuple>
+    template <
+        template <class...>
+        class Variant,
+        template <class...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <class...> class Variant>
@@ -264,25 +271,20 @@ struct _with<CPOs...>::any_scheduler_ref {
 
     _sender(_sender&&) noexcept = default;
 
-    template (typename Receiver)
-      (requires receiver_of<Receiver> AND
-        (invocable<CPOs, const Receiver&> &&...))
-    any_operation_state_for<Receiver> connect(Receiver rec) && {
+    template(typename Receiver)(requires receiver_of<Receiver> AND(
+        invocable<CPOs, const Receiver&>&&...))
+        any_operation_state_for<Receiver> connect(Receiver rec) && {
       any_scheduler_ref_impl<CPOs...> const& impl = sched_.impl_;
       return any_operation_state_for<Receiver>{
-          (Receiver&&) rec,
-          [&impl](_void_receiver_ref<CPOs...> rec2) {
+          (Receiver &&) rec, [&impl](_void_receiver_ref<CPOs...> rec2) {
             return _schedule_and_connect<CPOs...>(
-                impl, (_void_receiver_ref<CPOs...>&&) rec2);
-          }
-        };
+                impl, (_void_receiver_ref<CPOs...> &&) rec2);
+          }};
     }
 
   private:
     friend any_scheduler_ref;
-    _sender(const any_scheduler_ref* sched) noexcept
-      : sched_(*sched)
-    {}
+    _sender(const any_scheduler_ref* sched) noexcept : sched_(*sched) {}
     any_scheduler_ref sched_;
   };
 
@@ -295,10 +297,12 @@ struct _with<CPOs...>::any_scheduler_ref {
   }
 
   // Shallow equality comparison by default, for regularity:
-  friend bool operator==(const any_scheduler_ref& left, const any_scheduler_ref& right) noexcept {
+  friend bool operator==(
+      const any_scheduler_ref& left, const any_scheduler_ref& right) noexcept {
     return left.impl_ == right.impl_;
   }
-  friend bool operator!=(const any_scheduler_ref& left, const any_scheduler_ref& right) noexcept {
+  friend bool operator!=(
+      const any_scheduler_ref& left, const any_scheduler_ref& right) noexcept {
     return !(left == right);
   }
 
@@ -309,15 +313,14 @@ struct _with<CPOs...>::any_scheduler_ref {
   }
 
 private:
-
   any_scheduler_ref_impl<CPOs...> impl_;
 };
 
-} // namespace _any_sched
+}  // namespace _any_sched
 
 using any_scheduler = _any_sched::any_scheduler<>;
 using any_scheduler_ref = _any_sched::any_scheduler_ref<>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/any_sender_of.hpp
+++ b/include/unifex/any_sender_of.hpp
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <unifex/any_unique.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/with_query_value.hpp>
-#include <unifex/scheduler_concepts.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -44,12 +44,11 @@ using any_scheduler = typename _with<CPOs...>::any_scheduler;
 template <typename... CPOs>
 using any_scheduler_ref = typename _with<CPOs...>::any_scheduler_ref;
 
-} // _any_sched
+}  // namespace _any_sched
 
 namespace _any {
 
-using _operation_state =
-    any_unique_t<overload<void(this_&) noexcept>(start)>;
+using _operation_state = any_unique_t<overload<void(this_&) noexcept>(start)>;
 
 template <typename CPOs>
 struct _rec_ref_base;
@@ -58,20 +57,19 @@ template <typename... CPOs>
 struct _rec_ref_base<type_list<CPOs...>> {
 #if defined(_MSC_VER)
   template <typename... Values>
-  using type =
-      any_ref<
-          tag_t<overload(set_value, sig<void(this_&&, Values...)>)>,
-          tag_t<overload(set_error, sig<void(this_&&, std::exception_ptr) noexcept>)>,
-          tag_t<overload(set_done, sig<void(this_&&) noexcept>)>,
-          CPOs...>;
+  using type = any_ref<
+      tag_t<overload(set_value, sig<void(this_&&, Values...)>)>,
+      tag_t<overload(
+          set_error, sig<void(this_&&, std::exception_ptr) noexcept>)>,
+      tag_t<overload(set_done, sig<void(this_&&) noexcept>)>,
+      CPOs...>;
 #else
   template <typename... Values>
-  using type =
-      any_ref<
-          tag_t<overload<void(this_&&, Values...)>(set_value)>,
-          tag_t<overload<void(this_&&, std::exception_ptr) noexcept>(set_error)>,
-          tag_t<overload<void(this_&&) noexcept>(set_done)>,
-          CPOs...>;
+  using type = any_ref<
+      tag_t<overload<void(this_&&, Values...)>(set_value)>,
+      tag_t<overload<void(this_&&, std::exception_ptr) noexcept>(set_error)>,
+      tag_t<overload<void(this_&&) noexcept>(set_done)>,
+      CPOs...>;
 #endif
 };
 
@@ -82,14 +80,15 @@ struct _rec_ref {
 
 template <typename CPOs, typename... Values>
 struct _rec_ref<CPOs, Values...>::type
-    : _rec_ref_base<CPOs>::template type<Values...> {
+  : _rec_ref_base<CPOs>::template type<Values...> {
   template <typename Op>
   type(inplace_stop_token st, Op* op)
     : _rec_ref_base<CPOs>::template type<Values...>(*op)
     , stoken_(st) {}
 
 private:
-  friend inplace_stop_token tag_invoke(tag_t<get_stop_token>, const type& self) noexcept {
+  friend inplace_stop_token
+  tag_invoke(tag_t<get_stop_token>, const type& self) noexcept {
     return self.stoken_;
   }
 
@@ -122,12 +121,12 @@ struct _connect_fn<CPOs, Values...>::type {
   using _rec_ref_t = _receiver_ref<CPOs, Values...>;
   using type_erased_signature_t = _operation_state(this_&&, _rec_ref_t);
 
-  template(typename Sender)
-    (requires sender_to<Sender, _rec_ref_t>)
-  friend _operation_state
-  tag_invoke(const type&, Sender&& s, _rec_ref_t r) {
+  template(typename Sender)(
+      requires sender_to<Sender, _rec_ref_t>) friend _operation_state
+      tag_invoke(const type&, Sender&& s, _rec_ref_t r) {
     using Op = connect_result_t<Sender, _rec_ref_t>;
-    return _operation_state{unifex::in_place_type_t<Op>{}, _rvo{(Sender &&) s, std::move(r)}};
+    return _operation_state{
+        unifex::in_place_type_t<Op>{}, _rvo{(Sender &&) s, std::move(r)}};
   }
 
 #ifdef _MSC_VER
@@ -136,13 +135,13 @@ struct _connect_fn<CPOs, Values...>::type {
   template <typename Self>
   tag_invoke_result_t<type, Self, _rec_ref_t>
   operator()(Self&& s, _rec_ref_t r) const {
-    return tag_invoke(*this, (Self&&) s, std::move(r));
+    return tag_invoke(*this, (Self &&) s, std::move(r));
   }
 #else
-  template(typename Self)
-    (requires tag_invocable<type, Self, _rec_ref_t>)
-  _operation_state operator()(Self&& s, _rec_ref_t r) const {
-    return tag_invoke(*this, (Self&&) s, std::move(r));
+  template(typename Self)(requires tag_invocable<type, Self, _rec_ref_t>)
+      _operation_state
+      operator()(Self&& s, _rec_ref_t r) const {
+    return tag_invoke(*this, (Self &&) s, std::move(r));
   }
 #endif
 };
@@ -162,36 +161,34 @@ template <typename Receiver>
 struct _op_for<Receiver>::type {
   template <typename Fn>
   explicit type(Receiver r, Fn fn)
-    : rec_((Receiver&&) r)
-    , state_{fn({subscription_.subscribe(unifex::get_stop_token(rec_)), this})}
-  {}
+    : rec_((Receiver &&) r)
+    , state_{
+          fn({subscription_.subscribe(unifex::get_stop_token(rec_)), this})} {}
 
-  void start() & noexcept {
-    unifex::start(state_);
-  }
+  void start() & noexcept { unifex::start(state_); }
 
   // This operation state also implements the receiver CPOs and forwards them
   // to the receiver after unsubscribing the stop token.
-  template (typename CPO, typename... Args)
-    (requires is_receiver_cpo_v<CPO> AND is_callable_v<CPO, Receiver, Args...>)
-  friend void tag_invoke(CPO cpo, type&& self, Args&&... args)
-    noexcept(is_nothrow_callable_v<CPO, Receiver, Args...>) {
+  template(typename CPO, typename... Args)(requires is_receiver_cpo_v<CPO> AND is_callable_v<CPO, Receiver, Args...>) friend void tag_invoke(
+      CPO cpo,
+      type&& self,
+      Args&&... args) noexcept(is_nothrow_callable_v<CPO, Receiver, Args...>) {
     self.subscription_.unsubscribe();
-    cpo(std::move(self).rec_, (Args&&) args...);
+    cpo(std::move(self).rec_, (Args &&) args...);
   }
 
   // Forward other receiver queries
-  template (typename CPO)
-    (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const type& self)
-    noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-    -> callable_result_t<CPO, const Receiver&> {
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const type& self) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(self.rec_);
   }
 
   UNIFEX_NO_UNIQUE_ADDRESS
   Receiver rec_;
-  detail::inplace_stop_token_adapter_subscription<stop_token_type_t<Receiver>> subscription_{};
+  detail::inplace_stop_token_adapter_subscription<stop_token_type_t<Receiver>>
+      subscription_{};
   _operation_state state_;
 };
 
@@ -224,7 +221,7 @@ struct _with {
 template <typename... CPOs>
 template <typename... Values>
 struct _with<CPOs...>::_sender<Values...>::type
-    : private _sender_base<type_list<CPOs...>, Values...> {
+  : private _sender_base<type_list<CPOs...>, Values...> {
   template <template <class...> class Variant, template <class...> class Tuple>
   using value_types = Variant<Tuple<Values...>>;
 
@@ -233,17 +230,16 @@ struct _with<CPOs...>::_sender<Values...>::type
 
   static constexpr bool sends_done = true;
 
-  template (typename Receiver)
-    (requires receiver_of<Receiver, Values...> AND
-      (invocable<CPOs, Receiver const&> &&...))
-  _operation_state_for<Receiver> connect(Receiver r) && {
+  template(typename Receiver)(requires receiver_of<Receiver, Values...> AND(
+      invocable<CPOs, Receiver const&>&&...))
+      _operation_state_for<Receiver> connect(Receiver r) && {
     any_unique_t<_connect<type_list<CPOs...>, Values...>>& self = *this;
     return _operation_state_for<Receiver>{
         std::move(r),
         [&self](_receiver_ref<type_list<CPOs...>, Values...> rec) {
-          return _connect<type_list<CPOs...>, Values...>(std::move(self), std::move(rec));
-        }
-      };
+          return _connect<type_list<CPOs...>, Values...>(
+              std::move(self), std::move(rec));
+        }};
   }
 
   using _sender_base<type_list<CPOs...>, Values...>::_sender_base;
@@ -256,7 +252,7 @@ struct _sender<Values...>::type : _with<>::_sender<Values...>::type {
   using _with<>::_sender<Values...>::type::type;
 };
 
-} // namespace _any
+}  // namespace _any
 
 template <typename Receiver>
 using any_operation_state_for = _any::_operation_state_for<Receiver>;
@@ -270,6 +266,6 @@ using any_receiver_ref = _any::_receiver_ref<type_list<>, Values...>;
 template <auto&... CPOs>
 using with_receiver_queries = _any::_with<tag_t<CPOs>...>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -15,11 +15,11 @@
  */
 #pragma once
 
-#include <unifex/detail/atomic_intrusive_queue.hpp>
-#include <unifex/detail/intrusive_queue.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
+#include <unifex/detail/atomic_intrusive_queue.hpp>
+#include <unifex/detail/intrusive_queue.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -30,12 +30,12 @@ class async_mutex {
 
 public:
   async_mutex() noexcept;
-  async_mutex(const async_mutex &) = delete;
-  async_mutex(async_mutex &&) = delete;
+  async_mutex(const async_mutex&) = delete;
+  async_mutex(async_mutex&&) = delete;
   ~async_mutex();
 
-  async_mutex &operator=(const async_mutex &) = delete;
-  async_mutex &operator=(async_mutex &&) = delete;
+  async_mutex& operator=(const async_mutex&) = delete;
+  async_mutex& operator=(async_mutex&&) = delete;
 
   [[nodiscard]] bool try_lock() noexcept;
 
@@ -45,14 +45,17 @@ public:
 
 private:
   struct waiter_base {
-    void (*resume_)(waiter_base *) noexcept;
-    waiter_base *next_;
+    void (*resume_)(waiter_base*) noexcept;
+    waiter_base* next_;
   };
 
   class lock_sender {
   public:
-    template <template <typename...> class Variant,
-              template <typename...> class Tuple>
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <typename...> class Variant>
@@ -60,33 +63,34 @@ private:
 
     static constexpr bool sends_done = false;
 
-    lock_sender(const lock_sender &) = delete;
-    lock_sender(lock_sender &&) = default;
+    lock_sender(const lock_sender&) = delete;
+    lock_sender(lock_sender&&) = default;
 
   private:
     friend async_mutex;
 
-    explicit lock_sender(async_mutex &mutex) noexcept
-      : mutex_(mutex) {}
+    explicit lock_sender(async_mutex& mutex) noexcept : mutex_(mutex) {}
 
     template <typename Receiver>
     struct _op {
       class type : waiter_base {
         friend lock_sender;
+
       public:
         template <typename Receiver2>
-        explicit type(async_mutex &mutex, Receiver2 &&r) noexcept
-            : mutex_(mutex), receiver_((Receiver2 &&) r) {
-          this->resume_ = [](waiter_base * self) noexcept {
-            type &op = *static_cast<type *>(self);
+        explicit type(async_mutex& mutex, Receiver2&& r) noexcept
+          : mutex_(mutex)
+          , receiver_((Receiver2 &&) r) {
+          this->resume_ = [](waiter_base* self) noexcept {
+            type& op = *static_cast<type*>(self);
             unifex::set_value((Receiver &&) op.receiver_);
           };
         }
 
-        type(type &&) = delete;
+        type(type&&) = delete;
 
-       private:
-        friend void tag_invoke(tag_t<start>, type &op) noexcept {
+      private:
+        friend void tag_invoke(tag_t<start>, type& op) noexcept {
           if (!op.try_enqueue()) {
             // Failed to enqueue because we acquired the lock
             // synchronously. Invoke the continuation inline
@@ -95,31 +99,27 @@ private:
           }
         }
 
-        bool try_enqueue() noexcept {
-          return mutex_.try_enqueue(this);
-        }
+        bool try_enqueue() noexcept { return mutex_.try_enqueue(this); }
 
-        async_mutex &mutex_;
+        async_mutex& mutex_;
         Receiver receiver_;
       };
     };
     template <typename Receiver>
     using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend operation<Receiver>
-    tag_invoke(tag_t<connect>, lock_sender &&s, Receiver &&r) noexcept {
+    template(typename Receiver)(requires receiver<Receiver>) friend operation<
+        Receiver> tag_invoke(tag_t<connect>, lock_sender&& s, Receiver&& r) noexcept {
       return operation<Receiver>{s.mutex_, (Receiver &&) r};
     }
 
-    async_mutex &mutex_;
+    async_mutex& mutex_;
   };
 
   // Attempt to enqueue the waiter object to the queue.
   // Returns true if successfully enqueued, false if it was not enqueued because
   // the lock was acquired synchronously.
-  bool try_enqueue(waiter_base *waiter) noexcept;
+  bool try_enqueue(waiter_base* waiter) noexcept;
 
   atomic_intrusive_queue<waiter_base, &waiter_base::next_> atomicQueue_;
   intrusive_queue<waiter_base, &waiter_base::next_> pendingQueue_;
@@ -133,6 +133,6 @@ inline bool async_mutex::try_lock() noexcept {
   return atomicQueue_.try_mark_active();
 }
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -626,8 +626,8 @@ class _attached_op<Sender, Receiver>::type final {
 public:
   template <typename Receiver2>
   explicit type(Sender&& s, Receiver2&& r, async_scope* scope) noexcept(
-      is_nothrow_connectable_v<Sender, cleaning_receiver_t>&&
-          std::is_nothrow_constructible_v<cleaning_receiver_t, type*, Receiver2>&&
+      is_nothrow_connectable_v<Sender, cleaning_receiver_t>&& std::
+          is_nothrow_constructible_v<cleaning_receiver_t, type*, Receiver2>&&
               std::is_nothrow_constructible_v<Receiver, Receiver2>)
     : scope_(reinterpret_cast<std::uintptr_t>(scope) & started_mask)
     , receiverToken_(get_stop_token(r)) {

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -15,13 +15,13 @@
  */
 #pragma once
 
+#include <unifex/config.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
+#include <unifex/coroutine.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/config.hpp>
-#include <unifex/coroutine.hpp>
 #include <unifex/type_index.hpp>
-#include <unifex/continuations.hpp>
 
 #include <functional>
 #include <vector>
@@ -31,85 +31,88 @@
 namespace unifex {
 
 namespace _async_trace {
-  struct entry {
-    entry(
-        std::size_t depth,
-        std::size_t parentIndex,
-        const continuation_info& continuation) noexcept
-      : depth(depth)
-      , parentIndex(parentIndex)
-      , continuation(continuation) {}
+struct entry {
+  entry(
+      std::size_t depth,
+      std::size_t parentIndex,
+      const continuation_info& continuation) noexcept
+    : depth(depth)
+    , parentIndex(parentIndex)
+    , continuation(continuation) {}
 
-    std::size_t depth;
-    std::size_t parentIndex;
-    continuation_info continuation;
-  };
-} // namespace _async_trace
+  std::size_t depth;
+  std::size_t parentIndex;
+  continuation_info continuation;
+};
+}  // namespace _async_trace
 using async_trace_entry = _async_trace::entry;
 
 namespace _async_trace_cpo {
-  inline const struct _fn {
-    template <typename Continuation>
-    std::vector<async_trace_entry> operator()(const Continuation& c) const {
-      std::vector<async_trace_entry> results;
-      results.emplace_back(0, 0, continuation_info::from_continuation(c));
+inline const struct _fn {
+  template <typename Continuation>
+  std::vector<async_trace_entry> operator()(const Continuation& c) const {
+    std::vector<async_trace_entry> results;
+    results.emplace_back(0, 0, continuation_info::from_continuation(c));
 
-      // Breadth-first search of async call-stack graph.
-      for (std::size_t i = 0; i < results.size(); ++i) {
-        auto [depth, parentIndex, info] = results[i];
-        visit_continuations(
-            info, [depth = depth, i, &results](const continuation_info& x) {
-              results.emplace_back(depth + 1, i, x);
-            });
-      }
-      return results;
+    // Breadth-first search of async call-stack graph.
+    for (std::size_t i = 0; i < results.size(); ++i) {
+      auto [depth, parentIndex, info] = results[i];
+      visit_continuations(
+          info, [depth = depth, i, &results](const continuation_info& x) {
+            results.emplace_back(depth + 1, i, x);
+          });
     }
-  } async_trace {};
-} // namespace _async_trace_cpo
+    return results;
+  }
+} async_trace{};
+}  // namespace _async_trace_cpo
 using _async_trace_cpo::async_trace;
 
 namespace _async_trace {
-  template <typename Receiver>
-  struct _op {
-    struct type {
-      Receiver receiver_;
+template <typename Receiver>
+struct _op {
+  struct type {
+    Receiver receiver_;
 
-      void start() noexcept {
-        UNIFEX_TRY {
-          auto trace = async_trace(receiver_);
-          unifex::set_value(std::move(receiver_), std::move(trace));
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(std::move(receiver_), std::current_exception());
-        }
+    void start() noexcept {
+      UNIFEX_TRY {
+        auto trace = async_trace(receiver_);
+        unifex::set_value(std::move(receiver_), std::move(trace));
       }
-    };
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
+    }
   };
+};
+template <typename Receiver>
+using operation = typename _op<remove_cvref_t<Receiver>>::type;
+
+struct sender {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<std::vector<entry>>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = false;
+
   template <typename Receiver>
-  using operation = typename _op<remove_cvref_t<Receiver>>::type;
+  operation<Receiver> connect(Receiver&& r) const& {
+    return operation<Receiver>{(Receiver &&) r};
+  }
 
-  struct sender {
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<std::vector<entry>>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = false;
-
-    template <typename Receiver>
-    operation<Receiver> connect(Receiver&& r) const& {
-      return operation<Receiver>{(Receiver &&) r};
-    }
-
-    friend auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
-      return blocking_kind::always_inline;
-    }
-  };
-} // namespace _async_trace
+  friend auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
+    return blocking_kind::always_inline;
+  }
+};
+}  // namespace _async_trace
 using async_trace_sender = _async_trace::sender;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -15,20 +15,20 @@
  */
 #pragma once
 
-#include <unifex/coroutine.hpp>
-#include <unifex/tag_invoke.hpp>
+#include <unifex/any_scheduler.hpp>
 #include <unifex/await_transform.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/continuations.hpp>
+#include <unifex/coroutine.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/inline_scheduler.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
-#include <unifex/inline_scheduler.hpp>
-#include <unifex/any_scheduler.hpp>
-#include <unifex/blocking.hpp>
+#include <unifex/tag_invoke.hpp>
 #include <unifex/unstoppable_token.hpp>
-#include <unifex/get_stop_token.hpp>
 
 #if UNIFEX_NO_COROUTINES
-# error "Coroutine support is required to use this header"
+#  error "Coroutine support is required to use this header"
 #endif
 
 #include <tuple>
@@ -40,48 +40,57 @@ namespace unifex {
 
 namespace _xchg_cont {
 inline constexpr struct _fn {
-  template (typename ParentPromise, typename ChildPromise)
-    (requires tag_invocable<_fn, ParentPromise&, continuation_handle<ChildPromise>>)
-  UNIFEX_ALWAYS_INLINE
-  continuation_handle<> operator()(ParentPromise& parent, continuation_handle<ChildPromise> action) const noexcept {
-    return tag_invoke(*this, parent, (continuation_handle<ChildPromise>&&) action);
+  template(typename ParentPromise, typename ChildPromise)(
+      requires tag_invocable<
+          _fn,
+          ParentPromise&,
+          continuation_handle<ChildPromise>>)
+      UNIFEX_ALWAYS_INLINE continuation_handle<>
+      operator()(
+          ParentPromise& parent,
+          continuation_handle<ChildPromise> action) const noexcept {
+    return tag_invoke(
+        *this, parent, (continuation_handle<ChildPromise> &&) action);
   }
-} exchange_continuation {};
-} // _xchg_cont
+} exchange_continuation{};
+}  // namespace _xchg_cont
 using _xchg_cont::exchange_continuation;
 
 struct _cleanup_promise_base {
   struct final_awaitable {
-    bool await_ready() const noexcept {
-      return false;
-    }
+    bool await_ready() const noexcept { return false; }
 
     // Clang before clang-12 has a bug with coroutines that self-destruct in an
-    // await_suspend that uses symmetric transfer. It appears that MSVC has the same
-    // bug, while Emscripten, the WebAssembly compiler just doesn't support tail calls yet.
-    // So instead of symmetric transfer, we accept the stack growth and resume
-    // the continuation from within await_suspend.
-#if (defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 12)) || \
+    // await_suspend that uses symmetric transfer. It appears that MSVC has the
+    // same bug, while Emscripten, the WebAssembly compiler just doesn't support
+    // tail calls yet. So instead of symmetric transfer, we accept the stack
+    // growth and resume the continuation from within await_suspend.
+#if (                                                              \
+    defined(__clang__) &&                                          \
+    (defined(__apple_build_version__) || __clang_major__ < 12)) || \
     defined(_MSC_VER) || defined(__EMSCRIPTEN__)
     template <typename CleanupPromise>
     // Apple-clang and clang-10 and prior need for await_suspend to be noinline.
     // MSVC and clang-11 can tolerate await_suspend to be inlined, so force it.
-#if defined(__apple_build_version__) || (defined(__clang__) && __clang_major__ <= 10)
+#  if defined(__apple_build_version__) || \
+      (defined(__clang__) && __clang_major__ <= 10)
     UNIFEX_NO_INLINE
-#else
+#  else
     UNIFEX_ALWAYS_INLINE
-#endif
-    void await_suspend(coro::coroutine_handle<CleanupPromise> h) const noexcept {
+#  endif
+        void
+        await_suspend(coro::coroutine_handle<CleanupPromise> h) const noexcept {
       auto continuation = h.promise().next();
-      h.destroy(); // The cleanup action has finished executing. Destroy it.
+      h.destroy();  // The cleanup action has finished executing. Destroy it.
       continuation.resume();
     }
 #else
     // No bugs here! OK to use symmetric transfer.
     template <typename CleanupPromise>
-    coro::coroutine_handle<> await_suspend(coro::coroutine_handle<CleanupPromise> h) const noexcept {
+    coro::coroutine_handle<>
+    await_suspend(coro::coroutine_handle<CleanupPromise> h) const noexcept {
       auto continuation = h.promise().next();
-      h.destroy(); // The cleanup action has finished executing. Destroy it.
+      h.destroy();  // The cleanup action has finished executing. Destroy it.
       return continuation;
     }
 #endif
@@ -99,7 +108,8 @@ struct _cleanup_promise_base {
   }
 
   [[noreturn]] void unhandled_exception() noexcept {
-    UNIFEX_ASSERT(!"An exception happened in an async cleanup action. Calling terminate...");
+    UNIFEX_ASSERT(!"An exception happened in an async cleanup action. Calling "
+                   "terminate...");
     std::terminate();
   }
 
@@ -111,8 +121,8 @@ struct _cleanup_promise_base {
   }
 
   template <typename Func>
-  friend void
-  tag_invoke(tag_t<visit_continuations>, const _cleanup_promise_base& p, Func&& func) {
+  friend void tag_invoke(
+      tag_t<visit_continuations>, const _cleanup_promise_base& p, Func&& func) {
     // Skip cleanup actions when visiting continuations:
     visit_continuations(p.continuation_, (Func &&) func);
   }
@@ -141,26 +151,22 @@ template <typename Receiver>
 struct _die_on_done_rec {
   struct type {
     Receiver rec_;
-    template (typename... Ts)
-      (requires receiver_of<Receiver, Ts...>)
-    void set_value(Ts&&... ts) && noexcept(is_nothrow_receiver_of_v<Receiver, Ts...>) {
-      unifex::set_value((Receiver&&) rec_, (Ts&&) ts...);
+    template(typename... Ts)(requires receiver_of<Receiver, Ts...>) void set_value(
+        Ts&&... ts) && noexcept(is_nothrow_receiver_of_v<Receiver, Ts...>) {
+      unifex::set_value((Receiver &&) rec_, (Ts &&) ts...);
     }
-    template (typename E)
-      (requires receiver<Receiver, E>)
-    void set_error(E&& e) && noexcept {
-      unifex::set_error((Receiver&&) rec_, (E&&) e);
+    template(typename E)(requires receiver<Receiver, E>) void set_error(
+        E&& e) && noexcept {
+      unifex::set_error((Receiver &&) rec_, (E &&) e);
     }
     [[noreturn]] void set_done() && noexcept {
       UNIFEX_ASSERT(!"A cleanup action tried to cancel. Calling terminate...");
       std::terminate();
     }
 
-    template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND
-                is_callable_v<CPO, const Receiver&>)
-    friend auto tag_invoke(CPO cpo, const type& p)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+    template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+        CPO cpo,
+        const type& p) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
       return cpo(p.rec_);
     }
@@ -175,8 +181,10 @@ template <typename Sender>
 struct _die_on_done {
   struct type {
     template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types =
         typename sender_traits<Sender>::template value_types<Variant, Tuple>;
 
@@ -186,14 +194,12 @@ struct _die_on_done {
 
     static constexpr bool sends_done = false;
 
-    template (typename Receiver)
-      (requires sender_to<Sender, _die_on_done_rec_t<Receiver>>)
-    auto connect(Receiver&& rec) &&
-        noexcept(is_nothrow_connectable_v<Sender, _die_on_done_rec_t<Receiver>>)
+    template(typename Receiver)(requires sender_to<Sender, _die_on_done_rec_t<Receiver>>) auto connect(
+        Receiver&&
+            rec) && noexcept(is_nothrow_connectable_v<Sender, _die_on_done_rec_t<Receiver>>)
         -> connect_result_t<Sender, _die_on_done_rec_t<Receiver>> {
       return unifex::connect(
-          (Sender&&) sender_,
-          _die_on_done_rec_t<Receiver>{(Receiver&&) rec});
+          (Sender &&) sender_, _die_on_done_rec_t<Receiver>{(Receiver &&) rec});
     }
 
     UNIFEX_NO_UNIQUE_ADDRESS Sender sender_;
@@ -201,20 +207,19 @@ struct _die_on_done {
 };
 
 template <typename Sender>
-using _die_on_done_t =
-    typename _die_on_done<remove_cvref_t<Sender>>::type;
+using _die_on_done_t = typename _die_on_done<remove_cvref_t<Sender>>::type;
 
 struct _die_on_done_fn {
-  template (typename Value)
-    (requires (!detail::_awaitable<Value>) AND sender<Value>)
-  _die_on_done_t<Value> operator()(Value&& value) /*mutable*/
+  template(typename Value)(requires(!detail::_awaitable<Value>)
+                               AND sender<Value>) _die_on_done_t<Value>
+  operator()(Value&& value) /*mutable*/
       noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Value>, Value>) {
-    return _die_on_done_t<Value>{(Value&&) value};
+    return _die_on_done_t<Value>{(Value &&) value};
   }
 
   template <typename Value>
   Value&& operator()(Value&& value) const noexcept {
-    return (Value&&) value;
+    return (Value &&) value;
   }
 };
 
@@ -224,8 +229,7 @@ struct _cleanup_task;
 template <typename... Ts>
 struct _cleanup_promise : _cleanup_promise_base {
   template <typename Action>
-  explicit _cleanup_promise(Action&&, Ts&... ts) noexcept
-    : args_(ts...) {}
+  explicit _cleanup_promise(Action&&, Ts&... ts) noexcept : args_(ts...) {}
 
   _cleanup_task<Ts...> get_return_object() noexcept {
     return _cleanup_task<Ts...>(
@@ -233,19 +237,18 @@ struct _cleanup_promise : _cleanup_promise_base {
   }
 
   coro::coroutine_handle<> unhandled_done() noexcept {
-    // Record that we are processing an unhandled done signal. This is checked in
-    // the final_suspend of the cleanup action to know which subsequent continuation
-    // to resume.
+    // Record that we are processing an unhandled done signal. This is checked
+    // in the final_suspend of the cleanup action to know which subsequent
+    // continuation to resume.
     isUnhandledDone_ = true;
     // On unhandled_done, run the cleanup action:
     return coro::coroutine_handle<_cleanup_promise>::from_promise(*this);
   }
 
   template <typename Value>
-  decltype(auto) await_transform(Value&& value)
-      noexcept(noexcept(
-          unifex::await_transform(*this, _die_on_done_fn{}((Value&&) value)))) {
-    return unifex::await_transform(*this, _die_on_done_fn{}((Value&&) value));
+  decltype(auto) await_transform(Value&& value) noexcept(noexcept(
+      unifex::await_transform(*this, _die_on_done_fn{}((Value &&) value)))) {
+    return unifex::await_transform(*this, _die_on_done_fn{}((Value &&) value));
   }
 
   UNIFEX_NO_UNIQUE_ADDRESS std::tuple<Ts&...> args_;
@@ -261,13 +264,9 @@ struct [[nodiscard]] _cleanup_task {
   _cleanup_task(_cleanup_task&& that) noexcept
     : continuation_(std::exchange(that.continuation_, {})) {}
 
-  ~_cleanup_task() {
-    UNIFEX_ASSERT(!continuation_);
-  }
+  ~_cleanup_task() { UNIFEX_ASSERT(!continuation_); }
 
-  bool await_ready() const noexcept {
-    return false;
-  }
+  bool await_ready() const noexcept { return false; }
 
   template <typename Promise>
   bool await_suspend_impl_(Promise& parent) noexcept {
@@ -286,7 +285,8 @@ struct [[nodiscard]] _cleanup_task {
     return std::move(std::exchange(continuation_, {}).promise().args_);
   }
 
-  friend constexpr auto tag_invoke(tag_t<blocking>, const _cleanup_task&) noexcept {
+  friend constexpr auto
+  tag_invoke(tag_t<blocking>, const _cleanup_task&) noexcept {
     return blocking_kind::always_inline;
   }
 
@@ -295,23 +295,25 @@ private:
 };
 
 namespace _at_coroutine_exit {
-  inline constexpr struct _fn {
-  private:
-    template <typename Action, typename... Ts>
-    static _cleanup_task<Ts...> at_coroutine_exit(Action action, Ts... ts) {
-      co_await std::move(action)(std::move(ts)...);
-    }
-  public:
-    template (typename Action, typename... Ts)
-      (requires callable<std::decay_t<Action>, std::decay_t<Ts>...>)
-    _cleanup_task<std::decay_t<Ts>...> operator()(Action&& action, Ts&&... ts) const {
-      return _fn::at_coroutine_exit((Action&&) action, (Ts&&) ts...);
-    }
-  } at_coroutine_exit{};
-} // namespace _at_coroutine_exit
+inline constexpr struct _fn {
+private:
+  template <typename Action, typename... Ts>
+  static _cleanup_task<Ts...> at_coroutine_exit(Action action, Ts... ts) {
+    co_await std::move(action)(std::move(ts)...);
+  }
+
+public:
+  template(typename Action, typename... Ts)(
+      requires callable<std::decay_t<Action>, std::decay_t<Ts>...>)
+      _cleanup_task<std::decay_t<Ts>...>
+      operator()(Action&& action, Ts&&... ts) const {
+    return _fn::at_coroutine_exit((Action &&) action, (Ts &&) ts...);
+  }
+} at_coroutine_exit{};
+}  // namespace _at_coroutine_exit
 
 using _at_coroutine_exit::at_coroutine_exit;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -18,15 +18,15 @@
 #include <unifex/coroutine.hpp>
 
 #if UNIFEX_NO_COROUTINES
-# error "Coroutine support is required to use <unifex/await_transform.hpp>"
+#  error "Coroutine support is required to use <unifex/await_transform.hpp>"
 #endif
 
 #include <unifex/async_trace.hpp>
 #include <unifex/coroutine_concepts.hpp>
+#include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/manual_lifetime.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -43,28 +43,25 @@ struct _expected {
   void reset_value() noexcept {
     _reset_value(std::exchange(state_, _state::empty));
   }
-  ~_expected() {
-    _reset_value(state_);
-  }
+  ~_expected() { _reset_value(state_); }
   _state state_ = _state::empty;
   union {
     manual_lifetime<Value> value_;
     manual_lifetime<std::exception_ptr> exception_;
   };
+
 private:
   void _reset_value(_state s) noexcept {
-    switch(s) {
-    case _state::value:
-      unifex::deactivate_union_member(value_);
-      break;
-    case _state::exception:
-      unifex::deactivate_union_member(exception_);
-      break;
-    default:;
+    switch (s) {
+      case _state::value: unifex::deactivate_union_member(value_); break;
+      case _state::exception:
+        unifex::deactivate_union_member(exception_);
+        break;
+      default:;
     }
   }
 };
-} // namespace _util
+}  // namespace _util
 
 namespace _await_tfx {
 using namespace _util;
@@ -83,23 +80,22 @@ template <typename Promise, typename Value>
 struct _awaitable_base<Promise, Value>::type {
   struct _rec {
   public:
-    explicit _rec(_expected<Value>* result, coro::coroutine_handle<Promise> continuation) noexcept
+    explicit _rec(
+        _expected<Value>* result,
+        coro::coroutine_handle<Promise> continuation) noexcept
       : result_(result)
-      , continuation_(continuation)
-    {}
+      , continuation_(continuation) {}
 
     _rec(_rec&& r) noexcept
       : result_(std::exchange(r.result_, nullptr))
-      , continuation_(std::exchange(r.continuation_, nullptr))
-    {}
+      , continuation_(std::exchange(r.continuation_, nullptr)) {}
 
-    template(class... Us)
-      (requires (constructible_from<Value, Us...> ||
-          (std::is_void_v<Value> && sizeof...(Us) == 0)))
-    void set_value(Us&&... us) &&
-        noexcept(std::is_nothrow_constructible_v<Value, Us...> ||
-            std::is_void_v<Value>) {
-      unifex::activate_union_member(result_->value_, (Us&&) us...);
+    template(class... Us)(requires(
+        constructible_from<Value, Us...> ||
+        (std::is_void_v<Value> &&
+         sizeof...(Us) ==
+             0))) void set_value(Us&&... us) && noexcept(std::is_nothrow_constructible_v<Value, Us...> || std::is_void_v<Value>) {
+      unifex::activate_union_member(result_->value_, (Us &&) us...);
       result_->state_ = _state::value;
       continuation_.resume();
     }
@@ -115,10 +111,9 @@ struct _awaitable_base<Promise, Value>::type {
       continuation_.promise().unhandled_done().resume();
     }
 
-    template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Promise&>)
-    friend auto tag_invoke(CPO cpo, const _rec& r)
-        noexcept(is_nothrow_callable_v<CPO, const Promise&>)
+    template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Promise&>) friend auto tag_invoke(
+        CPO cpo,
+        const _rec& r) noexcept(is_nothrow_callable_v<CPO, const Promise&>)
         -> callable_result_t<CPO, const Promise&> {
       const Promise& p = r.continuation_.promise();
       return std::move(cpo)(p);
@@ -127,7 +122,7 @@ struct _awaitable_base<Promise, Value>::type {
     template <typename Func>
     friend void
     tag_invoke(tag_t<visit_continuations>, const _rec& r, Func&& func) {
-      visit_continuations(r.continuation_.promise(), (Func&&)func);
+      visit_continuations(r.continuation_.promise(), (Func &&) func);
     }
 
   private:
@@ -135,17 +130,14 @@ struct _awaitable_base<Promise, Value>::type {
     coro::coroutine_handle<Promise> continuation_;
   };
 
-  bool await_ready() const noexcept {
-    return false;
-  }
+  bool await_ready() const noexcept { return false; }
 
   Value await_resume() {
     switch (result_.state_) {
-    case _state::value:
-      return std::move(result_.value_).get();
-    default:
-      UNIFEX_ASSERT(result_.state_ == _state::exception);
-      std::rethrow_exception(result_.exception_.get());
+      case _state::value: return std::move(result_.value_).get();
+      default:
+        UNIFEX_ASSERT(result_.state_ == _state::exception);
+        std::rethrow_exception(result_.exception_.get());
     }
   }
 
@@ -154,8 +146,7 @@ protected:
 };
 
 template <typename Promise, typename Sender>
-using _awaitable_base_t =
-  typename _awaitable_base<
+using _awaitable_base_t = typename _awaitable_base<
     Promise,
     sender_single_value_return_type_t<remove_cvref_t<Sender>>>::type;
 
@@ -163,16 +154,15 @@ template <typename Promise, typename Sender>
 using _receiver_t = typename _awaitable_base_t<Promise, Sender>::_rec;
 
 template <typename Promise, typename Sender>
-struct _awaitable<Promise, Sender>::type
-  : _awaitable_base_t<Promise, Sender> {
+struct _awaitable<Promise, Sender>::type : _awaitable_base_t<Promise, Sender> {
 private:
   using _rec = _receiver_t<Promise, Sender>;
   connect_result_t<Sender, _rec> op_;
+
 public:
-  explicit type(Sender&& sender, coro::coroutine_handle<Promise> h)
-    noexcept(is_nothrow_connectable_v<Sender, _rec>)
-  : op_(unifex::connect((Sender&&)sender, _rec{&this->result_, h}))
-  {}
+  explicit type(Sender&& sender, coro::coroutine_handle<Promise> h) noexcept(
+      is_nothrow_connectable_v<Sender, _rec>)
+    : op_(unifex::connect((Sender &&) sender, _rec{&this->result_, h})) {}
 
   void await_suspend(coro::coroutine_handle<Promise>) noexcept {
     unifex::start(op_);
@@ -184,43 +174,44 @@ using _as_awaitable = typename _awaitable<Promise, Sender>::type;
 
 struct _fn {
   // Call custom implementation if present.
-  template(typename Promise, typename Value)
-    (requires tag_invocable<_fn, Promise&, Value>)
-  auto operator()(Promise& promise, Value&& value) const
-    noexcept(is_nothrow_tag_invocable_v<_fn, Promise&, Value>)
-    -> tag_invoke_result_t<_fn, Promise&, Value> {
-    static_assert(detail::_awaitable<tag_invoke_result_t<_fn, Promise&, Value>>,
+  template(typename Promise, typename Value)(
+      requires tag_invocable<_fn, Promise&, Value>) auto
+  operator()(Promise& promise, Value&& value) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Promise&, Value>)
+          -> tag_invoke_result_t<_fn, Promise&, Value> {
+    static_assert(
+        detail::_awaitable<tag_invoke_result_t<_fn, Promise&, Value>>,
         "The return type of a customization of unifex::await_transform() "
         "must satisfy the awaitable concept.");
-    return unifex::tag_invoke(_fn{}, promise, (Value&&)value);
+    return unifex::tag_invoke(_fn{}, promise, (Value &&) value);
   }
 
   // Default implementation.
-  template(typename Promise, typename Value)
-    (requires (!tag_invocable<_fn, Promise&, Value>))
-  decltype(auto) operator()(Promise& promise, Value&& value) const {
+  template(typename Promise, typename Value)(
+      requires(!tag_invocable<_fn, Promise&, Value>)) decltype(auto)
+  operator()(Promise& promise, Value&& value) const {
     // Note we don't fold the two '(Value&&) value'-returning cases here
     // to avoid instantiating 'unifex::sender<Value>' concept check in
     // the case that _awaitable<Value> evaluates to true.
     if constexpr (detail::_awaitable<Value>) {
-      return (Value&&) value;
+      return (Value &&) value;
     } else if constexpr (unifex::sender<Value>) {
       if constexpr (unifex::sender_to<Value, _receiver_t<Promise, Value>>) {
         auto h = coro::coroutine_handle<Promise>::from_promise(promise);
-        return _as_awaitable<Promise, Value>{(Value&&) value, h};
+        return _as_awaitable<Promise, Value>{(Value &&) value, h};
       } else {
         static_assert(
-          unifex::sender_to<Value, _receiver_t<Promise, Value>>,
-          "This sender is not awaitable in this coroutine type.");
-        return (Value&&) value;
+            unifex::sender_to<Value, _receiver_t<Promise, Value>>,
+            "This sender is not awaitable in this coroutine type.");
+        return (Value &&) value;
       }
     } else {
-      return (Value&&) value;
+      return (Value &&) value;
     }
   }
 };
 
-} // namespace _await_tfx
+}  // namespace _await_tfx
 
 // The await_transform() customisation point allows value-types to customise
 // what kind of awaitable object should be used for this type when it is used
@@ -231,8 +222,8 @@ struct _fn {
 //
 // Coroutine promise_types can implement their .await_transform() methods to
 // forward to this customisation point to enable use of type customisations.
-inline constexpr _await_tfx::_fn await_transform {};
+inline constexpr _await_tfx::_fn await_transform{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bind_back.hpp
+++ b/include/unifex/bind_back.hpp
@@ -28,16 +28,15 @@ namespace _compose {
 
 struct _fn {
   template <typename Target, typename Other, typename Self>
-  auto operator()(Target&& target, Other&& other, Self&& self) const
-    noexcept(
-      is_nothrow_callable_v<Other, Target> &&
-      is_nothrow_callable_v<Self, callable_result_t<Other, Target>>)
-    -> callable_result_t<Self, callable_result_t<Other, Target>> {
-    return ((Self&&) self)(((Other&&) other)((Target&&) target));
+  auto operator()(Target&& target, Other&& other, Self&& self) const noexcept(
+      is_nothrow_callable_v<Other, Target>&&
+          is_nothrow_callable_v<Self, callable_result_t<Other, Target>>)
+      -> callable_result_t<Self, callable_result_t<Other, Target>> {
+    return ((Self &&) self)(((Other &&) other)((Target &&) target));
   }
 };
 
-} // namespace _compose
+}  // namespace _compose
 
 namespace _bind_back {
 
@@ -54,12 +53,11 @@ struct _apply_fn_impl<Cpo, Target>::type {
   Cpo&& cpo_;
   Target&& target_;
 
-  template (typename... ArgN)
-    (requires callable<Cpo, Target, ArgN...>)
-  auto operator()(ArgN&&... argN)
-    noexcept(is_nothrow_callable_v<Cpo, Target, ArgN...>)
-    -> callable_result_t<Cpo, Target, ArgN...> {
-    return ((Cpo&&) cpo_)((Target&&) target_, (ArgN&&) argN...);
+  template(typename... ArgN)(requires callable<Cpo, Target, ArgN...>) auto
+  operator()(ArgN&&... argN) noexcept(
+      is_nothrow_callable_v<Cpo, Target, ArgN...>)
+      -> callable_result_t<Cpo, Target, ArgN...> {
+    return ((Cpo &&) cpo_)((Target &&) target_, (ArgN &&) argN...);
   }
 };
 
@@ -78,62 +76,67 @@ struct _result_impl<Cpo, ArgN...>::type : _result_base {
   UNIFEX_NO_UNIQUE_ADDRESS Cpo cpo_;
   std::tuple<ArgN...> argN_;
 
-  template (typename Target)
-    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
-      callable<Cpo const&, Target, ArgN const&...>)
-  decltype(auto) operator()(Target&& target) const &
-    noexcept(is_nothrow_callable_v<Cpo const&, Target, ArgN const&...>) {
-    return std::apply(_apply_fn<Cpo const&, Target>{cpo_, (Target&&) target}, argN_);
-  }
-  template (typename Target)
-    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
-      callable<Cpo, Target, ArgN...>)
-  decltype(auto) operator()(Target&& target) &&
-    noexcept(is_nothrow_callable_v<Cpo, Target, ArgN...>) {
+  template(typename Target)(
+      requires(!derived_from<remove_cvref_t<Target>, _result_base>)
+          AND callable<Cpo const&, Target, ArgN const&...>) decltype(auto)
+  operator()(Target&& target) const& noexcept(
+      is_nothrow_callable_v<Cpo const&, Target, ArgN const&...>) {
     return std::apply(
-        _apply_fn<Cpo, Target>{(Cpo&&) cpo_, (Target&&) target},
+        _apply_fn<Cpo const&, Target>{cpo_, (Target &&) target}, argN_);
+  }
+  template(typename Target)(
+      requires(!derived_from<remove_cvref_t<Target>, _result_base>)
+          AND callable<Cpo, Target, ArgN...>) decltype(auto)
+  operator()(Target&& target) && noexcept(
+      is_nothrow_callable_v<Cpo, Target, ArgN...>) {
+    return std::apply(
+        _apply_fn<Cpo, Target>{(Cpo &&) cpo_, (Target &&) target},
         std::move(argN_));
   }
 
-  template (typename Target, typename Self)
-    (requires (!derived_from<remove_cvref_t<Target>, _result_base>) AND
-      same_as<remove_cvref_t<Self>, type> AND
-      callable<member_t<Self, Cpo>, Target, member_t<Self, ArgN>...>)
-  friend decltype(auto) operator|(Target&& target, Self&& self)
-    noexcept(
-      is_nothrow_callable_v<member_t<Self, Cpo>, Target, member_t<Self, ArgN>...>) {
+  template(typename Target, typename Self)(
+      requires(!derived_from<remove_cvref_t<Target>, _result_base>)
+          AND same_as<remove_cvref_t<Self>, type> AND callable<
+              member_t<Self, Cpo>,
+              Target,
+              member_t<Self, ArgN>...>) friend decltype(auto)
+  operator|(Target&& target, Self&& self) noexcept(is_nothrow_callable_v<
+                                                   member_t<Self, Cpo>,
+                                                   Target,
+                                                   member_t<Self, ArgN>...>) {
     return std::apply(
-        _apply_fn<member_t<Self, Cpo>, Target>{((Self&&) self).cpo_, (Target&&) target},
-        ((Self&&) self).argN_);
+        _apply_fn<member_t<Self, Cpo>, Target>{
+            ((Self &&) self).cpo_, (Target &&) target},
+        ((Self &&) self).argN_);
   }
 
-  template (typename Other, typename Self)
-    (requires derived_from<remove_cvref_t<Other>, _result_base> AND
-      same_as<remove_cvref_t<Self>, type>)
-  friend decltype(auto) operator|(Other&& other, Self&& self)
-    noexcept(noexcept(
-      _result<_compose::_fn, remove_cvref_t<Other>, type>{
-          {}, // _result_base
-          {}, // _compose::_fn
-          std::tuple{(Other&&) other, (Self&&) self}})) {
+  template(typename Other, typename Self)(
+      requires derived_from<remove_cvref_t<Other>, _result_base> AND
+          same_as<remove_cvref_t<Self>, type>) friend decltype(auto)
+  operator|(Other&& other, Self&& self) noexcept(
+      noexcept(_result<_compose::_fn, remove_cvref_t<Other>, type>{
+          {},  // _result_base
+          {},  // _compose::_fn
+          std::tuple{(Other &&) other, (Self &&) self}})) {
     return _result<_compose::_fn, remove_cvref_t<Other>, type>{
-        {}, // _result_base
-        {}, // _compose::_fn
-        std::tuple{(Other&&) other, (Self&&) self}};
+        {},  // _result_base
+        {},  // _compose::_fn
+        std::tuple{(Other &&) other, (Self &&) self}};
   }
 };
 
 inline const struct _fn {
   template <typename Cpo, typename... ArgN>
   constexpr auto operator()(Cpo cpo, ArgN&&... argN) const
-      noexcept(noexcept(
-          _result<Cpo, std::decay_t<ArgN>...>{{}, (Cpo&&) cpo, std::tuple{(ArgN &&) argN...}}))
-      -> _result<Cpo, std::decay_t<ArgN>...> {
-    return _result<Cpo, std::decay_t<ArgN>...>{{}, (Cpo&&) cpo, std::tuple{(ArgN &&) argN...}};
+      noexcept(noexcept(_result<Cpo, std::decay_t<ArgN>...>{
+          {}, (Cpo &&) cpo, std::tuple{(ArgN &&) argN...}}))
+          -> _result<Cpo, std::decay_t<ArgN>...> {
+    return _result<Cpo, std::decay_t<ArgN>...>{
+        {}, (Cpo &&) cpo, std::tuple{(ArgN &&) argN...}};
   }
 } bind_back{};
 
-} // namespace _bind_back
+}  // namespace _bind_back
 
 using _bind_back::bind_back;
 
@@ -141,6 +144,6 @@ template <typename Cpo, typename... ArgN>
 using bind_back_result_t =
     _bind_back::_result<std::decay_t<Cpo>, std::decay_t<ArgN>...>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -15,12 +15,12 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
+#include <unifex/execution_policy.hpp>
+#include <unifex/get_execution_policy.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/execution_policy.hpp>
-#include <unifex/get_execution_policy.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -28,137 +28,134 @@ namespace unifex {
 
 namespace _bulk_join {
 
-template<typename Receiver>
+template <typename Receiver>
 struct _join_receiver {
-    class type;
+  class type;
 };
 
-template<typename Receiver>
+template <typename Receiver>
 using join_receiver = typename _join_receiver<Receiver>::type;
 
-template<typename Receiver>
+template <typename Receiver>
 class _join_receiver<Receiver>::type {
 public:
-    template(typename Receiver2)
-      (requires constructible_from<Receiver, Receiver2>)
-    explicit type(Receiver2&& r) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>)
-    : receiver_((Receiver2&&)r)
-    {}
+  template(typename Receiver2)(
+      requires constructible_from<
+          Receiver,
+          Receiver2>) explicit type(Receiver2&&
+                                        r) noexcept(std::
+                                                        is_nothrow_constructible_v<
+                                                            Receiver,
+                                                            Receiver2>)
+    : receiver_((Receiver2 &&) r) {}
 
-    void set_next() & noexcept {}
+  void set_next() & noexcept {}
 
-    template(typename... Values)
-        (requires receiver_of<Receiver, Values...>)
-    void set_value(Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
-        unifex::set_value(std::move(receiver_), (Values&&)values...);
-    }
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
+    unifex::set_value(std::move(receiver_), (Values &&) values...);
+  }
 
-    template(typename Error)
-        (requires receiver<Receiver, Error>)
-    void set_error(Error&& error) noexcept {
-        unifex::set_error(std::move(receiver_), (Error&&)error);
-    }
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) noexcept {
+    unifex::set_error(std::move(receiver_), (Error &&) error);
+  }
 
-    void set_done() noexcept {
-        unifex::set_done(std::move(receiver_));
-    }
+  void set_done() noexcept { unifex::set_done(std::move(receiver_)); }
 
-    friend constexpr unifex::parallel_unsequenced_policy tag_invoke(
-            tag_t<get_execution_policy>, [[maybe_unused]] const type& r) noexcept {
-        return {};
-    }
+  friend constexpr unifex::parallel_unsequenced_policy tag_invoke(
+      tag_t<get_execution_policy>, [[maybe_unused]] const type& r) noexcept {
+    return {};
+  }
 
-    template(typename CPO, typename Self)
-        (requires
-            is_receiver_query_cpo_v<CPO> AND
-            same_as<Self, type>)
-    friend auto tag_invoke(CPO cpo, const Self& self)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-        -> callable_result_t<CPO, const Receiver&> {
-        return cpo(self.receiver_);
-    }
+  template(typename CPO, typename Self)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<
+          Self,
+          type>) friend auto tag_invoke(CPO cpo, const Self& self) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return cpo(self.receiver_);
+  }
 
 private:
-    Receiver receiver_;
+  Receiver receiver_;
 };
 
-template<typename Source>
+template <typename Source>
 struct _join_sender {
-    class type;
+  class type;
 };
 
-template<typename Source>
+template <typename Source>
 using join_sender = typename _join_sender<Source>::type;
 
-template<typename Source>
+template <typename Source>
 class _join_sender<Source>::type {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = sender_value_types_t<Source, Variant, Tuple>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
-    template<template<typename...> class Variant>
-    using error_types = sender_error_types_t<Source, Variant>;
+  template <template <typename...> class Variant>
+  using error_types = sender_error_types_t<Source, Variant>;
 
-    static constexpr bool sends_done = sender_traits<Source>::sends_done;
+  static constexpr bool sends_done = sender_traits<Source>::sends_done;
 
-    template<typename Source2>
-    explicit type(Source2&& s)
-        noexcept(std::is_nothrow_constructible_v<Source, Source2>)
-    : source_((Source2&&)s)
-    {}
+  template <typename Source2>
+  explicit type(Source2&& s) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>)
+    : source_((Source2 &&) s) {}
 
-    template(typename Self, typename Receiver)
-        (requires
-            same_as<remove_cvref_t<Self>, type> AND
-            sender_to<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>)
-    friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
-        noexcept(
-            std::is_nothrow_constructible_v<remove_cvref_t<Receiver>> &&
-            is_nothrow_connectable_v<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>)
-        -> connect_result_t<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>
-    {
-        return unifex::connect(
-            static_cast<Self&&>(self).source_,
-            join_receiver<remove_cvref_t<Receiver>>{static_cast<Receiver&&>(r)});
-    }
+  template(typename Self, typename Receiver)(requires same_as<remove_cvref_t<Self>, type> AND sender_to<member_t<Self, Source>, join_receiver<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Self&& self,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<remove_cvref_t<Receiver>>&&
+                              is_nothrow_connectable_v<
+                                  member_t<Self, Source>,
+                                  join_receiver<remove_cvref_t<Receiver>>>)
+      -> connect_result_t<
+          member_t<Self, Source>,
+          join_receiver<remove_cvref_t<Receiver>>> {
+    return unifex::connect(
+        static_cast<Self&&>(self).source_,
+        join_receiver<remove_cvref_t<Receiver>>{static_cast<Receiver&&>(r)});
+  }
 
 private:
-    Source source_;
+  Source source_;
 };
 
 struct _fn {
-    template(typename Source)
-        (requires
-            typed_bulk_sender<Source> &&
-            tag_invocable<_fn, Source>)
-    auto operator()(Source&& source) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Source>)
-        -> tag_invoke_result_t<_fn, Source> {
-        return tag_invoke(_fn{}, (Source&&)source);
-    }
+  template(typename Source)(
+      requires typed_bulk_sender<Source>&& tag_invocable<_fn, Source>) auto
+  operator()(Source&& source) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Source>)
+          -> tag_invoke_result_t<_fn, Source> {
+    return tag_invoke(_fn{}, (Source &&) source);
+  }
 
-    template(typename Source)
-        (requires
-            typed_bulk_sender<Source> &&
-            (!tag_invocable<_fn, Source>))
-    auto operator()(Source&& source) const
-        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>)
-        -> join_sender<remove_cvref_t<Source>> {
-        return join_sender<remove_cvref_t<Source>>{
-            (Source&&)source};
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
+  template(typename Source)(
+      requires typed_bulk_sender<Source> && (!tag_invocable<_fn, Source>)) auto
+  operator()(Source&& source) const
+      noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>)
+          -> join_sender<remove_cvref_t<Source>> {
+    return join_sender<remove_cvref_t<Source>>{(Source &&) source};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
 };
 
-} // namespace _bulk_join
+}  // namespace _bulk_join
 
 inline constexpr _bulk_join::_fn bulk_join{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -17,14 +17,14 @@
 
 #include <algorithm>
 
+#include <unifex/bind_back.hpp>
+#include <unifex/execution_policy.hpp>
+#include <unifex/get_execution_policy.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/receiver_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/receiver_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/get_execution_policy.hpp>
-#include <unifex/execution_policy.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -34,196 +34,207 @@ constexpr size_t bulk_cancellation_chunk_size = 16;
 
 namespace _bulk_schedule {
 
-template<typename Integral, typename Receiver>
+template <typename Integral, typename Receiver>
 struct _schedule_receiver {
-    class type;
+  class type;
 };
 
-template<typename Integral, typename Receiver>
+template <typename Integral, typename Receiver>
 using schedule_receiver = typename _schedule_receiver<Integral, Receiver>::type;
 
-template<typename Integral, typename Receiver>
+template <typename Integral, typename Receiver>
 class _schedule_receiver<Integral, Receiver>::type {
 public:
-    template<typename Receiver2>
-    explicit type(Integral count, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(Integral count, Receiver2&& r)
     : count_(std::move(count))
-    , receiver_((Receiver2&&)r)
-    {}
+    , receiver_((Receiver2 &&) r) {}
 
-    void set_value()
-        noexcept(is_nothrow_receiver_of_v<Receiver> &&
-                 is_nothrow_next_receiver_v<Receiver, Integral>) {
-        using policy_t = decltype(get_execution_policy(receiver_));
-        auto stop_token = get_stop_token(receiver_);
-        const bool stop_possible = !is_stop_never_possible_v<decltype(stop_token)> && stop_token.stop_possible();
+  void
+  set_value() noexcept(is_nothrow_receiver_of_v<Receiver>&&
+                           is_nothrow_next_receiver_v<Receiver, Integral>) {
+    using policy_t = decltype(get_execution_policy(receiver_));
+    auto stop_token = get_stop_token(receiver_);
+    const bool stop_possible =
+        !is_stop_never_possible_v<decltype(stop_token)> &&
+        stop_token.stop_possible();
 
-        if(stop_possible) {
-            for (Integral chunk_start(0); chunk_start < count_; chunk_start += bulk_cancellation_chunk_size) {
-                if(stop_token.stop_requested()) {
-                    unifex::set_done(std::move(receiver_));
-                    return;
-                }
-                Integral chunk_end = std::min(chunk_start + static_cast<Integral>(bulk_cancellation_chunk_size), count_);
-                if constexpr (is_one_of_v<policy_t, unsequenced_policy, parallel_unsequenced_policy>) {
-UNIFEX_DIAGNOSTIC_PUSH
+    if (stop_possible) {
+      for (Integral chunk_start(0); chunk_start < count_;
+           chunk_start += bulk_cancellation_chunk_size) {
+        if (stop_token.stop_requested()) {
+          unifex::set_done(std::move(receiver_));
+          return;
+        }
+        Integral chunk_end = std::min(
+            chunk_start + static_cast<Integral>(bulk_cancellation_chunk_size),
+            count_);
+        if constexpr (is_one_of_v<
+                          policy_t,
+                          unsequenced_policy,
+                          parallel_unsequenced_policy>) {
+          UNIFEX_DIAGNOSTIC_PUSH
 
-                    // Vectorisable version
+          // Vectorisable version
 #if defined(__clang__)
-                    // When optimizing for size (e.g. with -Oz), Clang will not
-                    // vectorize this loop, and will emit a warning.  There's
-                    // nothing to be done about the warning, though, so just
-                    // suppress it.
-                    #pragma clang diagnostic ignored "-Wpass-failed"
-                    #pragma clang loop vectorize(enable) interleave(enable)
+// When optimizing for size (e.g. with -Oz), Clang will not
+// vectorize this loop, and will emit a warning.  There's
+// nothing to be done about the warning, though, so just
+// suppress it.
+#  pragma clang diagnostic ignored "-Wpass-failed"
+#  pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)
-                    #pragma GCC ivdep
+#  pragma GCC ivdep
 #elif defined(_MSC_VER)
-                    #pragma loop(ivdep)
+#  pragma loop(ivdep)
 #endif
-                    for (Integral i(chunk_start); i < chunk_end; ++i) {
-                        unifex::set_next(receiver_, Integral(i));
-                    }
+          for (Integral i(chunk_start); i < chunk_end; ++i) {
+            unifex::set_next(receiver_, Integral(i));
+          }
 
-UNIFEX_DIAGNOSTIC_POP
-                } else {
-                    // Sequenced version
-                    for (Integral i(chunk_start); i < chunk_end; ++i) {
-                        unifex::set_next(receiver_, Integral(i));
-                    }
-                }
-            }
+          UNIFEX_DIAGNOSTIC_POP
         } else {
-            if constexpr (is_one_of_v<policy_t, unsequenced_policy, parallel_unsequenced_policy>) {
-UNIFEX_DIAGNOSTIC_PUSH
+          // Sequenced version
+          for (Integral i(chunk_start); i < chunk_end; ++i) {
+            unifex::set_next(receiver_, Integral(i));
+          }
+        }
+      }
+    } else {
+      if constexpr (is_one_of_v<
+                        policy_t,
+                        unsequenced_policy,
+                        parallel_unsequenced_policy>) {
+        UNIFEX_DIAGNOSTIC_PUSH
 
-                // Vectorisable version
+        // Vectorisable version
 #if defined(__clang__)
-                // When optimizing for size (e.g. with -Oz), Clang will not
-                // vectorize this loop, and will emit a warning.  There's
-                // nothing to be done about the warning, though, so just
-                // suppress it.
-                #pragma clang diagnostic ignored "-Wpass-failed"
-                #pragma clang loop vectorize(enable) interleave(enable)
+// When optimizing for size (e.g. with -Oz), Clang will not
+// vectorize this loop, and will emit a warning.  There's
+// nothing to be done about the warning, though, so just
+// suppress it.
+#  pragma clang diagnostic ignored "-Wpass-failed"
+#  pragma clang loop vectorize(enable) interleave(enable)
 #elif defined(__GNUC__)
-                #pragma GCC ivdep
+#  pragma GCC ivdep
 #elif defined(_MSC_VER)
-                #pragma loop(ivdep)
+#  pragma loop(ivdep)
 #endif
-                for (Integral i(0); i < count_; ++i) {
-                    unifex::set_next(receiver_, Integral(i));
-                }
-
-UNIFEX_DIAGNOSTIC_POP
-            } else {
-                // Sequenced version
-                for (Integral i(0); i < count_; ++i) {
-                    unifex::set_next(receiver_, Integral(i));
-                }
-            }
+        for (Integral i(0); i < count_; ++i) {
+          unifex::set_next(receiver_, Integral(i));
         }
 
-        unifex::set_value(std::move(receiver_));
+        UNIFEX_DIAGNOSTIC_POP
+      } else {
+        // Sequenced version
+        for (Integral i(0); i < count_; ++i) {
+          unifex::set_next(receiver_, Integral(i));
+        }
+      }
     }
 
-    template(typename Error)
-        (requires receiver<Receiver, Error>)
-    void set_error(Error&& e) noexcept {
-        unifex::set_error(std::move(receiver_), (Error&&)e);
-    }
+    unifex::set_value(std::move(receiver_));
+  }
 
-    void set_done() noexcept {
-        unifex::set_done(std::move(receiver_));
-    }
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& e) noexcept {
+    unifex::set_error(std::move(receiver_), (Error &&) e);
+  }
+
+  void set_done() noexcept {
+    unifex::set_done(std::move(receiver_));
+  }
 
 private:
-    Integral count_;
-    Receiver receiver_;
+  Integral count_;
+  Receiver receiver_;
 };
 
-template<typename Scheduler, typename Integral>
+template <typename Scheduler, typename Integral>
 struct _default_sender {
-    class type;
+  class type;
 };
 
-template<typename Scheduler, typename Integral>
+template <typename Scheduler, typename Integral>
 using default_sender = typename _default_sender<Scheduler, Integral>::type;
 
-template<typename Scheduler, typename Integral>
+template <typename Scheduler, typename Integral>
 class _default_sender<Scheduler, Integral>::type {
-    using schedule_sender_t =
-        decltype(unifex::schedule(UNIFEX_DECLVAL(const Scheduler&)));
+  using schedule_sender_t =
+      decltype(unifex::schedule(UNIFEX_DECLVAL(const Scheduler&)));
 
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using next_types = Variant<Tuple<Integral>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using next_types = Variant<Tuple<Integral>>;
 
-    template<template<typename...> class Variant>
-    using error_types = sender_error_types_t<schedule_sender_t, Variant>;
+  template <template <typename...> class Variant>
+  using error_types = sender_error_types_t<schedule_sender_t, Variant>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    template<typename Scheduler2>
-    explicit type(Scheduler2&& s, Integral count)
+  template <typename Scheduler2>
+  explicit type(Scheduler2&& s, Integral count)
     : scheduler_(static_cast<Scheduler2&&>(s))
-    , count_(std::move(count))
-    {}
+    , count_(std::move(count)) {}
 
-    template(typename Self, typename BulkReceiver)
-        (requires
-            same_as<remove_cvref_t<Self>, type> AND
-            receiver_of<BulkReceiver> AND
-            is_next_receiver_v<BulkReceiver, Integral>)
-    friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, BulkReceiver&& r) {
-        return unifex::connect(
-            unifex::schedule(static_cast<Self&&>(s).scheduler_),
-            schedule_receiver<Integral, remove_cvref_t<BulkReceiver>>{
-                static_cast<Self&&>(s).count_,
-                static_cast<BulkReceiver&&>(r)});
-    }
+  template(typename Self, typename BulkReceiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND
+          receiver_of<BulkReceiver> AND is_next_receiver_v<
+              BulkReceiver,
+              Integral>) friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, BulkReceiver&& r) {
+    return unifex::connect(
+        unifex::schedule(static_cast<Self&&>(s).scheduler_),
+        schedule_receiver<Integral, remove_cvref_t<BulkReceiver>>{
+            static_cast<Self&&>(s).count_, static_cast<BulkReceiver&&>(r)});
+  }
 
 private:
-    Scheduler scheduler_;
-    Integral count_;
+  Scheduler scheduler_;
+  Integral count_;
 };
 
 struct _fn {
-    template(typename Scheduler, typename Integral)
-        (requires
-            tag_invocable<_fn, Scheduler, Integral>)
-    auto operator()(Scheduler&& s, Integral n) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler, Integral>)
-        -> tag_invoke_result_t<_fn, Scheduler, Integral> {
-        return tag_invoke(_fn{}, (Scheduler&&)s, std::move(n));
-    }
+  template(typename Scheduler, typename Integral)(
+      requires tag_invocable<_fn, Scheduler, Integral>) auto
+  operator()(Scheduler&& s, Integral n) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler, Integral>)
+          -> tag_invoke_result_t<_fn, Scheduler, Integral> {
+    return tag_invoke(_fn{}, (Scheduler &&) s, std::move(n));
+  }
 
-    template(typename Scheduler, typename Integral)
-        (requires
-            scheduler<Scheduler> AND
-            (!tag_invocable<_fn, Scheduler, Integral>))
-    auto operator()(Scheduler&& s, Integral n) const
-        noexcept(
-            std::is_nothrow_constructible_v<remove_cvref_t<Scheduler>, Scheduler> &&
-            std::is_nothrow_move_constructible_v<Integral>)
-        -> default_sender<remove_cvref_t<Scheduler>, Integral> {
-        return default_sender<remove_cvref_t<Scheduler>, Integral>{(Scheduler&&)s, std::move(n)};
-    }
-    template <typename Integral>
-    constexpr auto operator()(Integral n) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Integral>)
-        -> bind_back_result_t<_fn, Integral> {
-      return bind_back(*this, n);
-    }
+  template(typename Scheduler, typename Integral)(
+      requires scheduler<Scheduler> AND(
+          !tag_invocable<_fn, Scheduler, Integral>)) auto
+  operator()(Scheduler&& s, Integral n) const noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<Scheduler>, Scheduler>&&
+          std::is_nothrow_move_constructible_v<Integral>)
+      -> default_sender<remove_cvref_t<Scheduler>, Integral> {
+    return default_sender<remove_cvref_t<Scheduler>, Integral>{
+        (Scheduler &&) s, std::move(n)};
+  }
+  template <typename Integral>
+  constexpr auto operator()(Integral n) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Integral>)
+          -> bind_back_result_t<_fn, Integral> {
+    return bind_back(*this, n);
+  }
 };
 
-} // namespace _bulk_schedule
+}  // namespace _bulk_schedule
 
 inline constexpr _bulk_schedule::_fn bulk_schedule{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -16,10 +16,10 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
 #include <unifex/execution_policy.hpp>
 #include <unifex/get_execution_policy.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/type_list.hpp>
 
 #include <functional>
@@ -30,225 +30,249 @@ namespace unifex {
 
 namespace _bulk_tfx {
 
-template<typename Func, typename Policy, typename Receiver>
+template <typename Func, typename Policy, typename Receiver>
 struct _tfx_receiver {
-    class type;
+  class type;
 };
 
-template<typename Func, typename Policy, typename Receiver>
+template <typename Func, typename Policy, typename Receiver>
 using tfx_receiver = typename _tfx_receiver<Func, Policy, Receiver>::type;
 
-template<typename Func, typename Policy, typename Receiver>
+template <typename Func, typename Policy, typename Receiver>
 class _tfx_receiver<Func, Policy, Receiver>::type {
 public:
-    template<typename Func2, typename Receiver2>
-    explicit type(Func2&& f, Policy policy, Receiver2&& r)
-    : receiver_((Receiver2&&)r)
-    , func_((Func2&&)f)
-    , policy_(std::move(policy))
-    {}
+  template <typename Func2, typename Receiver2>
+  explicit type(Func2&& f, Policy policy, Receiver2&& r)
+    : receiver_((Receiver2 &&) r)
+    , func_((Func2 &&) f)
+    , policy_(std::move(policy)) {}
 
-    template(typename... Values)
-        (requires
-            invocable<Func&, Values...> AND
-            std::is_void_v<std::invoke_result_t<Func&, Values...>>)
-    void set_next(Values&&... values) &
-        noexcept(
-            std::is_nothrow_invocable_v<Func&, Values...> &&
-            is_nothrow_next_receiver_v<Receiver>) {
-        std::invoke(func_, (Values&&)values...);
-        unifex::set_next(receiver_);
+  template(typename... Values)(
+      requires invocable<Func&, Values...> AND std::is_void_v<std::invoke_result_t<
+          Func&,
+          Values...>>) void set_next(Values&&... values) & noexcept(std::
+                                                                        is_nothrow_invocable_v<
+                                                                            Func&,
+                                                                            Values...>&&
+                                                                            is_nothrow_next_receiver_v<
+                                                                                Receiver>) {
+    std::invoke(func_, (Values &&) values...);
+    unifex::set_next(receiver_);
+  }
+
+  template(typename... Values)(requires invocable<Func&, Values...> AND(
+      !std::is_void_v<std::invoke_result_t<
+          Func&,
+          Values...>>)) void set_next(Values&&... values) & noexcept(std::
+                                                                         is_nothrow_invocable_v<
+                                                                             Func&,
+                                                                             Values...>&&
+                                                                             is_nothrow_next_receiver_v<
+                                                                                 Receiver,
+                                                                                 std::invoke_result_t<
+                                                                                     Func&,
+                                                                                     Values...>>) {
+    unifex::set_next(receiver_, std::invoke(func_, (Values &&) values...));
+  }
+
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
+    unifex::set_value(std::move(receiver_), (Values &&) values...);
+  }
+
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) noexcept {
+    unifex::set_error(std::move(receiver_), (Error &&) error);
+  }
+
+  void set_done() noexcept { unifex::set_done(std::move(receiver_)); }
+
+  friend auto tag_invoke(tag_t<get_execution_policy>, const type& r) noexcept {
+    using receiver_policy = decltype(get_execution_policy(r.receiver_));
+    constexpr bool allowUnsequenced = is_one_of_v<
+                                          receiver_policy,
+                                          unsequenced_policy,
+                                          parallel_unsequenced_policy> &&
+        is_one_of_v<Policy, unsequenced_policy, parallel_unsequenced_policy>;
+    constexpr bool allowParallel = is_one_of_v<
+                                       receiver_policy,
+                                       parallel_policy,
+                                       parallel_unsequenced_policy> &&
+        is_one_of_v<Policy, parallel_policy, parallel_unsequenced_policy>;
+
+    if constexpr (allowUnsequenced && allowParallel) {
+      return unifex::par_unseq;
+    } else if constexpr (allowUnsequenced) {
+      return unifex::unseq;
+    } else if constexpr (allowParallel) {
+      return unifex::par;
+    } else {
+      return unifex::seq;
     }
+  }
 
-    template(typename... Values)
-        (requires
-            invocable<Func&, Values...> AND
-            (!std::is_void_v<std::invoke_result_t<Func&, Values...>>))
-    void set_next(Values&&... values) &
-        noexcept(
-            std::is_nothrow_invocable_v<Func&, Values...> &&
-            is_nothrow_next_receiver_v<Receiver, std::invoke_result_t<Func&, Values...>>) {
-        unifex::set_next(receiver_, std::invoke(func_, (Values&&)values...));
-    }
-
-    template(typename... Values)
-        (requires receiver_of<Receiver, Values...>)
-    void set_value(Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
-        unifex::set_value(std::move(receiver_), (Values&&)values...);
-    }
-
-    template(typename Error)
-        (requires receiver<Receiver, Error>)
-    void set_error(Error&& error) noexcept {
-        unifex::set_error(std::move(receiver_), (Error&&)error);
-    }
-
-    void set_done() noexcept {
-        unifex::set_done(std::move(receiver_));
-    }
-
-    friend auto tag_invoke(tag_t<get_execution_policy>, const type& r) noexcept {
-        using receiver_policy = decltype(get_execution_policy(r.receiver_));
-        constexpr bool allowUnsequenced =
-          is_one_of_v<receiver_policy, unsequenced_policy, parallel_unsequenced_policy> &&
-          is_one_of_v<Policy, unsequenced_policy, parallel_unsequenced_policy>;
-        constexpr bool allowParallel =
-          is_one_of_v<receiver_policy, parallel_policy, parallel_unsequenced_policy> &&
-          is_one_of_v<Policy, parallel_policy, parallel_unsequenced_policy>;
-
-        if constexpr (allowUnsequenced && allowParallel) {
-            return unifex::par_unseq;
-        } else if constexpr (allowUnsequenced) {
-            return unifex::unseq;
-        } else if constexpr (allowParallel) {
-            return unifex::par;
-        } else {
-            return unifex::seq;
-        }
-    }
-
-    template(typename CPO, typename Self)
-        (requires
-            is_receiver_query_cpo_v<CPO> AND
-            same_as<Self, type>)
-    friend auto tag_invoke(CPO cpo, const Self& self)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-        -> callable_result_t<CPO, const Receiver&> {
-        return cpo(self.receiver_);
-    }
+  template(typename CPO, typename Self)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<
+          Self,
+          type>) friend auto tag_invoke(CPO cpo, const Self& self) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return cpo(self.receiver_);
+  }
 
 private:
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Func func_;
-    UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+  UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
 };
 
-template<typename Source, typename Func, typename Policy>
+template <typename Source, typename Func, typename Policy>
 struct _tfx_sender {
-    class type;
+  class type;
 };
 
-template<typename Source, typename Func, typename Policy>
+template <typename Source, typename Func, typename Policy>
 using tfx_sender = typename _tfx_sender<Source, Func, Policy>::type;
 
 template <typename Result, typename = void>
 struct result_overload {
-using type = type_list<Result>;
+  using type = type_list<Result>;
 };
 template <typename Result>
 struct result_overload<Result, std::enable_if_t<std::is_void_v<Result>>> {
-using type = type_list<>;
+  using type = type_list<>;
 };
 
-template<typename Source, typename Func, typename Policy>
+template <typename Source, typename Func, typename Policy>
 class _tfx_sender<Source, Func, Policy>::type {
-    template<typename... Values>
-    using result = type_list<
-        typename result_overload<std::invoke_result_t<Func&, Values...>>::type>;
+  template <typename... Values>
+  using result = type_list<
+      typename result_overload<std::invoke_result_t<Func&, Values...>>::type>;
 
 public:
-    template<
-        template<typename...> class Variant,
-        template<typename...> class Tuple>
-    using next_types = type_list_nested_apply_t<
-        typename sender_traits<Source>::template next_types<concat_type_lists_unique_t, result>,
-        Variant,
-        Tuple>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using next_types = type_list_nested_apply_t<
+      typename sender_traits<
+          Source>::template next_types<concat_type_lists_unique_t, result>,
+      Variant,
+      Tuple>;
 
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = sender_value_types_t<Source, Variant, Tuple>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
-    template<template<typename...> class Variant>
-    using error_types = sender_error_types_t<Source, Variant>;
+  template <template <typename...> class Variant>
+  using error_types = sender_error_types_t<Source, Variant>;
 
-    static constexpr bool sends_done = sender_traits<Source>::sends_done;
+  static constexpr bool sends_done = sender_traits<Source>::sends_done;
 
-    template<typename Source2, typename Func2>
-    explicit type(Source2&& source, Func2&& func, Policy policy)
-    : source_((Source2&&)source)
-    , func_((Func2&&)func)
-    , policy_(std::move(policy))
-    {}
+  template <typename Source2, typename Func2>
+  explicit type(Source2&& source, Func2&& func, Policy policy)
+    : source_((Source2 &&) source)
+    , func_((Func2 &&) func)
+    , policy_(std::move(policy)) {}
 
-    template(typename Self, typename Receiver)
-        (requires
-            same_as<remove_cvref_t<Self>, type> AND
-            constructible_from<Func, member_t<Self, Func>> AND
-            receiver<Receiver> AND
-            sender_to<member_t<Self, Source>, tfx_receiver<Func, Policy, remove_cvref_t<Receiver>>>)
-    friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
-        noexcept(
-            std::is_nothrow_constructible_v<Source, member_t<Self, Source>> &&
-            std::is_nothrow_constructible_v<Func, member_t<Self, Func>> &&
-            std::is_nothrow_constructible_v<Policy, member_t<Self, Policy>> &&
-            std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>) {
-        return unifex::connect(
-            static_cast<Self&&>(self).source_,
-            tfx_receiver<Func, Policy, remove_cvref_t<Receiver>>{
-                static_cast<Self&&>(self).func_,
-                static_cast<Self&&>(self).policy_,
-                static_cast<Receiver&&>(r)});
-    }
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND constructible_from<
+          Func,
+          member_t<Self, Func>> AND receiver<Receiver> AND
+          sender_to<
+              member_t<Self, Source>,
+              tfx_receiver<
+                  Func,
+                  Policy,
+                  remove_cvref_t<
+                      Receiver>>>) friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r) noexcept(std::
+                                                                                                                          is_nothrow_constructible_v<
+                                                                                                                              Source,
+                                                                                                                              member_t<
+                                                                                                                                  Self,
+                                                                                                                                  Source>>&&
+                                                                                                                              std::is_nothrow_constructible_v<
+                                                                                                                                  Func,
+                                                                                                                                  member_t<
+                                                                                                                                      Self,
+                                                                                                                                      Func>>&&
+                                                                                                                                  std::is_nothrow_constructible_v<
+                                                                                                                                      Policy,
+                                                                                                                                      member_t<
+                                                                                                                                          Self,
+                                                                                                                                          Policy>>&&
+                                                                                                                                      std::is_nothrow_constructible_v<
+                                                                                                                                          remove_cvref_t<
+                                                                                                                                              Receiver>,
+                                                                                                                                          Receiver>) {
+    return unifex::connect(
+        static_cast<Self&&>(self).source_,
+        tfx_receiver<Func, Policy, remove_cvref_t<Receiver>>{
+            static_cast<Self&&>(self).func_,
+            static_cast<Self&&>(self).policy_,
+            static_cast<Receiver&&>(r)});
+  }
 
 private:
-    UNIFEX_NO_UNIQUE_ADDRESS Source source_;
-    UNIFEX_NO_UNIQUE_ADDRESS Func func_;
-    UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
+  UNIFEX_NO_UNIQUE_ADDRESS Source source_;
+  UNIFEX_NO_UNIQUE_ADDRESS Func func_;
+  UNIFEX_NO_UNIQUE_ADDRESS Policy policy_;
 };
 
 struct _fn {
-    template(typename Source, typename Func, typename FuncPolicy = decltype(get_execution_policy(UNIFEX_DECLVAL(Func&))))
-        (requires typed_bulk_sender<Source>)
-    auto operator()(Source&& s, Func&& f) const
-        noexcept(is_nothrow_callable_v<_fn, Source, Func, FuncPolicy>)
-        -> callable_result_t<_fn, Source, Func, FuncPolicy> {
-        return operator()((Source&&)s, (Func&&)f, get_execution_policy(f));
-    }
+  template(
+      typename Source,
+      typename Func,
+      typename FuncPolicy = decltype(get_execution_policy(
+          UNIFEX_DECLVAL(Func&))))(requires typed_bulk_sender<Source>) auto
+  operator()(Source&& s, Func&& f) const
+      noexcept(is_nothrow_callable_v<_fn, Source, Func, FuncPolicy>)
+          -> callable_result_t<_fn, Source, Func, FuncPolicy> {
+    return operator()((Source &&) s, (Func &&) f, get_execution_policy(f));
+  }
 
-    template(typename Source, typename Func, typename FuncPolicy)
-        (requires
-            typed_bulk_sender<Source> AND
-            tag_invocable<_fn, Source, Func, FuncPolicy>)
-    auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func, FuncPolicy>)
-        -> tag_invoke_result_t<_fn, Source, Func, FuncPolicy> {
-        return tag_invoke(_fn{}, (Source&&)s, (Func&&)f, (FuncPolicy&&)policy);
-    }
+  template(typename Source, typename Func, typename FuncPolicy)(
+      requires typed_bulk_sender<Source> AND
+          tag_invocable<_fn, Source, Func, FuncPolicy>) auto
+  operator()(Source&& s, Func&& f, FuncPolicy policy) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func, FuncPolicy>)
+          -> tag_invoke_result_t<_fn, Source, Func, FuncPolicy> {
+    return tag_invoke(
+        _fn{}, (Source &&) s, (Func &&) f, (FuncPolicy &&) policy);
+  }
 
-    template(typename Source, typename Func, typename FuncPolicy)
-        (requires
-            typed_bulk_sender<Source> AND
-            (!tag_invocable<_fn, Source, Func, FuncPolicy>))
-    auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
-        noexcept(
-            std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source> &&
-            std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func> &&
-            std::is_nothrow_move_constructible_v<FuncPolicy>)
-        -> tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy> {
-        return tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy>{
-            (Source&&)s, (Func&&)f, std::move(policy)
-            };
-    }
-    template <typename Func>
-    constexpr auto operator()(Func&& f) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func>)
-        -> bind_back_result_t<_fn, Func> {
-      return bind_back(*this, (Func&&)f);
-    }
-    template <typename Func, typename FuncPolicy>
-    constexpr auto operator()(Func&& f, FuncPolicy policy) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func, FuncPolicy>)
-        -> bind_back_result_t<_fn, Func, FuncPolicy> {
-      return bind_back(*this, (Func&&)f, (FuncPolicy&&)policy);
-    }
+  template(typename Source, typename Func, typename FuncPolicy)(
+      requires typed_bulk_sender<Source> AND(
+          !tag_invocable<_fn, Source, Func, FuncPolicy>)) auto
+  operator()(Source&& s, Func&& f, FuncPolicy policy) const noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>&&
+          std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func>&&
+              std::is_nothrow_move_constructible_v<FuncPolicy>)
+      -> tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy> {
+    return tfx_sender<remove_cvref_t<Source>, remove_cvref_t<Func>, FuncPolicy>{
+        (Source &&) s, (Func &&) f, std::move(policy)};
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& f) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&) f);
+  }
+  template <typename Func, typename FuncPolicy>
+  constexpr auto operator()(Func&& f, FuncPolicy policy) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func, FuncPolicy>)
+          -> bind_back_result_t<_fn, Func, FuncPolicy> {
+    return bind_back(*this, (Func &&) f, (FuncPolicy &&) policy);
+  }
 };
 
-} // namespace _bulk_transform
+}  // namespace _bulk_tfx
 
 inline constexpr _bulk_tfx::_fn bulk_transform{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -25,28 +25,27 @@
 #include <cassert>
 
 // the configured options and settings for unifex
-#define UNIFEX_VERSION_MAJOR @libunifex_VERSION_MAJOR @
-#define UNIFEX_VERSION_MINOR @libunifex_VERSION_MINOR @
+#define UNIFEX_VERSION_MAJOR @libunifex_VERSION_MAJOR@
+#define UNIFEX_VERSION_MINOR @libunifex_VERSION_MINOR@
 
 #cmakedefine01 UNIFEX_NO_MEMORY_RESOURCE
-#cmakedefine UNIFEX_MEMORY_RESOURCE_HEADER < @UNIFEX_MEMORY_RESOURCE_HEADER @>
-#cmakedefine UNIFEX_MEMORY_RESOURCE_NAMESPACE \
-    @UNIFEX_MEMORY_RESOURCE_NAMESPACE @
+#cmakedefine UNIFEX_MEMORY_RESOURCE_HEADER <@UNIFEX_MEMORY_RESOURCE_HEADER@>
+#cmakedefine UNIFEX_MEMORY_RESOURCE_NAMESPACE @UNIFEX_MEMORY_RESOURCE_NAMESPACE@
 
 #if !defined(__has_cpp_attribute)
-#  define UNIFEX_NO_UNIQUE_ADDRESS
+#define UNIFEX_NO_UNIQUE_ADDRESS
 #elif !__has_cpp_attribute(no_unique_address)
-#  define UNIFEX_NO_UNIQUE_ADDRESS
+#define UNIFEX_NO_UNIQUE_ADDRESS
 // prior to clang-10, [[no_unique_address]] leads to bad codegen
 #elif defined(__clang__) && __clang_major__ < 10
-#  define UNIFEX_NO_UNIQUE_ADDRESS
+#define UNIFEX_NO_UNIQUE_ADDRESS
 // GCC 10.3/11 introduced bug 98995, which fails to compile with no_uniq_addr.
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98995
 // For simplicity, assume anything above 9 is broken.
 #elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ > 9)
-#  define UNIFEX_NO_UNIQUE_ADDRESS
+#define UNIFEX_NO_UNIQUE_ADDRESS
 #else
-#  define UNIFEX_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#define UNIFEX_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 #if !defined(UNIFEX_NO_COROUTINES)
@@ -80,11 +79,11 @@
 #endif
 
 #if !defined(UNIFEX_NO_EPOLL)
-#  cmakedefine01 UNIFEX_NO_EPOLL
+#cmakedefine01 UNIFEX_NO_EPOLL
 #endif
 
 #if !defined(UNIFEX_NO_LIBURING)
-#  cmakedefine01 UNIFEX_NO_LIBURING
+#cmakedefine01 UNIFEX_NO_LIBURING
 #endif
 
 // UNIFEX_DECLARE_NON_DEDUCED_TYPE(type)
@@ -93,24 +92,21 @@
 // These macros work around a bug in MSVC that causes it to try to specialize
 // all found function templates for which it can successfully deduce template
 // arguments even if there are parameters that do not participate in template
-// parameter deduction for which there is no conversion possible from the
-// argument.
+// parameter deduction for which there is no conversion possible from the argument.
 //
 // This is most likely related to the core issue CWG1391 [*] which MSVC has not
 // yet implemented as of VS 2019.4.
 //
-// These macros are intended to be used in template functions, typically
-// tag_invoke() overloads, as follows.
+// These macros are intended to be used in template functions, typically tag_invoke()
+// overloads, as follows.
 //
 // Where you would normally write:
 //
 // class foo_sender {
 //    template<
 //      typename Receiver,
-//      std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int>
-//      = 0>
-//    friend auto tag_invoke(tag_t<connect>, foo_sender&& s, Receiver&& r) ->
-//    foo_operation<Receiver> {
+//      std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0>
+//    friend auto tag_invoke(tag_t<connect>, foo_sender&& s, Receiver&& r) -> foo_operation<Receiver> {
 //      return ...;
 //    }
 // };
@@ -122,8 +118,7 @@
 //     typename Receiver,
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(S, foo_sender),
-//     std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int>
-//     = 0?
+//     std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0?
 //   friend auto tag_invoke(
 //        UNIFEX_USE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //        UNIFEX_USE_NON_DEDUCED_TYPE(S, foo_sender)&& s,
@@ -133,22 +128,23 @@
 // };
 
 #if defined(_MSC_VER)
-#  define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) \
-    typename NAME, std::enable_if_t<std::is_same_v<NAME, __VA_ARGS__>, int> = 0
-#  define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) NAME
+# define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) \
+  typename NAME, \
+  std::enable_if_t<std::is_same_v<NAME, __VA_ARGS__>, int> = 0
+ # define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) NAME
 #else
-#  define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) typename NAME = __VA_ARGS__
-#  define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) __VA_ARGS__
+# define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) typename NAME = __VA_ARGS__
+# define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) __VA_ARGS__
 #endif
 
 #if !defined(UNIFEX_CXX_CONCEPTS)
-#  ifdef UNIFEX_DOXYGEN_INVOKED
-#    define UNIFEX_CXX_CONCEPTS 201800L
-#  elif defined(__cpp_concepts) && __cpp_concepts > 0
-#    define UNIFEX_CXX_CONCEPTS __cpp_concepts
-#  else
-#    define UNIFEX_CXX_CONCEPTS 0L
-#  endif
+#ifdef UNIFEX_DOXYGEN_INVOKED
+#define UNIFEX_CXX_CONCEPTS 201800L
+#elif defined(__cpp_concepts) && __cpp_concepts > 0
+#define UNIFEX_CXX_CONCEPTS __cpp_concepts
+#else
+#define UNIFEX_CXX_CONCEPTS 0L
+#endif
 #endif
 
 #if __cpp_rtti >= 199711
@@ -165,128 +161,124 @@
 #else
 #  define UNIFEX_NO_EXCEPTIONS 1
 #  define UNIFEX_TRY
-#  define UNIFEX_CATCH(...) \
-    if constexpr (true) {   \
-    } else
+#  define UNIFEX_CATCH(...) if constexpr (true) {} else
 #  define UNIFEX_RETHROW() ((void)0)
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#  define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
-#  define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
-#  define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
-#  define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
-#  define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
-#else  // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
-#  if defined(__GNUC__) || defined(__clang__)
-#    define UNIFEX_PRAGMA(X) _Pragma(#    X)
-#    define UNIFEX_DIAGNOSTIC_PUSH UNIFEX_PRAGMA(GCC diagnostic push)
-#    define UNIFEX_DIAGNOSTIC_POP UNIFEX_PRAGMA(GCC diagnostic pop)
-#    define UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
+  #define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
+  #define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
+  #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+  #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+  #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+#else // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
+  #if defined(__GNUC__) || defined(__clang__)
+    #define UNIFEX_PRAGMA(X) _Pragma(#X)
+    #define UNIFEX_DIAGNOSTIC_PUSH UNIFEX_PRAGMA(GCC diagnostic push)
+    #define UNIFEX_DIAGNOSTIC_POP UNIFEX_PRAGMA(GCC diagnostic pop)
+    #define UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
       UNIFEX_PRAGMA(GCC diagnostic ignored "-Wpragmas")
-#    define UNIFEX_DIAGNOSTIC_IGNORE(X)                         \
-      UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS                          \
+    #define UNIFEX_DIAGNOSTIC_IGNORE(X) \
+      UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
       UNIFEX_PRAGMA(GCC diagnostic ignored "-Wunknown-pragmas") \
       UNIFEX_PRAGMA(GCC diagnostic ignored X)
-#    define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME    \
+    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wunknown-warning-option") \
       UNIFEX_DIAGNOSTIC_IGNORE("-Winit-list-lifetime")
-#    define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL \
+    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wfloat-equal")
-#    define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT \
+    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wc++2a-compat")
-#  else
-#    define UNIFEX_DIAGNOSTIC_PUSH
-#    define UNIFEX_DIAGNOSTIC_POP
-#    define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
-#    define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
-#    define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
-#  endif
-#endif  // MSVC/Generic configuration switch
+  #else
+    #define UNIFEX_DIAGNOSTIC_PUSH
+    #define UNIFEX_DIAGNOSTIC_POP
+    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+  #endif
+#endif // MSVC/Generic configuration switch
 
 #if defined(__GNUC__) || defined(__clang__)
-#  define UNIFEX_ALWAYS_INLINE         \
-    __attribute__((__always_inline__)) \
-    __attribute__((__visibility__("hidden"))) inline
+  #define UNIFEX_ALWAYS_INLINE \
+    __attribute__((__always_inline__)) __attribute__((__visibility__("hidden"))) inline
 #elif defined(_MSC_VER)
-#  define UNIFEX_ALWAYS_INLINE __forceinline
+  #define UNIFEX_ALWAYS_INLINE __forceinline
 #else
-#  define UNIFEX_ALWAYS_INLINE inline
+  #define UNIFEX_ALWAYS_INLINE inline
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-#  define UNIFEX_NO_INLINE __attribute__((__noinline__))
+  #define UNIFEX_NO_INLINE __attribute__((__noinline__))
 #elif defined(_MSC_VER)
-#  define UNIFEX_NO_INLINE __declspec(noinline)
+  #define UNIFEX_NO_INLINE __declspec(noinline)
 #else
-#  define UNIFEX_NO_INLINE
+  #define UNIFEX_NO_INLINE
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-#  define UNIFEX_ASSUME_UNREACHABLE __builtin_unreachable()
+  #define UNIFEX_ASSUME_UNREACHABLE __builtin_unreachable()
 #elif defined(_MSC_VER)
-#  define UNIFEX_ASSUME_UNREACHABLE __assume(0)
+  #define UNIFEX_ASSUME_UNREACHABLE __assume(0)
 #else
-#  define UNIFEX_ASSUME_UNREACHABLE std::terminate()
+  #define UNIFEX_ASSUME_UNREACHABLE std::terminate()
 #endif
 
 #if defined(__clang__)
-#  define UNIFEX_IS_SAME(...) __is_same(__VA_ARGS__)
+#define UNIFEX_IS_SAME(...) __is_same(__VA_ARGS__)
 #elif defined(__GNUC__) && __GNUC__ >= 6
-#  define UNIFEX_IS_SAME(...) __is_same_as(__VA_ARGS__)
+#define UNIFEX_IS_SAME(...) __is_same_as(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#  define UNIFEX_IS_SAME(...) std::is_same_v<__VA_ARGS__>
+#define UNIFEX_IS_SAME(...) std::is_same_v<__VA_ARGS__>
 #else
-#  define UNIFEX_IS_SAME(...) std::is_same<__VA_ARGS__>::value
+#define UNIFEX_IS_SAME(...) std::is_same<__VA_ARGS__>::value
 #endif
 
 #if defined(__GNUC__) || defined(_MSC_VER)
-#  define UNIFEX_IS_BASE_OF(...) __is_base_of(__VA_ARGS__)
+#define UNIFEX_IS_BASE_OF(...) __is_base_of(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#  define UNIFEX_IS_BASE_OF(...) std::is_base_of_v<__VA_ARGS__>
+#define UNIFEX_IS_BASE_OF(...) std::is_base_of_v<__VA_ARGS__>
 #else
-#  define UNIFEX_IS_BASE_OF(...) std::is_base_of<__VA_ARGS__>::value
+#define UNIFEX_IS_BASE_OF(...) std::is_base_of<__VA_ARGS__>::value
 #endif
 
 #if defined(__clang__) || defined(_MSC_VER) || \
-    (defined(__GNUC__) && __GNUC__ >= 8)
-#  define UNIFEX_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
+  (defined(__GNUC__) && __GNUC__ >= 8)
+#define UNIFEX_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#  define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible_v<__VA_ARGS__>
+#define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible_v<__VA_ARGS__>
 #else
-#  define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible<__VA_ARGS__>::value
+#define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible<__VA_ARGS__>::value
 #endif
 
-#define UNIFEX_DECLVAL(...) static_cast<__VA_ARGS__ (*)() noexcept>(nullptr)()
+#define UNIFEX_DECLVAL(...) static_cast<__VA_ARGS__(*)()noexcept>(nullptr)()
 
 #ifndef UNIFEX_ASSERT
-#  define UNIFEX_ASSERT assert
+# define UNIFEX_ASSERT assert
 #endif
 
 #if defined(__clang__)
-// Clang's optimizer interacts badly with its address sanitizer. Certain
-// functions must have optimizations disabled in order to avoid triggering
-// stack-use-after-scope-exit errors.
-#  if __has_feature(address_sanitizer)
-#    define UNIFEX_CLANG_DISABLE_OPTIMIZATION __attribute__((__optnone__))
-#  else
-#    define UNIFEX_CLANG_DISABLE_OPTIMIZATION
-#  endif
+  // Clang's optimizer interacts badly with its address sanitizer. Certain
+  // functions must have optimizations disabled in order to avoid triggering
+  // stack-use-after-scope-exit errors.
+  #if __has_feature(address_sanitizer)
+    #define UNIFEX_CLANG_DISABLE_OPTIMIZATION __attribute__((__optnone__))
+  #else
+    #define UNIFEX_CLANG_DISABLE_OPTIMIZATION
+  #endif
 #else
-#  define UNIFEX_CLANG_DISABLE_OPTIMIZATION
+  #define UNIFEX_CLANG_DISABLE_OPTIMIZATION
 #endif
 
 #if !defined(UNIFEX_DEPRECATED_HEADER)
-#  ifdef __GNUC__
-#    define UNIFEX_PRAGMA(X) _Pragma(#    X)
-#    define UNIFEX_DEPRECATED_HEADER(MSG) UNIFEX_PRAGMA(GCC warning MSG)
-#  elif defined(_MSC_VER)
-#    define UNIFEX_STRINGIZE_(MSG) #    MSG
-#    define UNIFEX_STRINGIZE(MSG) UNIFEX_STRINGIZE_(MSG)
-#    define UNIFEX_DEPRECATED_HEADER(MSG) \
-      __pragma(message(__FILE__           \
-                       "(" UNIFEX_STRINGIZE(__LINE__) ") : Warning: " MSG))
-#  endif
+  #ifdef __GNUC__
+    #define UNIFEX_PRAGMA(X) _Pragma(#X)
+    #define UNIFEX_DEPRECATED_HEADER(MSG) UNIFEX_PRAGMA(GCC warning MSG)
+  #elif defined(_MSC_VER)
+    #define UNIFEX_STRINGIZE_(MSG) #MSG
+    #define UNIFEX_STRINGIZE(MSG) UNIFEX_STRINGIZE_(MSG)
+    #define UNIFEX_DEPRECATED_HEADER(MSG) \
+        __pragma(message(__FILE__ "(" UNIFEX_STRINGIZE(__LINE__) ") : Warning: " MSG))
+  #endif
 #else
-#  define UNIFEX_DEPRECATED_HEADER(MSG) /**/
+  #define UNIFEX_DEPRECATED_HEADER(MSG) /**/
 #endif

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -25,27 +25,28 @@
 #include <cassert>
 
 // the configured options and settings for unifex
-#define UNIFEX_VERSION_MAJOR @libunifex_VERSION_MAJOR@
-#define UNIFEX_VERSION_MINOR @libunifex_VERSION_MINOR@
+#define UNIFEX_VERSION_MAJOR @libunifex_VERSION_MAJOR @
+#define UNIFEX_VERSION_MINOR @libunifex_VERSION_MINOR @
 
 #cmakedefine01 UNIFEX_NO_MEMORY_RESOURCE
-#cmakedefine UNIFEX_MEMORY_RESOURCE_HEADER <@UNIFEX_MEMORY_RESOURCE_HEADER@>
-#cmakedefine UNIFEX_MEMORY_RESOURCE_NAMESPACE @UNIFEX_MEMORY_RESOURCE_NAMESPACE@
+#cmakedefine UNIFEX_MEMORY_RESOURCE_HEADER < @UNIFEX_MEMORY_RESOURCE_HEADER @>
+#cmakedefine UNIFEX_MEMORY_RESOURCE_NAMESPACE \
+    @UNIFEX_MEMORY_RESOURCE_NAMESPACE @
 
 #if !defined(__has_cpp_attribute)
-#define UNIFEX_NO_UNIQUE_ADDRESS
+#  define UNIFEX_NO_UNIQUE_ADDRESS
 #elif !__has_cpp_attribute(no_unique_address)
-#define UNIFEX_NO_UNIQUE_ADDRESS
+#  define UNIFEX_NO_UNIQUE_ADDRESS
 // prior to clang-10, [[no_unique_address]] leads to bad codegen
 #elif defined(__clang__) && __clang_major__ < 10
-#define UNIFEX_NO_UNIQUE_ADDRESS
+#  define UNIFEX_NO_UNIQUE_ADDRESS
 // GCC 10.3/11 introduced bug 98995, which fails to compile with no_uniq_addr.
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98995
 // For simplicity, assume anything above 9 is broken.
 #elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ > 9)
-#define UNIFEX_NO_UNIQUE_ADDRESS
+#  define UNIFEX_NO_UNIQUE_ADDRESS
 #else
-#define UNIFEX_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#  define UNIFEX_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 #if !defined(UNIFEX_NO_COROUTINES)
@@ -79,11 +80,11 @@
 #endif
 
 #if !defined(UNIFEX_NO_EPOLL)
-#cmakedefine01 UNIFEX_NO_EPOLL
+#  cmakedefine01 UNIFEX_NO_EPOLL
 #endif
 
 #if !defined(UNIFEX_NO_LIBURING)
-#cmakedefine01 UNIFEX_NO_LIBURING
+#  cmakedefine01 UNIFEX_NO_LIBURING
 #endif
 
 // UNIFEX_DECLARE_NON_DEDUCED_TYPE(type)
@@ -92,21 +93,24 @@
 // These macros work around a bug in MSVC that causes it to try to specialize
 // all found function templates for which it can successfully deduce template
 // arguments even if there are parameters that do not participate in template
-// parameter deduction for which there is no conversion possible from the argument.
+// parameter deduction for which there is no conversion possible from the
+// argument.
 //
 // This is most likely related to the core issue CWG1391 [*] which MSVC has not
 // yet implemented as of VS 2019.4.
 //
-// These macros are intended to be used in template functions, typically tag_invoke()
-// overloads, as follows.
+// These macros are intended to be used in template functions, typically
+// tag_invoke() overloads, as follows.
 //
 // Where you would normally write:
 //
 // class foo_sender {
 //    template<
 //      typename Receiver,
-//      std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0>
-//    friend auto tag_invoke(tag_t<connect>, foo_sender&& s, Receiver&& r) -> foo_operation<Receiver> {
+//      std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int>
+//      = 0>
+//    friend auto tag_invoke(tag_t<connect>, foo_sender&& s, Receiver&& r) ->
+//    foo_operation<Receiver> {
 //      return ...;
 //    }
 // };
@@ -118,7 +122,8 @@
 //     typename Receiver,
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(S, foo_sender),
-//     std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0?
+//     std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int>
+//     = 0?
 //   friend auto tag_invoke(
 //        UNIFEX_USE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //        UNIFEX_USE_NON_DEDUCED_TYPE(S, foo_sender)&& s,
@@ -128,23 +133,22 @@
 // };
 
 #if defined(_MSC_VER)
-# define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) \
-  typename NAME, \
-  std::enable_if_t<std::is_same_v<NAME, __VA_ARGS__>, int> = 0
- # define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) NAME
+#  define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) \
+    typename NAME, std::enable_if_t<std::is_same_v<NAME, __VA_ARGS__>, int> = 0
+#  define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) NAME
 #else
-# define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) typename NAME = __VA_ARGS__
-# define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) __VA_ARGS__
+#  define UNIFEX_DECLARE_NON_DEDUCED_TYPE(NAME, ...) typename NAME = __VA_ARGS__
+#  define UNIFEX_USE_NON_DEDUCED_TYPE(NAME, ...) __VA_ARGS__
 #endif
 
 #if !defined(UNIFEX_CXX_CONCEPTS)
-#ifdef UNIFEX_DOXYGEN_INVOKED
-#define UNIFEX_CXX_CONCEPTS 201800L
-#elif defined(__cpp_concepts) && __cpp_concepts > 0
-#define UNIFEX_CXX_CONCEPTS __cpp_concepts
-#else
-#define UNIFEX_CXX_CONCEPTS 0L
-#endif
+#  ifdef UNIFEX_DOXYGEN_INVOKED
+#    define UNIFEX_CXX_CONCEPTS 201800L
+#  elif defined(__cpp_concepts) && __cpp_concepts > 0
+#    define UNIFEX_CXX_CONCEPTS __cpp_concepts
+#  else
+#    define UNIFEX_CXX_CONCEPTS 0L
+#  endif
 #endif
 
 #if __cpp_rtti >= 199711
@@ -161,124 +165,128 @@
 #else
 #  define UNIFEX_NO_EXCEPTIONS 1
 #  define UNIFEX_TRY
-#  define UNIFEX_CATCH(...) if constexpr (true) {} else
+#  define UNIFEX_CATCH(...) \
+    if constexpr (true) {   \
+    } else
 #  define UNIFEX_RETHROW() ((void)0)
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-  #define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
-  #define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
-  #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
-  #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
-  #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
-#else // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
-  #if defined(__GNUC__) || defined(__clang__)
-    #define UNIFEX_PRAGMA(X) _Pragma(#X)
-    #define UNIFEX_DIAGNOSTIC_PUSH UNIFEX_PRAGMA(GCC diagnostic push)
-    #define UNIFEX_DIAGNOSTIC_POP UNIFEX_PRAGMA(GCC diagnostic pop)
-    #define UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
+#  define UNIFEX_DIAGNOSTIC_PUSH __pragma(warning(push))
+#  define UNIFEX_DIAGNOSTIC_POP __pragma(warning(pop))
+#  define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+#  define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+#  define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+#else  // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
+#  if defined(__GNUC__) || defined(__clang__)
+#    define UNIFEX_PRAGMA(X) _Pragma(#    X)
+#    define UNIFEX_DIAGNOSTIC_PUSH UNIFEX_PRAGMA(GCC diagnostic push)
+#    define UNIFEX_DIAGNOSTIC_POP UNIFEX_PRAGMA(GCC diagnostic pop)
+#    define UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
       UNIFEX_PRAGMA(GCC diagnostic ignored "-Wpragmas")
-    #define UNIFEX_DIAGNOSTIC_IGNORE(X) \
-      UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS \
+#    define UNIFEX_DIAGNOSTIC_IGNORE(X)                         \
+      UNIFEX_DIAGNOSTIC_IGNORE_PRAGMAS                          \
       UNIFEX_PRAGMA(GCC diagnostic ignored "-Wunknown-pragmas") \
       UNIFEX_PRAGMA(GCC diagnostic ignored X)
-    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME \
+#    define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME    \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wunknown-warning-option") \
       UNIFEX_DIAGNOSTIC_IGNORE("-Winit-list-lifetime")
-    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL \
+#    define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wfloat-equal")
-    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT \
+#    define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT \
       UNIFEX_DIAGNOSTIC_IGNORE("-Wc++2a-compat")
-  #else
-    #define UNIFEX_DIAGNOSTIC_PUSH
-    #define UNIFEX_DIAGNOSTIC_POP
-    #define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
-    #define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
-    #define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
-  #endif
-#endif // MSVC/Generic configuration switch
+#  else
+#    define UNIFEX_DIAGNOSTIC_PUSH
+#    define UNIFEX_DIAGNOSTIC_POP
+#    define UNIFEX_DIAGNOSTIC_IGNORE_INIT_LIST_LIFETIME
+#    define UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+#    define UNIFEX_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+#  endif
+#endif  // MSVC/Generic configuration switch
 
 #if defined(__GNUC__) || defined(__clang__)
-  #define UNIFEX_ALWAYS_INLINE \
-    __attribute__((__always_inline__)) __attribute__((__visibility__("hidden"))) inline
+#  define UNIFEX_ALWAYS_INLINE         \
+    __attribute__((__always_inline__)) \
+    __attribute__((__visibility__("hidden"))) inline
 #elif defined(_MSC_VER)
-  #define UNIFEX_ALWAYS_INLINE __forceinline
+#  define UNIFEX_ALWAYS_INLINE __forceinline
 #else
-  #define UNIFEX_ALWAYS_INLINE inline
+#  define UNIFEX_ALWAYS_INLINE inline
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-  #define UNIFEX_NO_INLINE __attribute__((__noinline__))
+#  define UNIFEX_NO_INLINE __attribute__((__noinline__))
 #elif defined(_MSC_VER)
-  #define UNIFEX_NO_INLINE __declspec(noinline)
+#  define UNIFEX_NO_INLINE __declspec(noinline)
 #else
-  #define UNIFEX_NO_INLINE
+#  define UNIFEX_NO_INLINE
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-  #define UNIFEX_ASSUME_UNREACHABLE __builtin_unreachable()
+#  define UNIFEX_ASSUME_UNREACHABLE __builtin_unreachable()
 #elif defined(_MSC_VER)
-  #define UNIFEX_ASSUME_UNREACHABLE __assume(0)
+#  define UNIFEX_ASSUME_UNREACHABLE __assume(0)
 #else
-  #define UNIFEX_ASSUME_UNREACHABLE std::terminate()
+#  define UNIFEX_ASSUME_UNREACHABLE std::terminate()
 #endif
 
 #if defined(__clang__)
-#define UNIFEX_IS_SAME(...) __is_same(__VA_ARGS__)
+#  define UNIFEX_IS_SAME(...) __is_same(__VA_ARGS__)
 #elif defined(__GNUC__) && __GNUC__ >= 6
-#define UNIFEX_IS_SAME(...) __is_same_as(__VA_ARGS__)
+#  define UNIFEX_IS_SAME(...) __is_same_as(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#define UNIFEX_IS_SAME(...) std::is_same_v<__VA_ARGS__>
+#  define UNIFEX_IS_SAME(...) std::is_same_v<__VA_ARGS__>
 #else
-#define UNIFEX_IS_SAME(...) std::is_same<__VA_ARGS__>::value
+#  define UNIFEX_IS_SAME(...) std::is_same<__VA_ARGS__>::value
 #endif
 
 #if defined(__GNUC__) || defined(_MSC_VER)
-#define UNIFEX_IS_BASE_OF(...) __is_base_of(__VA_ARGS__)
+#  define UNIFEX_IS_BASE_OF(...) __is_base_of(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#define UNIFEX_IS_BASE_OF(...) std::is_base_of_v<__VA_ARGS__>
+#  define UNIFEX_IS_BASE_OF(...) std::is_base_of_v<__VA_ARGS__>
 #else
-#define UNIFEX_IS_BASE_OF(...) std::is_base_of<__VA_ARGS__>::value
+#  define UNIFEX_IS_BASE_OF(...) std::is_base_of<__VA_ARGS__>::value
 #endif
 
 #if defined(__clang__) || defined(_MSC_VER) || \
-  (defined(__GNUC__) && __GNUC__ >= 8)
-#define UNIFEX_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
+    (defined(__GNUC__) && __GNUC__ >= 8)
+#  define UNIFEX_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
 #elif UNIFEX_CXX_TRAIT_VARIABLE_TEMPLATES
-#define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible_v<__VA_ARGS__>
+#  define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible_v<__VA_ARGS__>
 #else
-#define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible<__VA_ARGS__>::value
+#  define UNIFEX_IS_CONSTRUCTIBLE(...) std::is_constructible<__VA_ARGS__>::value
 #endif
 
-#define UNIFEX_DECLVAL(...) static_cast<__VA_ARGS__(*)()noexcept>(nullptr)()
+#define UNIFEX_DECLVAL(...) static_cast<__VA_ARGS__ (*)() noexcept>(nullptr)()
 
 #ifndef UNIFEX_ASSERT
-# define UNIFEX_ASSERT assert
+#  define UNIFEX_ASSERT assert
 #endif
 
 #if defined(__clang__)
-  // Clang's optimizer interacts badly with its address sanitizer. Certain
-  // functions must have optimizations disabled in order to avoid triggering
-  // stack-use-after-scope-exit errors.
-  #if __has_feature(address_sanitizer)
-    #define UNIFEX_CLANG_DISABLE_OPTIMIZATION __attribute__((__optnone__))
-  #else
-    #define UNIFEX_CLANG_DISABLE_OPTIMIZATION
-  #endif
+// Clang's optimizer interacts badly with its address sanitizer. Certain
+// functions must have optimizations disabled in order to avoid triggering
+// stack-use-after-scope-exit errors.
+#  if __has_feature(address_sanitizer)
+#    define UNIFEX_CLANG_DISABLE_OPTIMIZATION __attribute__((__optnone__))
+#  else
+#    define UNIFEX_CLANG_DISABLE_OPTIMIZATION
+#  endif
 #else
-  #define UNIFEX_CLANG_DISABLE_OPTIMIZATION
+#  define UNIFEX_CLANG_DISABLE_OPTIMIZATION
 #endif
 
 #if !defined(UNIFEX_DEPRECATED_HEADER)
-  #ifdef __GNUC__
-    #define UNIFEX_PRAGMA(X) _Pragma(#X)
-    #define UNIFEX_DEPRECATED_HEADER(MSG) UNIFEX_PRAGMA(GCC warning MSG)
-  #elif defined(_MSC_VER)
-    #define UNIFEX_STRINGIZE_(MSG) #MSG
-    #define UNIFEX_STRINGIZE(MSG) UNIFEX_STRINGIZE_(MSG)
-    #define UNIFEX_DEPRECATED_HEADER(MSG) \
-        __pragma(message(__FILE__ "(" UNIFEX_STRINGIZE(__LINE__) ") : Warning: " MSG))
-  #endif
+#  ifdef __GNUC__
+#    define UNIFEX_PRAGMA(X) _Pragma(#    X)
+#    define UNIFEX_DEPRECATED_HEADER(MSG) UNIFEX_PRAGMA(GCC warning MSG)
+#  elif defined(_MSC_VER)
+#    define UNIFEX_STRINGIZE_(MSG) #    MSG
+#    define UNIFEX_STRINGIZE(MSG) UNIFEX_STRINGIZE_(MSG)
+#    define UNIFEX_DEPRECATED_HEADER(MSG) \
+      __pragma(message(__FILE__           \
+                       "(" UNIFEX_STRINGIZE(__LINE__) ") : Warning: " MSG))
+#  endif
 #else
-  #define UNIFEX_DEPRECATED_HEADER(MSG) /**/
+#  define UNIFEX_DEPRECATED_HEADER(MSG) /**/
 #endif

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -17,15 +17,15 @@
 
 #include <unifex/async_trace.hpp>
 #include <unifex/await_transform.hpp>
-#include <unifex/coroutine_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/receiver_concepts.hpp>
 #include <unifex/coroutine.hpp>
+#include <unifex/coroutine_concepts.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/utility.hpp>
 
 #if UNIFEX_NO_COROUTINES
-# error "Coroutine support is required to use <unifex/connect_awaitable.hpp>"
+#  error "Coroutine support is required to use <unifex/connect_awaitable.hpp>"
 #endif
 
 #include <cassert>
@@ -37,39 +37,29 @@
 namespace unifex {
 namespace _await {
 
-template<typename Receiver>
+template <typename Receiver>
 struct _sender_task {
   class type;
 };
-template<typename Receiver>
+template <typename Receiver>
 using sender_task = typename _sender_task<Receiver>::type;
 
-template<typename Receiver>
+template <typename Receiver>
 class _sender_task<Receiver>::type {
 public:
   struct promise_type {
     template <typename Awaitable>
-    explicit promise_type(Awaitable&, Receiver& r) noexcept
-        : receiver_(r)
-    {}
+    explicit promise_type(Awaitable&, Receiver& r) noexcept : receiver_(r) {}
 
     type get_return_object() noexcept {
-      return type{
-          coro::coroutine_handle<promise_type>::from_promise(
-              *this)};
+      return type{coro::coroutine_handle<promise_type>::from_promise(*this)};
     }
-    coro::suspend_always initial_suspend() noexcept {
-      return {};
-    }
+    coro::suspend_always initial_suspend() noexcept { return {}; }
     [[noreturn]] coro::suspend_always final_suspend() noexcept {
       std::terminate();
     }
-    [[noreturn]] void unhandled_exception() noexcept {
-      std::terminate();
-    }
-    [[noreturn]] void return_void() noexcept {
-      std::terminate();
-    }
+    [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
+    [[noreturn]] void return_void() noexcept { std::terminate(); }
 
     coro::coroutine_handle<> unhandled_done() noexcept {
       unifex::set_done(std::move(receiver_));
@@ -80,35 +70,30 @@ public:
     auto yield_value(Func&& func) noexcept {
       struct awaiter {
         Func&& func_;
-        bool await_ready() noexcept {
-          return false;
-        }
+        bool await_ready() noexcept { return false; }
         void await_suspend(coro::coroutine_handle<promise_type>) {
           ((Func &&) func_)();
         }
-        [[noreturn]] void await_resume() noexcept {
-          std::terminate();
-        }
+        [[noreturn]] void await_resume() noexcept { std::terminate(); }
       };
       return awaiter{(Func &&) func};
     }
 
     template <typename Value>
     auto await_transform(Value&& value) -> decltype(auto) {
-      return unifex::await_transform(*this, (Value&&) value);
+      return unifex::await_transform(*this, (Value &&) value);
     }
 
     template <typename Func>
     friend void
     tag_invoke(tag_t<visit_continuations>, const promise_type& p, Func&& func) {
-      visit_continuations(p.receiver_, (Func&&) func);
+      visit_continuations(p.receiver_, (Func &&) func);
     }
 
-    template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND
-                is_callable_v<CPO, const Receiver&>)
-    friend auto tag_invoke(CPO cpo, const promise_type& p)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+    template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+        CPO cpo,
+        const promise_type&
+            p) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
       return cpo(std::as_const(p.receiver_));
     }
@@ -118,178 +103,182 @@ public:
 
   coro::coroutine_handle<promise_type> coro_;
 
-  explicit type(
-      coro::coroutine_handle<promise_type> coro) noexcept
-      : coro_(coro) {}
+  explicit type(coro::coroutine_handle<promise_type> coro) noexcept
+    : coro_(coro) {}
 
-  type(type&& other) noexcept
-      : coro_(std::exchange(other.coro_, {})) {}
+  type(type&& other) noexcept : coro_(std::exchange(other.coro_, {})) {}
 
   ~type() {
     if (coro_)
       coro_.destroy();
   }
 
-  void start() & noexcept {
-    coro_.resume();
-  }
+  void start() & noexcept { coro_.resume(); }
 };
 
-} // namespace _await
+}  // namespace _await
 
 namespace _await_cpo {
-  inline const struct _fn {
-  private:
-    template <typename Awaitable>
-    using awaitable_single_value_result_t =
-        non_void_t<wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>>;
+inline const struct _fn {
+private:
+  template <typename Awaitable>
+  using awaitable_single_value_result_t =
+      non_void_t<wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>>;
 
-    struct _comma_hack {
-      template <typename T>
-      friend T&& operator,(T&& t, _comma_hack) noexcept {
-        return (T&&) t;
-      }
-      operator unit() const noexcept { return {}; }
+  struct _comma_hack {
+    template <typename T>
+    friend T&& operator,(T&& t, _comma_hack) noexcept {
+      return (T &&) t;
+    }
+    operator unit() const noexcept { return {}; }
+  };
+
+  template <typename Awaitable, typename Receiver>
+  static auto connect_impl(Awaitable awaitable, Receiver receiver)
+      -> _await::sender_task<Receiver> {
+#if !UNIFEX_NO_EXCEPTIONS
+    std::exception_ptr ex;
+    try {
+#endif  // !UNIFEX_NO_EXCEPTIONS
+
+      // The _sender_task's promise type has an await_transform that passes the
+      // awaitable through unifex::await_transform. So take that into
+      // consideration when computing the result type:
+      using promise_type = typename _await::sender_task<Receiver>::promise_type;
+      using awaitable_type = callable_result_t<
+          tag_t<unifex::await_transform>,
+          promise_type&,
+          Awaitable>;
+      using result_type = awaitable_single_value_result_t<awaitable_type>;
+
+      // This is a bit mind bending control-flow wise.
+      // We are first evaluating the co_await expression.
+      // Then the result of that is passed into unifex::invoke
+      // which curries a reference to the result into another
+      // lambda which is then returned to 'co_yield'.
+      // The 'co_yield' expression then invokes this lambda
+      // after the coroutine is suspended so that it is safe
+      // for the receiver to destroy the coroutine.
+      co_yield [&](result_type&& result) {
+        return [&] {
+          if constexpr (std::is_void_v<await_result_t<awaitable_type>>) {
+            unifex::set_value(std::move(receiver));
+          } else {
+            unifex::set_value(
+                std::move(receiver), static_cast<result_type&&>(result));
+          }
+        };
+        // The _comma_hack here makes this well-formed when the co_await
+        // expression has type void. This could potentially run into trouble
+        // if the type of the co_await expression itself overloads operator
+        // comma, but that's pretty unlikely.
+      }((co_await (Awaitable &&) awaitable, _comma_hack{}));
+#if !UNIFEX_NO_EXCEPTIONS
+    } catch (...) {
+      ex = std::current_exception();
+    }
+    co_yield [&] {
+      unifex::set_error(std::move(receiver), std::move(ex));
     };
+#endif  // !UNIFEX_NO_EXCEPTIONS
+  }
 
-    template <typename Awaitable, typename Receiver>
-    static auto connect_impl(Awaitable awaitable, Receiver receiver)
-        -> _await::sender_task<Receiver> {
-#if !UNIFEX_NO_EXCEPTIONS
-      std::exception_ptr ex;
-      try {
-#endif // !UNIFEX_NO_EXCEPTIONS
-
-        // The _sender_task's promise type has an await_transform that passes the
-        // awaitable through unifex::await_transform. So take that into consideration
-        // when computing the result type:
-        using promise_type = typename _await::sender_task<Receiver>::promise_type;
-        using awaitable_type =
-            callable_result_t<tag_t<unifex::await_transform>, promise_type&, Awaitable>;
-        using result_type = awaitable_single_value_result_t<awaitable_type>;
-
-        // This is a bit mind bending control-flow wise.
-        // We are first evaluating the co_await expression.
-        // Then the result of that is passed into unifex::invoke
-        // which curries a reference to the result into another
-        // lambda which is then returned to 'co_yield'.
-        // The 'co_yield' expression then invokes this lambda
-        // after the coroutine is suspended so that it is safe
-        // for the receiver to destroy the coroutine.
-        co_yield [&](result_type&& result) {
-              return [&] {
-                if constexpr (std::is_void_v<await_result_t<awaitable_type>>) {
-                  unifex::set_value(std::move(receiver));
-                } else {
-                  unifex::set_value(std::move(receiver), static_cast<result_type&&>(result));
-                }
-              };
-            // The _comma_hack here makes this well-formed when the co_await
-            // expression has type void. This could potentially run into trouble
-            // if the type of the co_await expression itself overloads operator
-            // comma, but that's pretty unlikely.
-            }((co_await (Awaitable &&) awaitable, _comma_hack{}));
-#if !UNIFEX_NO_EXCEPTIONS
-      } catch (...) {
-        ex = std::current_exception();
-      }
-      co_yield[&] {
-        unifex::set_error(std::move(receiver), std::move(ex));
-      };
-#endif // !UNIFEX_NO_EXCEPTIONS
-    }
-
-  public:
-    template <typename Awaitable, typename Receiver>
-    auto operator()(Awaitable&& awaitable, Receiver&& receiver) const
+public:
+  template <typename Awaitable, typename Receiver>
+  auto operator()(Awaitable&& awaitable, Receiver&& receiver) const
       -> _await::sender_task<remove_cvref_t<Receiver>> {
-      return connect_impl((Awaitable&&) awaitable, (Receiver&&) receiver);
-    }
-  } connect_awaitable{};
-} // namespace _await_cpo
+    return connect_impl((Awaitable &&) awaitable, (Receiver &&) receiver);
+  }
+} connect_awaitable{};
+}  // namespace _await_cpo
 
 using _await_cpo::connect_awaitable;
 
 // as_sender, for adapting an awaitable to be a typed sender
 namespace _as_sender {
-  template <typename Awaitable, typename Result = await_result_t<Awaitable>>
-  struct _sndr {
-    struct type {
-      template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
-      using value_types = Variant<Tuple<Result>>;
+template <typename Awaitable, typename Result = await_result_t<Awaitable>>
+struct _sndr {
+  struct type {
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = Variant<Tuple<Result>>;
 
-      template <template <typename...> class Variant>
-      using error_types = Variant<std::exception_ptr>;
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
 
-      static constexpr bool sends_done = true;
+    static constexpr bool sends_done = true;
 
-      type(Awaitable awaitable)
-        : awaitable_((Awaitable&&) awaitable)
-      {}
+    type(Awaitable awaitable) : awaitable_((Awaitable &&) awaitable) {}
 
-      template (typename Receiver)
-        (requires receiver_of<Receiver, Result>)
-      friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-        return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
-      }
-
-      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
-        return unifex::blocking(t.awaitable_);
-      }
-    private:
-      Awaitable awaitable_;
-    };
-  };
-
-  template <typename Awaitable>
-  struct _sndr<Awaitable, void> {
-    struct type {
-      template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
-      using value_types = Variant<Tuple<>>;
-
-      template <template <typename...> class Variant>
-      using error_types = Variant<std::exception_ptr>;
-
-      static constexpr bool sends_done = true;
-
-      explicit type(Awaitable awaitable)
-          noexcept(std::is_nothrow_move_constructible_v<Awaitable>)
-        : awaitable_((Awaitable&&) awaitable)
-      {}
-
-      template (typename Receiver)
-        (requires receiver_of<Receiver>)
-      friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-        return unifex::connect_awaitable(((type&&) t).awaitable_, (Receiver&&) r);
-      }
-
-      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
-        return unifex::blocking(t.awaitable_);
-      }
-    private:
-      Awaitable awaitable_;
-    };
-  };
-
-  template <typename Awaitable>
-  using _sender = typename _sndr<Awaitable>::type;
-
-  struct _fn {
-    template (typename Awaitable)
-      (requires detail::_awaitable<Awaitable>)
-    _sender<remove_cvref_t<Awaitable>> operator()(Awaitable&& awaitable) const {
-      return _sender<remove_cvref_t<Awaitable>>{(Awaitable&&) awaitable};
+    template(typename Receiver)(requires receiver_of<Receiver, Result>) friend auto tag_invoke(
+        tag_t<unifex::connect>, type&& t, Receiver&& r) {
+      return unifex::connect_awaitable(
+          ((type &&) t).awaitable_, (Receiver &&) r);
     }
+
+    friend constexpr auto
+    tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
+      return unifex::blocking(t.awaitable_);
+    }
+
+  private:
+    Awaitable awaitable_;
   };
-} // namespace _as_sender
+};
+
+template <typename Awaitable>
+struct _sndr<Awaitable, void> {
+  struct type {
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = true;
+
+    explicit type(Awaitable awaitable) noexcept(
+        std::is_nothrow_move_constructible_v<Awaitable>)
+      : awaitable_((Awaitable &&) awaitable) {}
+
+    template(typename Receiver)(requires receiver_of<Receiver>) friend auto tag_invoke(
+        tag_t<unifex::connect>, type&& t, Receiver&& r) {
+      return unifex::connect_awaitable(
+          ((type &&) t).awaitable_, (Receiver &&) r);
+    }
+
+    friend constexpr auto
+    tag_invoke(tag_t<unifex::blocking>, const type& t) noexcept {
+      return unifex::blocking(t.awaitable_);
+    }
+
+  private:
+    Awaitable awaitable_;
+  };
+};
+
+template <typename Awaitable>
+using _sender = typename _sndr<Awaitable>::type;
+
+struct _fn {
+  template(typename Awaitable)(
+      requires detail::_awaitable<Awaitable>) _sender<remove_cvref_t<Awaitable>>
+  operator()(Awaitable&& awaitable) const {
+    return _sender<remove_cvref_t<Awaitable>>{(Awaitable &&) awaitable};
+  }
+};
+}  // namespace _as_sender
 
 // Transforms an awaitable into a typed sender:
-inline constexpr _as_sender::_fn as_sender {};
+inline constexpr _as_sender::_fn as_sender{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/continuations.hpp
+++ b/include/unifex/continuations.hpp
@@ -17,9 +17,9 @@
 
 #include <unifex/coroutine.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/type_traits.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_index.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <functional>
 
@@ -28,46 +28,39 @@
 namespace unifex {
 
 namespace _visit_continuations_cpo {
-  inline const struct _fn {
+inline const struct _fn {
 #if !UNIFEX_NO_COROUTINES
-    template(typename Promise, typename Func)
-        (requires (!same_as<Promise, void>) AND callable<_fn, Promise&, Func>)
-    friend void tag_invoke(
-        _fn cpo,
-        coro::coroutine_handle<Promise> h,
-        Func&& func) noexcept(is_nothrow_callable_v<_fn, Promise&, Func>) {
-      cpo(h.promise(), (Func &&) func);
-    }
-#endif // UNIFEX_NO_COROUTINES
+  template(typename Promise, typename Func)(requires(!same_as<Promise, void>) AND callable<_fn, Promise&, Func>) friend void tag_invoke(
+      _fn cpo,
+      coro::coroutine_handle<Promise> h,
+      Func&& func) noexcept(is_nothrow_callable_v<_fn, Promise&, Func>) {
+    cpo(h.promise(), (Func &&) func);
+  }
+#endif  // UNIFEX_NO_COROUTINES
 
-    template(typename Continuation, typename Func)
-      (requires tag_invocable<_fn, const Continuation&, Func>)
-    void operator()(const Continuation& c, Func&& func) const
-        noexcept(is_nothrow_tag_invocable_v<
-                _fn,
-                const Continuation&,
-                Func&&>) {
-      static_assert(
-          std::is_void_v<tag_invoke_result_t<
-              _fn,
-              const Continuation&,
-              Func&&>>,
-          "tag_invoke() overload for visit_continuations() must return void");
-      return tag_invoke(_fn{}, c, (Func &&) func);
-    }
+  template(typename Continuation, typename Func)(
+      requires tag_invocable<_fn, const Continuation&, Func>) void
+  operator()(const Continuation& c, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, const Continuation&, Func&&>) {
+    static_assert(
+        std::is_void_v<tag_invoke_result_t<_fn, const Continuation&, Func&&>>,
+        "tag_invoke() overload for visit_continuations() must return void");
+    return tag_invoke(_fn{}, c, (Func &&) func);
+  }
 
-    template(typename Continuation, typename Func)
-      (requires (!tag_invocable<_fn, const Continuation&, Func>))
-    void operator()(const Continuation&, Func&&) const noexcept {}
-  } visit_continuations {};
-} // namespace _visit_continuations_cpo
+  template(typename Continuation, typename Func)(
+      requires(!tag_invocable<_fn, const Continuation&, Func>)) void
+  operator()(const Continuation&, Func&&) const noexcept {
+  }
+} visit_continuations{};
+}  // namespace _visit_continuations_cpo
 using _visit_continuations_cpo::visit_continuations;
 
 #if !UNIFEX_NO_COROUTINES
 namespace _ch {
 template <typename Promise = void>
 struct continuation_handle;
-} // namespace _ch
+}  // namespace _ch
 using _ch::continuation_handle;
 #endif
 
@@ -87,7 +80,8 @@ inline type_index _default_type_index_getter() noexcept {
   return type_id<void>();
 }
 
-inline void _default_visit(const void*, _continuation_info_vtable::callback_t*, void*) {
+inline void
+_default_visit(const void*, _continuation_info_vtable::callback_t*, void*) {
 }
 
 template <typename F>
@@ -96,20 +90,21 @@ void _invoke_visitor(const continuation_info& info, void* data) {
 }
 
 class continuation_info {
- public:
+public:
   continuation_info() = default;
 
   template <typename Continuation>
   static continuation_info from_continuation(const Continuation& c) noexcept;
 
-  static continuation_info from_continuation(const continuation_info& c) noexcept {
+  static continuation_info
+  from_continuation(const continuation_info& c) noexcept {
     return c;
   }
 
 #if !UNIFEX_NO_COROUTINES
   template <typename Promise>
-  static continuation_info from_continuation(
-      const continuation_handle<Promise>& c) noexcept {
+  static continuation_info
+  from_continuation(const continuation_handle<Promise>& c) noexcept {
     return continuation_info{c.handle().address(), c.vtable_};
   }
 #endif
@@ -125,25 +120,23 @@ class continuation_info {
   template <typename F>
   friend void
   tag_invoke(tag_t<visit_continuations>, const continuation_info& c, F&& f) {
-    // Any const that gets stripped by the const_cast below gets reapplied by the
-    // static_cast in _invoke_visitor.
+    // Any const that gets stripped by the const_cast below gets reapplied by
+    // the static_cast in _invoke_visitor.
     c.vtable_->visit_(
         c.address_,
         &_invoke_visitor<F>,
         const_cast<void*>(static_cast<const void*>(std::addressof(f))));
   }
 
- private:
+private:
   explicit continuation_info(
-      const void* address,
-      const _continuation_info_vtable* vtable) noexcept
+      const void* address, const _continuation_info_vtable* vtable) noexcept
     : address_(address)
-    , vtable_(vtable) {}
+    , vtable_(vtable) {
+  }
 
-  inline static constexpr _continuation_info_vtable default_vtable_ {
-    &_default_type_index_getter,
-    &_default_visit
-  };
+  inline static constexpr _continuation_info_vtable default_vtable_{
+      &_default_type_index_getter, &_default_visit};
 
   const void* address_{nullptr};
   const _continuation_info_vtable* vtable_{&default_vtable_};
@@ -155,7 +148,10 @@ type_index _type_index_getter_for() noexcept {
 }
 
 template <typename Continuation>
-void _visit_for(const void* address, _continuation_info_vtable::callback_t* cb, void* data) {
+void _visit_for(
+    const void* address,
+    _continuation_info_vtable::callback_t* cb,
+    void* data) {
   visit_continuations(
       *static_cast<const Continuation*>(address),
       [cb, data](const auto& continuation) {
@@ -164,23 +160,22 @@ void _visit_for(const void* address, _continuation_info_vtable::callback_t* cb, 
 }
 
 template <typename Continuation>
-inline constexpr _continuation_info_vtable _vtable_for {
-  &_type_index_getter_for<Continuation>,
-  &_visit_for<Continuation>
-};
+inline constexpr _continuation_info_vtable _vtable_for{
+    &_type_index_getter_for<Continuation>, &_visit_for<Continuation>};
 
 template <typename Continuation>
-inline continuation_info continuation_info::from_continuation(
-    const Continuation& r) noexcept {
-  return continuation_info{static_cast<const void*>(std::addressof(r)),
-                           &_vtable_for<Continuation>};
+inline continuation_info
+continuation_info::from_continuation(const Continuation& r) noexcept {
+  return continuation_info{
+      static_cast<const void*>(std::addressof(r)), &_vtable_for<Continuation>};
 }
-} // namespace _ci
+}  // namespace _ci
 using _ci::continuation_info;
 
 #if !UNIFEX_NO_COROUTINES
 namespace _ch {
-[[noreturn]] inline coro::coroutine_handle<> _default_done_callback(void*) noexcept {
+[[noreturn]] inline coro::coroutine_handle<>
+_default_done_callback(void*) noexcept {
   std::terminate();
 }
 
@@ -197,23 +192,17 @@ struct continuation_handle<void> {
   // forward-declare a constrained function and provide its definition later. So
   // below we define a constrained constructor that trivially dispatches to an
   // unconstrained implementation defined elsewhere.
-  template (typename Promise)
-    (requires (!same_as<Promise, void>))
-  /*implicit*/ continuation_handle(coro::coroutine_handle<Promise> continuation) noexcept
-    : continuation_handle(0, (coro::coroutine_handle<Promise>&&) continuation)
-  {}
+  template(typename Promise)(requires(!same_as<Promise, void>))
+      /*implicit*/ continuation_handle(
+          coro::coroutine_handle<Promise> continuation) noexcept
+    : continuation_handle(
+          0, (coro::coroutine_handle<Promise> &&) continuation) {}
 
-  explicit operator bool() const noexcept {
-    return handle_ != nullptr;
-  }
+  explicit operator bool() const noexcept { return handle_ != nullptr; }
 
-  coro::coroutine_handle<> handle() const noexcept {
-    return handle_;
-  }
+  coro::coroutine_handle<> handle() const noexcept { return handle_; }
 
-  void resume() {
-    handle_.resume();
-  }
+  void resume() { handle_.resume(); }
 
   coro::coroutine_handle<> done() const noexcept {
     return vtable_->doneCallback_(handle_.address());
@@ -224,10 +213,10 @@ struct continuation_handle<void> {
   }
 
   template <typename F>
-  friend void
-  tag_invoke(tag_t<visit_continuations>, const continuation_handle<>& c, F&& f) {
-    // Any const that gets stripped by the const_cast below gets reapplied by the
-    // static_cast in _invoke_visitor.
+  friend void tag_invoke(
+      tag_t<visit_continuations>, const continuation_handle<>& c, F&& f) {
+    // Any const that gets stripped by the const_cast below gets reapplied by
+    // the static_cast in _invoke_visitor.
     c.vtable_->visit_(
         c.handle_.address(),
         &_ci::_invoke_visitor<F>,
@@ -237,27 +226,30 @@ struct continuation_handle<void> {
 private:
   friend continuation_info;
 
-  inline static constexpr _continuation_handle_vtable default_vtable_ {
-    {
-        &_ci::_default_type_index_getter,
-        &_ci::_default_visit,
-    },
-    &_default_done_callback
-  };
+  inline static constexpr _continuation_handle_vtable default_vtable_{
+      {
+          &_ci::_default_type_index_getter,
+          &_ci::_default_visit,
+      },
+      &_default_done_callback};
 
   template <typename Promise>
-  continuation_handle(int, coro::coroutine_handle<Promise> continuation) noexcept;
+  continuation_handle(
+      int, coro::coroutine_handle<Promise> continuation) noexcept;
 
   coro::coroutine_handle<> handle_{};
-  const _continuation_handle_vtable* vtable_ {&default_vtable_};
+  const _continuation_handle_vtable* vtable_{&default_vtable_};
 };
 
 template <typename Promise>
-void _visit_for(const void* address, _ci::_continuation_info_vtable::callback_t* cb, void* data) {
+void _visit_for(
+    const void* address,
+    _ci::_continuation_info_vtable::callback_t* cb,
+    void* data) {
   visit_continuations(
-      const_cast<const Promise&>(
-          coro::coroutine_handle<Promise>::from_address(
-              const_cast<void*>(address)).promise()),
+      const_cast<const Promise&>(coro::coroutine_handle<Promise>::from_address(
+                                     const_cast<void*>(address))
+                                     .promise()),
       [cb, data](const auto& continuation) {
         cb(continuation_info::from_continuation(continuation), data);
       });
@@ -265,65 +257,57 @@ void _visit_for(const void* address, _ci::_continuation_info_vtable::callback_t*
 
 template <typename Promise>
 coro::coroutine_handle<> _done_callback_for(void* address) noexcept {
-  return coro::coroutine_handle<Promise>::from_address(address).promise().unhandled_done();
+  return coro::coroutine_handle<Promise>::from_address(address)
+      .promise()
+      .unhandled_done();
 }
 
 template <typename Promise>
-inline constexpr _continuation_handle_vtable _vtable_for {
-  {
+inline constexpr _continuation_handle_vtable _vtable_for{
+    {
         &_ci::_type_index_getter_for<Promise>,
         &_visit_for<Promise>,
-  },
-  &_done_callback_for<Promise>
-};
+    },
+    &_done_callback_for<Promise>};
 
 template <typename Promise>
-continuation_handle<void>::continuation_handle(int, coro::coroutine_handle<Promise> continuation) noexcept
-  : handle_((coro::coroutine_handle<Promise>&&) continuation)
-  , vtable_(&_vtable_for<Promise>)
-{}
+continuation_handle<void>::continuation_handle(
+    int, coro::coroutine_handle<Promise> continuation) noexcept
+  : handle_((coro::coroutine_handle<Promise> &&) continuation)
+  , vtable_(&_vtable_for<Promise>) {
+}
 
 template <typename Promise>
 struct continuation_handle {
   continuation_handle() = default;
 
-  /*implicit*/ continuation_handle(coro::coroutine_handle<Promise> continuation) noexcept
-    : self_((coro::coroutine_handle<Promise>&&) continuation)
-  {}
+  /*implicit*/ continuation_handle(
+      coro::coroutine_handle<Promise> continuation) noexcept
+    : self_((coro::coroutine_handle<Promise> &&) continuation) {}
 
-  explicit operator bool() const noexcept {
-    return !!self_;
-  }
+  explicit operator bool() const noexcept { return !!self_; }
 
-  /*implicit*/ operator continuation_handle<>() const noexcept {
-    return self_;
-  }
+  /*implicit*/ operator continuation_handle<>() const noexcept { return self_; }
 
   coro::coroutine_handle<Promise> handle() const noexcept {
     return coro::coroutine_handle<Promise>::from_address(
         self_.handle().address());
   }
 
-  void resume() {
-    self_.resume();
-  }
+  void resume() { self_.resume(); }
 
-  Promise& promise() const noexcept {
-    return handle().promise();
-  }
+  Promise& promise() const noexcept { return handle().promise(); }
 
-  coro::coroutine_handle<> done() const noexcept {
-    return self_.done();
-  }
+  coro::coroutine_handle<> done() const noexcept { return self_.done(); }
 
-  continuation_info info() const noexcept {
-    return self_.info();
-  }
+  continuation_info info() const noexcept { return self_.info(); }
 
   template <typename F>
-  friend void
-  tag_invoke(tag_t<visit_continuations>, const continuation_handle<Promise>& c, F&& f) {
-    visit_continuations(c.self_, (F&&) f);
+  friend void tag_invoke(
+      tag_t<visit_continuations>,
+      const continuation_handle<Promise>& c,
+      F&& f) {
+    visit_continuations(c.self_, (F &&) f);
   }
 
 private:
@@ -331,10 +315,10 @@ private:
 
   continuation_handle<> self_;
 };
-} // namespace _ch
+}  // namespace _ch
 using _ch::continuation_handle;
 #endif
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/coroutine.hpp
+++ b/include/unifex/coroutine.hpp
@@ -18,9 +18,9 @@
 #include <unifex/config.hpp>
 
 #if !UNIFEX_NO_COROUTINES
-#include UNIFEX_COROUTINES_HEADER
+#  include UNIFEX_COROUTINES_HEADER
 
 namespace unifex {
-    namespace coro = UNIFEX_COROUTINES_NAMESPACE;
+namespace coro = UNIFEX_COROUTINES_NAMESPACE;
 }
 #endif

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -17,11 +17,11 @@
 
 #include <unifex/config.hpp>
 
-#include <unifex/type_traits.hpp>
 #include <unifex/coroutine.hpp>
+#include <unifex/type_traits.hpp>
 
 #if UNIFEX_NO_COROUTINES
-# error "Coroutine support is required to use <unifex/coroutine_concepts.hpp>"
+#  error "Coroutine support is required to use <unifex/coroutine_concepts.hpp>"
 #endif
 
 #include <unifex/detail/prologue.hpp>
@@ -58,7 +58,7 @@ struct await_result_impl<
   using type = decltype(std::declval<Awaiter&>().await_resume());
 };
 
-} // namespace detail
+}  // namespace detail
 
 namespace _get_awaiter {
 struct _fn {
@@ -73,9 +73,9 @@ struct _fn {
     }
   }
 };
-} // namespace _get_awaiter
+}  // namespace _get_awaiter
 
-inline constexpr _get_awaiter::_fn get_awaiter {};
+inline constexpr _get_awaiter::_fn get_awaiter{};
 
 template <typename Awaitable>
 using awaiter_type_t = decltype(get_awaiter(std::declval<Awaitable>()));
@@ -85,18 +85,17 @@ using await_result_t =
     typename detail::await_result_impl<awaiter_type_t<Awaitable>>::type;
 
 namespace detail {
-  template <typename Awaitable>
-  UNIFEX_CONCEPT_FRAGMENT( //
-    _awaitable_impl,         //
-      requires() (         //
-        typename(await_result_t<Awaitable>)
-      ));
-  template <typename Awaitable>
-  UNIFEX_CONCEPT //
-    _awaitable = //
-      UNIFEX_FRAGMENT(detail::_awaitable_impl, Awaitable);
-} // namespace detail
+template <typename Awaitable>
+UNIFEX_CONCEPT_FRAGMENT(  //
+    _awaitable_impl,      //
+    requires()(           //
+        typename(await_result_t<Awaitable>)));
+template <typename Awaitable>
+UNIFEX_CONCEPT    //
+    _awaitable =  //
+    UNIFEX_FRAGMENT(detail::_awaitable_impl, Awaitable);
+}  // namespace detail
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/create.hpp
+++ b/include/unifex/create.hpp
@@ -27,49 +27,48 @@ namespace _create {
 template <typename Receiver, typename Fn, typename Context>
 struct _op {
   struct type {
-    explicit type(Receiver rec, Fn fn, Context ctx)
-        noexcept(std::is_nothrow_move_constructible_v<Receiver> &&
-          std::is_nothrow_move_constructible_v<Fn> &&
-          std::is_nothrow_move_constructible_v<Context>)
-      : rec_((Receiver&&) rec), fn_((Fn&&) fn), ctx_((Context&&) ctx) {}
+    explicit type(Receiver rec, Fn fn, Context ctx) noexcept(
+        std::is_nothrow_move_constructible_v<Receiver>&&
+            std::is_nothrow_move_constructible_v<Fn>&&
+                std::is_nothrow_move_constructible_v<Context>)
+      : rec_((Receiver &&) rec)
+      , fn_((Fn &&) fn)
+      , ctx_((Context &&) ctx) {}
 
-    template (typename... Ts)
-      (requires receiver_of<Receiver, Ts...>)
-    void set_value(Ts&&... ts) noexcept(is_nothrow_receiver_of_v<Receiver, Ts...>) {
-      unifex::set_value((Receiver&&) rec_, (Ts&&) ts...);
+    template(typename... Ts)(requires receiver_of<Receiver, Ts...>) void set_value(
+        Ts&&... ts) noexcept(is_nothrow_receiver_of_v<Receiver, Ts...>) {
+      unifex::set_value((Receiver &&) rec_, (Ts &&) ts...);
     }
 
-    template (typename Error)
-      (requires receiver<Receiver, Error>)
-    void set_error(Error&& error) noexcept {
-      unifex::set_error((Receiver&&) rec_, (Error&&) error);
+    template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+        Error&& error) noexcept {
+      unifex::set_error((Receiver &&) rec_, (Error &&) error);
     }
 
-    void set_done() noexcept {
-      unifex::set_done((Receiver&&) rec_);
+    void set_done() noexcept { unifex::set_done((Receiver &&) rec_); }
+
+    template(class Ctx = Context)(requires(!same_as<Ctx, detail::_empty<>>))
+        Context const& context() const& noexcept {
+      return ctx_;
     }
 
-    template (class Ctx = Context)
-      (requires (!same_as<Ctx, detail::_empty<>>))
-    Context const& context() const & noexcept { return ctx_; }
-
-    template (class Ctx = Context)
-      (requires (!same_as<Ctx, detail::_empty<>>))
-    Context&& context() && noexcept { return (Context&&) ctx_; }
+    template(class Ctx = Context)(requires(
+        !same_as<Ctx, detail::_empty<>>)) Context&& context() && noexcept {
+      return (Context &&) ctx_;
+    }
 
   private:
     friend void tag_invoke(tag_t<start>, type& self) noexcept try {
       self.fn_(self);
-    } catch(...) {
-      unifex::set_error((Receiver&&) self.rec_, std::current_exception());
+    } catch (...) {
+      unifex::set_error((Receiver &&) self.rec_, std::current_exception());
     }
 
     // Forward other receiver queries
-    template (typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>)
-    friend auto tag_invoke(CPO cpo, const type& self)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-      -> callable_result_t<CPO, const Receiver&> {
+    template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+        CPO cpo,
+        const type& self) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+        -> callable_result_t<CPO, const Receiver&> {
       return std::move(cpo)(self.rec_);
     }
 
@@ -85,26 +84,29 @@ using _operation = typename _op<Receiver, Fn, Context>::type;
 template <typename Fn, typename Context>
 struct _snd_base {
   struct type {
-    template <template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     static constexpr bool sends_done = true;
 
-    template (typename Self, typename Receiver)
-      (requires derived_from<remove_cvref_t<Self>, type> AND
-        constructible_from<Fn, member_t<Self, Fn>> AND
-        constructible_from<Context, member_t<Self, Context>>)
-    friend _operation<remove_cvref_t<Receiver>, Fn, Context>
-    tag_invoke(tag_t<connect>, Self&& self, Receiver&& rec)
-        noexcept(std::is_nothrow_constructible_v<
-          _operation<Receiver, Fn, Context>,
-          Receiver,
-          member_t<Self, Fn>,
-          member_t<Self, Context>>) {
+    template(typename Self, typename Receiver)(requires derived_from<remove_cvref_t<Self>, type> AND constructible_from<Fn, member_t<Self, Fn>> AND constructible_from<Context, member_t<Self, Context>>) friend _operation<
+        remove_cvref_t<Receiver>,
+        Fn,
+        Context> tag_invoke(tag_t<connect>, Self&& self, Receiver&& rec) noexcept(std::
+                                                                                      is_nothrow_constructible_v<
+                                                                                          _operation<
+                                                                                              Receiver,
+                                                                                              Fn,
+                                                                                              Context>,
+                                                                                          Receiver,
+                                                                                          member_t<
+                                                                                              Self,
+                                                                                              Fn>,
+                                                                                          member_t<
+                                                                                              Self,
+                                                                                              Context>>) {
       return _operation<remove_cvref_t<Receiver>, Fn, Context>{
-        (Receiver&&) rec,
-        ((Self&&) self).fn_,
-        ((Self&&) self).ctx_};
+          (Receiver &&) rec, ((Self &&) self).fn_, ((Self &&) self).ctx_};
     }
 
     UNIFEX_NO_UNIQUE_ADDRESS Fn fn_;
@@ -115,7 +117,11 @@ struct _snd_base {
 template <typename Fn, typename Context, typename... ValueTypes>
 struct _snd {
   struct type : _snd_base<Fn, Context>::type {
-    template <template<typename...> class Variant, template <typename...> class Tuple>
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<ValueTypes...>>;
   };
 };
@@ -134,24 +140,26 @@ T void_cast(void* pv) noexcept {
 namespace _cpo {
 template <typename... ValueTypes>
 struct _fn {
-  template (typename Fn)
-    (requires move_constructible<Fn>)
-  _sender<Fn, ValueTypes...> operator()(Fn fn) const
-      noexcept(std::is_nothrow_constructible_v<_sender<Fn, ValueTypes...>, Fn>) {
-    return _sender<Fn, ValueTypes...>{{(Fn&&) fn}};
+  template(typename Fn)(
+      requires move_constructible<Fn>) _sender<Fn, ValueTypes...>
+  operator()(Fn fn) const noexcept(
+      std::is_nothrow_constructible_v<_sender<Fn, ValueTypes...>, Fn>) {
+    return _sender<Fn, ValueTypes...>{{(Fn &&) fn}};
   }
-  template (typename Fn, typename Context)
-    (requires move_constructible<Fn> AND move_constructible<Context>)
-  _sender_with_context<Fn, Context, ValueTypes...> operator()(Fn fn, Context ctx) const
+  template(typename Fn, typename Context)(
+      requires move_constructible<Fn> AND move_constructible<Context>)
+      _sender_with_context<Fn, Context, ValueTypes...>
+      operator()(Fn fn, Context ctx) const
       noexcept(std::is_nothrow_constructible_v<
-          _sender_with_context<Fn, Context, ValueTypes...>,
-          Fn,
-          Context>) {
-    return _sender_with_context<Fn, Context, ValueTypes...>{{(Fn&&) fn, (Context&&) ctx}};
+               _sender_with_context<Fn, Context, ValueTypes...>,
+               Fn,
+               Context>) {
+    return _sender_with_context<Fn, Context, ValueTypes...>{
+        {(Fn &&) fn, (Context &&) ctx}};
   }
 };
-} // namespace _cpo
-} // namespace _create
+}  // namespace _cpo
+}  // namespace _create
 
 /**
  * \fn template <class... ValueTypes> auto create(auto fn [, auto ctx])
@@ -160,38 +168,38 @@ struct _fn {
  *
  * \em Example:
  * \code
- *  // A void-returning C-style async API that accepts a context and a continuation:
- *  using callback_t = void(void* context, int result);
- *  void old_c_style_api(int a, int b, void* context, callback_t* callback_fn);
+ *  // A void-returning C-style async API that accepts a context and a
+ * continuation: using callback_t = void(void* context, int result); void
+ * old_c_style_api(int a, int b, void* context, callback_t* callback_fn);
  *
- *  // A sender-based async API implemented in terms of the C-style API (using C++20):
- *  unifex::typed_sender auto new_sender_api(int a, int b) {
- *    return unifex::create<int>([=](auto& rec) {
- *      old_c_style_api(a, b, &rec, [](void* context, int result) {
+ *  // A sender-based async API implemented in terms of the C-style API (using
+ * C++20): unifex::typed_sender auto new_sender_api(int a, int b) { return
+ * unifex::create<int>([=](auto& rec) { old_c_style_api(a, b, &rec, [](void*
+ * context, int result) {
  *        unifex::void_cast<decltype(rec)>(context).set_value(result);
  *      });
  *    });
  *  }
  * \endcode
- * \tparam ValueTypes The value types of the resulting sender. Should be the list of
- *   value type(s) accepted by the callback (with the exception of the void*
- *   context).
- * \param[in] fn A void-returning callable that accepts an lvalue reference to an object
- *   whose type satisfies the \c unifex::receiver_of<ValueTypes...> concept. This function
- *   should dispatch to the C-style callback (see example).
- * \param[in] ctx An optional extra bit of data to be bundled with the receiver passed to
- *   \c fn. E.g., if \c fn is a lambda that accepts <tt>(auto& rec)</tt> and \c ctx is 42,
- *   then from within the body of \c fn , the value of the expression \c rec.context() is
- *   42.
- * \return A sender that, when connected and started, dispatches to the wrapped C-style
- *   API with the callback of your choosing. The receiver passed to \c fn wraps the
- *   receiver passed to \c connect . Your callback should "complete" the receiver passed
- *   to \c fn , which will complete the receiver passed to \c connect in turn.
+ * \tparam ValueTypes The value types of the resulting sender. Should be the
+ * list of value type(s) accepted by the callback (with the exception of the
+ * void* context). \param[in] fn A void-returning callable that accepts an
+ * lvalue reference to an object whose type satisfies the \c
+ * unifex::receiver_of<ValueTypes...> concept. This function should dispatch to
+ * the C-style callback (see example). \param[in] ctx An optional extra bit of
+ * data to be bundled with the receiver passed to \c fn. E.g., if \c fn is a
+ * lambda that accepts <tt>(auto& rec)</tt> and \c ctx is 42, then from within
+ * the body of \c fn , the value of the expression \c rec.context() is 42.
+ * \return A sender that, when connected and started, dispatches to the wrapped
+ * C-style API with the callback of your choosing. The receiver passed to \c fn
+ * wraps the receiver passed to \c connect . Your callback should "complete" the
+ * receiver passed to \c fn , which will complete the receiver passed to \c
+ * connect in turn.
  */
 template <typename... ValueTypes>
-inline constexpr _create::_cpo::_fn<ValueTypes...> create {};
+inline constexpr _create::_cpo::_fn<ValueTypes...> create{};
 
 using _create::void_cast;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/defer.hpp
+++ b/include/unifex/defer.hpp
@@ -21,18 +21,18 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _defer {
-    inline const struct _fn {
-      template (typename Callable)
-        (requires callable<Callable> AND sender<callable_result_t<Callable>>)
-      constexpr auto operator()(Callable&& callable) const {
-        return let_value(just(), (Callable&&) callable);
-      }
-    } defer{};
-  } // namespace _defer
-  using _defer::defer;
-} // namespace unifex
+namespace unifex {
+namespace _defer {
+inline const struct _fn {
+  template(typename Callable)(
+      requires callable<Callable> AND
+          sender<callable_result_t<Callable>>) constexpr auto
+  operator()(Callable&& callable) const {
+    return let_value(just(), (Callable &&) callable);
+  }
+} defer{};
+}  // namespace _defer
+using _defer::defer;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/delay.hpp
+++ b/include/unifex/delay.hpp
@@ -17,39 +17,39 @@
 
 #include <unifex/config.hpp>
 #include <unifex/adapt_stream.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/finally.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/finally.hpp>
+#include <unifex/scheduler_concepts.hpp>
 
 #include <type_traits>
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _delay {
-    inline const struct _fn {
-      template <typename Stream, typename Scheduler, typename Duration>
-      auto operator()(Stream&& stream, Scheduler&& scheduler, Duration&& duration) const {
-        return adapt_stream(
-            (Stream &&) stream,
-            [scheduler = (Scheduler &&) scheduler,
-            duration = (Duration &&) duration](auto&& sender) {
-              return finally(
-                  static_cast<decltype(sender)>(sender),
-                  schedule_after(scheduler, duration));
-            });
-      }
-      template <typename Scheduler, typename Duration>
-      constexpr auto operator()(Scheduler&& scheduler, Duration&& duration) const
-          noexcept(is_nothrow_callable_v<
-            tag_t<bind_back>, _fn, Scheduler, Duration>)
+namespace unifex {
+namespace _delay {
+inline const struct _fn {
+  template <typename Stream, typename Scheduler, typename Duration>
+  auto operator()(
+      Stream&& stream, Scheduler&& scheduler, Duration&& duration) const {
+    return adapt_stream(
+        (Stream &&) stream,
+        [scheduler = (Scheduler &&) scheduler,
+         duration = (Duration &&) duration](auto&& sender) {
+          return finally(
+              static_cast<decltype(sender)>(sender),
+              schedule_after(scheduler, duration));
+        });
+  }
+  template <typename Scheduler, typename Duration>
+  constexpr auto operator()(Scheduler&& scheduler, Duration&& duration) const
+      noexcept(
+          is_nothrow_callable_v<tag_t<bind_back>, _fn, Scheduler, Duration>)
           -> bind_back_result_t<_fn, Scheduler, Duration> {
-        return bind_back(*this, (Scheduler&&)scheduler, (Duration&&)duration);
-      }
-    } delay{};
-  } // namespace _delay
-  using _delay::delay;
-} // namespace unifex
+    return bind_back(*this, (Scheduler &&) scheduler, (Duration &&) duration);
+  }
+} delay{};
+}  // namespace _delay
+using _delay::delay;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -17,15 +17,15 @@
 
 #include <unifex/config.hpp>
 #include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
 #include <unifex/utility.hpp>
-#include <unifex/blocking.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -34,194 +34,196 @@
 
 namespace unifex {
 namespace _demat {
-  template <typename Receiver>
-  struct _receiver {
-    class type;
-  };
-  template <typename Receiver>
-  using receiver_t = typename _receiver<remove_cvref_t<Receiver>>::type;
+template <typename Receiver>
+struct _receiver {
+  class type;
+};
+template <typename Receiver>
+using receiver_t = typename _receiver<remove_cvref_t<Receiver>>::type;
 
-  template <typename Receiver>
-  class _receiver<Receiver>::type {
-   public:
-    template(typename Receiver2)
-      (requires constructible_from<Receiver, Receiver2>)
-    explicit type(Receiver2&& receiver) noexcept(
-        std::is_nothrow_constructible_v<Receiver, Receiver2>)
-      : receiver_(static_cast<Receiver2&&>(receiver)) {}
+template <typename Receiver>
+class _receiver<Receiver>::type {
+public:
+  template(typename Receiver2)(
+      requires constructible_from<
+          Receiver,
+          Receiver2>) explicit type(Receiver2&&
+                                        receiver) noexcept(std::
+                                                               is_nothrow_constructible_v<
+                                                                   Receiver,
+                                                                   Receiver2>)
+    : receiver_(static_cast<Receiver2&&>(receiver)) {}
 
-    template(typename CPO, typename... Values)
-        (requires is_receiver_cpo_v<CPO> AND is_callable_v<CPO, Receiver, Values...>)
-    void set_value(CPO cpo, Values&&... values) && noexcept(
-        is_nothrow_callable_v<CPO, Receiver, Values...>) {
-      static_cast<CPO&&>(cpo)(
-          static_cast<Receiver&&>(receiver_),
-          static_cast<Values&&>(values)...);
-    }
+  template(typename CPO, typename... Values)(
+      requires is_receiver_cpo_v<CPO> AND is_callable_v<
+          CPO,
+          Receiver,
+          Values...>) void set_value(CPO cpo, Values&&... values) && noexcept(is_nothrow_callable_v<CPO, Receiver, Values...>) {
+    static_cast<CPO&&>(cpo)(
+        static_cast<Receiver&&>(receiver_), static_cast<Values&&>(values)...);
+  }
 
-    template(typename Error)
-        (requires receiver<Receiver, Error>)
-    void set_error(Error&& error) && noexcept {
-      unifex::set_error(
-          static_cast<Receiver&&>(receiver_), static_cast<Error&&>(error));
-    }
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
+    unifex::set_error(
+        static_cast<Receiver&&>(receiver_), static_cast<Error&&>(error));
+  }
 
-    void set_done() && noexcept {
-      unifex::set_done(static_cast<Receiver&&>(receiver_));
-    }
+  void set_done() && noexcept {
+    unifex::set_done(static_cast<Receiver&&>(receiver_));
+  }
 
-    template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))
-        (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>)
-    friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r)
-        noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-        -> callable_result_t<CPO, const Receiver&> {
-      return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
-    }
+  template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))(
+      requires is_receiver_query_cpo_v<CPO> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type) & r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
+  }
 
-    template <typename Func>
-    friend void tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) noexcept(
-                                  std::is_nothrow_invocable_v<
-                                      Func&,
-                                      const Receiver&>) {
-      std::invoke(func, std::as_const(r.receiver_));
-    }
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) noexcept(
+      std::is_nothrow_invocable_v<Func&, const Receiver&>) {
+    std::invoke(func, std::as_const(r.receiver_));
+  }
 
-   private:
-    Receiver receiver_;
-  };
+private:
+  Receiver receiver_;
+};
 
-  template <typename CPO, template <typename...> class Tuple>
-  struct tuple {
-   private:
-    template <typename... Values>
-    struct apply_impl;
+template <typename CPO, template <typename...> class Tuple>
+struct tuple {
+private:
+  template <typename... Values>
+  struct apply_impl;
 
-    template <typename First, typename... Rest>
-    struct apply_impl<First, Rest...>
-      : std::conditional<
-            std::is_base_of_v<CPO, std::decay_t<First>>,
-            type_list<Tuple<Rest...>>,
-            type_list<>> {};
+  template <typename First, typename... Rest>
+  struct apply_impl<First, Rest...>
+    : std::conditional<
+          std::is_base_of_v<CPO, std::decay_t<First>>,
+          type_list<Tuple<Rest...>>,
+          type_list<>> {};
 
-   public:
-    template <typename... Values>
-    using apply = typename apply_impl<Values...>::type;
-  };
+public:
+  template <typename... Values>
+  using apply = typename apply_impl<Values...>::type;
+};
 
+template <template <typename...> class Variant>
+struct variant {
+  template <typename... Lists>
+  using apply =
+      typename concat_type_lists<Lists...>::type::template apply<Variant>;
+};
+
+template <typename Source>
+struct _sender {
+  class type;
+};
+template <typename Source>
+using sender = typename _sender<remove_cvref_t<Source>>::type;
+
+template <typename Source>
+class _sender<Source>::type {
   template <template <typename...> class Variant>
-  struct variant {
-    template <typename... Lists>
-    using apply =
-        typename concat_type_lists<Lists...>::type::template apply<Variant>;
-  };
-
-  template <typename Source>
-  struct _sender {
-    class type;
-  };
-  template <typename Source>
-  using sender = typename _sender<remove_cvref_t<Source>>::type;
-
-  template <typename Source>
-  class _sender<Source>::type {
-    template <template <typename...> class Variant>
-    struct append_error_types {
-    private:
-      template <typename... Errors>
-      struct impl {
-        // Concatenate and deduplicate errors from value_types, error_types along with
-        // std::exception_ptr.
-        template <typename... OtherErrors>
-        using apply = typename concat_type_lists_unique<
-            type_list<Errors...>,
-            type_list<OtherErrors...>,
-            type_list<std::exception_ptr>>::template apply<Variant>;
-      };
-
-    public:
-      template <typename... Errors>
-      using apply = typename Source::template error_types<
-          impl<Errors...>::template apply>;
+  struct append_error_types {
+  private:
+    template <typename... Errors>
+    struct impl {
+      // Concatenate and deduplicate errors from value_types, error_types along
+      // with std::exception_ptr.
+      template <typename... OtherErrors>
+      using apply = typename concat_type_lists_unique<
+          type_list<Errors...>,
+          type_list<OtherErrors...>,
+          type_list<std::exception_ptr>>::template apply<Variant>;
     };
 
   public:
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types =
-        sender_value_types_t<
-            Source,
-            variant<Variant>::template apply,
-            tuple<tag_t<set_value>, Tuple>::template apply>;
-
-    template <template <typename...> class Variant>
-    using error_types =
-        sender_value_types_t<
-            Source,
-            variant<append_error_types<Variant>::template apply>::template apply,
-            tuple<tag_t<set_error>, single_type_t>::template apply>;
-
-    static constexpr bool sends_done = sender_traits<Source>::sends_done;
-
-    template <typename Source2>
-    explicit type(Source2&& source)
-        noexcept(std::is_nothrow_constructible_v<Source, Source2>)
-      : source_(static_cast<Source2&&>(source)) {}
-
-    template(typename Self, typename Receiver)
-        (requires same_as<remove_cvref_t<Self>, type> AND
-          sender_to<member_t<Self, Source>, receiver_t<Receiver>>)
-    friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
-        noexcept(is_nothrow_connectable_v<member_t<Self, Source>, receiver_t<Receiver>> &&
-                 std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
-        -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
-      return unifex::connect(
-          static_cast<Self&&>(self).source_,
-          receiver_t<Receiver>{static_cast<Receiver&&>(r)});
-    }
-
-    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
-      return blocking(self.source_);
-    }
-  private:
-    Source source_;
+    template <typename... Errors>
+    using apply =
+        typename Source::template error_types<impl<Errors...>::template apply>;
   };
-} // namespace _demat
+
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<
+      Source,
+      variant<Variant>::template apply,
+      tuple<tag_t<set_value>, Tuple>::template apply>;
+
+  template <template <typename...> class Variant>
+  using error_types = sender_value_types_t<
+      Source,
+      variant<append_error_types<Variant>::template apply>::template apply,
+      tuple<tag_t<set_error>, single_type_t>::template apply>;
+
+  static constexpr bool sends_done = sender_traits<Source>::sends_done;
+
+  template <typename Source2>
+  explicit type(Source2&& source) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>)
+    : source_(static_cast<Source2&&>(source)) {}
+
+  template(typename Self, typename Receiver)(requires same_as<remove_cvref_t<Self>, type> AND sender_to<member_t<Self, Source>, receiver_t<Receiver>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Self&& self,
+      Receiver&&
+          r) noexcept(is_nothrow_connectable_v<member_t<Self, Source>, receiver_t<Receiver>>&&
+                          std::is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>)
+      -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
+    return unifex::connect(
+        static_cast<Self&&>(self).source_,
+        receiver_t<Receiver>{static_cast<Receiver&&>(r)});
+  }
+
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+    return blocking(self.source_);
+  }
+
+private:
+  Source source_;
+};
+}  // namespace _demat
 
 namespace _demat_cpo {
-  inline const struct _fn {
-  private:
-    template <typename Sender>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Sender>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote1<_demat::sender>>::template apply<Sender>;
-  public:
-    template(typename Sender)
-      (requires tag_invocable<_fn, Sender>)
-    auto operator()(Sender&& predecessor) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Sender>)
-        -> _result_t<Sender> {
-      return unifex::tag_invoke(_fn{}, (Sender&&) predecessor);
-    }
-    template(typename Sender)
-      (requires (!tag_invocable<_fn, Sender>))
-    auto operator()(Sender&& predecessor) const
-        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>)
-        -> _result_t<Sender> {
-      return _demat::sender<Sender>{(Sender &&) predecessor};
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
-  } dematerialize{};
-} // namespace _demat_cpo
+inline const struct _fn {
+private:
+  template <typename Sender>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_demat::sender>>::template apply<Sender>;
+
+public:
+  template(typename Sender)(requires tag_invocable<_fn, Sender>) auto
+  operator()(Sender&& predecessor) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender>) -> _result_t<Sender> {
+    return unifex::tag_invoke(_fn{}, (Sender &&) predecessor);
+  }
+  template(typename Sender)(requires(!tag_invocable<_fn, Sender>)) auto
+  operator()(Sender&& predecessor) const
+      noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>)
+          -> _result_t<Sender> {
+    return _demat::sender<Sender>{(Sender &&) predecessor};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
+} dematerialize{};
+}  // namespace _demat_cpo
 using _demat_cpo::dematerialize;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detach_on_cancel.hpp
+++ b/include/unifex/detach_on_cancel.hpp
@@ -119,10 +119,11 @@ public:
 };
 
 template <typename UpstreamSender, typename DownstreamReceiver>
-struct operation_state<UpstreamSender, DownstreamReceiver>::detached_state final {
+struct operation_state<UpstreamSender, DownstreamReceiver>::detached_state
+    final {
   detached_state(
       typename operation_state<UpstreamSender, DownstreamReceiver>::type* op,
-      UpstreamSender&& s) //
+      UpstreamSender&& s)  //
       noexcept(is_nothrow_connectable_v<UpstreamSender, _receiver>)
     : parentOp_(op)
     , childOp_(connect(std::move(s), _receiver{this})) {}
@@ -160,8 +161,10 @@ struct _sender<Sender>::type {
 
   static constexpr bool sends_done = true;
 
-  friend constexpr auto tag_invoke(tag_t<blocking>, const type& sender) noexcept {
-    if constexpr (same_as<blocking_kind,
+  friend constexpr auto
+  tag_invoke(tag_t<blocking>, const type& sender) noexcept {
+    if constexpr (same_as<
+                      blocking_kind,
                       decltype(blocking(sender.upstreamSender_))>) {
       // the sender returns a runtime-determined blocking_kind
       blocking_kind blockValue = blocking(sender.upstreamSender_);
@@ -184,9 +187,10 @@ struct _sender<Sender>::type {
   template(typename This, typename Receiver)  //
       (requires same_as<remove_cvref_t<This>, type> AND
            receiver<Receiver> AND  //
-               sender_to<member_t<This, Sender>, //
+               sender_to<
+                   member_t<This, Sender>,                                  //
                    typename operation_state_t<This, Receiver>::_receiver>)  //
-  friend typename operation_state_t<This, Receiver>::type tag_invoke(
+      friend typename operation_state_t<This, Receiver>::type tag_invoke(
           tag_t<unifex::connect>, This&& s, Receiver&& r) noexcept(false) {
     return typename operation_state_t<This, Receiver>::type{
         static_cast<This&&>(s).upstreamSender_, static_cast<Receiver&&>(r)};
@@ -198,7 +202,8 @@ namespace detach_on_cancel_impl {
 inline constexpr struct detach_on_cancel_fn {
   template(typename Sender)(requires sender<Sender>) constexpr auto
   operator()(Sender&& sender) const
-      noexcept(std::is_nothrow_constructible_v<_detach_on_cancel::sender<remove_cvref_t<Sender>>,
+      noexcept(std::is_nothrow_constructible_v<
+               _detach_on_cancel::sender<remove_cvref_t<Sender>>,
                Sender>) -> _detach_on_cancel::sender<remove_cvref_t<Sender>> {
     return _detach_on_cancel::sender<remove_cvref_t<Sender>>{(Sender &&)
                                                                  sender};

--- a/include/unifex/detail/atomic_intrusive_queue.hpp
+++ b/include/unifex/detail/atomic_intrusive_queue.hpp
@@ -42,7 +42,7 @@ public:
   atomic_intrusive_queue() noexcept : head_(nullptr) {}
 
   explicit atomic_intrusive_queue(bool initiallyActive) noexcept
-      : head_(initiallyActive ? nullptr : producer_inactive_value()) {}
+    : head_(initiallyActive ? nullptr : producer_inactive_value()) {}
 
   ~atomic_intrusive_queue() {
     // Check that all items in this queue have beel dequeued.
@@ -62,10 +62,12 @@ public:
   // operation successfully marked it as active.
   // Returns false if the previous state was active.
   [[nodiscard]] bool try_mark_active() noexcept {
-    void *oldValue = producer_inactive_value();
-    return head_.compare_exchange_strong(oldValue, nullptr,
-                                         std::memory_order_acquire,
-                                         std::memory_order_relaxed);
+    void* oldValue = producer_inactive_value();
+    return head_.compare_exchange_strong(
+        oldValue,
+        nullptr,
+        std::memory_order_acquire,
+        std::memory_order_relaxed);
   }
 
   // Either enqueue an item to the queue if the producer is
@@ -77,19 +79,19 @@ public:
   // Returns true if the item was enqueued.
   // Returns false if the item was not enqueued and the queue
   // was transitioned from inactive to active.
-  [[nodiscard]] bool enqueue_or_mark_active(Item *item) noexcept {
-    void *const inactive = producer_inactive_value();
-    void *oldValue = head_.load(std::memory_order_relaxed);
-    void *newValue;
+  [[nodiscard]] bool enqueue_or_mark_active(Item* item) noexcept {
+    void* const inactive = producer_inactive_value();
+    void* oldValue = head_.load(std::memory_order_relaxed);
+    void* newValue;
     do {
       if (oldValue == inactive) {
         newValue = nullptr;
       } else {
-        item->*Next = static_cast<Item *>(oldValue);
+        item->*Next = static_cast<Item*>(oldValue);
         newValue = item;
       }
-    } while (!head_.compare_exchange_weak(oldValue, newValue,
-                                          std::memory_order_acq_rel));
+    } while (!head_.compare_exchange_weak(
+        oldValue, newValue, std::memory_order_acq_rel));
     return oldValue != inactive;
   }
 
@@ -156,7 +158,7 @@ public:
       }
     }
 
-    // The queue was 
+    // The queue was
     UNIFEX_ASSERT(oldValue != nullptr);
     UNIFEX_ASSERT(oldValue != inactive);
     return false;
@@ -180,7 +182,7 @@ public:
         static_cast<Item*>(oldValue));
   }
 
- private:
+private:
   void* producer_inactive_value() const noexcept {
     // Pick some pointer that is not nullptr and that is
     // guaranteed to not be the address of a valid item.
@@ -190,6 +192,6 @@ public:
   std::atomic<void*> head_;
 };
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/concept_macros.hpp
+++ b/include/unifex/detail/concept_macros.hpp
@@ -20,21 +20,23 @@
 #include <unifex/config.hpp>
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define UNIFEX_WORKAROUND_MSVC_779763 // FATAL_UNREACHABLE calling constexpr function via template parameter
-#define UNIFEX_WORKAROUND_MSVC_780775 // Incorrect substitution in function template return type
+#  define UNIFEX_WORKAROUND_MSVC_779763  // FATAL_UNREACHABLE calling constexpr
+                                         // function via template parameter
+#  define UNIFEX_WORKAROUND_MSVC_780775  // Incorrect substitution in function
+                                         // template return type
 #endif
 
-#define UNIFEX_PP_CAT_(X, ...)  X ## __VA_ARGS__
-#define UNIFEX_PP_CAT(X, ...)   UNIFEX_PP_CAT_(X, __VA_ARGS__)
+#define UNIFEX_PP_CAT_(X, ...) X##__VA_ARGS__
+#define UNIFEX_PP_CAT(X, ...) UNIFEX_PP_CAT_(X, __VA_ARGS__)
 
-#define UNIFEX_PP_CAT2_(X, ...)  X ## __VA_ARGS__
-#define UNIFEX_PP_CAT2(X, ...)   UNIFEX_PP_CAT2_(X, __VA_ARGS__)
+#define UNIFEX_PP_CAT2_(X, ...) X##__VA_ARGS__
+#define UNIFEX_PP_CAT2(X, ...) UNIFEX_PP_CAT2_(X, __VA_ARGS__)
 
-#define UNIFEX_PP_CAT3_(X, ...)  X ## __VA_ARGS__
-#define UNIFEX_PP_CAT3(X, ...)   UNIFEX_PP_CAT3_(X, __VA_ARGS__)
+#define UNIFEX_PP_CAT3_(X, ...) X##__VA_ARGS__
+#define UNIFEX_PP_CAT3(X, ...) UNIFEX_PP_CAT3_(X, __VA_ARGS__)
 
-#define UNIFEX_PP_CAT4_(X, ...)  X ## __VA_ARGS__
-#define UNIFEX_PP_CAT4(X, ...)   UNIFEX_PP_CAT4_(X, __VA_ARGS__)
+#define UNIFEX_PP_CAT4_(X, ...) X##__VA_ARGS__
+#define UNIFEX_PP_CAT4(X, ...) UNIFEX_PP_CAT4_(X, __VA_ARGS__)
 
 #define UNIFEX_PP_EVAL_(X, ARGS) X ARGS
 #define UNIFEX_PP_EVAL(X, ...) UNIFEX_PP_EVAL_(X, (__VA_ARGS__))
@@ -45,7 +47,8 @@
 #define UNIFEX_PP_EXPAND(...) __VA_ARGS__
 #define UNIFEX_PP_EAT(...)
 
-#define UNIFEX_PP_CHECK(...) UNIFEX_PP_EXPAND(UNIFEX_PP_CHECK_N(__VA_ARGS__, 0,))
+#define UNIFEX_PP_CHECK(...) \
+  UNIFEX_PP_EXPAND(UNIFEX_PP_CHECK_N(__VA_ARGS__, 0, ))
 #define UNIFEX_PP_CHECK_N(x, n, ...) n
 #define UNIFEX_PP_PROBE(x) x, 1,
 #define UNIFEX_PP_PROBE_N(x, n) x, n,
@@ -55,22 +58,114 @@
 
 // The final UNIFEX_PP_EXPAND here is to avoid
 // https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
-#define UNIFEX_PP_COUNT(...) \
-  UNIFEX_PP_EXPAND(UNIFEX_PP_COUNT_(__VA_ARGS__, \
-    50, 49, 48, 47, 46, 45, 44, 43, 42, 41, \
-    40, 39, 38, 37, 36, 35, 34, 33, 32, 31, \
-    30, 29, 28, 27, 26, 25, 24, 23, 22, 21, \
-    20, 19, 18, 17, 16, 15, 14, 13, 12, 11, \
-    10, 9, 8, 7, 6, 5, 4, 3, 2, 1,)) \
+#define UNIFEX_PP_COUNT(...)         \
+  UNIFEX_PP_EXPAND(UNIFEX_PP_COUNT_( \
+      __VA_ARGS__,                   \
+      50,                            \
+      49,                            \
+      48,                            \
+      47,                            \
+      46,                            \
+      45,                            \
+      44,                            \
+      43,                            \
+      42,                            \
+      41,                            \
+      40,                            \
+      39,                            \
+      38,                            \
+      37,                            \
+      36,                            \
+      35,                            \
+      34,                            \
+      33,                            \
+      32,                            \
+      31,                            \
+      30,                            \
+      29,                            \
+      28,                            \
+      27,                            \
+      26,                            \
+      25,                            \
+      24,                            \
+      23,                            \
+      22,                            \
+      21,                            \
+      20,                            \
+      19,                            \
+      18,                            \
+      17,                            \
+      16,                            \
+      15,                            \
+      14,                            \
+      13,                            \
+      12,                            \
+      11,                            \
+      10,                            \
+      9,                             \
+      8,                             \
+      7,                             \
+      6,                             \
+      5,                             \
+      4,                             \
+      3,                             \
+      2,                             \
+      1, ))                          \
   /**/
 #define UNIFEX_PP_COUNT_( \
-  _01, _02, _03, _04, _05, _06, _07, _08, _09, _10, \
-  _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
-  _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
-  _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
-  _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, N, ...) \
-  N \
-  /**/
+    _01,                  \
+    _02,                  \
+    _03,                  \
+    _04,                  \
+    _05,                  \
+    _06,                  \
+    _07,                  \
+    _08,                  \
+    _09,                  \
+    _10,                  \
+    _11,                  \
+    _12,                  \
+    _13,                  \
+    _14,                  \
+    _15,                  \
+    _16,                  \
+    _17,                  \
+    _18,                  \
+    _19,                  \
+    _20,                  \
+    _21,                  \
+    _22,                  \
+    _23,                  \
+    _24,                  \
+    _25,                  \
+    _26,                  \
+    _27,                  \
+    _28,                  \
+    _29,                  \
+    _30,                  \
+    _31,                  \
+    _32,                  \
+    _33,                  \
+    _34,                  \
+    _35,                  \
+    _36,                  \
+    _37,                  \
+    _38,                  \
+    _39,                  \
+    _40,                  \
+    _41,                  \
+    _42,                  \
+    _43,                  \
+    _44,                  \
+    _45,                  \
+    _46,                  \
+    _47,                  \
+    _48,                  \
+    _49,                  \
+    _50,                  \
+    N,                    \
+    ...)                  \
+  N /**/
 
 #define UNIFEX_PP_IIF(BIT) UNIFEX_PP_CAT_(UNIFEX_PP_IIF_, BIT)
 #define UNIFEX_PP_IIF_0(TRUE, ...) __VA_ARGS__
@@ -87,21 +182,16 @@
 #define UNIFEX_PP_LBRACE() {
 #define UNIFEX_PP_RBRACE() }
 #define UNIFEX_PP_COMMA_IIF(X) \
-  UNIFEX_PP_IIF(X)(UNIFEX_PP_EMPTY, UNIFEX_PP_COMMA)() \
-  /**/
+  UNIFEX_PP_IIF(X)(UNIFEX_PP_EMPTY, UNIFEX_PP_COMMA)() /**/
 
 #define UNIFEX_PP_FOR_EACH(M, ...) \
   UNIFEX_PP_FOR_EACH_N(UNIFEX_PP_COUNT(__VA_ARGS__), M, __VA_ARGS__)
 #define UNIFEX_PP_FOR_EACH_N(N, M, ...) \
   UNIFEX_PP_CAT2(UNIFEX_PP_FOR_EACH_, N)(M, __VA_ARGS__)
-#define UNIFEX_PP_FOR_EACH_1(M, _1) \
-  M(_1)
-#define UNIFEX_PP_FOR_EACH_2(M, _1, _2) \
-  M(_1) M(_2)
-#define UNIFEX_PP_FOR_EACH_3(M, _1, _2, _3) \
-  M(_1) M(_2) M(_3)
-#define UNIFEX_PP_FOR_EACH_4(M, _1, _2, _3, _4) \
-  M(_1) M(_2) M(_3) M(_4)
+#define UNIFEX_PP_FOR_EACH_1(M, _1) M(_1)
+#define UNIFEX_PP_FOR_EACH_2(M, _1, _2) M(_1) M(_2)
+#define UNIFEX_PP_FOR_EACH_3(M, _1, _2, _3) M(_1) M(_2) M(_3)
+#define UNIFEX_PP_FOR_EACH_4(M, _1, _2, _3, _4) M(_1) M(_2) M(_3) M(_4)
 #define UNIFEX_PP_FOR_EACH_5(M, _1, _2, _3, _4, _5) \
   M(_1) M(_2) M(_3) M(_4) M(_5)
 #define UNIFEX_PP_FOR_EACH_6(M, _1, _2, _3, _4, _5, _6) \
@@ -111,16 +201,14 @@
 #define UNIFEX_PP_FOR_EACH_8(M, _1, _2, _3, _4, _5, _6, _7, _8) \
   M(_1) M(_2) M(_3) M(_4) M(_5) M(_6) M(_7) M(_8)
 
-#define UNIFEX_PP_PROBE_EMPTY_PROBE_UNIFEX_PP_PROBE_EMPTY \
-  UNIFEX_PP_PROBE(~) \
+#define UNIFEX_PP_PROBE_EMPTY_PROBE_UNIFEX_PP_PROBE_EMPTY UNIFEX_PP_PROBE(~)
 
 #define UNIFEX_PP_PROBE_EMPTY()
-#define UNIFEX_PP_IS_NOT_EMPTY(...) \
-  UNIFEX_PP_EVAL( \
-    UNIFEX_PP_CHECK, \
-    UNIFEX_PP_CAT( \
-      UNIFEX_PP_PROBE_EMPTY_PROBE_, \
-      UNIFEX_PP_PROBE_EMPTY __VA_ARGS__ ())) \
+#define UNIFEX_PP_IS_NOT_EMPTY(...)                                           \
+  UNIFEX_PP_EVAL(                                                             \
+      UNIFEX_PP_CHECK,                                                        \
+      UNIFEX_PP_CAT(                                                          \
+          UNIFEX_PP_PROBE_EMPTY_PROBE_, UNIFEX_PP_PROBE_EMPTY __VA_ARGS__())) \
   /**/
 
 #define UNIFEX_PP_TAIL(_, ...) __VA_ARGS__
@@ -130,32 +218,37 @@
 #define UNIFEX_CONCEPT_FRAGMENT_REQS_M1(REQ) UNIFEX_PP_EXPAND REQ
 #define UNIFEX_CONCEPT_FRAGMENT_REQS_(...) \
   { UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) }
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_(REQ) \
-  UNIFEX_PP_CAT3(UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_, \
-    UNIFEX_PP_EVAL(UNIFEX_PP_CHECK, UNIFEX_PP_CAT3( \
-      UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_, \
-      REQ))) \
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_(REQ)                           \
+  UNIFEX_PP_CAT3(                                                           \
+      UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_,                                 \
+      UNIFEX_PP_EVAL(                                                       \
+          UNIFEX_PP_CHECK,                                                  \
+          UNIFEX_PP_CAT3(UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_, REQ))) \
   /**/
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_requires UNIFEX_PP_PROBE_N(~, 1)
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_noexcept UNIFEX_PP_PROBE_N(~, 2)
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_typename UNIFEX_PP_PROBE_N(~, 3)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_requires \
+  UNIFEX_PP_PROBE_N(~, 1)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_noexcept \
+  UNIFEX_PP_PROBE_N(~, 2)
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_PROBE_typename \
+  UNIFEX_PP_PROBE_N(~, 3)
 
 #define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_0 UNIFEX_PP_EXPAND
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_1 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_2 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
-#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_3 UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_1 \
+  UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_2 \
+  UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
+#define UNIFEX_CONCEPT_FRAGMENT_REQS_SELECT_3 \
+  UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT
 #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_OR_NOEXCEPT(REQ) \
-  UNIFEX_PP_CAT4( \
-    UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_, \
-    REQ)
+  UNIFEX_PP_CAT4(UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_, REQ)
 #define UNIFEX_PP_EAT_TYPENAME_PROBE_typename UNIFEX_PP_PROBE(~)
-#define UNIFEX_PP_EAT_TYPENAME_SELECT_(X,...) \
-  UNIFEX_PP_CAT3(UNIFEX_PP_EAT_TYPENAME_SELECT_, \
-    UNIFEX_PP_EVAL(UNIFEX_PP_CHECK, UNIFEX_PP_CAT3( \
-      UNIFEX_PP_EAT_TYPENAME_PROBE_, \
-      X)))
+#define UNIFEX_PP_EAT_TYPENAME_SELECT_(X, ...) \
+  UNIFEX_PP_CAT3(                              \
+      UNIFEX_PP_EAT_TYPENAME_SELECT_,          \
+      UNIFEX_PP_EVAL(                          \
+          UNIFEX_PP_CHECK, UNIFEX_PP_CAT3(UNIFEX_PP_EAT_TYPENAME_PROBE_, X)))
 #define UNIFEX_PP_EAT_TYPENAME_(...) \
-  UNIFEX_PP_EVAL2(UNIFEX_PP_EAT_TYPENAME_SELECT_, __VA_ARGS__,)(__VA_ARGS__)
+  UNIFEX_PP_EVAL2(UNIFEX_PP_EAT_TYPENAME_SELECT_, __VA_ARGS__, )(__VA_ARGS__)
 #define UNIFEX_PP_EAT_TYPENAME_SELECT_0(...) __VA_ARGS__
 #define UNIFEX_PP_EAT_TYPENAME_SELECT_1(...) \
   UNIFEX_PP_CAT3(UNIFEX_PP_EAT_TYPENAME_, __VA_ARGS__)
@@ -163,72 +256,72 @@
 
 #if UNIFEX_CXX_CONCEPTS || defined(UNIFEX_DOXYGEN_INVOKED)
 
-  #define UNIFEX_CONCEPT concept
+#  define UNIFEX_CONCEPT concept
 
-  #define UNIFEX_CONCEPT_FRAGMENT(NAME, ...) \
+#  define UNIFEX_CONCEPT_FRAGMENT(NAME, ...) \
     concept NAME = UNIFEX_PP_CAT(UNIFEX_CONCEPT_FRAGMENT_REQS_, __VA_ARGS__)
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
     requires(__VA_ARGS__) UNIFEX_CONCEPT_FRAGMENT_REQS_
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ) \
-    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ))(REQ);
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ)                               \
+    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ)) \
+    (REQ);
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
     requires __VA_ARGS__
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
     typename UNIFEX_PP_EAT_TYPENAME_(__VA_ARGS__)
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
-    { __VA_ARGS__ } noexcept
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
+    { __VA_ARGS__ }                                           \
+    noexcept
 
-  #define UNIFEX_FRAGMENT(NAME, ...) \
-    NAME<__VA_ARGS__>
+#  define UNIFEX_FRAGMENT(NAME, ...) NAME<__VA_ARGS__>
 
 #else
 
-  #define UNIFEX_CONCEPT inline constexpr bool
+#  define UNIFEX_CONCEPT inline constexpr bool
 
-  #define UNIFEX_CONCEPT_FRAGMENT(NAME, ...) \
-    auto NAME ## UNIFEX_CONCEPT_FRAGMENT_impl_ \
-      UNIFEX_CONCEPT_FRAGMENT_REQS_ ## __VA_ARGS__> {} \
-    template <typename... As> \
-    char NAME ## UNIFEX_CONCEPT_FRAGMENT_( \
-      ::unifex::_concept::tag<As...> *, \
-      decltype(&NAME ## UNIFEX_CONCEPT_FRAGMENT_impl_<As...>)); \
-    char (&NAME ## UNIFEX_CONCEPT_FRAGMENT_(...))[2] \
-    /**/
-  #if defined(_MSC_VER) && !defined(__clang__)
-    #define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
-      ::unifex::_concept::true_<decltype( \
-        UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) \
-        void())>()
-  #else
-    #define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
-      !(decltype(UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) \
-      void(), \
-      false){})
-  #endif
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
-    (__VA_ARGS__) -> std::enable_if_t<UNIFEX_CONCEPT_FRAGMENT_REQS_2_
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_2_(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT(NAME, ...)                    \
+    auto NAME##UNIFEX_CONCEPT_FRAGMENT_impl_                    \
+            UNIFEX_CONCEPT_FRAGMENT_REQS_##__VA_ARGS__ > {      \
+    }                                                           \
+    template <typename... As>                                   \
+    char NAME##UNIFEX_CONCEPT_FRAGMENT_(                        \
+        ::unifex::_concept::tag<As...>*,                        \
+        decltype(&NAME##UNIFEX_CONCEPT_FRAGMENT_impl_<As...>)); \
+    char(&NAME##UNIFEX_CONCEPT_FRAGMENT_(...))[2] /**/
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    define UNIFEX_CONCEPT_FRAGMENT_TRUE(...)                \
+      ::unifex::_concept::true_<decltype(UNIFEX_PP_FOR_EACH( \
+          UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) void())>()
+#  else
+#    define UNIFEX_CONCEPT_FRAGMENT_TRUE(...) \
+      !(decltype(UNIFEX_PP_FOR_EACH(UNIFEX_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__) void(), false){})
+#  endif
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_requires(...) \
+    (__VA_ARGS__)->std::enable_if_t < UNIFEX_CONCEPT_FRAGMENT_REQS_2_
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_2_(...) \
     UNIFEX_CONCEPT_FRAGMENT_TRUE(__VA_ARGS__)
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ) \
-    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ))(REQ),
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_M(REQ)                               \
+    UNIFEX_PP_CAT2(UNIFEX_CONCEPT_FRAGMENT_REQS_M, UNIFEX_PP_IS_PAREN(REQ)) \
+    (REQ),
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_requires(...) \
     ::unifex::requires_<__VA_ARGS__>
-  #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
-    static_cast<::unifex::_concept::tag<__VA_ARGS__> *>(nullptr)
-  #if defined(__GNUC__) && !defined(__clang__)
-    // GCC can't mangle noexcept expressions, so just check that the
-    // expression is well-formed.
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70790
-    #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
-      __VA_ARGS__
-  #else
-    #define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
+#  define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_typename(...) \
+    static_cast<::unifex::_concept::tag<__VA_ARGS__>*>(nullptr)
+#  if defined(__GNUC__) && !defined(__clang__)
+// GCC can't mangle noexcept expressions, so just check that the
+// expression is well-formed.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70790
+#    define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) __VA_ARGS__
+#  else
+#    define UNIFEX_CONCEPT_FRAGMENT_REQS_REQUIRES_noexcept(...) \
       ::unifex::requires_<noexcept(__VA_ARGS__)>
-  #endif
+#  endif
 
-  #define UNIFEX_FRAGMENT(NAME, ...) \
-    (1u==sizeof(NAME ## UNIFEX_CONCEPT_FRAGMENT_( \
-      static_cast<::unifex::_concept::tag<__VA_ARGS__> *>(nullptr), nullptr)))
+#  define UNIFEX_FRAGMENT(NAME, ...)                                  \
+    (1u ==                                                            \
+     sizeof(NAME##UNIFEX_CONCEPT_FRAGMENT_(                           \
+         static_cast<::unifex::_concept::tag<__VA_ARGS__>*>(nullptr), \
+         nullptr)))
 
 #endif
 
@@ -240,50 +333,47 @@
 //   void foo(A a, B b)
 //   {}
 #if UNIFEX_CXX_CONCEPTS
-  #define UNIFEX_TEMPLATE(...) \
-    template <__VA_ARGS__> UNIFEX_PP_EXPAND \
-    /**/
-  #define UNIFEX_AND && \
-    /**/
+#  define UNIFEX_TEMPLATE(...) \
+    template <__VA_ARGS__>     \
+    UNIFEX_PP_EXPAND   /**/
+#  define UNIFEX_AND &&/**/
 #else
-  #define UNIFEX_TEMPLATE(...) \
-    template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
-    /**/
-  #define UNIFEX_AND && UNIFEX_true_, int> = 0, std::enable_if_t< \
-    /**/
+#  define UNIFEX_TEMPLATE(...) \
+    template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_              /**/
+#  define UNIFEX_AND &&UNIFEX_true_, int > = 0, std::enable_if_t < /**/
 #endif
 
 #define UNIFEX_TEMPLATE_SFINAE(...) \
-  template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
-  /**/
-#define UNIFEX_TEMPLATE_SFINAE_AUX_(...) , \
-  bool UNIFEX_true_ = true, \
-  std::enable_if_t< \
-    UNIFEX_PP_CAT(UNIFEX_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) && UNIFEX_true_, \
-    int> = 0> \
-  /**/
+  template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ /**/
+#define UNIFEX_TEMPLATE_SFINAE_AUX_(...)                               \
+  , bool UNIFEX_true_ = true,                                          \
+         std::enable_if_t <                                            \
+          UNIFEX_PP_CAT(UNIFEX_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) && \
+      UNIFEX_true_,                                                    \
+         int > = 0 > /**/
 #define UNIFEX_TEMPLATE_SFINAE_AUX_3_requires
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
-  namespace _concept {
-    template <typename...>
-    struct tag;
-    template <class>
-    inline constexpr bool true_() {
-      return true;
-    }
-  } // namespace _concept
+namespace _concept {
+template <typename...>
+struct tag;
+template <class>
+inline constexpr bool true_() {
+  return true;
+}
+}  // namespace _concept
 
 #if defined(__clang__) || defined(_MSC_VER)
-  template <bool B>
-  std::enable_if_t<B> requires_() {}
+template <bool B>
+std::enable_if_t<B> requires_() {
+}
 #else
-  template <bool B>
-  inline constexpr std::enable_if_t<B, int> requires_ = 0;
+template <bool B>
+inline constexpr std::enable_if_t<B, int> requires_ = 0;
 #endif
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/epilogue.hpp
+++ b/include/unifex/detail/epilogue.hpp
@@ -18,7 +18,7 @@
 // multiple times.
 
 #ifndef UNIFEX_PROLOGUE_HPP
-#error Epilogue included but prologue has not
+#  error Epilogue included but prologue has not
 #endif
 #undef UNIFEX_PROLOGUE_HPP
 

--- a/include/unifex/detail/intrusive_heap.hpp
+++ b/include/unifex/detail/intrusive_heap.hpp
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
@@ -24,7 +23,7 @@ namespace unifex {
 // field of the list items.
 template <typename T, T* T::*Next, T* T::*Prev, typename Key, Key T::*SortKey>
 class intrusive_heap {
- public:
+public:
   intrusive_heap() noexcept : head_(nullptr) {}
 
   ~intrusive_heap() {
@@ -42,9 +41,7 @@ class intrusive_heap {
     UNIFEX_ASSERT(empty());
   }
 
-  bool empty() const noexcept {
-    return head_ == nullptr;
-  }
+  bool empty() const noexcept { return head_ == nullptr; }
 
   T* top() const noexcept {
     UNIFEX_ASSERT(!empty());
@@ -106,10 +103,10 @@ class intrusive_heap {
     }
   }
 
- private:
+private:
   T* head_;
 };
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/intrusive_list.hpp
+++ b/include/unifex/detail/intrusive_list.hpp
@@ -19,109 +19,104 @@
 
 namespace unifex {
 
-template<typename T, T* T::*Next, T* T::*Prev>
+template <typename T, T* T::*Next, T* T::*Prev>
 class intrusive_list {
 public:
-    intrusive_list() noexcept : head_(nullptr), tail_(nullptr) {}
+  intrusive_list() noexcept : head_(nullptr), tail_(nullptr) {}
 
-    intrusive_list(intrusive_list&& other) noexcept
+  intrusive_list(intrusive_list&& other) noexcept
     : head_(std::exchange(other.head_, nullptr))
-    , tail_(std::exchange(other.tail_, nullptr))
-    {}
+    , tail_(std::exchange(other.tail_, nullptr)) {}
 
-    ~intrusive_list() {
-        UNIFEX_ASSERT(empty());
+  ~intrusive_list() { UNIFEX_ASSERT(empty()); }
+
+  intrusive_list& operator=(const intrusive_list&) = delete;
+  intrusive_list& operator=(intrusive_list&&) = delete;
+
+  [[nodiscard]] bool empty() const noexcept { return head_ == nullptr; }
+
+  void swap(intrusive_list& other) noexcept {
+    std::swap(head_, other.head_);
+    std::swap(tail_, other.tail_);
+  }
+
+  void push_back(T* item) noexcept {
+    item->*Prev = tail_;
+    item->*Next = nullptr;
+    if (tail_ == nullptr) {
+      head_ = item;
+    } else {
+      tail_->*Next = item;
     }
+    tail_ = item;
+  }
 
-    intrusive_list& operator=(const intrusive_list&) = delete;
-    intrusive_list& operator=(intrusive_list&&) = delete;
-
-    [[nodiscard]] bool empty() const noexcept {
-        return head_ == nullptr;
+  void push_front(T* item) noexcept {
+    item->*Prev = nullptr;
+    item->*Next = head_;
+    if (head_ == nullptr) {
+      tail_ = item;
+    } else {
+      head_->*Prev = item;
     }
+    head_ = item;
+  }
 
-    void swap(intrusive_list& other) noexcept {
-        std::swap(head_, other.head_);
-        std::swap(tail_, other.tail_);
+  [[nodiscard]] T* pop_front() noexcept {
+    UNIFEX_ASSERT(!empty());
+    T* item = head_;
+    head_ = item->*Next;
+    if (head_ != nullptr) {
+      head_->*Prev = nullptr;
+    } else {
+      tail_ = nullptr;
     }
+    return item;
+  }
 
-    void push_back(T* item) noexcept {
-        item->*Prev = tail_;
-        item->*Next = nullptr;
-        if (tail_ == nullptr) {
-            head_ = item;
-        } else {
-            tail_->*Next = item;
-        }
-        tail_ = item;
+  [[nodiscard]] T* pop_back() noexcept {
+    UNIFEX_ASSERT(!empty());
+    T* item = tail_;
+    tail_ = item->*Prev;
+    if (tail_ != nullptr) {
+      tail_->*Next = nullptr;
+    } else {
+      head_ = nullptr;
     }
+    return item;
+  }
 
-    void push_front(T* item) noexcept {
-        item->*Prev = nullptr;
-        item->*Next = head_;
-        if (head_ == nullptr) {
-            tail_ = item;
-        } else {
-            head_->*Prev = item;
-        }
-        head_ = item;
+  void remove(T* item) noexcept {
+    UNIFEX_ASSERT(!empty());
+    auto* prev = item->*Prev;
+    auto* next = item->*Next;
+    if (prev != nullptr) {
+      prev->*Next = next;
+    } else {
+      head_ = next;
     }
+    if (next != nullptr) {
+      next->*Prev = prev;
+    } else {
+      tail_ = prev;
+    }
+  }
 
-    [[nodiscard]] T* pop_front() noexcept {
-        UNIFEX_ASSERT(!empty());
-        T* item = head_;
-        head_ = item->*Next;
-        if (head_ != nullptr) {
-            head_->*Prev = nullptr;
-        } else {
-            tail_ = nullptr;
-        }
-        return item;
+  void append(intrusive_list other) noexcept {
+    if (empty()) {
+      swap(other);
+    } else if (!other.empty()) {
+      tail_->*Next = other.head_;
+      tail_->*Next->*Prev = tail_;
+      tail_ = other.tail_;
+      other.head_ = nullptr;
+      other.tail_ = nullptr;
     }
-
-    [[nodiscard]] T* pop_back() noexcept {
-        UNIFEX_ASSERT(!empty());
-        T* item = tail_;
-        tail_ = item->*Prev;
-        if (tail_ != nullptr) {
-            tail_->*Next = nullptr;
-        } else {
-            head_ = nullptr;
-        }
-        return item;
-    }
-
-    void remove(T* item) noexcept {
-        UNIFEX_ASSERT(!empty());
-        auto* prev = item->*Prev;
-        auto* next = item->*Next;
-        if (prev != nullptr) {
-            prev->*Next = next;
-        } else {
-            head_ = next;
-        }
-        if (next != nullptr) {
-            next->*Prev = prev;
-        } else {
-            tail_ = prev;
-        }
-    }
-
-    void append(intrusive_list other) noexcept {
-        if (empty()) {
-            swap(other);
-        } else if (!other.empty()) {
-            tail_->*Next = other.head_;
-            tail_->*Next->*Prev = tail_;
-            tail_ = other.tail_;
-            other.head_ = nullptr;
-            other.tail_ = nullptr;
-        }
-    }
+  }
 
 private:
-    T* head_;
-    T* tail_;
+  T* head_;
+  T* tail_;
 };
 
-} // namespace unifex
+}  // namespace unifex

--- a/include/unifex/detail/intrusive_queue.hpp
+++ b/include/unifex/detail/intrusive_queue.hpp
@@ -24,12 +24,12 @@ namespace unifex {
 
 template <typename Item, Item* Item::*Next>
 class intrusive_queue {
- public:
+public:
   intrusive_queue() noexcept = default;
 
   intrusive_queue(intrusive_queue&& other) noexcept
-      : head_(std::exchange(other.head_, nullptr)),
-        tail_(std::exchange(other.tail_, nullptr)) {}
+    : head_(std::exchange(other.head_, nullptr))
+    , tail_(std::exchange(other.tail_, nullptr)) {}
 
   intrusive_queue& operator=(intrusive_queue other) noexcept {
     std::swap(head_, other.head_);
@@ -37,9 +37,7 @@ class intrusive_queue {
     return *this;
   }
 
-  ~intrusive_queue() {
-    UNIFEX_ASSERT(empty());
-  }
+  ~intrusive_queue() { UNIFEX_ASSERT(empty()); }
 
   static intrusive_queue make_reversed(Item* list) noexcept {
     Item* newHead = nullptr;
@@ -57,9 +55,7 @@ class intrusive_queue {
     return result;
   }
 
-  [[nodiscard]] bool empty() const noexcept {
-    return head_ == nullptr;
-  }
+  [[nodiscard]] bool empty() const noexcept { return head_ == nullptr; }
 
   [[nodiscard]] Item* pop_front() noexcept {
     UNIFEX_ASSERT(!empty());
@@ -116,11 +112,11 @@ class intrusive_queue {
     other.head_ = nullptr;
   }
 
- private:
+private:
   Item* head_ = nullptr;
   Item* tail_ = nullptr;
 };
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/detail/intrusive_stack.hpp
+++ b/include/unifex/detail/intrusive_stack.hpp
@@ -19,50 +19,45 @@
 
 namespace unifex {
 
-template<typename T, T* T::*Next>
+template <typename T, T* T::*Next>
 class intrusive_stack {
 public:
-    intrusive_stack() : head_(nullptr) {}
+  intrusive_stack() : head_(nullptr) {}
 
-    intrusive_stack(intrusive_stack&& other) noexcept : head_(std::exchange(other.head_, nullptr)) {}
+  intrusive_stack(intrusive_stack&& other) noexcept
+    : head_(std::exchange(other.head_, nullptr)) {}
 
-    intrusive_stack(const intrusive_stack&) = delete;
-    intrusive_stack& operator=(const intrusive_stack&) = delete;
-    intrusive_stack& operator=(intrusive_stack&&) = delete;
+  intrusive_stack(const intrusive_stack&) = delete;
+  intrusive_stack& operator=(const intrusive_stack&) = delete;
+  intrusive_stack& operator=(intrusive_stack&&) = delete;
 
-    ~intrusive_stack() {
-        UNIFEX_ASSERT(empty());
-    }
+  ~intrusive_stack() { UNIFEX_ASSERT(empty()); }
 
-    // Adopt an existing linked-list as a stack.
-    static intrusive_stack adopt(T* head) noexcept {
-        intrusive_stack stack;
-        stack.head_ = head;
-        return stack;
-    }
+  // Adopt an existing linked-list as a stack.
+  static intrusive_stack adopt(T* head) noexcept {
+    intrusive_stack stack;
+    stack.head_ = head;
+    return stack;
+  }
 
-    T* release() noexcept {
-        return std::exchange(head_, nullptr);
-    }
+  T* release() noexcept { return std::exchange(head_, nullptr); }
 
-    [[nodiscard]] bool empty() const noexcept {
-        return head_ == nullptr;
-    }
+  [[nodiscard]] bool empty() const noexcept { return head_ == nullptr; }
 
-    void push_front(T* item) noexcept {
-        item->*Next = head_;
-        head_ = item;
-    }
+  void push_front(T* item) noexcept {
+    item->*Next = head_;
+    head_ = item;
+  }
 
-    [[nodiscard]] T* pop_front() noexcept {
-        UNIFEX_ASSERT(!empty());
-        T* item = head_;
-        head_ = item->*Next;
-        return item;
-    }
+  [[nodiscard]] T* pop_front() noexcept {
+    UNIFEX_ASSERT(!empty());
+    T* item = head_;
+    head_ = item->*Next;
+    return item;
+  }
 
 private:
-    T* head_;
+  T* head_;
 };
 
-} // namespace unifex
+}  // namespace unifex

--- a/include/unifex/detail/prologue.hpp
+++ b/include/unifex/detail/prologue.hpp
@@ -18,7 +18,7 @@
 // multiple times.
 
 #ifdef UNIFEX_PROLOGUE_HPP
-#error Prologue has already been included
+#  error Prologue has already been included
 #endif
 #define UNIFEX_PROLOGUE_HPP
 
@@ -27,17 +27,15 @@
 UNIFEX_DIAGNOSTIC_PUSH
 
 #if defined(__clang__)
-    #pragma clang diagnostic ignored "-Wkeyword-macro"
+#  pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
 
 #if UNIFEX_CXX_CONCEPTS
-  #define template(...) \
-    template <__VA_ARGS__> UNIFEX_PP_EXPAND \
-    /**/
+#  define template(...)    \
+    template <__VA_ARGS__> \
+    UNIFEX_PP_EXPAND /**/
 #else
-  #define template(...) \
-    template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ \
-    /**/
+#  define template(...) template <__VA_ARGS__ UNIFEX_TEMPLATE_SFINAE_AUX_ /**/
 #endif
 
 UNIFEX_DIAGNOSTIC_POP

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -19,73 +19,72 @@
 #include <unifex/config.hpp>
 
 namespace unifex {
-  namespace detail {
-    struct _ignore {
-      template <typename T>
-      /*implicit*/ _ignore(T&&) noexcept {}
-    };
+namespace detail {
+struct _ignore {
+  template <typename T>
+  /*implicit*/ _ignore(T&&) noexcept {}
+};
 
-    template <int=0>
-    struct _empty {};
-  } // namespace detail
+template <int = 0>
+struct _empty {};
+}  // namespace detail
 
-  namespace _kv
-  {
-    template <typename Key, typename Value>
-    struct _kv {
-      struct type {
-        using key_type = Key;
-        using value_type = Value;
-        UNIFEX_NO_UNIQUE_ADDRESS Key key;
-        Value value;
-      };
-    };
-  } // namespace _kv
-  template <typename Key, typename Value>
-  using kv = typename _kv::_kv<Key, Value>::type;
+namespace _kv {
+template <typename Key, typename Value>
+struct _kv {
+  struct type {
+    using key_type = Key;
+    using value_type = Value;
+    UNIFEX_NO_UNIQUE_ADDRESS Key key;
+    Value value;
+  };
+};
+}  // namespace _kv
+template <typename Key, typename Value>
+using kv = typename _kv::_kv<Key, Value>::type;
 
-  namespace _execute::_cpo {
-    struct _fn;
-  } // namespace _execute::_cpo
-  extern const _execute::_cpo::_fn execute;
+namespace _execute::_cpo {
+struct _fn;
+}  // namespace _execute::_cpo
+extern const _execute::_cpo::_fn execute;
 
-  namespace _submit_cpo {
-    extern const struct _fn submit;
-  } // namespace _submit_cpo
-  using _submit_cpo::submit;
+namespace _submit_cpo {
+extern const struct _fn submit;
+}  // namespace _submit_cpo
+using _submit_cpo::submit;
 
-  namespace _connect::_cpo {
-    struct _fn;
-  } // namespace _connect::_cpo
-  extern const _connect::_cpo::_fn connect;
+namespace _connect::_cpo {
+struct _fn;
+}  // namespace _connect::_cpo
+extern const _connect::_cpo::_fn connect;
 
 #if !UNIFEX_NO_COROUTINES
-  namespace _await_tfx {
-    struct _fn;
-  } // namespace _await_tfx
-  extern const _await_tfx::_fn await_transform;
+namespace _await_tfx {
+struct _fn;
+}  // namespace _await_tfx
+extern const _await_tfx::_fn await_transform;
 #endif
 
-  namespace _schedule {
-    struct _fn;
-  } // namespace _schedule
-  extern const _schedule::_fn schedule;
+namespace _schedule {
+struct _fn;
+}  // namespace _schedule
+extern const _schedule::_fn schedule;
 
-  namespace _sf {
-    template <const auto&, typename, typename>
-    struct sender_for;
-  } // namespace _sf
-  using _sf::sender_for;
+namespace _sf {
+template <const auto&, typename, typename>
+struct sender_for;
+}  // namespace _sf
+using _sf::sender_for;
 
-  namespace _xchg_cont {
-    extern const struct _fn exchange_continuation;
-  } // _xchg_cont
-  using _xchg_cont::exchange_continuation;
+namespace _xchg_cont {
+extern const struct _fn exchange_continuation;
+}  // namespace _xchg_cont
+using _xchg_cont::exchange_continuation;
 
-  template <typename>
-  struct sender_traits;
+template <typename>
+struct sender_traits;
 
-  template <const auto& CPO, typename Sender, typename Context>
-  struct sender_traits<sender_for<CPO, Sender, Context>>;
+template <const auto& CPO, typename Sender, typename Context>
+struct sender_traits<sender_for<CPO, Sender, Context>>;
 
-} // namespace unifex
+}  // namespace unifex

--- a/include/unifex/exception.hpp
+++ b/include/unifex/exception.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <exception>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 #include <unifex/std_concepts.hpp>
 
@@ -28,26 +28,26 @@
 // move as much exception machinery into a cpp file as possible to avoid
 // template code bloat.
 #if !defined(_LIBCPP_ABI_MICROSOFT) && !defined(_MSVC_STL_VERSION)
-#define UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR 0
+#  define UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR 0
 #else
-#define UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR 1
+#  define UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR 1
 #endif
 
 namespace unifex {
 namespace _throw {
 struct _fn {
   template <typename Exception>
-  [[noreturn]] UNIFEX_ALWAYS_INLINE
-  void operator()([[maybe_unused]] Exception&& ex) const {
-  #if !UNIFEX_NO_EXCEPTIONS
-    throw (Exception&&) ex;
-  #else
+  [[noreturn]] UNIFEX_ALWAYS_INLINE void
+  operator()([[maybe_unused]] Exception&& ex) const {
+#if !UNIFEX_NO_EXCEPTIONS
+    throw(Exception &&) ex;
+#else
     std::terminate();
-  #endif
+#endif
   }
 };
-} // namespace _throw
-inline constexpr _throw::_fn throw_ {};
+}  // namespace _throw
+inline constexpr _throw::_fn throw_{};
 
 namespace _except_ptr {
 
@@ -55,16 +55,15 @@ namespace _except_ptr {
 // If std::make_exeption_ptr() is slow, then move it into a cpp
 // file to generate less code elsewhere.
 struct _ref {
-  template (typename Obj)
-    (requires (!same_as<remove_cvref_t<Obj>, _ref>))
-  _ref(Obj&& obj) noexcept
-    : p_((void*) std::addressof(obj))
+  template(typename Obj)(requires(!same_as<remove_cvref_t<Obj>, _ref>))
+      _ref(Obj&& obj) noexcept
+    : p_((void*)std::addressof(obj))
     , throw_([](void* p) {
-        unifex::throw_((Obj&&) *(std::add_pointer_t<Obj>) p);
-      })
-  {}
+      unifex::throw_((Obj &&) * (std::add_pointer_t<Obj>)p);
+    }) {}
   _ref(_ref&&) = delete;
   [[noreturn]] void rethrow() const;
+
 private:
   void* p_;
   void (*throw_)(void*);
@@ -73,19 +72,19 @@ private:
 struct _fn {
   [[nodiscard]] std::exception_ptr operator()(_ref) const noexcept;
 };
-#else // !UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR
+#else  // !UNIFEX_HAS_FAST_MAKE_EXCEPTION_PTR
 struct _fn {
   template <typename Obj>
-  [[nodiscard]] UNIFEX_ALWAYS_INLINE
-  std::exception_ptr operator()(Obj&& obj) const noexcept {
-      return std::make_exception_ptr((Obj&&) obj);
+  [[nodiscard]] UNIFEX_ALWAYS_INLINE std::exception_ptr
+  operator()(Obj&& obj) const noexcept {
+    return std::make_exception_ptr((Obj &&) obj);
   }
 };
 #endif
 
-} // namespace _except_ptr
+}  // namespace _except_ptr
 
-inline constexpr _except_ptr::_fn make_exception_ptr {};
-} // namespace unifex
+inline constexpr _except_ptr::_fn make_exception_ptr{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/execution_policy.hpp
+++ b/include/unifex/execution_policy.hpp
@@ -17,30 +17,37 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-    // Execution policies are used to describe constraints on the safe execution
-    // of bulk operations with respect to each other.
-    //
-    // sequenced - Operations must be sequenced with respect to each other.
-    //             They are not safe to executed concurrently on differen threads or to
-    //             interleaved with each other on the same thread.
-    //
-    // unsequenced - Operations are safe to be interleaved with each other, e.g. using vectorised
-    //               SIMD instructions, but may not be executed concurrently on different
-    //               threads. This generally implies that forward progress of one operation
-    //               is not dependent on forward progress of other operations.   
-    //
-    // parallel - Operations are safe to be executed concurrently with each other on different
-    //            threads but operations on each thread must not be interleaved.
-    //
-    // parallel_unsequenced - Operations are safe to be executed concurrently on different
-    //            threads and may be interleaved with each other on the same thread.
+namespace unifex {
+// Execution policies are used to describe constraints on the safe execution
+// of bulk operations with respect to each other.
+//
+// sequenced - Operations must be sequenced with respect to each other.
+//             They are not safe to executed concurrently on differen threads or
+//             to interleaved with each other on the same thread.
+//
+// unsequenced - Operations are safe to be interleaved with each other, e.g.
+// using vectorised
+//               SIMD instructions, but may not be executed concurrently on
+//               different threads. This generally implies that forward progress
+//               of one operation is not dependent on forward progress of other
+//               operations.
+//
+// parallel - Operations are safe to be executed concurrently with each other on
+// different
+//            threads but operations on each thread must not be interleaved.
+//
+// parallel_unsequenced - Operations are safe to be executed concurrently on
+// different
+//            threads and may be interleaved with each other on the same thread.
 
-    inline constexpr struct sequenced_policy {} seq;
-    inline constexpr struct unsequenced_policy {} unseq;
-    inline constexpr struct parallel_policy {} par;
-    inline constexpr struct parallel_unsequenced_policy {} par_unseq;
-}
+inline constexpr struct sequenced_policy {
+} seq;
+inline constexpr struct unsequenced_policy {
+} unseq;
+inline constexpr struct parallel_policy {
+} par;
+inline constexpr struct parallel_unsequenced_policy {
+} par_unseq;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/file_concepts.hpp
+++ b/include/unifex/file_concepts.hpp
@@ -69,11 +69,11 @@ inline const struct open_file_read_write_cpo {
     return unifex::tag_invoke(*this, (Executor &&) executor, path);
   }
 } open_file_read_write{};
-} // namespace _filesystem
+}  // namespace _filesystem
 
 using _filesystem::open_file_read_only;
-using _filesystem::open_file_write_only;
 using _filesystem::open_file_read_write;
-} // namespace unifex
+using _filesystem::open_file_write_only;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/filesystem.hpp
+++ b/include/unifex/filesystem.hpp
@@ -16,38 +16,34 @@
 #pragma once
 
 #if __cplusplus >= 201703L
-# ifdef __has_include
-#  if __has_include(<version>)
-#   include <version>
-#   if __cpp_lib_filesystem >= 201703L && __has_include(<filesystem>)
-#    include <filesystem>
-#    define UNIFEX_HAVE_FILESYSTEM 1
+#  ifdef __has_include
+#    if __has_include(<version>)
+#      include <version>
+#      if __cpp_lib_filesystem >= 201703L && __has_include(<filesystem>)
+#        include <filesystem>
+#        define UNIFEX_HAVE_FILESYSTEM 1
 
-namespace unifex
-{
-    namespace filesystem
-    {
-        using std::filesystem::path;
-    }
+namespace unifex {
+namespace filesystem {
+using std::filesystem::path;
 }
-#   endif
-#  endif
-#  ifndef UNIFEX_HAVE_FILESYSTEM
-#   if __has_include(<experimental/filesystem>)
-#    include <experimental/filesystem>
-#    define UNIFEX_HAVE_FILESYSTEM 1
+}  // namespace unifex
+#      endif
+#    endif
+#    ifndef UNIFEX_HAVE_FILESYSTEM
+#      if __has_include(<experimental/filesystem>)
+#        include <experimental/filesystem>
+#        define UNIFEX_HAVE_FILESYSTEM 1
 
-namespace unifex
-{
-    namespace filesystem
-    {
-        using std::experimental::filesystem::path;
-    }
+namespace unifex {
+namespace filesystem {
+using std::experimental::filesystem::path;
 }
-#   endif
+}  // namespace unifex
+#      endif
+#    endif
 #  endif
-# endif
 #endif
 #ifndef UNIFEX_HAVE_FILESYSTEM
-# define UNIFEX_HAVE_FILESYSTEM 0
+#  define UNIFEX_HAVE_FILESYSTEM 0
 #endif

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -16,15 +16,15 @@
 #pragma once
 
 #include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/scope_guard.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <exception>
 #include <functional>
@@ -34,736 +34,697 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _final
-  {
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver>
-    struct _op {
-      class type;
-    };
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver>
-    using operation =
-        typename _op<SourceSender, CompletionSender, remove_cvref_t<Receiver>>::type;
+namespace unifex {
+namespace _final {
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+struct _op {
+  class type;
+};
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+using operation =
+    typename _op<SourceSender, CompletionSender, remove_cvref_t<Receiver>>::
+        type;
 
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename... Values>
-    struct _value_receiver {
-      class type;
-    };
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename... Values>
-    using value_receiver =
-      typename _value_receiver<
-        SourceSender,
-        CompletionSender,
-        Receiver,
-        std::decay_t<Values>...>::type;
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename... Values>
+struct _value_receiver {
+  class type;
+};
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename... Values>
+using value_receiver = typename _value_receiver<
+    SourceSender,
+    CompletionSender,
+    Receiver,
+    std::decay_t<Values>...>::type;
 
-    constexpr blocking_kind _blocking_kind(
-        blocking_kind source,
-        blocking_kind completion) noexcept {
-      if (source == blocking_kind::never || completion == blocking_kind::never) {
-        return blocking_kind::never;
-      } else if (
-          source == blocking_kind::always_inline &&
-          completion == blocking_kind::always_inline) {
-        return blocking_kind::always_inline;
-      } else if (
-          (source == blocking_kind::always_inline ||
-          source == blocking_kind::always) &&
-          (completion == blocking_kind::always_inline ||
-          completion == blocking_kind::always)) {
-        return blocking_kind::always;
-      } else {
-        return blocking_kind::maybe;
-      }
+constexpr blocking_kind
+_blocking_kind(blocking_kind source, blocking_kind completion) noexcept {
+  if (source == blocking_kind::never || completion == blocking_kind::never) {
+    return blocking_kind::never;
+  } else if (
+      source == blocking_kind::always_inline &&
+      completion == blocking_kind::always_inline) {
+    return blocking_kind::always_inline;
+  } else if (
+      (source == blocking_kind::always_inline ||
+       source == blocking_kind::always) &&
+      (completion == blocking_kind::always_inline ||
+       completion == blocking_kind::always)) {
+    return blocking_kind::always;
+  } else {
+    return blocking_kind::maybe;
+  }
+}
+
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename... Values>
+class _value_receiver<SourceSender, CompletionSender, Receiver, Values...>::type
+    final {
+  using value_receiver = type;
+  using operation_type = operation<SourceSender, CompletionSender, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+  void set_value() && noexcept {
+    auto* const op = op_;
+
+    using completion_value_op_t =
+        connect_result_t<CompletionSender, value_receiver>;
+    unifex::deactivate_union_member<completion_value_op_t>(
+        op->completionValueOp_);
+
+    UNIFEX_TRY {
+      // Move the stored values onto the stack so that we can
+      // destroy the ones stored in the operation-state. This
+      // prevents the need to add a big switch to the operation
+      // state destructor to determine which value-tuple type
+      // destructor needs to be run.
+      auto values = [op]() -> std::tuple<Values...> {
+        scope_guard g{[op]() noexcept {
+          unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
+        }};
+        return static_cast<std::tuple<Values...>&&>(
+            op->value_.template get<std::tuple<Values...>>());
+      }();
+
+      std::apply(
+          [&](Values&&... values) {
+            unifex::set_value(
+                static_cast<Receiver&&>(op->receiver_),
+                static_cast<Values&&>(values)...);
+          },
+          static_cast<std::tuple<Values...>&&>(values));
+    }
+    UNIFEX_CATCH(...) {
+      unifex::set_error(
+          static_cast<Receiver&&>(op->receiver_), std::current_exception());
+    }
+  }
+
+  template <typename Error>
+  void set_error(Error&& error) && noexcept {
+    auto* const op = op_;
+
+    using completion_value_op_t =
+        connect_result_t<CompletionSender, value_receiver>;
+    unifex::deactivate_union_member<completion_value_op_t>(
+        op->completionValueOp_);
+
+    // Discard the stored value.
+    unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
+
+    unifex::set_error(
+        static_cast<Receiver&&>(op->receiver_), static_cast<Error&&>(error));
+  }
+
+  void set_done() && noexcept {
+    auto* const op = op_;
+
+    using completion_value_op_t =
+        connect_result_t<CompletionSender, value_receiver>;
+    unifex::deactivate_union_member<completion_value_op_t>(
+        op->completionValueOp_);
+
+    // Discard the stored value.
+    unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
+
+    unifex::set_done(static_cast<Receiver&&>(op->receiver_));
+  }
+
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, value_receiver> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_receiver());
+  }
+
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const value_receiver& r, Func&& func) {
+    std::invoke(func, r.get_receiver());
+  }
+
+private:
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename Error>
+struct _error_receiver {
+  class type;
+};
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename Error>
+using error_receiver = typename _error_receiver<
+    SourceSender,
+    CompletionSender,
+    Receiver,
+    std::decay_t<Error>>::type;
+
+template <
+    typename SourceSender,
+    typename CompletionSender,
+    typename Receiver,
+    typename Error>
+class _error_receiver<SourceSender, CompletionSender, Receiver, Error>::type
+    final {
+  using error_receiver = type;
+  using operation_type = operation<SourceSender, CompletionSender, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+  void set_value() && noexcept {
+    auto* const op = op_;
+
+    using completion_error_op_t =
+        connect_result_t<CompletionSender, error_receiver>;
+    unifex::deactivate_union_member<completion_error_op_t>(
+        op->completionErrorOp_);
+
+    Error errorCopy = static_cast<Error&&>(op->error_.template get<Error>());
+    unifex::deactivate_union_member<Error>(op->error_);
+
+    unifex::set_error(
+        static_cast<Receiver&&>(op->receiver_),
+        static_cast<Error&&>(errorCopy));
+  }
+
+  template(typename OtherError)(
+      requires receiver<
+          Receiver,
+          OtherError>) void set_error(OtherError otherError) && noexcept {
+    auto* const op = op_;
+
+    using completion_error_op_t =
+        connect_result_t<CompletionSender, error_receiver>;
+    unifex::deactivate_union_member<completion_error_op_t>(
+        op->completionErrorOp_);
+
+    // Discard existing stored error from source-sender.
+    unifex::deactivate_union_member<Error>(op->error_);
+
+    unifex::set_error(
+        static_cast<Receiver&&>(op->receiver_),
+        static_cast<OtherError&&>(otherError));
+  }
+
+  void set_done() && noexcept {
+    auto* const op = op_;
+
+    using completion_error_op_t =
+        connect_result_t<CompletionSender, error_receiver>;
+    unifex::deactivate_union_member<completion_error_op_t>(
+        op->completionErrorOp_);
+
+    // Discard existing stored error from source-sender.
+    unifex::deactivate_union_member<Error>(op->error_);
+
+    unifex::set_done(static_cast<Receiver&&>(op->receiver_));
+  }
+
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, error_receiver> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_receiver());
+  }
+
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const error_receiver& r, Func&& func) {
+    std::invoke(func, r.get_receiver());
+  }
+
+private:
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+struct _done_receiver {
+  class type;
+};
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+using done_receiver =
+    typename _done_receiver<SourceSender, CompletionSender, Receiver>::type;
+
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+class _done_receiver<SourceSender, CompletionSender, Receiver>::type final {
+  using done_receiver = type;
+  using operation_type = operation<SourceSender, CompletionSender, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+  void set_value() && noexcept {
+    auto* const op = op_;
+    unifex::deactivate_union_member(op->completionDoneOp_);
+    unifex::set_done(static_cast<Receiver&&>(op->receiver_));
+  }
+
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
+    auto* const op = op_;
+    unifex::deactivate_union_member(op->completionDoneOp_);
+    unifex::set_error(
+        static_cast<Receiver&&>(op->receiver_), static_cast<Error&&>(error));
+  }
+
+  void set_done() && noexcept {
+    auto* const op = op_;
+    unifex::deactivate_union_member(op->completionDoneOp_);
+    unifex::set_done(static_cast<Receiver&&>(op->receiver_));
+  }
+
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, done_receiver> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_receiver());
+  }
+
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const done_receiver& r, Func&& func) {
+    std::invoke(func, r.get_receiver());
+  }
+
+private:
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+struct _receiver {
+  class type;
+};
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+using receiver_t =
+    typename _receiver<SourceSender, CompletionSender, Receiver>::type;
+
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+class _receiver<SourceSender, CompletionSender, Receiver>::type final {
+  using operation_type = operation<SourceSender, CompletionSender, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+  template(typename... Values)(
+      requires receiver_of<
+          Receiver,
+          Values...>) void set_value(Values&&... values) && noexcept {
+    auto* const op = op_;
+
+    UNIFEX_TRY {
+      unifex::activate_union_member<std::tuple<std::decay_t<Values>...>>(
+          op->value_, static_cast<Values&&>(values)...);
+    }
+    UNIFEX_CATCH(...) {
+      std::move(*this).set_error(std::current_exception());
+      return;
     }
 
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename... Values>
-    class _value_receiver<SourceSender, CompletionSender, Receiver, Values...>::type final {
-      using value_receiver = type;
-      using operation_type = operation<SourceSender, CompletionSender, Receiver>;
-
-    public:
-      explicit type(operation_type* op) noexcept : op_(op) {}
-
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
-
-      void set_value() && noexcept {
-        auto* const op = op_;
-
-        using completion_value_op_t = connect_result_t<CompletionSender, value_receiver>;
-        unifex::deactivate_union_member<completion_value_op_t>(op->completionValueOp_);
-
-        UNIFEX_TRY {
-          // Move the stored values onto the stack so that we can
-          // destroy the ones stored in the operation-state. This
-          // prevents the need to add a big switch to the operation
-          // state destructor to determine which value-tuple type
-          // destructor needs to be run.
-          auto values = [op]() -> std::tuple<Values...> {
-            scope_guard g{[op]() noexcept {
-              unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
-            }};
-            return static_cast<std::tuple<Values...>&&>(
-              op->value_.template get<std::tuple<Values...>>());
-          }
-          ();
-
-          std::apply(
-              [&](Values&&... values) {
-                unifex::set_value(
-                    static_cast<Receiver&&>(op->receiver_),
-                    static_cast<Values&&>(values)...);
-              },
-              static_cast<std::tuple<Values...>&&>(values));
-
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(
-              static_cast<Receiver&&>(op->receiver_), std::current_exception());
-        }
-      }
-
-      template <typename Error>
-      void set_error(Error&& error) && noexcept {
-        auto* const op = op_;
-
-        using completion_value_op_t = connect_result_t<CompletionSender, value_receiver>;
-        unifex::deactivate_union_member<completion_value_op_t>(op->completionValueOp_);
-
-        // Discard the stored value.
-        unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
-
-        unifex::set_error(
-            static_cast<Receiver&&>(op->receiver_),
-            static_cast<Error&&>(error));
-      }
-
-      void set_done() && noexcept {
-        auto* const op = op_;
-
-        using completion_value_op_t = connect_result_t<CompletionSender, value_receiver>;
-        unifex::deactivate_union_member<completion_value_op_t>(op->completionValueOp_);
-
-        // Discard the stored value.
-        unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
-
-        unifex::set_done(static_cast<Receiver&&>(op->receiver_));
-      }
-
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, value_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const R& r) noexcept(is_nothrow_callable_v<
-                                          CPO,
-                                          const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const value_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.get_receiver());
-      }
-
-    private:
-      const Receiver& get_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename Error>
-    struct _error_receiver {
-      class type;
-    };
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename Error>
-    using error_receiver =
-      typename _error_receiver<
-        SourceSender,
-        CompletionSender,
-        Receiver,
-        std::decay_t<Error>>::type;
-
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver,
-        typename Error>
-    class _error_receiver<SourceSender, CompletionSender, Receiver, Error>::type final {
-      using error_receiver = type;
-      using operation_type = operation<SourceSender, CompletionSender, Receiver>;
-
-    public:
-      explicit type(operation_type* op) noexcept : op_(op) {}
-
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
-
-      void set_value() && noexcept {
-        auto* const op = op_;
-
-        using completion_error_op_t = connect_result_t<CompletionSender, error_receiver>;
-        unifex::deactivate_union_member<completion_error_op_t>(op->completionErrorOp_);
-
-        Error errorCopy = static_cast<Error&&>(op->error_.template get<Error>());
-        unifex::deactivate_union_member<Error>(op->error_);
-
-        unifex::set_error(
-            static_cast<Receiver&&>(op->receiver_),
-            static_cast<Error&&>(errorCopy));
-      }
-
-      template(typename OtherError)
-          (requires receiver<Receiver, OtherError>)
-      void set_error(OtherError otherError) && noexcept {
-        auto* const op = op_;
-
-        using completion_error_op_t = connect_result_t<CompletionSender, error_receiver>;
-        unifex::deactivate_union_member<completion_error_op_t>(op->completionErrorOp_);
-
-        // Discard existing stored error from source-sender.
-        unifex::deactivate_union_member<Error>(op->error_);
-
-        unifex::set_error(
-            static_cast<Receiver&&>(op->receiver_),
-            static_cast<OtherError&&>(otherError));
-      }
-
-      void set_done() && noexcept {
-        auto* const op = op_;
-
-        using completion_error_op_t = connect_result_t<CompletionSender, error_receiver>;
-        unifex::deactivate_union_member<completion_error_op_t>(op->completionErrorOp_);
-
-        // Discard existing stored error from source-sender.
-        unifex::deactivate_union_member<Error>(op->error_);
-
-        unifex::set_done(static_cast<Receiver&&>(op->receiver_));
-      }
-
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, error_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const R& r) noexcept(is_nothrow_callable_v<
-                                          CPO,
-                                          const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const error_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.get_receiver());
-      }
-
-    private:
-      const Receiver& get_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    struct _done_receiver {
-      class type;
-    };
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    using done_receiver =
-        typename _done_receiver<SourceSender, CompletionSender, Receiver>::type;
-
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    class _done_receiver<SourceSender, CompletionSender, Receiver>::type final {
-      using done_receiver = type;
-      using operation_type = operation<SourceSender, CompletionSender, Receiver>;
-
-    public:
-      explicit type(operation_type* op) noexcept : op_(op) {}
-
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
-
-      void set_value() && noexcept {
-        auto* const op = op_;
-        unifex::deactivate_union_member(op->completionDoneOp_);
-        unifex::set_done(static_cast<Receiver&&>(op->receiver_));
-      }
-
-      template(typename Error)
-          (requires receiver<Receiver, Error>)
-      void set_error(Error&& error) && noexcept {
-        auto* const op = op_;
-        unifex::deactivate_union_member(op->completionDoneOp_);
-        unifex::set_error(
-            static_cast<Receiver&&>(op->receiver_),
-            static_cast<Error&&>(error));
-      }
-
-      void set_done() && noexcept {
-        auto* const op = op_;
-        unifex::deactivate_union_member(op->completionDoneOp_);
-        unifex::set_done(static_cast<Receiver&&>(op->receiver_));
-      }
-
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, done_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const R& r) noexcept(is_nothrow_callable_v<
-                                          CPO,
-                                          const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const done_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.get_receiver());
-      }
-
-    private:
-      const Receiver& get_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    struct _receiver {
-      class type;
-    };
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    using receiver_t = typename _receiver<SourceSender, CompletionSender, Receiver>::type;
-
-    template <typename SourceSender, typename CompletionSender, typename Receiver>
-    class _receiver<SourceSender, CompletionSender, Receiver>::type final {
-      using operation_type = operation<SourceSender, CompletionSender, Receiver>;
-
-    public:
-      explicit type(operation_type* op) noexcept : op_(op) {}
-
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
-
-      template(typename... Values)
-          (requires receiver_of<Receiver, Values...>)
-      void set_value(Values&&... values) && noexcept {
-        auto* const op = op_;
-
-        UNIFEX_TRY {
-          unifex::activate_union_member<std::tuple<std::decay_t<Values>...>>(
-            op->value_, static_cast<Values&&>(values)...);
-        } UNIFEX_CATCH (...) {
-          std::move(*this).set_error(std::current_exception());
-          return;
-        }
-
-        unifex::deactivate_union_member(op->sourceOp_);
-
-        UNIFEX_TRY {
-          using value_receiver = value_receiver<
-              SourceSender,
-              CompletionSender,
-              Receiver,
-              Values...>;
-          using completion_value_op_t =
-            connect_result_t<CompletionSender, value_receiver>;
-          auto& completionOp =
-              unifex::activate_union_member_with<completion_value_op_t>(
-                  op->completionValueOp_,
-                  [&] {
-                    return unifex::connect(
-                        static_cast<CompletionSender&&>(op->completionSender_),
-                        value_receiver{op});
-                  });
-          unifex::start(completionOp);
-        } UNIFEX_CATCH (...) {
-          using decayed_tuple_t = std::tuple<std::decay_t<Values>...>;
-          unifex::deactivate_union_member<decayed_tuple_t>(op->value_);
-          unifex::set_error(
-              static_cast<Receiver&&>(op->receiver_), std::current_exception());
-        }
-      }
-
-      template <typename Error>
-      void set_error(Error&& error) && noexcept {
-        static_assert(
-            std::is_nothrow_constructible_v<std::decay_t<Error>, Error>);
-
-        auto* const op = op_;
-        unifex::activate_union_member<std::decay_t<Error>>(
-            op->error_, static_cast<Error&&>(error));
-
-        unifex::deactivate_union_member(op->sourceOp_);
-
-        UNIFEX_TRY {
-          using error_receiver_t = error_receiver<
-              SourceSender,
-              CompletionSender,
-              Receiver,
-              Error>;
-          using completion_error_op_t =
-            connect_result_t<CompletionSender, error_receiver_t>;
-          auto& completionOp =
-              unifex::activate_union_member_with<completion_error_op_t>(
-                  op->completionErrorOp_,
-                  [&] {
-                    return unifex::connect(
-                        static_cast<CompletionSender&&>(op->completionSender_),
-                        error_receiver_t{op});
-                  });
-          unifex::start(completionOp);
-        } UNIFEX_CATCH (...) {
-          unifex::deactivate_union_member<std::decay_t<Error>>(op->error_);
-          unifex::set_error(
-              static_cast<Receiver&&>(op->receiver_), std::current_exception());
-        }
-      }
-
-      void set_done() && noexcept {
-        auto* const op = op_;
-
-        unifex::deactivate_union_member(op->sourceOp_);
-
-        UNIFEX_TRY {
-          using done_receiver =
-              done_receiver<SourceSender, CompletionSender, Receiver>;
-          auto& completionOp = unifex::activate_union_member_with(
-            op->completionDoneOp_,
-            [&] {
-              return unifex::connect(
-                  static_cast<CompletionSender&&>(op->completionSender_),
-                  done_receiver{op});
-            });
-          unifex::start(completionOp);
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(
-              static_cast<Receiver&&>(op->receiver_), std::current_exception());
-        }
-      }
-
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, type> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto
-      tag_invoke(CPO cpo, const R& r) noexcept(
-          is_nothrow_callable_v<CPO, const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>, const type& r, Func&& func) {
-        std::invoke(func, r.get_receiver());
-      }
-
-    private:
-      const Receiver& get_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <
-        typename SourceSender,
-        typename CompletionSender,
-        typename Receiver>
-    class _op<SourceSender, CompletionSender, Receiver>::type {
-      friend receiver_t<SourceSender, CompletionSender, Receiver>;
-      friend done_receiver<SourceSender, CompletionSender, Receiver>;
-
-      template <
-          typename SourceSender2,
-          typename CompletionSender2,
-          typename Receiver2,
-          typename... Values>
-      friend struct _value_receiver;
-
-      template <
-          typename SourceSender2,
-          typename CompletionSender2,
-          typename Receiver2,
-          typename Error>
-      friend struct _error_receiver;
-
-      template <typename... Values>
-      using value_operation = connect_result_t<
-          CompletionSender,
-          value_receiver<SourceSender, CompletionSender, Receiver, Values...>>;
-
-      template <typename Error>
-      using error_operation = connect_result_t<
-          CompletionSender,
-          error_receiver<SourceSender, CompletionSender, Receiver, Error>>;
-
-      template <typename... Errors>
-      using error_operation_union =
-          manual_lifetime_union<
-            error_operation<std::exception_ptr>,
-            error_operation<Errors>...>;
-
-      using done_operation = connect_result_t<
-          CompletionSender,
-          done_receiver<SourceSender, CompletionSender, Receiver>>;
-
-      template <typename... Errors>
-      using error_result_union =
-        manual_lifetime_union<std::exception_ptr, Errors...>;
-
-    public:
-      template <typename CompletionSender2, typename Receiver2>
-      explicit type(
-          SourceSender&& sourceSender,
-          CompletionSender2&& completionSender,
-          Receiver2&& r)
-        : completionSender_(static_cast<CompletionSender2&&>(completionSender))
-        , receiver_(static_cast<Receiver2&&>(r))
-        , sourceOp_{} {
-        sourceOp_.construct_with([&] {
-          return unifex::connect(
-              static_cast<SourceSender&&>(sourceSender),
-              receiver_t<SourceSender, CompletionSender, Receiver>{this});
-        });
-      }
-
-      ~type() {
-        if (!started_) {
-          unifex::deactivate_union_member(sourceOp_);
-        }
-      }
-
-      void start() & noexcept {
-        UNIFEX_ASSERT(!started_);
-        started_ = true;
-        unifex::start(sourceOp_.get());
-      }
-
-    private:
-      UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<CompletionSender> completionSender_;
-      UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-      bool started_ = false;
-
-      // Result storage.
-      union {
-        // Storage for error-types that might be produced by SourceSender.
-        UNIFEX_NO_UNIQUE_ADDRESS
-        sender_error_types_t<remove_cvref_t<SourceSender>, error_result_union>
-            error_;
-
-        // Storage for value-types that might be produced by SourceSender.
-        UNIFEX_NO_UNIQUE_ADDRESS
-        sender_value_types_t<
-            remove_cvref_t<SourceSender>,
-            manual_lifetime_union,
-            decayed_tuple<std::tuple>::template apply>
-                value_;
-      };
-
-      using source_operation_t =
-          manual_lifetime<connect_result_t<
-            SourceSender,
-            receiver_t<SourceSender, CompletionSender, Receiver>>>;
-
-      using completion_value_union_t =
-          sender_value_types_t<
-              remove_cvref_t<SourceSender>,
-              manual_lifetime_union,
-              value_operation>;
-
-      using completion_error_union_t =
-          sender_error_types_t<remove_cvref_t<SourceSender>, error_operation_union>;
-
-      // Operation storage.
-      union {
-        // Storage for the source operation state.
-        source_operation_t sourceOp_;
-
-        // Storage for the completion operation for the case where
-        // the source operation completed with a value.
-        completion_value_union_t completionValueOp_;
-
-        // Storage for the completion operation for the case where the
-        // source operation completed with an error.
-        completion_error_union_t completionErrorOp_;
-
-        // Storage for the completion operation for the case where the
-        // source operation completed with 'done'.
-        manual_lifetime<done_operation> completionDoneOp_;
-      };
-    };
-
-    template <typename SourceSender, typename CompletionSender>
-    struct _sender {
-      class type;
-    };
-    template <typename SourceSender, typename CompletionSender>
-    using sender = typename _sender<
+    unifex::deactivate_union_member(op->sourceOp_);
+
+    UNIFEX_TRY {
+      using value_receiver =
+          value_receiver<SourceSender, CompletionSender, Receiver, Values...>;
+      using completion_value_op_t =
+          connect_result_t<CompletionSender, value_receiver>;
+      auto& completionOp =
+          unifex::activate_union_member_with<completion_value_op_t>(
+              op->completionValueOp_, [&] {
+                return unifex::connect(
+                    static_cast<CompletionSender&&>(op->completionSender_),
+                    value_receiver{op});
+              });
+      unifex::start(completionOp);
+    }
+    UNIFEX_CATCH(...) {
+      using decayed_tuple_t = std::tuple<std::decay_t<Values>...>;
+      unifex::deactivate_union_member<decayed_tuple_t>(op->value_);
+      unifex::set_error(
+          static_cast<Receiver&&>(op->receiver_), std::current_exception());
+    }
+  }
+
+  template <typename Error>
+  void set_error(Error&& error) && noexcept {
+    static_assert(std::is_nothrow_constructible_v<std::decay_t<Error>, Error>);
+
+    auto* const op = op_;
+    unifex::activate_union_member<std::decay_t<Error>>(
+        op->error_, static_cast<Error&&>(error));
+
+    unifex::deactivate_union_member(op->sourceOp_);
+
+    UNIFEX_TRY {
+      using error_receiver_t =
+          error_receiver<SourceSender, CompletionSender, Receiver, Error>;
+      using completion_error_op_t =
+          connect_result_t<CompletionSender, error_receiver_t>;
+      auto& completionOp =
+          unifex::activate_union_member_with<completion_error_op_t>(
+              op->completionErrorOp_, [&] {
+                return unifex::connect(
+                    static_cast<CompletionSender&&>(op->completionSender_),
+                    error_receiver_t{op});
+              });
+      unifex::start(completionOp);
+    }
+    UNIFEX_CATCH(...) {
+      unifex::deactivate_union_member<std::decay_t<Error>>(op->error_);
+      unifex::set_error(
+          static_cast<Receiver&&>(op->receiver_), std::current_exception());
+    }
+  }
+
+  void set_done() && noexcept {
+    auto* const op = op_;
+
+    unifex::deactivate_union_member(op->sourceOp_);
+
+    UNIFEX_TRY {
+      using done_receiver =
+          done_receiver<SourceSender, CompletionSender, Receiver>;
+      auto& completionOp =
+          unifex::activate_union_member_with(op->completionDoneOp_, [&] {
+            return unifex::connect(
+                static_cast<CompletionSender&&>(op->completionSender_),
+                done_receiver{op});
+          });
+      unifex::start(completionOp);
+    }
+    UNIFEX_CATCH(...) {
+      unifex::set_error(
+          static_cast<Receiver&&>(op->receiver_), std::current_exception());
+    }
+  }
+
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, type> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_receiver());
+  }
+
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+    std::invoke(func, r.get_receiver());
+  }
+
+private:
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <typename SourceSender, typename CompletionSender, typename Receiver>
+class _op<SourceSender, CompletionSender, Receiver>::type {
+  friend receiver_t<SourceSender, CompletionSender, Receiver>;
+  friend done_receiver<SourceSender, CompletionSender, Receiver>;
+
+  template <
+      typename SourceSender2,
+      typename CompletionSender2,
+      typename Receiver2,
+      typename... Values>
+  friend struct _value_receiver;
+
+  template <
+      typename SourceSender2,
+      typename CompletionSender2,
+      typename Receiver2,
+      typename Error>
+  friend struct _error_receiver;
+
+  template <typename... Values>
+  using value_operation = connect_result_t<
+      CompletionSender,
+      value_receiver<SourceSender, CompletionSender, Receiver, Values...>>;
+
+  template <typename Error>
+  using error_operation = connect_result_t<
+      CompletionSender,
+      error_receiver<SourceSender, CompletionSender, Receiver, Error>>;
+
+  template <typename... Errors>
+  using error_operation_union = manual_lifetime_union<
+      error_operation<std::exception_ptr>,
+      error_operation<Errors>...>;
+
+  using done_operation = connect_result_t<
+      CompletionSender,
+      done_receiver<SourceSender, CompletionSender, Receiver>>;
+
+  template <typename... Errors>
+  using error_result_union =
+      manual_lifetime_union<std::exception_ptr, Errors...>;
+
+public:
+  template <typename CompletionSender2, typename Receiver2>
+  explicit type(
+      SourceSender&& sourceSender,
+      CompletionSender2&& completionSender,
+      Receiver2&& r)
+    : completionSender_(static_cast<CompletionSender2&&>(completionSender))
+    , receiver_(static_cast<Receiver2&&>(r))
+    , sourceOp_{} {
+    sourceOp_.construct_with([&] {
+      return unifex::connect(
+          static_cast<SourceSender&&>(sourceSender),
+          receiver_t<SourceSender, CompletionSender, Receiver>{this});
+    });
+  }
+
+  ~type() {
+    if (!started_) {
+      unifex::deactivate_union_member(sourceOp_);
+    }
+  }
+
+  void start() & noexcept {
+    UNIFEX_ASSERT(!started_);
+    started_ = true;
+    unifex::start(sourceOp_.get());
+  }
+
+private:
+  UNIFEX_NO_UNIQUE_ADDRESS remove_cvref_t<CompletionSender> completionSender_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  bool started_ = false;
+
+  // Result storage.
+  union {
+    // Storage for error-types that might be produced by SourceSender.
+    UNIFEX_NO_UNIQUE_ADDRESS
+    sender_error_types_t<remove_cvref_t<SourceSender>, error_result_union>
+        error_;
+
+    // Storage for value-types that might be produced by SourceSender.
+    UNIFEX_NO_UNIQUE_ADDRESS
+    sender_value_types_t<
         remove_cvref_t<SourceSender>,
-        remove_cvref_t<CompletionSender>>::type;
+        manual_lifetime_union,
+        decayed_tuple<std::tuple>::template apply>
+        value_;
+  };
 
-    template <typename SourceSender, typename CompletionSender>
-    class _sender<SourceSender, CompletionSender>::type {
-      using sender = type;
-    public:
-      template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
-      using value_types = typename sender_traits<SourceSender>::
-          template value_types<Variant, decayed_tuple<Tuple>::template apply>;
+  using source_operation_t = manual_lifetime<connect_result_t<
+      SourceSender,
+      receiver_t<SourceSender, CompletionSender, Receiver>>>;
 
-      // This can produce any of the error_types of SourceSender, or of
-      // CompletionSender or an exception_ptr corresponding to an exception thrown
-      // by the copy/move of the value result.
-      // TODO: In theory we could eliminate exception_ptr in the case that the
-      // connect() operation and move/copy of values
-      template <template <typename...> class Variant>
-      using error_types =
-          typename concat_type_lists_unique_t<
-              sender_error_types_t<SourceSender, decayed_tuple<type_list>::template apply>,
-              sender_error_types_t<CompletionSender, decayed_tuple<type_list>::template apply>,
-              type_list<std::exception_ptr>>::template apply<Variant>;
+  using completion_value_union_t = sender_value_types_t<
+      remove_cvref_t<SourceSender>,
+      manual_lifetime_union,
+      value_operation>;
 
-      static constexpr bool sends_done =
-          sender_traits<SourceSender>::sends_done ||
-          sender_traits<CompletionSender>::sends_done;
+  using completion_error_union_t =
+      sender_error_types_t<remove_cvref_t<SourceSender>, error_operation_union>;
 
-      template <typename SourceSender2, typename CompletionSender2>
-      explicit type(
-          SourceSender2&& source, CompletionSender2&& completion)
-          noexcept(std::is_nothrow_constructible_v<SourceSender, SourceSender2> &&
-              std::is_nothrow_constructible_v<CompletionSender, CompletionSender2>)
-        : source_(static_cast<SourceSender2&&>(source))
-        , completion_(static_cast<CompletionSender2&&>(completion)) {}
+  // Operation storage.
+  union {
+    // Storage for the source operation state.
+    source_operation_t sourceOp_;
 
-    private:
+    // Storage for the completion operation for the case where
+    // the source operation completed with a value.
+    completion_value_union_t completionValueOp_;
 
-      // TODO: Also constrain these methods to check that the CompletionSender
-      // is connectable to any of the instantiations of done/value/error_receiver
-      // that could be created for each of the results that SourceSender might
-      // complete with. For now we just check done_receiver as an approximation.
+    // Storage for the completion operation for the case where the
+    // source operation completed with an error.
+    completion_error_union_t completionErrorOp_;
 
-      template(typename CPO, typename S, typename Receiver)
-        (requires
-          same_as<CPO, tag_t<connect>> AND
-          same_as<remove_cvref_t<S>, sender> AND
-          receiver<Receiver> AND
+    // Storage for the completion operation for the case where the
+    // source operation completed with 'done'.
+    manual_lifetime<done_operation> completionDoneOp_;
+  };
+};
+
+template <typename SourceSender, typename CompletionSender>
+struct _sender {
+  class type;
+};
+template <typename SourceSender, typename CompletionSender>
+using sender = typename _sender<
+    remove_cvref_t<SourceSender>,
+    remove_cvref_t<CompletionSender>>::type;
+
+template <typename SourceSender, typename CompletionSender>
+class _sender<SourceSender, CompletionSender>::type {
+  using sender = type;
+
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename sender_traits<SourceSender>::
+      template value_types<Variant, decayed_tuple<Tuple>::template apply>;
+
+  // This can produce any of the error_types of SourceSender, or of
+  // CompletionSender or an exception_ptr corresponding to an exception thrown
+  // by the copy/move of the value result.
+  // TODO: In theory we could eliminate exception_ptr in the case that the
+  // connect() operation and move/copy of values
+  template <template <typename...> class Variant>
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<
+          SourceSender,
+          decayed_tuple<type_list>::template apply>,
+      sender_error_types_t<
+          CompletionSender,
+          decayed_tuple<type_list>::template apply>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
+
+  static constexpr bool sends_done = sender_traits<SourceSender>::sends_done ||
+      sender_traits<CompletionSender>::sends_done;
+
+  template <typename SourceSender2, typename CompletionSender2>
+  explicit type(
+      SourceSender2&& source,
+      CompletionSender2&&
+          completion) noexcept(std::
+                                   is_nothrow_constructible_v<
+                                       SourceSender,
+                                       SourceSender2>&&
+                                       std::is_nothrow_constructible_v<
+                                           CompletionSender,
+                                           CompletionSender2>)
+    : source_(static_cast<SourceSender2&&>(source))
+    , completion_(static_cast<CompletionSender2&&>(completion)) {}
+
+private:
+  // TODO: Also constrain these methods to check that the CompletionSender
+  // is connectable to any of the instantiations of done/value/error_receiver
+  // that could be created for each of the results that SourceSender might
+  // complete with. For now we just check done_receiver as an approximation.
+
+  template(typename CPO, typename S, typename Receiver)(
+      requires same_as<CPO, tag_t<connect>> AND same_as<
+          remove_cvref_t<S>,
+          sender> AND receiver<Receiver> AND
           sender_to<
-            member_t<S, SourceSender>,
-            receiver_t<
               member_t<S, SourceSender>,
-              CompletionSender,
-              remove_cvref_t<Receiver>>> AND
-          sender_to<
-            CompletionSender,
-            done_receiver<
-              member_t<S, SourceSender>,
-              CompletionSender,
-              remove_cvref_t<Receiver>>>)
-      friend auto tag_invoke(CPO, S&& s, Receiver&& r)
-          -> operation<member_t<S, SourceSender>, CompletionSender, Receiver> {
-        return operation<member_t<S, SourceSender>, CompletionSender, Receiver>{
-                static_cast<S&&>(s).source_,
-                static_cast<S&&>(s).completion_,
-                static_cast<Receiver&&>(r)};
-      }
+              receiver_t<
+                  member_t<S, SourceSender>,
+                  CompletionSender,
+                  remove_cvref_t<Receiver>>> AND
+              sender_to<
+                  CompletionSender,
+                  done_receiver<
+                      member_t<S, SourceSender>,
+                      CompletionSender,
+                      remove_cvref_t<
+                          Receiver>>>) friend auto tag_invoke(CPO, S&& s, Receiver&& r)
+      -> operation<member_t<S, SourceSender>, CompletionSender, Receiver> {
+    return operation<member_t<S, SourceSender>, CompletionSender, Receiver>{
+        static_cast<S&&>(s).source_,
+        static_cast<S&&>(s).completion_,
+        static_cast<Receiver&&>(r)};
+  }
 
-      friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
-        if constexpr (
-            blocking_kind::never == cblocking<SourceSender>() ||
-            blocking_kind::never == cblocking<CompletionSender>()) {
-          return blocking_kind::never;
-        } else if constexpr (
-            blocking_kind::maybe != cblocking<SourceSender>() &&
-            blocking_kind::maybe != cblocking<CompletionSender>()) {
-          return blocking_kind::constant<
-              _final::_blocking_kind(
-                  cblocking<SourceSender>(),
-                  cblocking<CompletionSender>())>{};
-        } else {
-          return _final::_blocking_kind(
-              blocking(self.source_),
-              blocking(self.completion_));
-        }
-      }
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+    if constexpr (
+        blocking_kind::never == cblocking<SourceSender>() ||
+        blocking_kind::never == cblocking<CompletionSender>()) {
+      return blocking_kind::never;
+    } else if constexpr (
+        blocking_kind::maybe != cblocking<SourceSender>() &&
+        blocking_kind::maybe != cblocking<CompletionSender>()) {
+      return blocking_kind::constant<_final::_blocking_kind(
+          cblocking<SourceSender>(), cblocking<CompletionSender>())>{};
+    } else {
+      return _final::_blocking_kind(
+          blocking(self.source_), blocking(self.completion_));
+    }
+  }
 
-      SourceSender source_;
-      CompletionSender completion_;
-    };
+  SourceSender source_;
+  CompletionSender completion_;
+};
 
-    namespace _cpo
-    {
-      struct _fn {
-        template <typename SourceSender, typename CompletionSender>
-        auto operator()(SourceSender&& source, CompletionSender&& completion) const
-            noexcept(std::is_nothrow_constructible_v<
-                    _final::sender<SourceSender, CompletionSender>,
-                    SourceSender,
-                    CompletionSender>) -> _final::sender<SourceSender, CompletionSender> {
-          return _final::sender<SourceSender, CompletionSender>{
-              static_cast<SourceSender&&>(source),
-              static_cast<CompletionSender&&>(completion)};
-        }
-        template <typename CompletionSender>
-        constexpr auto operator()(CompletionSender&& completion) const
-            noexcept(is_nothrow_callable_v<
-              tag_t<bind_back>, _fn, CompletionSender>)
-            -> bind_back_result_t<_fn, CompletionSender> {
-          return bind_back(*this, (CompletionSender&&)completion);
-        }
-      };
-    } // namespace _cpo
-  } // namespace _final
+namespace _cpo {
+struct _fn {
+  template <typename SourceSender, typename CompletionSender>
+  auto operator()(SourceSender&& source, CompletionSender&& completion) const
+      noexcept(std::is_nothrow_constructible_v<
+               _final::sender<SourceSender, CompletionSender>,
+               SourceSender,
+               CompletionSender>)
+          -> _final::sender<SourceSender, CompletionSender> {
+    return _final::sender<SourceSender, CompletionSender>{
+        static_cast<SourceSender&&>(source),
+        static_cast<CompletionSender&&>(completion)};
+  }
+  template <typename CompletionSender>
+  constexpr auto operator()(CompletionSender&& completion) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, CompletionSender>)
+          -> bind_back_result_t<_fn, CompletionSender> {
+    return bind_back(*this, (CompletionSender &&) completion);
+  }
+};
+}  // namespace _cpo
+}  // namespace _final
 
-  inline constexpr _final::_cpo::_fn finally {};
-} // namespace unifex
+inline constexpr _final::_cpo::_fn finally{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -16,48 +16,65 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/bulk_join.hpp>
+#include <unifex/bulk_schedule.hpp>
+#include <unifex/bulk_transform.hpp>
+#include <unifex/execution_policy.hpp>
+#include <unifex/get_stop_token.hpp>
 #include <unifex/just.hpp>
+#include <unifex/let_done.hpp>
 #include <unifex/let_value_with.hpp>
 #include <unifex/let_value_with_stop_source.hpp>
-#include <unifex/execution_policy.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/stream_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/blocking.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/async_trace.hpp>
-#include <unifex/then.hpp>
-#include <unifex/let_done.hpp>
-#include <unifex/type_list.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/bulk_join.hpp>
-#include <unifex/bulk_transform.hpp>
-#include <unifex/bulk_schedule.hpp>
-#include <unifex/bind_back.hpp>
+#include <unifex/stream_concepts.hpp>
+#include <unifex/then.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 #include <unifex/utility.hpp>
 
 #include <exception>
 #include <functional>
-#include <type_traits>
 #include <memory>
+#include <type_traits>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _find_if {
 
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
 struct _receiver {
   struct type;
 };
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
-using receiver_t = typename _receiver<Predecessor, Receiver, Func, FuncPolicy>::type;
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
+using receiver_t =
+    typename _receiver<Predecessor, Receiver, Func, FuncPolicy>::type;
 
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
 struct _operation_state;
 
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
 struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
@@ -66,16 +83,18 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
   _operation_state<Predecessor, Receiver, Func, FuncPolicy>& operation_state_;
 
   // Helper receiver type to unpack a tuple
-  template<typename OutputReceiver>
+  template <typename OutputReceiver>
   struct unpack_receiver {
     OutputReceiver output_receiver_;
     _operation_state<Predecessor, Receiver, Func, FuncPolicy>& operation_state_;
 
-    template<typename Tuple, size_t... Idx>
-    void unpack_helper(OutputReceiver&& output_receiver, Tuple&& t, std::index_sequence<Idx...>) {
+    template <typename Tuple, size_t... Idx>
+    void unpack_helper(
+        OutputReceiver&& output_receiver,
+        Tuple&& t,
+        std::index_sequence<Idx...>) {
       unifex::set_value(
-        (OutputReceiver&&) output_receiver,
-        std::move(std::get<Idx>(t))...);
+          (OutputReceiver &&) output_receiver, std::move(std::get<Idx>(t))...);
     }
 
     template <typename Iterator, typename... Values>
@@ -83,12 +102,14 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
       operation_state_.cleanup();
       UNIFEX_TRY {
         unpack_helper(
-          (OutputReceiver&&) output_receiver_,
-          std::move(packedResult),
-          std::make_index_sequence<
-            std::tuple_size<std::tuple<Iterator, Values...>>::value>{});
-      } UNIFEX_CATCH(...) {
-        unifex::set_error((OutputReceiver&&)output_receiver_, std::current_exception());
+            (OutputReceiver &&) output_receiver_,
+            std::move(packedResult),
+            std::make_index_sequence<
+                std::tuple_size<std::tuple<Iterator, Values...>>::value>{});
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            (OutputReceiver &&) output_receiver_, std::current_exception());
       }
     }
 
@@ -103,10 +124,11 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
       unifex::set_done((OutputReceiver &&) output_receiver_);
     }
 
-    template(typename CPO, typename R)
-        (requires is_receiver_query_cpo_v<CPO> AND same_as<R, unpack_receiver<OutputReceiver>>)
-    friend auto tag_invoke(CPO cpo, const R& r) noexcept(
-        is_nothrow_callable_v<CPO, const OutputReceiver&>)
+    template(typename CPO, typename R)(
+        requires is_receiver_query_cpo_v<CPO> AND same_as<
+            R,
+            unpack_receiver<
+                OutputReceiver>>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const OutputReceiver&>)
         -> callable_result_t<CPO, const OutputReceiver&> {
       return std::move(cpo)(std::as_const(r.output_receiver_));
     }
@@ -115,9 +137,9 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
   struct find_if_helper {
     Func func_;
 
-    template<typename Scheduler, typename Iterator, typename... Values>
+    template <typename Scheduler, typename Iterator, typename... Values>
     auto operator()(
-        Scheduler&&  /*unused*/,
+        Scheduler&& /*unused*/,
         const sequenced_policy&,
         Iterator begin_it,
         Iterator end_it,
@@ -126,14 +148,15 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
       return unifex::then(
           unifex::just(std::forward<Values>(values)...),
           [this, begin_it, end_it](auto... values) {
-            for(auto it = begin_it; it != end_it; ++it) {
-              if(std::invoke((Func &&) func_, *it, values...)) {
-                return std::tuple<Iterator, Values...>(it, std::move(values)...);
+            for (auto it = begin_it; it != end_it; ++it) {
+              if (std::invoke((Func &&) func_, *it, values...)) {
+                return std::tuple<Iterator, Values...>(
+                    it, std::move(values)...);
               }
             }
-            return std::tuple<Iterator, Values...>(end_it, std::move(values)...);
-          }
-        );
+            return std::tuple<Iterator, Values...>(
+                end_it, std::move(values)...);
+          });
     }
 
     // Cancellable parallel algorithm.
@@ -141,10 +164,10 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
     // With more built-in algorithms it can be simplified:
     //  * let_value_with to allocate non-movable state in the operation state.
     //  * unpack to deal with tuple to pack conversion
-    // It could also be simplified by making more of the code custom, but I wanted
-    // to demonstrate reuse of internal algorithms to build something more compelex
-    // and cancellable.
-    template<typename Scheduler, typename Iterator, typename... Values>
+    // It could also be simplified by making more of the code custom, but I
+    // wanted to demonstrate reuse of internal algorithms to build something
+    // more compelex and cancellable.
+    template <typename Scheduler, typename Iterator, typename... Values>
     auto operator()(
         Scheduler&& sched,
         const parallel_policy&,
@@ -153,181 +176,197 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
         Values&&... values) noexcept {
       // func_ is safe to run concurrently so let's make use of that
 
-      // NOTE: Assumes random access iterator for now, on the assumption that the policy was accurate
+      // NOTE: Assumes random access iterator for now, on the assumption that
+      // the policy was accurate
       auto distance = std::distance(begin_it, end_it);
       using diff_t = decltype(distance);
       constexpr diff_t max_num_chunks = 32;
       constexpr diff_t min_chunk_size = 4;
-      diff_t num_chunks = (distance/max_num_chunks) > min_chunk_size ?
-        max_num_chunks : ((distance+min_chunk_size)/min_chunk_size);
-      diff_t chunk_size = (distance+num_chunks)/num_chunks;
+      diff_t num_chunks = (distance / max_num_chunks) > min_chunk_size
+          ? max_num_chunks
+          : ((distance + min_chunk_size) / min_chunk_size);
+      diff_t chunk_size = (distance + num_chunks) / num_chunks;
 
-      // Found flag and vector that will be constructed in-place in the operation state
+      // Found flag and vector that will be constructed in-place in the
+      // operation state
       struct State {
         std::atomic<bool> found_flag;
         std::vector<Iterator> perChunkState;
       };
 
-      // The outer let_value keeps the vector of found results and the found flag
-      // alive for the duration.
-      // let_value_with constructs the vector and found_flag directly in the operation
-      // state.
-      // Use a two phase process largely to demonstrate a simple multi-phase algorithm
-      // and to avoid using a cmpexch loop on an intermediate iterator.
-      return
-      unifex::let_value(
-        unifex::just(std::forward<Values>(values)...),
-        [func = std::move(func_), sched = std::move(sched), begin_it,
-        chunk_size, end_it, num_chunks](Values&... values) mutable {
-          return unifex::let_value_with([&](){return State{false, std::vector<Iterator>(num_chunks, end_it)};},[&](State& state) {
-            // Inject a stop source and make it available for inner operations.
-            // This stop source propagates into the algorithm through the receiver,
-            // such that it will cancel the bulk_schedule operation.
-            // It is also triggered if the downstream stop source is triggered.
-            return unifex::let_value_with_stop_source([&](unifex::inplace_stop_source& stopSource) mutable {
-              auto bulk_phase = unifex::bulk_join(
-                  unifex::bulk_transform(
-                    unifex::bulk_schedule(std::move(sched), num_chunks),
-                    [&](diff_t index){
-                      auto chunk_begin_it = begin_it + (chunk_size*index);
-                      auto chunk_end_it = chunk_begin_it;
-                      if(index < (num_chunks-1)) {
-                        std::advance(chunk_end_it, chunk_size);
-                      } else {
-                        chunk_end_it = end_it;
-                      }
+      // The outer let_value keeps the vector of found results and the found
+      // flag alive for the duration. let_value_with constructs the vector and
+      // found_flag directly in the operation state. Use a two phase process
+      // largely to demonstrate a simple multi-phase algorithm and to avoid
+      // using a cmpexch loop on an intermediate iterator.
+      return unifex::let_value(
+          unifex::just(std::forward<Values>(values)...),
+          [func = std::move(func_),
+           sched = std::move(sched),
+           begin_it,
+           chunk_size,
+           end_it,
+           num_chunks](Values&... values) mutable {
+            return unifex::let_value_with(
+                [&]() {
+                  return State{
+                      false, std::vector<Iterator>(num_chunks, end_it)};
+                },
+                [&](State& state) {
+                  // Inject a stop source and make it available for inner
+                  // operations. This stop source propagates into the algorithm
+                  // through the receiver, such that it will cancel the
+                  // bulk_schedule operation. It is also triggered if the
+                  // downstream stop source is triggered.
+                  return unifex::let_value_with_stop_source(
+                      [&](unifex::inplace_stop_source& stopSource) mutable {
+                        auto bulk_phase =
+                            unifex::bulk_join(unifex::bulk_transform(
+                                unifex::bulk_schedule(
+                                    std::move(sched), num_chunks),
+                                [&](diff_t index) {
+                                  auto chunk_begin_it =
+                                      begin_it + (chunk_size * index);
+                                  auto chunk_end_it = chunk_begin_it;
+                                  if (index < (num_chunks - 1)) {
+                                    std::advance(chunk_end_it, chunk_size);
+                                  } else {
+                                    chunk_end_it = end_it;
+                                  }
 
-                      for(auto it = chunk_begin_it; it != chunk_end_it; ++it) {
-                        if(std::invoke(func, *it, values...)) {
-                          // On success, store the value in the output array
-                          // and cancel future work.
-                          // This works on the assumption that bulk_schedule will launch
-                          // tasks (or at least, test for cancellation) in
-                          // iteration-space order, and hence only cancel future work,
-                          // to maintain the find-first property.
-                          state.perChunkState[index] = it;
-                          state.found_flag = true;
-                          stopSource.request_stop();
-                          return;
-                        }
-                      }
-                    },
-                    unifex::par
-                  )
-                );
-              return
-                unifex::then(
-                  unifex::let_done(
-                    std::move(bulk_phase),
-                    [&state](){
-                      if(state.found_flag == true) {
-                        // If the item was found, then continue as if not cancelled
-                        return just();
-                      } else {
-                        // If there was cancellation and we did not find the item
-                        // then propagate the cancellation and assume failure
-                        // TODO: We are temporarily always recovering from cancellation
-                        // until a variant sender is implemented to unify the two
-                        // algorithms
-                        return just();
-                      }
-                    }
-                  ),
-                  [&state, end_it, &values...]() mutable -> std::tuple<Iterator, Values...> {
-                    for(auto it : state.perChunkState) {
-                      if(it != end_it) {
-                        return std::tuple<Iterator, Values...>(it, std::move(values)...);
-                      }
-                    }
-                    return std::tuple<Iterator, Values...>(end_it, std::move(values)...);
-                  }
-                );
-              });
-            });
+                                  for (auto it = chunk_begin_it;
+                                       it != chunk_end_it;
+                                       ++it) {
+                                    if (std::invoke(func, *it, values...)) {
+                                      // On success, store the value in the
+                                      // output array and cancel future work.
+                                      // This works on the assumption that
+                                      // bulk_schedule will launch tasks (or at
+                                      // least, test for cancellation) in
+                                      // iteration-space order, and hence only
+                                      // cancel future work, to maintain the
+                                      // find-first property.
+                                      state.perChunkState[index] = it;
+                                      state.found_flag = true;
+                                      stopSource.request_stop();
+                                      return;
+                                    }
+                                  }
+                                },
+                                unifex::par));
+                        return unifex::then(
+                            unifex::let_done(
+                                std::move(bulk_phase),
+                                [&state]() {
+                                  if (state.found_flag == true) {
+                                    // If the item was found, then continue as
+                                    // if not cancelled
+                                    return just();
+                                  } else {
+                                    // If there was cancellation and we did not
+                                    // find the item then propagate the
+                                    // cancellation and assume failure
+                                    // TODO: We are temporarily always
+                                    // recovering from cancellation until a
+                                    // variant sender is implemented to unify
+                                    // the two algorithms
+                                    return just();
+                                  }
+                                }),
+                            [&state, end_it, &values...]() mutable
+                            -> std::tuple<Iterator, Values...> {
+                              for (auto it : state.perChunkState) {
+                                if (it != end_it) {
+                                  return std::tuple<Iterator, Values...>(
+                                      it, std::move(values)...);
+                                }
+                              }
+                              return std::tuple<Iterator, Values...>(
+                                  end_it, std::move(values)...);
+                            });
+                      });
+                });
           });
     }
   };
 
   template <typename Iterator, typename... Values>
-  void set_value(Iterator begin_it, Iterator end_it, Values&&... values) && noexcept;
+  void
+  set_value(Iterator begin_it, Iterator end_it, Values&&... values) && noexcept;
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
     unifex::set_error((Receiver &&) receiver_, (Error &&) error);
   }
 
-  void set_done() && noexcept {
-    unifex::set_done((Receiver &&) receiver_);
-  }
+  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
 
-  template(typename CPO, typename R)
-      (requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>)
-  friend auto tag_invoke(CPO cpo, const R& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO, typename R)(requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>) friend auto tag_invoke(
+      CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
     std::invoke(visit, r.receiver_);
   }
 };
 
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
 struct _operation_state {
   using receiver_type = receiver_t<Predecessor, Receiver, Func, FuncPolicy>;
 
   template <typename... Ts>
-  using find_if_apply_t =
-      connect_result_t<
-          callable_result_t<
-              typename receiver_type::find_if_helper,
-              std::decay_t<get_scheduler_result_t<const Receiver&>>&&,
-              FuncPolicy,
-              Ts&&...>,
-          typename receiver_type::template unpack_receiver<Receiver>>;
+  using find_if_apply_t = connect_result_t<
+      callable_result_t<
+          typename receiver_type::find_if_helper,
+          std::decay_t<get_scheduler_result_t<const Receiver&>>&&,
+          FuncPolicy,
+          Ts&&...>,
+      typename receiver_type::template unpack_receiver<Receiver>>;
 
-  using operation_state_t =
-      typename sender_value_types_t<
-          Predecessor,
-          single_overload,
-          find_if_apply_t>::type;
+  using operation_state_t = typename sender_value_types_t<
+      Predecessor,
+      single_overload,
+      find_if_apply_t>::type;
 
-  template<typename Sender>
-  _operation_state(Sender&& s, Receiver&& r) :
-    predOp_{unifex::connect(
+  template <typename Sender>
+  _operation_state(Sender&& s, Receiver&& r)
+    : predOp_{unifex::connect(
           static_cast<Sender&&>(s).pred_,
           receiver_type{
-            static_cast<Sender&&>(s).func_,
-            static_cast<Receiver&&>(r),
-            static_cast<Sender&&>(s).funcPolicy_,
-            *this
-          })} {
-  }
+              static_cast<Sender&&>(s).func_,
+              static_cast<Receiver&&>(r),
+              static_cast<Sender&&>(s).funcPolicy_,
+              *this})} {}
 
-  ~_operation_state() noexcept {
-  }
+  ~_operation_state() noexcept {}
 
-  void start() noexcept {
-    unifex::start(predOp_);
-  }
+  void start() noexcept { unifex::start(predOp_); }
 
   void startInner() noexcept {
     started_ = true;
     unifex::start(innerOp_.get());
   }
 
-  void cleanup() noexcept {
-    innerOp_.destruct();
-  }
+  void cleanup() noexcept { innerOp_.destruct(); }
 
   connect_result_t<Predecessor, receiver_type> predOp_;
   manual_lifetime<operation_state_t> innerOp_;
   bool started_ = false;
 };
 
-template <typename Predecessor, typename Receiver, typename Func, typename FuncPolicy>
+template <
+    typename Predecessor,
+    typename Receiver,
+    typename Func,
+    typename FuncPolicy>
 template <typename Iterator, typename... Values>
 void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     Iterator begin_it, Iterator end_it, Values&&... values) && noexcept {
@@ -335,14 +374,16 @@ void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
   unpack_receiver<Receiver> unpack{(Receiver &&) receiver_, operation_state_};
   UNIFEX_TRY {
     auto find_if_implementation_sender = find_if_helper{std::move(func_)}(
-        std::move(sched), funcPolicy_, begin_it, end_it, (Values&&) values...);
+        std::move(sched), funcPolicy_, begin_it, end_it, (Values &&) values...);
     // Store nested operation state inside find_if's operation state
     operation_state_.innerOp_.construct_with([&]() mutable {
-      return unifex::connect(std::move(find_if_implementation_sender), std::move(unpack));
+      return unifex::connect(
+          std::move(find_if_implementation_sender), std::move(unpack));
     });
 
     operation_state_.startInner();
-  } UNIFEX_CATCH(...) {
+  }
+  UNIFEX_CATCH(...) {
     unifex::set_error(std::move(unpack), std::current_exception());
   }
 }
@@ -364,18 +405,19 @@ struct _sender<Predecessor, Func, FuncPolicy>::type {
   using result = type_list<type_list<BeginIt, Args...>>;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = type_list_nested_apply_t<
       sender_value_types_t<Predecessor, concat_type_lists_unique_t, result>,
       Variant,
       Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Predecessor, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = true;
 
@@ -386,53 +428,60 @@ struct _sender<Predecessor, Func, FuncPolicy>::type {
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-    noexcept(
-      std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-      std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
-      is_nothrow_connectable_v<
-        member_t<Sender, Predecessor>,
-        receiver_type<remove_cvref_t<Receiver>>>)
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>&&
+                              std::is_nothrow_constructible_v<
+                                  Func,
+                                  member_t<Sender, Func>>&&
+                                  is_nothrow_connectable_v<
+                                      member_t<Sender, Predecessor>,
+                                      receiver_type<remove_cvref_t<Receiver>>>)
       -> _operation_state<Predecessor, Receiver, Func, FuncPolicy> {
     return _operation_state<Predecessor, Receiver, Func, FuncPolicy>{
-      static_cast<Sender&&>(s), static_cast<Receiver&&>(r)};
+        static_cast<Sender&&>(s), static_cast<Receiver&&>(r)};
   }
 };
-} // namespace _find_if
+}  // namespace _find_if
 
 namespace _find_if_cpo {
-  inline const struct _fn {
-  public:
-    template(typename Sender, typename Func, typename FuncPolicy)
-      (requires tag_invocable<_fn, Sender, Func, FuncPolicy>)
-    auto operator()(Sender&& predecessor, Func&& func, FuncPolicy policy) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func, FuncPolicy>)
-        -> tag_invoke_result_t<_fn, Sender, Func, FuncPolicy> {
-      return unifex::tag_invoke(_fn{}, (Sender&&)predecessor, (Func&&)func, (FuncPolicy&&)policy);
-    }
-    template(typename Sender, typename Func, typename FuncPolicy)
-      (requires (!tag_invocable<_fn, Sender, Func, FuncPolicy>))
-    auto operator()(Sender&& predecessor, Func&& func, FuncPolicy policy) const
-        noexcept(
-        std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<FuncPolicy>, FuncPolicy>)
-        -> _find_if::sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy>{
-      return _find_if::sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy>{
-        (Sender &&) predecessor, (Func &&) func, (FuncPolicy &&) policy};
-    }
-    template <typename Func, typename FuncPolicy>
-    constexpr auto operator()(Func&& f, const FuncPolicy& policy) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func, const FuncPolicy&>)
-        -> bind_back_result_t<_fn, Func, const FuncPolicy&> {
-      return bind_back(*this, (Func&&)f, policy);
-    }
-  } find_if{};
-} // namespace _find_if_cpo
+inline const struct _fn {
+public:
+  template(typename Sender, typename Func, typename FuncPolicy)(
+      requires tag_invocable<_fn, Sender, Func, FuncPolicy>) auto
+  operator()(Sender&& predecessor, Func&& func, FuncPolicy policy) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func, FuncPolicy>)
+          -> tag_invoke_result_t<_fn, Sender, Func, FuncPolicy> {
+    return unifex::tag_invoke(
+        _fn{}, (Sender &&) predecessor, (Func &&) func, (FuncPolicy &&) policy);
+  }
+  template(typename Sender, typename Func, typename FuncPolicy)(
+      requires(!tag_invocable<_fn, Sender, Func, FuncPolicy>)) auto
+  operator()(Sender&& predecessor, Func&& func, FuncPolicy policy) const
+      noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>&&
+                   std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func>&&
+                       std::is_nothrow_constructible_v<
+                           remove_cvref_t<FuncPolicy>,
+                           FuncPolicy>) -> _find_if::
+          sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy> {
+    return _find_if::
+        sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy>{
+            (Sender &&) predecessor, (Func &&) func, (FuncPolicy &&) policy};
+  }
+  template <typename Func, typename FuncPolicy>
+  constexpr auto operator()(Func&& f, const FuncPolicy& policy) const noexcept(
+      is_nothrow_callable_v<tag_t<bind_back>, _fn, Func, const FuncPolicy&>)
+      -> bind_back_result_t<_fn, Func, const FuncPolicy&> {
+    return bind_back(*this, (Func &&) f, policy);
+  }
+} find_if{};
+}  // namespace _find_if_cpo
 using _find_if_cpo::find_if;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/for_each.hpp
+++ b/include/unifex/for_each.hpp
@@ -15,10 +15,10 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
 #include <unifex/reduce_stream.hpp>
 #include <unifex/then.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <functional>
 
@@ -26,69 +26,65 @@
 
 namespace unifex {
 namespace _for_each {
-  namespace _impl {
-    template <typename Func>
-    struct _map {
-      Func func_;
-      template(typename... Ts)
-        (requires invocable<Func&, Ts...>)
-      unit operator()(unit s, Ts&&... values)
-          noexcept(std::is_nothrow_invocable_v<Func&, Ts...>) {
-        std::invoke(func_, (Ts&&) values...);
-        return s;
-      }
-    };
-    struct _reduce {
-      void operator()(unit) const noexcept {}
-    };
-  } // namespace _impl
+namespace _impl {
+template <typename Func>
+struct _map {
+  Func func_;
+  template(typename... Ts)(requires invocable<Func&, Ts...>) unit operator()(
+      unit s,
+      Ts&&... values) noexcept(std::is_nothrow_invocable_v<Func&, Ts...>) {
+    std::invoke(func_, (Ts &&) values...);
+    return s;
+  }
+};
+struct _reduce {
+  void operator()(unit) const noexcept {}
+};
+}  // namespace _impl
 
-  inline const struct _fn {
-  private:
-    template <typename Stream, typename Func>
-    using _default_result_t =
-        decltype(then(
-          reduce_stream(
-            UNIFEX_DECLVAL(Stream),
+inline const struct _fn {
+private:
+  template <typename Stream, typename Func>
+  using _default_result_t = decltype(then(
+      reduce_stream(
+          UNIFEX_DECLVAL(Stream),
+          unit{},
+          UNIFEX_DECLVAL(_impl::_map<remove_cvref_t<Func>>)),
+      _impl::_reduce{}));
+  template <typename Stream, typename Func>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Stream, Func>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_default_result_t>>::template apply<Stream, Func>;
+
+public:
+  template(typename Stream, typename Func)(
+      requires tag_invocable<_fn, Stream, Func>) auto
+  operator()(Stream&& stream, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Stream, Func>)
+          -> _result_t<Stream, Func> {
+    return unifex::tag_invoke(_fn{}, (Stream &&) stream, (Func &&) func);
+  }
+  template(typename Stream, typename Func)(
+      requires(!tag_invocable<_fn, Stream, Func>)) auto
+  operator()(Stream&& stream, Func&& func) const -> _result_t<Stream, Func> {
+    return then(
+        reduce_stream(
+            (Stream &&) stream,
             unit{},
-            UNIFEX_DECLVAL(_impl::_map<remove_cvref_t<Func>>)),
-          _impl::_reduce{}));
-    template <typename Stream, typename Func>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Stream, Func>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote2<_default_result_t>>::template apply<Stream, Func>;
-  public:
-    template(typename Stream, typename Func)
-      (requires tag_invocable<_fn, Stream, Func>)
-    auto operator()(Stream&& stream, Func&& func) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Stream, Func>)
-        -> _result_t<Stream, Func> {
-      return unifex::tag_invoke(_fn{}, (Stream&&) stream, (Func&&) func);
-    }
-    template(typename Stream, typename Func)
-      (requires (!tag_invocable<_fn, Stream, Func>))
-    auto operator()(Stream&& stream, Func&& func) const
-        -> _result_t<Stream, Func> {
-      return then(
-          reduce_stream(
-              (Stream &&) stream,
-              unit{},
-              _impl::_map<remove_cvref_t<Func>>{(Func &&) func}),
-          _impl::_reduce{});
-    }
-    template <typename Func>
-    constexpr auto operator()(Func&& f) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func>)
-        -> bind_back_result_t<_fn, Func> {
-      return bind_back(*this, (Func&&)f);
-    }
-  } for_each{};
-} // namespace _for_each
+            _impl::_map<remove_cvref_t<Func>>{(Func &&) func}),
+        _impl::_reduce{});
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& f) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&) f);
+  }
+} for_each{};
+}  // namespace _for_each
 
 using _for_each::for_each;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_allocator.hpp
+++ b/include/unifex/get_allocator.hpp
@@ -25,27 +25,27 @@
 
 namespace unifex {
 namespace _get_alloc {
-  inline const struct _fn {
-    template <typename T>
-    constexpr auto operator()(const T&) const noexcept
-        -> std::enable_if_t<!is_tag_invocable_v<_fn, const T&>,
-                            std::allocator<std::byte>> {
-      return std::allocator<std::byte>{};
-    }
+inline const struct _fn {
+  template <typename T>
+  constexpr auto operator()(const T&) const noexcept -> std::enable_if_t<
+      !is_tag_invocable_v<_fn, const T&>,
+      std::allocator<std::byte>> {
+    return std::allocator<std::byte>{};
+  }
 
-    template <typename T>
-    constexpr auto operator()(const T& object) const noexcept
-        -> tag_invoke_result_t<_fn, const T&> {
-      return tag_invoke(*this, object);
-    }
-  } get_allocator{};
-} // namespace _get_alloc
+  template <typename T>
+  constexpr auto operator()(const T& object) const noexcept
+      -> tag_invoke_result_t<_fn, const T&> {
+    return tag_invoke(*this, object);
+  }
+} get_allocator{};
+}  // namespace _get_alloc
 
 using _get_alloc::get_allocator;
 
 template <typename T>
 using get_allocator_t = decltype(get_allocator(std::declval<T>()));
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_execution_policy.hpp
+++ b/include/unifex/get_execution_policy.hpp
@@ -20,26 +20,25 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-    namespace _get_execution_policy {
-        struct _fn {
-            template(typename PolicyProvider)
-                (requires tag_invocable<_fn, const PolicyProvider&>)
-            constexpr auto operator()(const PolicyProvider& provider) const noexcept
-                -> tag_invoke_result_t<_fn, const PolicyProvider&> {
-                return tag_invoke(_fn{}, provider);
-            }
+namespace unifex {
+namespace _get_execution_policy {
+struct _fn {
+  template(typename PolicyProvider)(
+      requires tag_invocable<_fn, const PolicyProvider&>) constexpr auto
+  operator()(const PolicyProvider& provider) const noexcept
+      -> tag_invoke_result_t<_fn, const PolicyProvider&> {
+    return tag_invoke(_fn{}, provider);
+  }
 
-            template(typename PolicyProvider)
-                (requires (!tag_invocable<_fn, const PolicyProvider&>))
-            constexpr sequenced_policy operator()([[maybe_unused]] const PolicyProvider&) const noexcept {
-                return {};
-            }
-        };
-    }
+  template(typename PolicyProvider)(requires(
+      !tag_invocable<_fn, const PolicyProvider&>)) constexpr sequenced_policy
+  operator()([[maybe_unused]] const PolicyProvider&) const noexcept {
+    return {};
+  }
+};
+}  // namespace _get_execution_policy
 
-    inline constexpr _get_execution_policy::_fn get_execution_policy{};
-}
+inline constexpr _get_execution_policy::_fn get_execution_policy{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -15,98 +15,91 @@
  */
 #pragma once
 
-#include <unifex/detail/unifex_fwd.hpp>
-#include <unifex/stop_token_concepts.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/coroutine.hpp>
 #include <unifex/inplace_stop_token.hpp>
+#include <unifex/stop_token_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/coroutine.hpp>
 #include <unifex/unstoppable_token.hpp>
-#include <unifex/blocking.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _get_stop_token {
-  inline const struct _fn {
+inline const struct _fn {
 #if !UNIFEX_NO_COROUTINES
-  private:
-    class _awaitable {
-      template <typename StopToken>
-      struct _awaiter {
-        StopToken stoken_;
-        bool await_ready() const noexcept {
-          return true;
-        }
-        void await_suspend(coro::coroutine_handle<>) const noexcept {
-        }
-        StopToken await_resume() noexcept {
-          return (StopToken&&) stoken_;
-        }
+private:
+  class _awaitable {
+    template <typename StopToken>
+    struct _awaiter {
+      StopToken stoken_;
+      bool await_ready() const noexcept { return true; }
+      void await_suspend(coro::coroutine_handle<>) const noexcept {}
+      StopToken await_resume() noexcept { return (StopToken &&) stoken_; }
 
-        friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
-          return blocking_kind::always_inline;
-        }
-      };
-#if !defined(__GNUC__) || defined(__clang__)
-      // gcc bug 79501 - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79501
-      //
-      // GCC currently does not permit member deduction guides unless they
-      // are at a namespace scope and fails with error:
-      //    deduction guide '...' must be declared at namespace scope
-      // This deduction guide is probably not necessary, per P0091, and
-      // compiles on GCC without it, but clang-12 on macOS requires it.
-      //
-      // The above compile guard will ensure clang has the guide and GCC
-      // does not until 79501 is solved.
-      template <typename StopToken>
-      _awaiter(StopToken) -> _awaiter<StopToken>;
-
-#endif // !defined(__GNUC__) || defined(__clang__)
-
-      template (typename Tag, typename Promise)
-        (requires same_as<Tag, tag_t<await_transform>>)
-      friend auto tag_invoke(Tag, Promise& promise, _awaitable) noexcept {
-        return _awaiter{_fn{}(promise)};
+      friend constexpr auto
+      tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
+        return blocking_kind::always_inline;
       }
     };
+#  if !defined(__GNUC__) || defined(__clang__)
+    // gcc bug 79501 - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79501
+    //
+    // GCC currently does not permit member deduction guides unless they
+    // are at a namespace scope and fails with error:
+    //    deduction guide '...' must be declared at namespace scope
+    // This deduction guide is probably not necessary, per P0091, and
+    // compiles on GCC without it, but clang-12 on macOS requires it.
+    //
+    // The above compile guard will ensure clang has the guide and GCC
+    // does not until 79501 is solved.
+    template <typename StopToken>
+    _awaiter(StopToken) -> _awaiter<StopToken>;
 
-  public:
-    // `co_await get_stop_token()` to fetch a coroutine's current stop token.
-    [[nodiscard]] constexpr _awaitable operator()() const noexcept {
-      return {};
+#  endif  // !defined(__GNUC__) || defined(__clang__)
+
+    template(typename Tag, typename Promise)(
+        requires same_as<
+            Tag,
+            tag_t<
+                await_transform>>) friend auto tag_invoke(Tag, Promise& promise, _awaitable) noexcept {
+      return _awaiter{_fn{}(promise)};
     }
+  };
+
+public:
+  // `co_await get_stop_token()` to fetch a coroutine's current stop token.
+  [[nodiscard]] constexpr _awaitable operator()() const noexcept {
+    return {};
+  }
 #endif
 
-    template (typename T)
-      (requires (!tag_invocable<_fn, const T&>))
-    constexpr auto operator()(const T&) const noexcept
-        -> unstoppable_token {
-      return unstoppable_token{};
-    }
+  template(typename T)(requires(!tag_invocable<_fn, const T&>)) constexpr auto
+  operator()(const T&) const noexcept -> unstoppable_token {
+    return unstoppable_token{};
+  }
 
-    template (typename T)
-      (requires tag_invocable<_fn, const T&>)
-    constexpr auto operator()(const T& object) const noexcept
-        -> tag_invoke_result_t<_fn, const T&> {
-      static_assert(
-          is_nothrow_tag_invocable_v<_fn, const T&>,
-          "get_stop_token() customisations must be declared noexcept");
-      return tag_invoke(_fn{}, object);
-    }
-  } get_stop_token{};
-} // namespace _get_stop_token
+  template(typename T)(requires tag_invocable<_fn, const T&>) constexpr auto
+  operator()(const T& object) const noexcept
+      -> tag_invoke_result_t<_fn, const T&> {
+    static_assert(
+        is_nothrow_tag_invocable_v<_fn, const T&>,
+        "get_stop_token() customisations must be declared noexcept");
+    return tag_invoke(_fn{}, object);
+  }
+} get_stop_token{};
+}  // namespace _get_stop_token
 
 using _get_stop_token::get_stop_token;
 
 template <typename T>
-using get_stop_token_result_t =
-    callable_result_t<decltype(get_stop_token), T>;
+using get_stop_token_result_t = callable_result_t<decltype(get_stop_token), T>;
 
 template <typename Receiver>
-using stop_token_type_t =
-    remove_cvref_t<get_stop_token_result_t<Receiver>>;
+using stop_token_type_t = remove_cvref_t<get_stop_token_result_t<Receiver>>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -16,14 +16,14 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
+#include <unifex/async_trace.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/get_stop_token.hpp>
-#include <unifex/async_trace.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 #include <unifex/utility.hpp>
 
 #include <functional>
@@ -32,7 +32,7 @@
 namespace execution {
 class sequenced_policy;
 class parallel_policy;
-}
+}  // namespace execution
 
 #include <unifex/detail/prologue.hpp>
 
@@ -54,17 +54,35 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
 
   // sequenced_policy version supports forward range
   template <typename... Values>
-  static void apply_func_with_policy(const execution::sequenced_policy&, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
-    for(auto idx : range) {
+  static void apply_func_with_policy(
+      const execution::sequenced_policy&,
+      Range&& range,
+      Func&& func,
+      Values&... values) noexcept(std::
+                                      is_nothrow_invocable_v<
+                                          Func,
+                                          typename std::iterator_traits<
+                                              typename Range::iterator>::
+                                              reference,
+                                          Values...>) {
+    for (auto idx : range) {
       std::invoke(func, idx, values...);
     }
   }
 
   // parallel_policy version requires random access range
   template <typename... Values>
-  static void apply_func_with_policy(const execution::parallel_policy&, Range&& range, Func&& func, Values&... values)
-      noexcept(std::is_nothrow_invocable_v<Func, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
+  static void apply_func_with_policy(
+      const execution::parallel_policy&,
+      Range&& range,
+      Func&& func,
+      Values&... values) noexcept(std::
+                                      is_nothrow_invocable_v<
+                                          Func,
+                                          typename std::iterator_traits<
+                                              typename Range::iterator>::
+                                              reference,
+                                          Values...>) {
     auto first = range.begin();
     using size_type = decltype(range.size());
     for (size_type idx = 0; idx < range.size(); ++idx) {
@@ -74,14 +92,21 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
 
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
-    if constexpr (std::is_nothrow_invocable_v<Func&, typename std::iterator_traits<typename Range::iterator>::reference, Values...>) {
-      apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
+    if constexpr (std::is_nothrow_invocable_v<
+                      Func&,
+                      typename std::iterator_traits<
+                          typename Range::iterator>::reference,
+                      Values...>) {
+      apply_func_with_policy(
+          policy_, (Range &&) range_, (Func &&) func_, values...);
       unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
     } else {
       UNIFEX_TRY {
-        apply_func_with_policy(policy_, (Range&&) range_, (Func &&) func_, values...);
+        apply_func_with_policy(
+            policy_, (Range &&) range_, (Func &&) func_, values...);
         unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
-      } UNIFEX_CATCH (...) {
+      }
+      UNIFEX_CATCH(...) {
         unifex::set_error((Receiver &&) receiver_, std::current_exception());
       }
     }
@@ -92,23 +117,18 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
     unifex::set_error((Receiver &&) receiver_, (Error &&) error);
   }
 
-  void set_done() && noexcept {
-    unifex::set_done((Receiver &&) receiver_);
-  }
+  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const type& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const type& r,
-      Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
     std::invoke(visit, r.receiver_);
   }
 };
@@ -133,21 +153,20 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = sender_value_types_t<Predecessor, Variant, Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Predecessor, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 
-  friend constexpr auto tag_invoke(
-      tag_t<blocking>,
-      const sender& sender) {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender& sender) {
     return blocking(sender.pred_);
   }
 
@@ -162,27 +181,31 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
             (Receiver &&) receiver});
   }
 };
-} // namespace _ifor
+}  // namespace _ifor
 
 namespace _ifor_cpo {
-  struct _fn {
-    template <typename Sender, typename Policy, typename Range, typename Func>
-    auto operator()(Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) const
-        -> _ifor::sender<Sender, Policy, Range, Func> {
-      return _ifor::sender<Sender, Policy, Range, Func>{
-          (Sender &&) predecessor, (Policy &&) policy, (Range &&) range, (Func &&) func};
-    }
-    template <typename Policy, typename Range, typename Func>
-    constexpr auto operator()(Policy&& policy, Range&& range, Func&& f) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Policy, Range, Func>)
-        -> bind_back_result_t<_fn, Policy, Range, Func> {
-      return bind_back(*this, (Policy&&)policy, (Range&&)range, (Func&&)f);
-    }
-  } indexed_for{};
-} // namespace _ifor_cpo
+struct _fn {
+  template <typename Sender, typename Policy, typename Range, typename Func>
+  auto operator()(
+      Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) const
+      -> _ifor::sender<Sender, Policy, Range, Func> {
+    return _ifor::sender<Sender, Policy, Range, Func>{
+        (Sender &&) predecessor,
+        (Policy &&) policy,
+        (Range &&) range,
+        (Func &&) func};
+  }
+  template <typename Policy, typename Range, typename Func>
+  constexpr auto operator()(Policy&& policy, Range&& range, Func&& f) const
+      noexcept(
+          is_nothrow_callable_v<tag_t<bind_back>, _fn, Policy, Range, Func>)
+          -> bind_back_result_t<_fn, Policy, Range, Func> {
+    return bind_back(*this, (Policy &&) policy, (Range &&) range, (Func &&) f);
+  }
+} indexed_for{};
+}  // namespace _ifor_cpo
 using _ifor_cpo::indexed_for;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/into_variant.hpp
+++ b/include/unifex/into_variant.hpp
@@ -22,8 +22,8 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_list.hpp>
 
-#include <tuple>
 #include <unifex/variant.hpp>
+#include <tuple>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -41,33 +41,32 @@ template <typename Receiver, typename VariantType>
 struct _receiver<Receiver, VariantType>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  template(typename... Values)
-      (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) && {
-    unifex::set_value((Receiver &&) receiver_,
+  template(typename... Values)(
+      requires receiver_of<
+          Receiver,
+          Values...>) void set_value(Values&&... values) && {
+    unifex::set_value(
+        (Receiver &&) receiver_,
         VariantType(std::make_tuple((Values &&)(values)...)));
   }
 
-  template(typename Error)
-      (requires receiver<Receiver, Error>)
-  void set_error(Error&& error) && noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
     unifex::set_error((Receiver &&)(receiver_), (Error &&)(error));
   }
 
-  void set_done() && noexcept {
-    unifex::set_done((Receiver &&) receiver_);
-  }
+  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const type& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
     std::invoke(visit, self.receiver_);
   }
 };
@@ -84,10 +83,12 @@ struct _sender<Predecessor>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Predecessor pred_;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
-  using value_types = Variant<Tuple<
-      sender_value_types_t<Predecessor, variant, std::tuple>>>;
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types =
+      Variant<Tuple<sender_value_types_t<Predecessor, variant, std::tuple>>>;
 
   template <template <typename...> class Variant>
   using error_types = sender_error_types_t<Predecessor, Variant>;
@@ -95,61 +96,66 @@ struct _sender<Predecessor>::type {
   static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 
   template <typename Receiver>
-  using receiver_t = receiver_t<Receiver, sender_value_types_t<Predecessor, variant, std::tuple>>;
+  using receiver_t = receiver_t<
+      Receiver,
+      sender_value_types_t<Predecessor, variant, std::tuple>>;
 
   friend constexpr auto tag_invoke(tag_t<blocking>, const type& sender) {
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND
-        sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t< Receiver>>>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-    noexcept(
-      std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-      is_nothrow_connectable_v<member_t< Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>)
-      -> connect_result_t<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>> {
+  template(typename Sender, typename Receiver)(
+      requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<
+              Receiver>>>) friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(std::
+                                                                                                                 is_nothrow_constructible_v<
+                                                                                                                     remove_cvref_t<
+                                                                                                                         Receiver>,
+                                                                                                                     Receiver>&&
+                                                                                                                     is_nothrow_connectable_v<
+                                                                                                                         member_t<
+                                                                                                                             Sender,
+                                                                                                                             Predecessor>,
+                                                                                                                         receiver_t<remove_cvref_t<
+                                                                                                                             Receiver>>>)
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
     return unifex::connect(
-      static_cast<Sender&&>(s).pred_,
-      receiver_t<remove_cvref_t<Receiver>>{
-        static_cast<Receiver&&>(r)});
+        static_cast<Sender&&>(s).pred_,
+        receiver_t<remove_cvref_t<Receiver>>{static_cast<Receiver&&>(r)});
   }
 };
 
 namespace _cpo {
-  struct _fn {
-  private:
-    template <typename Sender>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Sender>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote1<_into_variant::sender>>::template apply<Sender>;
+struct _fn {
+private:
+  template <typename Sender>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_into_variant::sender>>::template apply<Sender>;
 
-  public:
-    template(typename Sender)
-      (requires tag_invocable<_fn, Sender>)
-    auto operator()(Sender&& predecessor) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Sender>)
-        -> _result_t<Sender> {
-      return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor));
-    }
+public:
+  template(typename Sender)(requires tag_invocable<_fn, Sender>) auto
+  operator()(Sender&& predecessor) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender>) -> _result_t<Sender> {
+    return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor));
+  }
 
-    template(typename Sender)
-      (requires(!tag_invocable<_fn, Sender>))
-    auto operator()(Sender&& predecessor) const
-        noexcept(std::is_nothrow_constructible_v<
-          _into_variant::sender<Sender>, Sender>)
-        -> _result_t<Sender> {
-      return _into_variant::sender<Sender>{(Sender &&) predecessor};
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
-  };
+  template(typename Sender)(requires(!tag_invocable<_fn, Sender>)) auto
+  operator()(Sender&& predecessor) const noexcept(
+      std::is_nothrow_constructible_v<_into_variant::sender<Sender>, Sender>)
+      -> _result_t<Sender> {
+    return _into_variant::sender<Sender>{(Sender &&) predecessor};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
+};
 }  // namespace _cpo
 }  // namespace _into_variant
 

--- a/include/unifex/invoke.hpp
+++ b/include/unifex/invoke.hpp
@@ -26,34 +26,34 @@ namespace unifex {
 
 namespace _co_invoke {
 inline constexpr struct _fn {
-    template (typename Fn, typename... Args)
-      (requires tag_invocable<
+  template(typename Fn, typename... Args)(
+      requires tag_invocable<
           _fn,
           type_identity<std::invoke_result_t<Fn, Args...>>,
           Fn,
-          Args...>)
-    UNIFEX_ALWAYS_INLINE constexpr auto operator()(Fn&& fn, Args&&... args) const
+          Args...>) UNIFEX_ALWAYS_INLINE constexpr auto
+  operator()(Fn&& fn, Args&&... args) const
       noexcept(is_nothrow_tag_invocable_v<
-          _fn,
-          type_identity<std::invoke_result_t<Fn, Args...>>,
-          Fn,
-          Args...>)
-      -> tag_invoke_result_t<
-          _fn,
-          type_identity<std::invoke_result_t<Fn, Args...>>,
-          Fn,
-          Args...> {
-      return tag_invoke(
-          *this,
-          type_identity<std::invoke_result_t<Fn, Args...>>{},
-          (Fn&&) fn,
-          (Args&&) args...);
-    }
+               _fn,
+               type_identity<std::invoke_result_t<Fn, Args...>>,
+               Fn,
+               Args...>)
+          -> tag_invoke_result_t<
+              _fn,
+              type_identity<std::invoke_result_t<Fn, Args...>>,
+              Fn,
+              Args...> {
+    return tag_invoke(
+        *this,
+        type_identity<std::invoke_result_t<Fn, Args...>>{},
+        (Fn &&) fn,
+        (Args &&) args...);
+  }
 } co_invoke{};
-} // namespace _co_invoke
+}  // namespace _co_invoke
 
 using _co_invoke::co_invoke;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/io_concepts.hpp
+++ b/include/unifex/io_concepts.hpp
@@ -59,9 +59,7 @@ namespace _io_cpo {
 //
 inline const struct async_read_some_cpo {
   template <typename ForwardReader, typename BufferSequence>
-  auto operator()(
-      ForwardReader& socket,
-      BufferSequence&& bufferSequence) const
+  auto operator()(ForwardReader& socket, BufferSequence&& bufferSequence) const
       noexcept(is_nothrow_tag_invocable_v<
                async_read_some_cpo,
                ForwardReader&,
@@ -75,14 +73,9 @@ inline const struct async_read_some_cpo {
   }
 
   template <typename ForwardReader>
-  auto operator()(
-      ForwardReader& socket) const
-      noexcept(is_nothrow_tag_invocable_v<
-               async_read_some_cpo,
-               ForwardReader&>)
-          -> tag_invoke_result_t<
-              async_read_some_cpo,
-              ForwardReader&> {
+  auto operator()(ForwardReader& socket) const
+      noexcept(is_nothrow_tag_invocable_v<async_read_some_cpo, ForwardReader&>)
+          -> tag_invoke_result_t<async_read_some_cpo, ForwardReader&> {
     return unifex::tag_invoke(*this, socket);
   }
 } async_read_some{};
@@ -97,9 +90,7 @@ inline const struct async_read_some_cpo {
 //
 inline const struct async_write_some_cpo {
   template <typename ForwardWriter, typename BufferSequence>
-  auto operator()(
-      ForwardWriter& socket,
-      BufferSequence&& bufferSequence) const
+  auto operator()(ForwardWriter& socket, BufferSequence&& bufferSequence) const
       noexcept(is_nothrow_tag_invocable_v<
                async_write_some_cpo,
                ForwardWriter&,
@@ -113,16 +104,10 @@ inline const struct async_write_some_cpo {
   }
 
   template <typename ForwardWriter>
-  auto operator()(
-      ForwardWriter& socket) const
-      noexcept(is_nothrow_tag_invocable_v<
-               async_write_some_cpo,
-               ForwardWriter&>)
-          -> tag_invoke_result_t<
-              async_write_some_cpo,
-              ForwardWriter&> {
-    return unifex::tag_invoke(
-        *this, socket);
+  auto operator()(ForwardWriter& socket) const
+      noexcept(is_nothrow_tag_invocable_v<async_write_some_cpo, ForwardWriter&>)
+          -> tag_invoke_result_t<async_write_some_cpo, ForwardWriter&> {
+    return unifex::tag_invoke(*this, socket);
   }
 } async_write_some{};
 
@@ -147,16 +132,10 @@ inline const struct async_read_some_at_cpo {
   }
 
   template <typename RandomReader>
-  auto operator()(
-      RandomReader& file) const
-      noexcept(is_nothrow_tag_invocable_v<
-               async_read_some_at_cpo,
-               RandomReader&>)
-          -> tag_invoke_result_t<
-              async_read_some_at_cpo,
-              RandomReader&> {
-    return unifex::tag_invoke(
-        *this, file);
+  auto operator()(RandomReader& file) const noexcept(
+      is_nothrow_tag_invocable_v<async_read_some_at_cpo, RandomReader&>)
+      -> tag_invoke_result_t<async_read_some_at_cpo, RandomReader&> {
+    return unifex::tag_invoke(*this, file);
   }
 } async_read_some_at{};
 
@@ -181,25 +160,19 @@ inline const struct async_write_some_at_cpo {
   }
 
   template <typename RandomWriter>
-  auto operator()(
-      RandomWriter& file) const
-      noexcept(is_nothrow_tag_invocable_v<
-               async_write_some_at_cpo,
-               RandomWriter&>)
-          -> tag_invoke_result_t<
-              async_write_some_at_cpo,
-              RandomWriter&> {
-    return unifex::tag_invoke(
-        *this, file);
+  auto operator()(RandomWriter& file) const noexcept(
+      is_nothrow_tag_invocable_v<async_write_some_at_cpo, RandomWriter&>)
+      -> tag_invoke_result_t<async_write_some_at_cpo, RandomWriter&> {
+    return unifex::tag_invoke(*this, file);
   }
 } async_write_some_at{};
-} // namespace _io_cpo
+}  // namespace _io_cpo
 
 using _io_cpo::async_read_some;
-using _io_cpo::async_write_some;
 using _io_cpo::async_read_some_at;
+using _io_cpo::async_write_some;
 using _io_cpo::async_write_some_at;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -16,11 +16,11 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/blocking.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/optional.hpp>
 
 #include <exception>
 #include <tuple>
@@ -51,7 +51,8 @@ struct _op<Receiver, Values...>::type {
             unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
           },
           std::move(values_));
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error((Receiver &&) receiver_, std::current_exception());
     }
   }
@@ -68,10 +69,12 @@ template <typename... Values>
 class _sender<Values...>::type {
   UNIFEX_NO_UNIQUE_ADDRESS std::tuple<Values...> values_;
 
-  public:
+public:
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<Values...>>;
 
   template <template <typename...> class Variant>
@@ -79,19 +82,30 @@ class _sender<Values...>::type {
 
   static constexpr bool sends_done = false;
 
-  template(typename... Values2)
-    (requires (sizeof...(Values2) == sizeof...(Values)) AND
-      constructible_from<std::tuple<Values...>, Values2...>)
-  explicit type(in_place_t, Values2&&... values)
-    noexcept(std::is_nothrow_constructible_v<std::tuple<Values...>, Values2...>)
+  template(typename... Values2)(
+      requires(sizeof...(Values2) == sizeof...(Values)) AND constructible_from<
+          std::tuple<Values...>,
+          Values2...>) explicit type(in_place_t, Values2&&... values) noexcept(std::
+                                                                                   is_nothrow_constructible_v<
+                                                                                       std::tuple<
+                                                                                           Values...>,
+                                                                                       Values2...>)
     : values_((Values2 &&) values...) {}
 
-  template(typename This, typename Receiver)
-      (requires same_as<remove_cvref_t<This>, type> AND
-        receiver<Receiver> AND
-        constructible_from<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)
-  friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r)
-      noexcept(std::is_nothrow_constructible_v<std::tuple<Values...>, member_t<This, std::tuple<Values...>>>)
+  template(typename This, typename Receiver)(
+      requires same_as<remove_cvref_t<This>, type> AND receiver<Receiver> AND constructible_from<
+          std::tuple<Values...>,
+          member_t<
+              This,
+              std::tuple<
+                  Values...>>>) friend auto tag_invoke(tag_t<connect>, This&& that, Receiver&& r) noexcept(std::
+                                                                                                               is_nothrow_constructible_v<
+                                                                                                                   std::tuple<
+                                                                                                                       Values...>,
+                                                                                                                   member_t<
+                                                                                                                       This,
+                                                                                                                       std::tuple<
+                                                                                                                           Values...>>>)
       -> operation<Receiver, Values...> {
     return {static_cast<This&&>(that).values_, static_cast<Receiver&&>(r)};
   }
@@ -100,20 +114,22 @@ class _sender<Values...>::type {
     return blocking_kind::always_inline;
   }
 };
-} // namespace _just
+}  // namespace _just
 
 namespace _just_cpo {
-  inline const struct just_fn {
-    template <typename... Values>
-    constexpr auto operator()(Values&&... values) const
-      noexcept(std::is_nothrow_constructible_v<_just::sender<Values...>, in_place_t, Values...>)
-      -> _just::sender<Values...> {
-      return _just::sender<Values...>{in_place, (Values&&)values...};
-    }
-  } just{};
-} // namespace _just_cpo
+inline const struct just_fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&... values) const
+      noexcept(std::is_nothrow_constructible_v<
+               _just::sender<Values...>,
+               in_place_t,
+               Values...>) -> _just::sender<Values...> {
+    return _just::sender<Values...>{in_place, (Values &&) values...};
+  }
+} just{};
+}  // namespace _just_cpo
 using _just_cpo::just;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/just_done.hpp
+++ b/include/unifex/just_done.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/blocking.hpp>
 #include <unifex/std_concepts.hpp>
 
 #include <exception>
@@ -42,16 +42,16 @@ template <typename Receiver>
 struct _op<Receiver>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  void start() & noexcept {
-    unifex::set_done((Receiver &&) receiver_);
-  }
+  void start() & noexcept { unifex::set_done((Receiver &&) receiver_); }
 };
 
 class sender {
- public:
+public:
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<>;
 
   template <template <typename...> class Variant>
@@ -59,11 +59,9 @@ class sender {
 
   static constexpr bool sends_done = true;
 
-  template(typename This, typename Receiver)
-      (requires same_as<remove_cvref_t<This>, sender> AND
-        receiver<Receiver>)
-  friend auto tag_invoke(tag_t<connect>, This&&, Receiver&& r)
-      noexcept
+  template(typename This, typename Receiver)(
+      requires same_as<remove_cvref_t<This>, sender> AND receiver<
+          Receiver>) friend auto tag_invoke(tag_t<connect>, This&&, Receiver&& r) noexcept
       -> operation<Receiver> {
     return {static_cast<Receiver&&>(r)};
   }
@@ -72,18 +70,17 @@ class sender {
     return blocking_kind::always_inline;
   }
 };
-} // namespace _just_done
+}  // namespace _just_done
 
 namespace _just_done_cpo {
-  inline const struct just_done_fn {
-    constexpr auto operator()() const noexcept
-      -> _just_done::sender {
-      return _just_done::sender{};
-    }
-  } just_done{};
-} // namespace _just_done_cpo
+inline const struct just_done_fn {
+  constexpr auto operator()() const noexcept -> _just_done::sender {
+    return _just_done::sender{};
+  }
+} just_done{};
+}  // namespace _just_done_cpo
 using _just_done_cpo::just_done;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/just_from.hpp
+++ b/include/unifex/just_from.hpp
@@ -21,18 +21,16 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _just_from {
-    inline const struct _fn {
-      template (typename Callable)
-        (requires callable<Callable>)
-      constexpr auto operator()(Callable&& callable) const {
-        return then(just(), (Callable&&) callable);
-      }
-    } just_from{};
-  } // namespace _just_froom
-  using _just_from::just_from;
-} // namespace unifex
+namespace unifex {
+namespace _just_from {
+inline const struct _fn {
+  template(typename Callable)(requires callable<Callable>) constexpr auto
+  operator()(Callable&& callable) const {
+    return then(just(), (Callable &&) callable);
+  }
+} just_from{};
+}  // namespace _just_from
+using _just_from::just_from;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/let_done.hpp
+++ b/include/unifex/let_done.hpp
@@ -16,17 +16,17 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
-#include <unifex/manual_lifetime.hpp>
 #include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
-#include <utility>
 #include <exception>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -38,21 +38,24 @@ struct _op {
   class type;
 };
 template <typename Source, typename Done, typename Receiver>
-using operation_type = typename _op<Source, Done, remove_cvref_t<Receiver>>::type;
+using operation_type =
+    typename _op<Source, Done, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Done, typename Receiver>
 struct _rcvr {
   class type;
 };
 template <typename Source, typename Done, typename Receiver>
-using receiver_type = typename _rcvr<Source, Done, remove_cvref_t<Receiver>>::type;
+using receiver_type =
+    typename _rcvr<Source, Done, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Done, typename Receiver>
 struct _frcvr {
   class type;
 };
 template <typename Source, typename Done, typename Receiver>
-using final_receiver_type = typename _frcvr<Source, Done, remove_cvref_t<Receiver>>::type;
+using final_receiver_type =
+    typename _frcvr<Source, Done, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Done>
 struct _sndr {
@@ -69,27 +72,22 @@ class _rcvr<Source, Done, Receiver>::type {
   using final_sender_t = callable_result_t<Done&>;
 
 public:
-  explicit type(operation* op) noexcept
-  : op_(op) {}
+  explicit type(operation* op) noexcept : op_(op) {}
 
-  type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
-  {}
- 
-  template(typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) noexcept(
-      is_nothrow_receiver_of_v<Receiver, Values...>) {
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
+
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
+    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
   }
 
   void set_done() noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    auto op = op_; // preserve pointer value.
+    auto op = op_;  // preserve pointer value.
     if constexpr (
-      is_nothrow_callable_v<Done> &&
-      is_nothrow_connectable_v<final_sender_t, final_receiver>) {
+        is_nothrow_callable_v<Done> &&
+        is_nothrow_connectable_v<final_sender_t, final_receiver>) {
       op->startedOp_ = 0;
       unifex::deactivate_union_member(op->sourceOp_);
       unifex::activate_union_member_with(op->finalOp_, [&] {
@@ -106,42 +104,40 @@ public:
         });
         op->startedOp_ = 0 - 1;
         unifex::start(op->finalOp_.get());
-      } UNIFEX_CATCH (...) {
+      }
+      UNIFEX_CATCH(...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
     }
   }
 
-  template(typename Error)
-      (requires receiver<Receiver, Error>)
-  void set_error(Error&& error) noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
+    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
   }
 
 private:
-  template(typename CPO, typename Self)
-    (requires is_receiver_query_cpo_v<CPO> AND
-        same_as<remove_cvref_t<Self>, type> AND
-        is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, Self&& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO, typename Self)(
+      requires is_receiver_query_cpo_v<CPO> AND
+          same_as<remove_cvref_t<Self>, type> AND is_callable_v<
+              CPO,
+              const Receiver&>) friend auto tag_invoke(CPO cpo, Self&& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
-  
+
   template <typename VisitFunc>
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&& func) noexcept(is_nothrow_callable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&&
+          func) noexcept(is_nothrow_callable_v<VisitFunc&, const Receiver&>) {
     func(r.get_receiver());
   }
 
   const Receiver& get_receiver() const noexcept {
-    UNIFEX_ASSERT(op_ != nullptr);   
+    UNIFEX_ASSERT(op_ != nullptr);
     return op_->receiver_;
   }
 
@@ -153,19 +149,14 @@ class _frcvr<Source, Done, Receiver>::type {
   using operation = operation_type<Source, Done, Receiver>;
 
 public:
-  explicit type(operation* op) noexcept
-  : op_(op) {}
+  explicit type(operation* op) noexcept : op_(op) {}
 
-  type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
-  {}
- 
-  template(typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) noexcept(
-      is_nothrow_receiver_of_v<Receiver, Values...>) {
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
+
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
+    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
   }
 
   void set_done() noexcept {
@@ -173,35 +164,31 @@ public:
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  template(typename Error)
-    (requires receiver<Receiver, Error>)
-  void set_error(Error&& error) noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
+    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
   }
 
 private:
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND
-          is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const type& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
-  
+
   template <typename VisitFunc>
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&& func) noexcept(is_nothrow_callable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&&
+          func) noexcept(is_nothrow_callable_v<VisitFunc&, const Receiver&>) {
     func(r.get_receiver());
   }
 
   const Receiver& get_receiver() const noexcept {
-    UNIFEX_ASSERT(op_ != nullptr);   
+    UNIFEX_ASSERT(op_ != nullptr);
     return op_->receiver_;
   }
 
@@ -215,16 +202,15 @@ class _op<Source, Done, Receiver>::type {
 
 public:
   template <typename Done2, typename Receiver2>
-  explicit type(Source&& source, Done2&& done, Receiver2&& dest)
-      noexcept(std::is_nothrow_move_constructible_v<Receiver> &&
-               std::is_nothrow_move_constructible_v<Done> &&
-               is_nothrow_connectable_v<Source, source_receiver>)
-  : done_((Done2&&)done)
-  , receiver_((Receiver2&&)dest)
-  {
+  explicit type(Source&& source, Done2&& done, Receiver2&& dest) noexcept(
+      std::is_nothrow_move_constructible_v<Receiver>&&
+          std::is_nothrow_move_constructible_v<Done>&&
+              is_nothrow_connectable_v<Source, source_receiver>)
+    : done_((Done2 &&) done)
+    , receiver_((Receiver2 &&) dest) {
     unifex::activate_union_member_with(sourceOp_, [&] {
-        return unifex::connect((Source&&)source, source_receiver{this});
-      });
+      return unifex::connect((Source &&) source, source_receiver{this});
+    });
     startedOp_ = 0 + 1;
   }
 
@@ -237,9 +223,7 @@ public:
     startedOp_ = 0;
   }
 
-  void start() & noexcept {
-    unifex::start(sourceOp_.get());
-  }
+  void start() & noexcept { unifex::start(sourceOp_.get()); }
 
 private:
   friend source_receiver;
@@ -265,53 +249,60 @@ class _sndr<Source, Done>::type {
   using final_sender_t = callable_result_t<Done>;
 
 public:
-  template <template <typename...> class Variant,
-            template <typename...> class Tuple>
-  using value_types =
-      typename concat_type_lists_unique_t<
-          sender_value_types_t<Source, type_list, Tuple>,
-          sender_value_types_t<final_sender_t, type_list, Tuple>>::template
-              apply<Variant>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename concat_type_lists_unique_t<
+      sender_value_types_t<Source, type_list, Tuple>,
+      sender_value_types_t<final_sender_t, type_list, Tuple>>::
+      template apply<Variant>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Source, type_list>,
-          sender_error_types_t<final_sender_t, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Source, type_list>,
+      sender_error_types_t<final_sender_t, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<final_sender_t>::sends_done;
 
   template <typename Source2, typename Done2>
-  explicit type(Source2&& source, Done2&& done)
-    noexcept(
-      std::is_nothrow_constructible_v<Source, Source2> &&
-      std::is_nothrow_constructible_v<Done, Done2>)
-    : source_((Source2&&)source)
-    , done_((Done2&&)done)
-  {}
+  explicit type(Source2&& source, Done2&& done) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
+          std::is_nothrow_constructible_v<Done, Done2>)
+    : source_((Source2 &&) source)
+    , done_((Done2 &&) done) {}
 
   template(
-    typename Sender,
-    typename Receiver,
-    typename SourceReceiver = receiver_type<member_t<Sender, Source>, Done, Receiver>,
-    typename FinalReceiver = final_receiver_type<member_t<Sender, Source>, Done, Receiver>)
-      (requires same_as<remove_cvref_t<Sender>, type> AND
-          constructible_from<Done, member_t<Sender, Done>> AND
-          constructible_from<remove_cvref_t<Receiver>, Receiver> AND
-          sender_to<member_t<Sender, Source>, SourceReceiver> AND
-          sender_to<final_sender_t, FinalReceiver>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-       noexcept(
-        is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver> &&
-        std::is_nothrow_constructible_v<Done, member_t<Sender, Done>> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+      typename Sender,
+      typename Receiver,
+      typename SourceReceiver =
+          receiver_type<member_t<Sender, Source>, Done, Receiver>,
+      typename FinalReceiver =
+          final_receiver_type<member_t<Sender, Source>, Done, Receiver>)(
+      requires same_as<remove_cvref_t<Sender>, type> AND constructible_from<
+          Done,
+          member_t<
+              Sender,
+              Done>> AND constructible_from<remove_cvref_t<Receiver>, Receiver>
+          AND sender_to<member_t<Sender, Source>, SourceReceiver> AND sender_to<
+              final_sender_t,
+              FinalReceiver>) friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver>&&
+                                                                                                                    std::is_nothrow_constructible_v<
+                                                                                                                        Done,
+                                                                                                                        member_t<
+                                                                                                                            Sender,
+                                                                                                                            Done>>&&
+                                                                                                                        std::is_nothrow_constructible_v<
+                                                                                                                            remove_cvref_t<
+                                                                                                                                Receiver>,
+                                                                                                                            Receiver>)
       -> operation_type<member_t<Sender, Source>, Done, Receiver> {
     return operation_type<member_t<Sender, Source>, Done, Receiver>{
-      static_cast<Sender&&>(s).source_,
-      static_cast<Sender&&>(s).done_,
-      static_cast<Receiver&&>(r)
-    };
+        static_cast<Sender&&>(s).source_,
+        static_cast<Sender&&>(s).done_,
+        static_cast<Receiver&&>(r)};
   }
 
 private:
@@ -319,51 +310,46 @@ private:
   Done done_;
 };
 
-namespace _cpo
-{
+namespace _cpo {
 struct _fn {
-  template(typename Source, typename Done)
-    (requires tag_invocable<_fn, Source, Done> AND
-        sender<Source> AND
-        callable<remove_cvref_t<Done>> AND
-        sender<callable_result_t<remove_cvref_t<Done>>>)
-  auto operator()(Source&& source, Done&& done) const
+  template(typename Source, typename Done)(
+      requires tag_invocable<_fn, Source, Done> AND sender<Source> AND
+          callable<remove_cvref_t<Done>> AND
+              sender<callable_result_t<remove_cvref_t<Done>>>) auto
+  operator()(Source&& source, Done&& done) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source, Done>)
-      -> tag_invoke_result_t<_fn, Source, Done> {
-    return tag_invoke(*this, (Source&&)source, (Done&&)done);
+          -> tag_invoke_result_t<_fn, Source, Done> {
+    return tag_invoke(*this, (Source &&) source, (Done &&) done);
   }
 
-  template(typename Source, typename Done)
-    (requires (!tag_invocable<_fn, Source, Done>) AND
-        sender<Source> AND
-        constructible_from<remove_cvref_t<Source>, Source> AND
-        constructible_from<remove_cvref_t<Done>, Done> AND
-        callable<remove_cvref_t<Done>> AND
-        sender<callable_result_t<remove_cvref_t<Done>>>)
-  auto operator()(Source&& source, Done&& done) const
+  template(typename Source, typename Done)(
+      requires(!tag_invocable<_fn, Source, Done>) AND sender<Source> AND
+          constructible_from<remove_cvref_t<Source>, Source> AND
+              constructible_from<remove_cvref_t<Done>, Done> AND
+                  callable<remove_cvref_t<Done>> AND
+                      sender<callable_result_t<remove_cvref_t<Done>>>) auto
+  operator()(Source&& source, Done&& done) const
       noexcept(std::is_nothrow_constructible_v<
-                   _sender<remove_cvref_t<Source>, remove_cvref_t<Done>>,
-                   Source, 
-                   Done>)
-      -> _sender<remove_cvref_t<Source>, remove_cvref_t<Done>> {
+               _sender<remove_cvref_t<Source>, remove_cvref_t<Done>>,
+               Source,
+               Done>) -> _sender<remove_cvref_t<Source>, remove_cvref_t<Done>> {
     return _sender<remove_cvref_t<Source>, remove_cvref_t<Done>>{
-        (Source&&)source, (Done&&)done};
+        (Source &&) source, (Done &&) done};
   }
-  template(typename Done)
-      (requires callable<remove_cvref_t<Done>> AND
-        sender<callable_result_t<remove_cvref_t<Done>>>)
-  constexpr auto operator()(Done&& done) const
-      noexcept(is_nothrow_callable_v<
-        tag_t<bind_back>, _fn, Done>)
-      -> bind_back_result_t<_fn, Done> {
-    return bind_back(*this, (Done&&)done);
+  template(typename Done)(
+      requires callable<remove_cvref_t<Done>> AND
+          sender<callable_result_t<remove_cvref_t<Done>>>) constexpr auto
+  operator()(Done&& done) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Done>)
+          -> bind_back_result_t<_fn, Done> {
+    return bind_back(*this, (Done &&) done);
   }
 };
-} // namespace _cpo
-} // namespace _let_d
+}  // namespace _cpo
+}  // namespace _let_d
 
-inline constexpr _let_d::_cpo::_fn let_done {};
+inline constexpr _let_d::_cpo::_fn let_done{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -16,17 +16,17 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
-#include <unifex/manual_lifetime.hpp>
 #include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
-#include <utility>
 #include <exception>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -38,21 +38,24 @@ struct _op {
   class type;
 };
 template <typename Source, typename Error, typename Receiver>
-using operation_type = typename _op<Source, Error, remove_cvref_t<Receiver>>::type;
+using operation_type =
+    typename _op<Source, Error, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Error, typename Receiver>
 struct _rcvr {
   class type;
 };
 template <typename Source, typename Error, typename Receiver>
-using receiver_type = typename _rcvr<Source, Error, remove_cvref_t<Receiver>>::type;
+using receiver_type =
+    typename _rcvr<Source, Error, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Error, typename Receiver>
 struct _frcvr {
   class type;
 };
 template <typename Source, typename Error, typename Receiver>
-using final_receiver_type = typename _frcvr<Source, Error, remove_cvref_t<Receiver>>::type;
+using final_receiver_type =
+    typename _frcvr<Source, Error, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Error>
 struct _sndr {
@@ -71,19 +74,14 @@ class _rcvr<Source, Error, Receiver>::type final {
   using final_sender_t = callable_result_t<Error&>;
 
 public:
-  explicit type(operation* op) noexcept
-    : op_(op) {}
+  explicit type(operation* op) noexcept : op_(op) {}
 
-  type(type&& other) noexcept
-    : op_(std::exchange(other.op_, {}))
-  {}
- 
-  template(typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) noexcept(
-      is_nothrow_receiver_of_v<Receiver, Values...>) {
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
+
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
+    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
   }
 
   void set_done() noexcept {
@@ -93,10 +91,10 @@ public:
 
   void set_error(detail::_ignore) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    auto op = op_; // preserve pointer value.
+    auto op = op_;  // preserve pointer value.
     if constexpr (
-      is_nothrow_callable_v<Error> &&
-      is_nothrow_connectable_v<final_sender_t, final_receiver>) {
+        is_nothrow_callable_v<Error> &&
+        is_nothrow_connectable_v<final_sender_t, final_receiver>) {
       op->startedOp_ = state::neither;
       unifex::deactivate_union_member(op->sourceOp_);
       unifex::activate_union_member_with(op->finalOp_, [&] {
@@ -113,35 +111,34 @@ public:
         });
         op->startedOp_ = state::final;
         unifex::start(op->finalOp_.get());
-      } UNIFEX_CATCH (...) {
+      }
+      UNIFEX_CATCH(...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
     }
   }
 
 private:
-  template(typename CPO, typename Self)
-    (requires is_receiver_query_cpo_v<CPO> AND
-        same_as<remove_cvref_t<Self>, type> AND
-        is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, Self&& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO, typename Self)(
+      requires is_receiver_query_cpo_v<CPO> AND
+          same_as<remove_cvref_t<Self>, type> AND is_callable_v<
+              CPO,
+              const Receiver&>) friend auto tag_invoke(CPO cpo, Self&& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
-  
+
   template <typename VisitFunc>
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&& func) noexcept(is_nothrow_callable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&&
+          func) noexcept(is_nothrow_callable_v<VisitFunc&, const Receiver&>) {
     func(r.get_receiver());
   }
 
   const Receiver& get_receiver() const noexcept {
-    UNIFEX_ASSERT(op_ != nullptr);   
+    UNIFEX_ASSERT(op_ != nullptr);
     return op_->receiver_;
   }
 
@@ -153,19 +150,14 @@ class _frcvr<Source, Error, Receiver>::type {
   using operation = operation_type<Source, Error, Receiver>;
 
 public:
-  explicit type(operation* op) noexcept
-    : op_(op) {}
+  explicit type(operation* op) noexcept : op_(op) {}
 
-  type(type&& other) noexcept
-    : op_(std::exchange(other.op_, {}))
-  {}
- 
-  template(typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) noexcept(
-      is_nothrow_receiver_of_v<Receiver, Values...>) {
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
+
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
+    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
   }
 
   void set_done() noexcept {
@@ -173,35 +165,31 @@ public:
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  template(typename Error2)
-    (requires receiver<Receiver, Error2>)
-  void set_error(Error2&& error2) noexcept {
+  template(typename Error2)(requires receiver<Receiver, Error2>) void set_error(
+      Error2&& error2) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error2&&)error2);
+    unifex::set_error(std::move(op_->receiver_), (Error2 &&) error2);
   }
 
 private:
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND
-          is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const type& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
-  
+
   template <typename VisitFunc>
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&& func) noexcept(is_nothrow_callable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&&
+          func) noexcept(is_nothrow_callable_v<VisitFunc&, const Receiver&>) {
     func(r.get_receiver());
   }
 
   const Receiver& get_receiver() const noexcept {
-    UNIFEX_ASSERT(op_ != nullptr);   
+    UNIFEX_ASSERT(op_ != nullptr);
     return op_->receiver_;
   }
 
@@ -215,36 +203,28 @@ class _op<Source, Error, Receiver>::type {
 
 public:
   template <typename Error2, typename Receiver2>
-  explicit type(Source&& source, Error2&& error, Receiver2&& dest)
-      noexcept(std::is_nothrow_move_constructible_v<Receiver> &&
-               std::is_nothrow_move_constructible_v<Error> &&
-               is_nothrow_connectable_v<Source, source_receiver>)
-    : error_((Error2&&)error)
-    , receiver_((Receiver2&&)dest)
-  {
+  explicit type(Source&& source, Error2&& error, Receiver2&& dest) noexcept(
+      std::is_nothrow_move_constructible_v<Receiver>&&
+          std::is_nothrow_move_constructible_v<Error>&&
+              is_nothrow_connectable_v<Source, source_receiver>)
+    : error_((Error2 &&) error)
+    , receiver_((Receiver2 &&) dest) {
     unifex::activate_union_member_with(sourceOp_, [&] {
-        return unifex::connect((Source&&)source, source_receiver{this});
-      });
+      return unifex::connect((Source &&) source, source_receiver{this});
+    });
     startedOp_ = state::source;
   }
 
   ~type() {
     switch (startedOp_) {
-    case state::neither:
-      break;
-    case state::source:
-      unifex::deactivate_union_member(sourceOp_);
-      break;
-    case state::final:
-      unifex::deactivate_union_member(finalOp_);
-      break;
+      case state::neither: break;
+      case state::source: unifex::deactivate_union_member(sourceOp_); break;
+      case state::final: unifex::deactivate_union_member(finalOp_); break;
     }
     startedOp_ = state::neither;
   }
 
-  void start() & noexcept {
-    unifex::start(sourceOp_.get());
-  }
+  void start() & noexcept { unifex::start(sourceOp_.get()); }
 
 private:
   friend source_receiver;
@@ -270,56 +250,64 @@ class _sndr<Source, Error>::type {
   using final_sender_t = callable_result_t<Error>;
 
   template <typename Sender, typename Receiver>
-  using source_receiver_t = receiver_type<member_t<Sender, Source>, Error, Receiver>;
+  using source_receiver_t =
+      receiver_type<member_t<Sender, Source>, Error, Receiver>;
 
   template <typename Sender, typename Receiver>
-  using final_receiver_t = final_receiver_type<member_t<Sender, Source>, Error, Receiver>;
+  using final_receiver_t =
+      final_receiver_type<member_t<Sender, Source>, Error, Receiver>;
 
 public:
-  template <template <typename...> class Variant,
-            template <typename...> class Tuple>
-  using value_types =
-      typename concat_type_lists_unique_t<
-          sender_value_types_t<Source, type_list, Tuple>,
-          sender_value_types_t<final_sender_t, type_list, Tuple>>::template
-              apply<Variant>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename concat_type_lists_unique_t<
+      sender_value_types_t<Source, type_list, Tuple>,
+      sender_value_types_t<final_sender_t, type_list, Tuple>>::
+      template apply<Variant>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Source, type_list>,
-          sender_error_types_t<final_sender_t, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Source, type_list>,
+      sender_error_types_t<final_sender_t, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<final_sender_t>::sends_done;
 
   template <typename Source2, typename Error2>
-  explicit type(Source2&& source, Error2&& error)
-    noexcept(
-      std::is_nothrow_constructible_v<Source, Source2> &&
-      std::is_nothrow_constructible_v<Error, Error2>)
-    : source_((Source2&&)source)
-    , error_((Error2&&)error)
-  {}
+  explicit type(Source2&& source, Error2&& error) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
+          std::is_nothrow_constructible_v<Error, Error2>)
+    : source_((Source2 &&) source)
+    , error_((Error2 &&) error) {}
 
-  template(typename Sender, typename Receiver)
-      (requires same_as<remove_cvref_t<Sender>, type> AND
-          constructible_from<Error, member_t<Sender, Error>> AND
-          constructible_from<remove_cvref_t<Receiver>, Receiver> AND
-          receiver<Receiver> AND
-          sender_to<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>> AND
-          sender_to<final_sender_t, final_receiver_t<Sender, Receiver>>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-      noexcept(
-        is_nothrow_connectable_v<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>> &&
-        std::is_nothrow_constructible_v<Error, member_t<Sender, Error>> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+  template(typename Sender, typename Receiver)(
+      requires same_as<remove_cvref_t<Sender>, type> AND constructible_from<
+          Error,
+          member_t<
+              Sender,
+              Error>> AND constructible_from<remove_cvref_t<Receiver>, Receiver> AND receiver<Receiver>
+          AND sender_to<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>> AND sender_to<
+              final_sender_t,
+              final_receiver_t<
+                  Sender,
+                  Receiver>>) friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(is_nothrow_connectable_v<member_t<Sender, Source>, source_receiver_t<Sender, Receiver>>&&
+                                                                                                                    std::is_nothrow_constructible_v<
+                                                                                                                        Error,
+                                                                                                                        member_t<
+                                                                                                                            Sender,
+                                                                                                                            Error>>&&
+                                                                                                                        std::is_nothrow_constructible_v<
+                                                                                                                            remove_cvref_t<
+                                                                                                                                Receiver>,
+                                                                                                                            Receiver>)
       -> operation_type<member_t<Sender, Source>, Error, Receiver> {
     return operation_type<member_t<Sender, Source>, Error, Receiver>{
-      static_cast<Sender&&>(s).source_,
-      static_cast<Sender&&>(s).error_,
-      static_cast<Receiver&&>(r)
-    };
+        static_cast<Sender&&>(s).source_,
+        static_cast<Sender&&>(s).error_,
+        static_cast<Receiver&&>(r)};
   }
 
 private:
@@ -327,50 +315,47 @@ private:
   Error error_;
 };
 
-namespace _cpo
-{
+namespace _cpo {
 struct _fn {
-  template(typename Source, typename Error)
-    (requires tag_invocable<_fn, Source, Error> AND
-        sender<Source> AND
-        callable<remove_cvref_t<Error>> AND
-        sender<callable_result_t<remove_cvref_t<Error>>>)
-  auto operator()(Source&& source, Error&& error) const
+  template(typename Source, typename Error)(
+      requires tag_invocable<_fn, Source, Error> AND sender<Source> AND
+          callable<remove_cvref_t<Error>> AND
+              sender<callable_result_t<remove_cvref_t<Error>>>) auto
+  operator()(Source&& source, Error&& error) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source, Error>)
-      -> tag_invoke_result_t<_fn, Source, Error> {
-    return tag_invoke(*this, (Source&&)source, (Error&&)error);
+          -> tag_invoke_result_t<_fn, Source, Error> {
+    return tag_invoke(*this, (Source &&) source, (Error &&) error);
   }
 
-  template(typename Source, typename Error)
-    (requires (!tag_invocable<_fn, Source, Error>) AND
-        constructible_from<remove_cvref_t<Source>, Source> AND
-        constructible_from<remove_cvref_t<Error>, Error> AND
-        callable<remove_cvref_t<Error>> AND
-        sender<callable_result_t<remove_cvref_t<Error>>>)
-  auto operator()(Source&& source, Error&& error) const
+  template(typename Source, typename Error)(
+      requires(!tag_invocable<_fn, Source, Error>)
+          AND constructible_from<remove_cvref_t<Source>, Source> AND
+              constructible_from<remove_cvref_t<Error>, Error> AND
+                  callable<remove_cvref_t<Error>> AND
+                      sender<callable_result_t<remove_cvref_t<Error>>>) auto
+  operator()(Source&& source, Error&& error) const
       noexcept(std::is_nothrow_constructible_v<
-                   _sender<remove_cvref_t<Source>, remove_cvref_t<Error>>,
-                   Source, 
-                   Error>)
-      -> _sender<remove_cvref_t<Source>, remove_cvref_t<Error>> {
+               _sender<remove_cvref_t<Source>, remove_cvref_t<Error>>,
+               Source,
+               Error>)
+          -> _sender<remove_cvref_t<Source>, remove_cvref_t<Error>> {
     return _sender<remove_cvref_t<Source>, remove_cvref_t<Error>>{
-        (Source&&)source, (Error&&)error};
+        (Source &&) source, (Error &&) error};
   }
-  template(typename Error)
-      (requires callable<remove_cvref_t<Error>> AND
-        sender<callable_result_t<remove_cvref_t<Error>>>)
-  constexpr auto operator()(Error&& error) const
-      noexcept(is_nothrow_callable_v<
-        tag_t<bind_back>, _fn, Error>)
-      -> bind_back_result_t<_fn, Error> {
-    return bind_back(*this, (Error&&)error);
+  template(typename Error)(
+      requires callable<remove_cvref_t<Error>> AND
+          sender<callable_result_t<remove_cvref_t<Error>>>) constexpr auto
+  operator()(Error&& error) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Error>)
+          -> bind_back_result_t<_fn, Error> {
+    return bind_back(*this, (Error &&) error);
   }
 };
-} // namespace _cpo
-} // namespace _let_e
+}  // namespace _cpo
+}  // namespace _let_e
 
-inline constexpr _let_e::_cpo::_fn let_error {};
+inline constexpr _let_e::_cpo::_fn let_error{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -16,15 +16,15 @@
 #pragma once
 
 #include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <exception>
 #include <functional>
@@ -43,7 +43,8 @@ struct _successor_receiver {
   struct type;
 };
 template <typename Operation, typename... Values>
-using successor_receiver = typename _successor_receiver<Operation, Values...>::type;
+using successor_receiver =
+    typename _successor_receiver<Operation, Values...>::type;
 
 template <typename Operation, typename... Values>
 struct _successor_receiver<Operation, Values...>::type {
@@ -64,9 +65,10 @@ struct _successor_receiver<Operation, Values...>::type {
       [&](auto... copies) {
         cleanup();
         unifex::set_value(
-            std::move(op.receiver_), (decltype(copies) &&) copies...);
-      } ((SuccessorValues&&) values...);
-    } UNIFEX_CATCH (...) {
+            std::move(op.receiver_), (decltype(copies)&&)copies...);
+      }((SuccessorValues &&) values...);
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(std::move(op.receiver_), std::current_exception());
     }
   }
@@ -89,7 +91,8 @@ struct _successor_receiver<Operation, Values...>::type {
 
 private:
   template <typename... Values2>
-  using successor_operation = typename Operation::template successor_operation<Values2...>;
+  using successor_operation =
+      typename Operation::template successor_operation<Values2...>;
 
   void cleanup() noexcept {
     auto& op = op_;
@@ -97,19 +100,17 @@ private:
     op.values_.template destruct<decayed_tuple<Values...>>();
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const typename Operation::receiver_type&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const successor_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const typename Operation::receiver_type&>)
       -> callable_result_t<CPO, const typename Operation::receiver_type&> {
     return std::move(cpo)(std::as_const(r.get_receiver()));
   }
 
   template <typename Func>
   friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const successor_receiver& r,
-      Func&& f) {
+      tag_t<visit_continuations>, const successor_receiver& r, Func&& f) {
     std::invoke(f, r.get_receiver());
   }
 };
@@ -127,37 +128,38 @@ struct _predecessor_receiver<Operation>::type {
   using receiver_type = typename Operation::receiver_type;
 
   template <typename... Values>
-  using successor_operation = typename Operation::template successor_operation<Values...>;
+  using successor_operation =
+      typename Operation::template successor_operation<Values...>;
 
   Operation& op_;
 
-  receiver_type& get_receiver() const noexcept {
-    return op_.receiver_;
-  }
+  receiver_type& get_receiver() const noexcept { return op_.receiver_; }
 
   template <typename... Values>
   void set_value(Values&&... values) && noexcept {
     auto& op = op_;
     UNIFEX_TRY {
-      scope_guard destroyPredOp =
-        [&]() noexcept { unifex::deactivate_union_member(op.predOp_); };
+      scope_guard destroyPredOp = [&]() noexcept {
+        unifex::deactivate_union_member(op.predOp_);
+      };
       auto& valueTuple =
-        op.values_.template construct<decayed_tuple<Values...>>((Values &&) values...);
+          op.values_.template construct<decayed_tuple<Values...>>(
+              (Values &&) values...);
       destroyPredOp.reset();
       scope_guard destroyValues = [&]() noexcept {
         op.values_.template destruct<decayed_tuple<Values...>>();
       };
       auto& succOp =
           unifex::activate_union_member_with<successor_operation<Values...>>(
-            op.succOp_,
-            [&] {
-              return unifex::connect(
-                  std::apply(std::move(op.func_), valueTuple),
-                  successor_receiver<Operation, Values...>{op});
-            });
+              op.succOp_, [&] {
+                return unifex::connect(
+                    std::apply(std::move(op.func_), valueTuple),
+                    successor_receiver<Operation, Values...>{op});
+              });
       unifex::start(succOp);
       destroyValues.release();
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(std::move(op.receiver_), std::current_exception());
     }
   }
@@ -178,19 +180,17 @@ struct _predecessor_receiver<Operation>::type {
     unifex::set_error(std::move(op.receiver_), (Error &&) error);
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const receiver_type&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const predecessor_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const receiver_type&>)
       -> callable_result_t<CPO, const receiver_type&> {
     return std::move(cpo)(std::as_const(r.get_receiver()));
   }
 
   template <typename Func>
   friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const predecessor_receiver& r,
-      Func&& f) {
+      tag_t<visit_continuations>, const predecessor_receiver& r, Func&& f) {
     std::invoke(f, r.get_receiver());
   }
 };
@@ -200,10 +200,8 @@ struct _op {
   struct type;
 };
 template <typename Predecessor, typename SuccessorFactory, typename Receiver>
-using operation = typename _op<
-    Predecessor,
-    SuccessorFactory,
-    remove_cvref_t<Receiver>>::type;
+using operation =
+    typename _op<Predecessor, SuccessorFactory, remove_cvref_t<Receiver>>::type;
 
 template <typename Predecessor, typename SuccessorFactory, typename Receiver>
 struct _op<Predecessor, SuccessorFactory, Receiver>::type {
@@ -215,8 +213,9 @@ struct _op<Predecessor, SuccessorFactory, Receiver>::type {
       std::invoke_result_t<SuccessorFactory, std::decay_t<Values>&...>;
 
   template <typename... Values>
-  using successor_operation =
-      connect_result_t<successor_type<Values...>, successor_receiver<operation, Values...>>;
+  using successor_operation = connect_result_t<
+      successor_type<Values...>,
+      successor_receiver<operation, Values...>>;
 
   friend predecessor_receiver<operation>;
   template <typename Operation, typename... Values>
@@ -224,11 +223,9 @@ struct _op<Predecessor, SuccessorFactory, Receiver>::type {
 
   template <typename SuccessorFactory2, typename Receiver2>
   explicit type(
-      Predecessor&& pred,
-      SuccessorFactory2&& func,
-      Receiver2&& receiver)
-      : func_((SuccessorFactory2 &&) func),
-        receiver_((Receiver2 &&) receiver) {
+      Predecessor&& pred, SuccessorFactory2&& func, Receiver2&& receiver)
+    : func_((SuccessorFactory2 &&) func)
+    , receiver_((Receiver2 &&) receiver) {
     unifex::activate_union_member_with(predOp_, [&] {
       return unifex::connect(
           (Predecessor &&) pred, predecessor_receiver<operation>{*this});
@@ -254,9 +251,11 @@ private:
       template value_types<manual_lifetime_union, decayed_tuple>
           values_;
   union {
-    manual_lifetime<connect_result_t<Predecessor, predecessor_receiver<operation>>> predOp_;
-    typename predecessor_type::template
-        value_types<manual_lifetime_union, successor_operation>
+    manual_lifetime<
+        connect_result_t<Predecessor, predecessor_receiver<operation>>>
+        predOp_;
+    typename predecessor_type::
+        template value_types<manual_lifetime_union, successor_operation>
             succOp_;
   };
   bool started_ = false;
@@ -271,8 +270,9 @@ using sender = typename _sender<
     remove_cvref_t<Predecessor>,
     remove_cvref_t<SuccessorFactory>>::type;
 
-template<typename Sender>
-struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {};
+template <typename Sender>
+struct sends_done_impl
+  : std::bool_constant<sender_traits<Sender>::sends_done> {};
 
 template <typename... Successors>
 using any_sends_done = std::disjunction<sends_done_impl<Successors>...>;
@@ -304,7 +304,8 @@ struct max_blocking_kind<First, Second, Rest...> {
   }
 };
 
-constexpr blocking_kind _blocking_kind(blocking_kind source, blocking_kind completion) noexcept {
+constexpr blocking_kind
+_blocking_kind(blocking_kind source, blocking_kind completion) noexcept {
   if (source == blocking_kind::never || completion == blocking_kind::never) {
     return blocking_kind::never;
   } else if (
@@ -329,20 +330,23 @@ class _sender<Predecessor, SuccessorFactory>::type {
   SuccessorFactory func_;
 
   template <typename... Values>
-  using successor_type = std::invoke_result_t<SuccessorFactory, std::decay_t<Values>&...>;
+  using successor_type =
+      std::invoke_result_t<SuccessorFactory, std::decay_t<Values>&...>;
 
   template <template <typename...> class List>
   using successor_types =
       sender_value_types_t<Predecessor, List, successor_type>;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   struct value_types_impl {
     template <typename... Senders>
-    using apply =
-        typename concat_type_lists_unique_t<
-            sender_value_types_t<Senders, type_list, Tuple>...>::template apply<Variant>;
+    using apply = typename concat_type_lists_unique_t<
+        sender_value_types_t<Senders, type_list, Tuple>...>::
+        template apply<Variant>;
   };
 
   // TODO: Ideally we'd only conditionally add the std::exception_ptr type
@@ -361,16 +365,17 @@ class _sender<Predecessor, SuccessorFactory>::type {
   template <template <typename...> class Variant>
   struct error_types_impl {
     template <typename... Senders>
-    using apply =
-        typename concat_type_lists_unique_t<
-            sender_error_types_t<Senders, type_list>...,
-            type_list<std::exception_ptr>>::template apply<Variant>;
+    using apply = typename concat_type_lists_unique_t<
+        sender_error_types_t<Senders, type_list>...,
+        type_list<std::exception_ptr>>::template apply<Variant>;
   };
 
 public:
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types =
       successor_types<value_types_impl<Variant, Tuple>::template apply>;
 
@@ -378,36 +383,47 @@ public:
   using error_types =
       successor_types<error_types_impl<Variant>::template apply>;
 
-  static constexpr bool sends_done =
-    sender_traits<Predecessor>::sends_done ||
-    successor_types<any_sends_done>::value;
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done ||
+      successor_types<any_sends_done>::value;
 
- public:
+public:
   template <typename Predecessor2, typename SuccessorFactory2>
-  explicit type(Predecessor2&& pred, SuccessorFactory2&& func)
-      noexcept(std::is_nothrow_constructible_v<Predecessor, Predecessor2> &&
+  explicit type(Predecessor2&& pred, SuccessorFactory2&& func) noexcept(
+      std::is_nothrow_constructible_v<Predecessor, Predecessor2>&&
           std::is_nothrow_constructible_v<SuccessorFactory, SuccessorFactory2>)
-    : pred_((Predecessor2 &&) pred), func_((SuccessorFactory2 &&) func) {}
+    : pred_((Predecessor2 &&) pred)
+    , func_((SuccessorFactory2 &&) func) {}
 
-  template(typename CPO, typename Sender, typename Receiver)
-      (requires same_as<CPO, tag_t<unifex::connect>> AND
-        same_as<remove_cvref_t<Sender>, type>)
-  friend auto tag_invoke([[maybe_unused]] CPO cpo, Sender&& sender, Receiver&& receiver)
-      -> operation<decltype((static_cast<Sender&&>(sender).pred_)), SuccessorFactory, Receiver> {
-    return operation<decltype((static_cast<Sender&&>(sender).pred_)), SuccessorFactory, Receiver>{
+  template(typename CPO, typename Sender, typename Receiver)(
+      requires same_as<CPO, tag_t<unifex::connect>> AND same_as<
+          remove_cvref_t<Sender>,
+          type>) friend auto tag_invoke([[maybe_unused]] CPO cpo, Sender&& sender, Receiver&& receiver)
+      -> operation<
+          decltype((static_cast<Sender&&>(sender).pred_)),
+          SuccessorFactory,
+          Receiver> {
+    return operation<
+        decltype((static_cast<Sender&&>(sender).pred_)),
+        SuccessorFactory,
+        Receiver>{
         static_cast<Sender&&>(sender).pred_,
         static_cast<Sender&&>(sender).func_,
         static_cast<Receiver&&>(receiver)};
   }
 
-  friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type&) noexcept {
-    constexpr blocking_kind succ = successor_types<_let_v::max_blocking_kind>{}();
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type&) noexcept {
+    constexpr blocking_kind succ =
+        successor_types<_let_v::max_blocking_kind>{}();
     if constexpr (
-        blocking_kind::never == cblocking<Predecessor>() || blocking_kind::never == succ) {
+        blocking_kind::never == cblocking<Predecessor>() ||
+        blocking_kind::never == succ) {
       return blocking_kind::never;
     } else if constexpr (
-        blocking_kind::maybe != cblocking<Predecessor>() && blocking_kind::maybe != succ) {
-      return blocking_kind::constant<_let_v::_blocking_kind(cblocking<Predecessor>(), succ)>{};
+        blocking_kind::maybe != cblocking<Predecessor>() &&
+        blocking_kind::maybe != succ) {
+      return blocking_kind::constant<_let_v::_blocking_kind(
+          cblocking<Predecessor>(), succ)>{};
     } else {
       return _let_v::_blocking_kind(cblocking<Predecessor>(), succ);
     }
@@ -415,29 +431,29 @@ public:
 };
 
 namespace _cpo {
-  struct _fn {
-    template <typename Predecessor, typename SuccessorFactory>
-    auto operator()(Predecessor&& pred, SuccessorFactory&& func) const
-        noexcept(std::is_nothrow_constructible_v<
-            _let_v::sender<Predecessor, SuccessorFactory>, Predecessor, SuccessorFactory>)
-        -> _let_v::sender<Predecessor, SuccessorFactory> {
-      return _let_v::sender<Predecessor, SuccessorFactory>{
-          (Predecessor &&) pred,
-          (SuccessorFactory &&) func};
-    }
-    template <typename SuccessorFactory>
-    constexpr auto operator()(SuccessorFactory&& func) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, SuccessorFactory>)
-        -> bind_back_result_t<_fn, SuccessorFactory> {
-      return bind_back(*this, (SuccessorFactory&&)func);
-    }
-  };
-} // namespace _cpo
-} // namespace _let_v
+struct _fn {
+  template <typename Predecessor, typename SuccessorFactory>
+  auto operator()(Predecessor&& pred, SuccessorFactory&& func) const
+      noexcept(std::is_nothrow_constructible_v<
+               _let_v::sender<Predecessor, SuccessorFactory>,
+               Predecessor,
+               SuccessorFactory>)
+          -> _let_v::sender<Predecessor, SuccessorFactory> {
+    return _let_v::sender<Predecessor, SuccessorFactory>{
+        (Predecessor &&) pred, (SuccessorFactory &&) func};
+  }
+  template <typename SuccessorFactory>
+  constexpr auto operator()(SuccessorFactory&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, SuccessorFactory>)
+          -> bind_back_result_t<_fn, SuccessorFactory> {
+    return bind_back(*this, (SuccessorFactory &&) func);
+  }
+};
+}  // namespace _cpo
+}  // namespace _let_v
 
-inline constexpr _let_v::_cpo::_fn let_value {};
+inline constexpr _let_v::_cpo::_fn let_value{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/let_value_with.hpp
+++ b/include/unifex/let_value_with.hpp
@@ -16,11 +16,11 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/execution_policy.hpp>
 #include <unifex/just.hpp>
 #include <unifex/let_value.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/execution_policy.hpp>
 #include <unifex/type_list.hpp>
 
 #include <unifex/detail/prologue.hpp>
@@ -29,60 +29,64 @@ namespace unifex {
 
 namespace _let_v_w {
 
-template<typename StateFactory, typename InnerOp, typename Receiver>
+template <typename StateFactory, typename InnerOp, typename Receiver>
 struct _operation {
   struct type;
 };
 
 template <typename StateFactory, typename InnerOp, typename Receiver>
-using operation =  typename _operation<
-  StateFactory, InnerOp, Receiver>::type;
+using operation = typename _operation<StateFactory, InnerOp, Receiver>::type;
 
-template<typename StateFactory, typename SuccessorFactory>
+template <typename StateFactory, typename SuccessorFactory>
 struct _sender {
   class type;
 };
 
-template<typename StateFactory, typename SuccessorFactory>
+template <typename StateFactory, typename SuccessorFactory>
 using let_with_sender = typename _sender<StateFactory, SuccessorFactory>::type;
 
-template<typename StateFactory, typename SuccessorFactory>
+template <typename StateFactory, typename SuccessorFactory>
 class _sender<StateFactory, SuccessorFactory>::type {
 public:
-  using InnerOp = std::invoke_result_t<SuccessorFactory, callable_result_t<StateFactory>&>;
+  using InnerOp =
+      std::invoke_result_t<SuccessorFactory, callable_result_t<StateFactory>&>;
 
-  template<template<typename...> class Variant, template<typename...> class Tuple>
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = sender_value_types_t<InnerOp, Variant, Tuple>;
 
-  template<template<typename...> class Variant>
+  template <template <typename...> class Variant>
   using error_types = sender_error_types_t<InnerOp, Variant>;
 
   static constexpr bool sends_done = sender_traits<InnerOp>::sends_done;
 
-  template<typename StateFactory2, typename SuccessorFactory2>
-  explicit type(StateFactory2&& stateFactory, SuccessorFactory2&& func) :
-    stateFactory_((StateFactory2&&)stateFactory),
-    func_((SuccessorFactory2&&)func)
-  {}
+  template <typename StateFactory2, typename SuccessorFactory2>
+  explicit type(StateFactory2&& stateFactory, SuccessorFactory2&& func)
+    : stateFactory_((StateFactory2 &&) stateFactory)
+    , func_((SuccessorFactory2 &&) func) {}
 
-  template(typename Self, typename Receiver)
-    (requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r)
-    noexcept(
-      is_nothrow_callable_v<member_t<Self, StateFactory>> &&
-      std::is_nothrow_invocable_v<
-        member_t<Self, SuccessorFactory>,
-        callable_result_t<member_t<Self, StateFactory>>&> &&
-      is_nothrow_connectable_v<
-        callable_result_t<
-          member_t<Self, SuccessorFactory>,
-          callable_result_t<member_t<Self, StateFactory>>&>,
-        remove_cvref_t<Receiver>>) {
-
+  template(typename Self, typename Receiver)(requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Self&& self,
+      Receiver&&
+          r) noexcept(is_nothrow_callable_v<member_t<Self, StateFactory>>&&
+                          std::is_nothrow_invocable_v<
+                              member_t<Self, SuccessorFactory>,
+                              callable_result_t<
+                                  member_t<Self, StateFactory>>&>&&
+                              is_nothrow_connectable_v<
+                                  callable_result_t<
+                                      member_t<Self, SuccessorFactory>,
+                                      callable_result_t<
+                                          member_t<Self, StateFactory>>&>,
+                                  remove_cvref_t<Receiver>>) {
     return operation<StateFactory, SuccessorFactory, Receiver>(
-      static_cast<Self&&>(self).stateFactory_,
-      static_cast<Self&&>(self).func_,
-      static_cast<Receiver&&>(r));
+        static_cast<Self&&>(self).stateFactory_,
+        static_cast<Self&&>(self).func_,
+        static_cast<Receiver&&>(r));
   }
 
 private:
@@ -90,59 +94,58 @@ private:
   UNIFEX_NO_UNIQUE_ADDRESS SuccessorFactory func_;
 };
 
-
-template<typename StateFactory, typename SuccessorFactory, typename Receiver>
+template <typename StateFactory, typename SuccessorFactory, typename Receiver>
 struct _operation<StateFactory, SuccessorFactory, Receiver>::type {
-  type(StateFactory&& stateFactory, SuccessorFactory&& func, Receiver&& r) :
-    stateFactory_(static_cast<StateFactory&&>(stateFactory)),
-    func_(static_cast<SuccessorFactory&&>(func)),
-    state_(static_cast<StateFactory&&>(stateFactory_)()),
-    innerOp_(
-        unifex::connect(
-        static_cast<SuccessorFactory&&>(func_)(state_),
-        static_cast<Receiver&&>(r))) {
-  }
+  type(StateFactory&& stateFactory, SuccessorFactory&& func, Receiver&& r)
+    : stateFactory_(static_cast<StateFactory&&>(stateFactory))
+    , func_(static_cast<SuccessorFactory&&>(func))
+    , state_(static_cast<StateFactory&&>(stateFactory_)())
+    , innerOp_(unifex::connect(
+          static_cast<SuccessorFactory&&>(func_)(state_),
+          static_cast<Receiver&&>(r))) {}
 
-  void start() & noexcept {
-    unifex::start(innerOp_);
-  }
+  void start() & noexcept { unifex::start(innerOp_); }
 
   StateFactory stateFactory_;
   SuccessorFactory func_;
   callable_result_t<StateFactory> state_;
   connect_result_t<
-    callable_result_t<SuccessorFactory, callable_result_t<StateFactory>&>,
-    remove_cvref_t<Receiver>>
-    innerOp_;
+      callable_result_t<SuccessorFactory, callable_result_t<StateFactory>&>,
+      remove_cvref_t<Receiver>>
+      innerOp_;
 };
 
 namespace _cpo {
-  struct _fn {
-    template (typename StateFactory, typename SuccessorFactory)
-      (requires
-        callable<std::decay_t<StateFactory>> AND
-        callable<
+struct _fn {
+  template(typename StateFactory, typename SuccessorFactory)(
+      requires callable<std::decay_t<StateFactory>> AND callable<
           std::decay_t<SuccessorFactory>,
           callable_result_t<std::decay_t<StateFactory>>&> AND
-        sender<
-          callable_result_t<
-            std::decay_t<SuccessorFactory>,
-            callable_result_t<std::decay_t<StateFactory>>&>>)
-    auto operator()(StateFactory&& stateFactory, SuccessorFactory&& successor_factory) const
-      noexcept(std::is_nothrow_constructible_v<std::decay_t<SuccessorFactory>, SuccessorFactory> &&
-          std::is_nothrow_constructible_v<std::decay_t<StateFactory>, StateFactory>)
-      -> _let_v_w::let_with_sender<
-         std::decay_t<StateFactory>, std::decay_t<SuccessorFactory>> {
-      return _let_v_w::let_with_sender<
-        std::decay_t<StateFactory>, std::decay_t<SuccessorFactory>>{
-        (StateFactory&&)stateFactory, (SuccessorFactory&&)successor_factory};
-    }
-  };
-} // namespace _cpo
-} // namespace _let_v_w
+          sender<callable_result_t<
+              std::decay_t<SuccessorFactory>,
+              callable_result_t<std::decay_t<StateFactory>>&>>) auto
+  operator()(StateFactory&& stateFactory, SuccessorFactory&& successor_factory)
+      const noexcept(std::is_nothrow_constructible_v<
+                     std::decay_t<SuccessorFactory>,
+                     SuccessorFactory>&&
+                         std::is_nothrow_constructible_v<
+                             std::decay_t<StateFactory>,
+                             StateFactory>)
+          -> _let_v_w::let_with_sender<
+              std::decay_t<StateFactory>,
+              std::decay_t<SuccessorFactory>> {
+    return _let_v_w::let_with_sender<
+        std::decay_t<StateFactory>,
+        std::decay_t<SuccessorFactory>>{
+        (StateFactory &&) stateFactory,
+        (SuccessorFactory &&) successor_factory};
+  }
+};
+}  // namespace _cpo
+}  // namespace _let_v_w
 
 inline constexpr _let_v_w::_cpo::_fn let_value_with{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -18,39 +18,39 @@
 #include <unifex/config.hpp>
 #if !UNIFEX_NO_LIBURING
 
-#include <unifex/detail/atomic_intrusive_queue.hpp>
-#include <unifex/detail/intrusive_heap.hpp>
-#include <unifex/detail/intrusive_queue.hpp>
-#include <unifex/file_concepts.hpp>
-#include <unifex/filesystem.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/manual_lifetime.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/span.hpp>
-#include <unifex/stop_token_concepts.hpp>
-#include <unifex/optional.hpp>
+#  include <unifex/file_concepts.hpp>
+#  include <unifex/filesystem.hpp>
+#  include <unifex/get_stop_token.hpp>
+#  include <unifex/manual_lifetime.hpp>
+#  include <unifex/optional.hpp>
+#  include <unifex/receiver_concepts.hpp>
+#  include <unifex/span.hpp>
+#  include <unifex/stop_token_concepts.hpp>
+#  include <unifex/detail/atomic_intrusive_queue.hpp>
+#  include <unifex/detail/intrusive_heap.hpp>
+#  include <unifex/detail/intrusive_queue.hpp>
 
-#include <unifex/linux/mmap_region.hpp>
-#include <unifex/linux/monotonic_clock.hpp>
-#include <unifex/linux/safe_file_descriptor.hpp>
+#  include <unifex/linux/mmap_region.hpp>
+#  include <unifex/linux/monotonic_clock.hpp>
+#  include <unifex/linux/safe_file_descriptor.hpp>
 
-#include <atomic>
-#include <cstddef>
-#include <cstdint>
-#include <system_error>
-#include <utility>
+#  include <atomic>
+#  include <cstddef>
+#  include <cstdint>
+#  include <system_error>
+#  include <utility>
 
-#include <liburing/io_uring.h>
+#  include <liburing/io_uring.h>
 
-#include <sys/uio.h>
+#  include <sys/uio.h>
 
-#include <unifex/detail/prologue.hpp>
+#  include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace linuxos {
 
 class io_uring_context {
- public:
+public:
   class schedule_sender;
   class schedule_at_sender;
   template <typename Duration>
@@ -71,7 +71,7 @@ class io_uring_context {
 
   scheduler get_scheduler() noexcept;
 
- private:
+private:
   struct operation_base {
     operation_base() noexcept {}
     operation_base* next_;
@@ -84,7 +84,7 @@ class io_uring_context {
 
   struct stop_operation : operation_base {
     stop_operation() noexcept {
-      this->execute_ = [](operation_base * op) noexcept {
+      this->execute_ = [](operation_base* op) noexcept {
         static_cast<stop_operation*>(op)->shouldStop_ = true;
       };
     }
@@ -98,9 +98,9 @@ class io_uring_context {
         io_uring_context& context,
         const time_point& dueTime,
         bool canBeCancelled) noexcept
-        : context_(context),
-          dueTime_(dueTime),
-          canBeCancelled_(canBeCancelled) {}
+      : context_(context)
+      , dueTime_(dueTime)
+      , canBeCancelled_(canBeCancelled) {}
 
     schedule_at_operation* timerNext_;
     schedule_at_operation* timerPrev_;
@@ -280,7 +280,9 @@ class io_uring_context {
 template <typename StopToken>
 void io_uring_context::run(StopToken stopToken) {
   stop_operation stopOp;
-  auto onStopRequested = [&] { this->schedule_impl(&stopOp); };
+  auto onStopRequested = [&] {
+    this->schedule_impl(&stopOp);
+  };
   typename StopToken::template callback_type<decltype(onStopRequested)>
       stopCallback{std::move(stopToken), std::move(onStopRequested)};
   run_impl(stopOp.shouldStop_);
@@ -324,22 +326,24 @@ bool io_uring_context::try_submit_io(PopulateFn populateSqe) noexcept {
 class io_uring_context::schedule_sender {
   template <typename Receiver>
   class operation : private operation_base {
-   public:
+  public:
     void start() noexcept {
       UNIFEX_TRY {
         context_.schedule_impl(this);
-      } UNIFEX_CATCH (...) {
+      }
+      UNIFEX_CATCH(...) {
         unifex::set_error(
             static_cast<Receiver&&>(receiver_), std::current_exception());
       }
     }
 
-   private:
+  private:
     friend schedule_sender;
 
     template <typename Receiver2>
     explicit operation(io_uring_context& context, Receiver2&& r)
-        : context_(context), receiver_((Receiver2 &&) r) {
+      : context_(context)
+      , receiver_((Receiver2 &&) r) {
       this->execute_ = &execute_impl;
     }
 
@@ -352,13 +356,16 @@ class io_uring_context::schedule_sender {
         }
       }
 
-      if constexpr (noexcept(unifex::set_value(static_cast<Receiver&&>(op.receiver_)))) {
+      if constexpr (noexcept(unifex::set_value(
+                        static_cast<Receiver&&>(op.receiver_)))) {
         unifex::set_value(static_cast<Receiver&&>(op.receiver_));
       } else {
         UNIFEX_TRY {
           unifex::set_value(static_cast<Receiver&&>(op.receiver_));
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::current_exception());
+        }
+        UNIFEX_CATCH(...) {
+          unifex::set_error(
+              static_cast<Receiver&&>(op.receiver_), std::current_exception());
         }
       }
     }
@@ -367,10 +374,12 @@ class io_uring_context::schedule_sender {
     Receiver receiver_;
   };
 
- public:
+public:
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<>>;
 
   template <template <typename...> class Variant>
@@ -380,15 +389,15 @@ class io_uring_context::schedule_sender {
 
   template <typename Receiver>
   operation<std::remove_reference_t<Receiver>> connect(Receiver&& r) {
-    return operation<std::remove_reference_t<Receiver>>{context_,
-                                                        (Receiver &&) r};
+    return operation<std::remove_reference_t<Receiver>>{
+        context_, (Receiver &&) r};
   }
 
- private:
+private:
   friend io_uring_context::scheduler;
 
   explicit schedule_sender(io_uring_context& context) noexcept
-      : context_(context) {}
+    : context_(context) {}
 
   io_uring_context& context_;
 };
@@ -400,13 +409,13 @@ class io_uring_context::read_sender {
   class operation : private completion_base {
     friend io_uring_context;
 
-   public:
+  public:
     template <typename Receiver2>
     explicit operation(const read_sender& sender, Receiver2&& r)
-        : context_(sender.context_),
-          fd_(sender.fd_),
-          offset_(sender.offset_),
-          receiver_((Receiver2 &&) r) {
+      : context_(sender.context_)
+      , fd_(sender.fd_)
+      , offset_(sender.offset_)
+      , receiver_((Receiver2 &&) r) {
       buffer_[0].iov_base = sender.buffer_.data();
       buffer_[0].iov_len = sender.buffer_.size();
     }
@@ -420,7 +429,7 @@ class io_uring_context::read_sender {
       }
     }
 
-   private:
+  private:
     static void on_schedule_complete(operation_base* op) noexcept {
       static_cast<operation*>(op)->start_io();
     }
@@ -428,7 +437,7 @@ class io_uring_context::read_sender {
     void start_io() noexcept {
       UNIFEX_ASSERT(context_.is_running_on_io_thread());
 
-      auto populateSqe = [this](io_uring_sqe & sqe) noexcept {
+      auto populateSqe = [this](io_uring_sqe& sqe) noexcept {
         sqe.opcode = IORING_OP_READV;
         sqe.flags = 0;
         sqe.ioprio = 0;
@@ -453,13 +462,16 @@ class io_uring_context::read_sender {
     static void on_read_complete(operation_base* op) noexcept {
       auto& self = *static_cast<operation*>(op);
       if (self.result_ >= 0) {
-        if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
+        if constexpr (noexcept(unifex::set_value(
+                          std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
           UNIFEX_TRY {
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(std::move(self.receiver_), std::current_exception());
+          }
+          UNIFEX_CATCH(...) {
+            unifex::set_error(
+                std::move(self.receiver_), std::current_exception());
           }
         }
       } else if (self.result_ == -ECANCELED) {
@@ -478,11 +490,13 @@ class io_uring_context::read_sender {
     Receiver receiver_;
   };
 
- public:
+public:
   // Produces number of bytes read.
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<ssize_t>>;
 
   // Note: Only case it might complete with exception_ptr is if the
@@ -497,14 +511,17 @@ class io_uring_context::read_sender {
       int fd,
       offset_t offset,
       span<std::byte> buffer) noexcept
-      : context_(context), fd_(fd), offset_(offset), buffer_(buffer) {}
+    : context_(context)
+    , fd_(fd)
+    , offset_(offset)
+    , buffer_(buffer) {}
 
   template <typename Receiver>
   operation<remove_cvref_t<Receiver>> connect(Receiver&& r) && {
     return operation<remove_cvref_t<Receiver>>{*this, (Receiver &&) r};
   }
 
- private:
+private:
   io_uring_context& context_;
   int fd_;
   offset_t offset_;
@@ -518,13 +535,13 @@ class io_uring_context::write_sender {
   class operation : private completion_base {
     friend io_uring_context;
 
-   public:
+  public:
     template <typename Receiver2>
     explicit operation(const write_sender& sender, Receiver2&& r)
-        : context_(sender.context_),
-          fd_(sender.fd_),
-          offset_(sender.offset_),
-          receiver_((Receiver2 &&) r) {
+      : context_(sender.context_)
+      , fd_(sender.fd_)
+      , offset_(sender.offset_)
+      , receiver_((Receiver2 &&) r) {
       buffer_[0].iov_base = (void*)sender.buffer_.data();
       buffer_[0].iov_len = sender.buffer_.size();
     }
@@ -538,7 +555,7 @@ class io_uring_context::write_sender {
       }
     }
 
-   private:
+  private:
     static void on_schedule_complete(operation_base* op) noexcept {
       static_cast<operation*>(op)->start_io();
     }
@@ -546,7 +563,7 @@ class io_uring_context::write_sender {
     void start_io() noexcept {
       UNIFEX_ASSERT(context_.is_running_on_io_thread());
 
-      auto populateSqe = [this](io_uring_sqe & sqe) noexcept {
+      auto populateSqe = [this](io_uring_sqe& sqe) noexcept {
         sqe.opcode = IORING_OP_WRITEV;
         sqe.flags = 0;
         sqe.ioprio = 0;
@@ -571,13 +588,16 @@ class io_uring_context::write_sender {
     static void on_write_complete(operation_base* op) noexcept {
       auto& self = *static_cast<operation*>(op);
       if (self.result_ >= 0) {
-        if constexpr (noexcept(unifex::set_value(std::move(self.receiver_), ssize_t(self.result_)))) {
+        if constexpr (noexcept(unifex::set_value(
+                          std::move(self.receiver_), ssize_t(self.result_)))) {
           unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
         } else {
           UNIFEX_TRY {
             unifex::set_value(std::move(self.receiver_), ssize_t(self.result_));
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(std::move(self.receiver_), std::current_exception());
+          }
+          UNIFEX_CATCH(...) {
+            unifex::set_error(
+                std::move(self.receiver_), std::current_exception());
           }
         }
       } else if (self.result_ == -ECANCELED) {
@@ -596,11 +616,13 @@ class io_uring_context::write_sender {
     Receiver receiver_;
   };
 
- public:
+public:
   // Produces number of bytes read.
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<ssize_t>>;
 
   // Note: Only case it might complete with exception_ptr is if the
@@ -615,14 +637,17 @@ class io_uring_context::write_sender {
       int fd,
       offset_t offset,
       span<const std::byte> buffer) noexcept
-      : context_(context), fd_(fd), offset_(offset), buffer_(buffer) {}
+    : context_(context)
+    , fd_(fd)
+    , offset_(offset)
+    , buffer_(buffer) {}
 
   template <typename Receiver>
   operation<remove_cvref_t<Receiver>> connect(Receiver&& r) {
     return operation<remove_cvref_t<Receiver>>{*this, (Receiver &&) r};
   }
 
- private:
+private:
   io_uring_context& context_;
   int fd_;
   offset_t offset_;
@@ -630,13 +655,14 @@ class io_uring_context::write_sender {
 };
 
 class io_uring_context::async_read_only_file {
- public:
+public:
   using offset_t = std::int64_t;
 
   explicit async_read_only_file(io_uring_context& context, int fd) noexcept
-      : context_(context), fd_(fd) {}
+    : context_(context)
+    , fd_(fd) {}
 
- private:
+private:
   friend scheduler;
 
   friend read_sender tag_invoke(
@@ -652,13 +678,14 @@ class io_uring_context::async_read_only_file {
 };
 
 class io_uring_context::async_write_only_file {
- public:
+public:
   using offset_t = std::int64_t;
 
   explicit async_write_only_file(io_uring_context& context, int fd) noexcept
-      : context_(context), fd_(fd) {}
+    : context_(context)
+    , fd_(fd) {}
 
- private:
+private:
   friend scheduler;
 
   friend write_sender tag_invoke(
@@ -674,13 +701,14 @@ class io_uring_context::async_write_only_file {
 };
 
 class io_uring_context::async_read_write_file {
- public:
+public:
   using offset_t = std::int64_t;
 
   explicit async_read_write_file(io_uring_context& context, int fd) noexcept
-      : context_(context), fd_(fd) {}
+    : context_(context)
+    , fd_(fd) {}
 
- private:
+private:
   friend scheduler;
 
   friend write_sender tag_invoke(
@@ -709,16 +737,12 @@ class io_uring_context::schedule_at_sender {
     static constexpr bool is_stop_ever_possible =
         !is_stop_never_possible_v<stop_token_type_t<Receiver>>;
 
-   public:
+  public:
     explicit operation(
-        io_uring_context& context,
-        const time_point& dueTime,
-        Receiver&& r)
-        : schedule_at_operation(
-              context,
-              dueTime,
-              get_stop_token(r).stop_possible()),
-          receiver_((Receiver &&) r) {}
+        io_uring_context& context, const time_point& dueTime, Receiver&& r)
+      : schedule_at_operation(
+            context, dueTime, get_stop_token(r).stop_possible())
+      , receiver_((Receiver &&) r) {}
 
     void start() noexcept {
       if (this->context_.is_running_on_io_thread()) {
@@ -728,7 +752,7 @@ class io_uring_context::schedule_at_sender {
       }
     }
 
-   private:
+  private:
     static void on_schedule_complete(operation_base* op) noexcept {
       static_cast<operation*>(op)->start_local();
     }
@@ -761,8 +785,10 @@ class io_uring_context::schedule_at_sender {
       } else {
         UNIFEX_TRY {
           unifex::set_value(std::move(timerOp).receiver_);
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(std::move(timerOp).receiver_, std::current_exception());
+        }
+        UNIFEX_CATCH(...) {
+          unifex::set_error(
+              std::move(timerOp).receiver_, std::current_exception());
         }
       }
     }
@@ -856,9 +882,7 @@ class io_uring_context::schedule_at_sender {
     struct cancel_callback {
       operation& op_;
 
-      void operator()() noexcept {
-        op_.request_stop();
-      }
+      void operator()() noexcept { op_.request_stop(); }
     };
 
     Receiver receiver_;
@@ -867,10 +891,12 @@ class io_uring_context::schedule_at_sender {
         stopCallback_;
   };
 
- public:
+public:
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<>>;
 
   // Note: Only case it might complete with exception_ptr is if the
@@ -881,9 +907,9 @@ class io_uring_context::schedule_at_sender {
   static constexpr bool sends_done = true;
 
   explicit schedule_at_sender(
-      io_uring_context& context,
-      const time_point& dueTime) noexcept
-      : context_(context), dueTime_(dueTime) {}
+      io_uring_context& context, const time_point& dueTime) noexcept
+    : context_(context)
+    , dueTime_(dueTime) {}
 
   template <typename Receiver>
   operation<remove_cvref_t<Receiver>> connect(Receiver&& r) {
@@ -891,13 +917,13 @@ class io_uring_context::schedule_at_sender {
         context_, dueTime_, (Receiver &&) r};
   }
 
- private:
+private:
   io_uring_context& context_;
   time_point dueTime_;
 };
 
 class io_uring_context::scheduler {
- public:
+public:
   scheduler(const scheduler&) noexcept = default;
   scheduler& operator=(const scheduler&) = default;
   ~scheduler() = default;
@@ -906,29 +932,21 @@ class io_uring_context::scheduler {
     return schedule_sender{*context_};
   }
 
-  time_point now() const noexcept {
-    return monotonic_clock::now();
-  }
+  time_point now() const noexcept { return monotonic_clock::now(); }
 
   schedule_at_sender schedule_at(const time_point& dueTime) const noexcept {
     return schedule_at_sender{*context_, dueTime};
   }
 
- private:
+private:
   friend io_uring_context;
 
   friend async_read_only_file tag_invoke(
-      tag_t<open_file_read_only>,
-      scheduler s,
-      const filesystem::path& path);
+      tag_t<open_file_read_only>, scheduler s, const filesystem::path& path);
   friend async_read_write_file tag_invoke(
-      tag_t<open_file_read_write>,
-      scheduler s,
-      const filesystem::path& path);
+      tag_t<open_file_read_write>, scheduler s, const filesystem::path& path);
   friend async_write_only_file tag_invoke(
-      tag_t<open_file_write_only>,
-      scheduler s,
-      const filesystem::path& path);
+      tag_t<open_file_write_only>, scheduler s, const filesystem::path& path);
 
   friend bool operator==(scheduler a, scheduler b) noexcept {
     return a.context_ == b.context_;
@@ -946,9 +964,9 @@ inline io_uring_context::scheduler io_uring_context::get_scheduler() noexcept {
   return scheduler{*this};
 }
 
-} // namespace linuxos
-} // namespace unifex
+}  // namespace linuxos
+}  // namespace unifex
 
-#include <unifex/detail/epilogue.hpp>
+#  include <unifex/detail/epilogue.hpp>
 
-#endif // __has_include(<liburing.h>)
+#endif  // __has_include(<liburing.h>)

--- a/include/unifex/linux/mmap_region.hpp
+++ b/include/unifex/linux/mmap_region.hpp
@@ -27,11 +27,12 @@ struct mmap_region {
   mmap_region() noexcept : ptr_(nullptr), size_(0) {}
 
   mmap_region(mmap_region&& r) noexcept
-      : ptr_(std::exchange(r.ptr_, nullptr)),
-        size_(std::exchange(r.size_, 0)) {}
+    : ptr_(std::exchange(r.ptr_, nullptr))
+    , size_(std::exchange(r.size_, 0)) {}
 
   explicit mmap_region(void* ptr, std::size_t size) noexcept
-      : ptr_(ptr), size_(size) {}
+    : ptr_(ptr)
+    , size_(size) {}
 
   ~mmap_region();
 
@@ -41,20 +42,16 @@ struct mmap_region {
     return *this;
   }
 
-  void* data() const noexcept {
-    return ptr_;
-  }
+  void* data() const noexcept { return ptr_; }
 
-  std::size_t size() const noexcept {
-    return size_;
-  }
+  std::size_t size() const noexcept { return size_; }
 
- private:
+private:
   void* ptr_;
   std::size_t size_;
 };
 
-} // namespace linuxos
-} // namespace unifex
+}  // namespace linuxos
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/monotonic_clock.hpp
+++ b/include/unifex/linux/monotonic_clock.hpp
@@ -31,15 +31,15 @@ namespace linuxos {
 // This is the clock-type used for timers by the io_uring IORING_OP_TIMEOUT
 // operations with absolute times.
 class monotonic_clock {
- public:
+public:
   using rep = std::int64_t;
-  using ratio = std::ratio<1, 10'000'000>; // 100ns
+  using ratio = std::ratio<1, 10'000'000>;  // 100ns
   using duration = std::chrono::duration<rep, ratio>;
 
   static constexpr bool is_steady = true;
 
   class time_point {
-   public:
+  public:
     using duration = monotonic_clock::duration;
 
     constexpr time_point() noexcept : seconds_(0), nanoseconds_(0) {}
@@ -63,28 +63,22 @@ class monotonic_clock {
     }
 
     static time_point from_seconds_and_nanoseconds(
-        std::int64_t seconds,
-        long long nanoseconds) noexcept;
+        std::int64_t seconds, long long nanoseconds) noexcept;
 
-    constexpr std::int64_t seconds_part() const noexcept {
-      return seconds_;
-    }
+    constexpr std::int64_t seconds_part() const noexcept { return seconds_; }
 
     constexpr long long nanoseconds_part() const noexcept {
       return nanoseconds_;
     }
 
     template <typename Rep, typename Ratio>
-    time_point& operator+=(
-        const std::chrono::duration<Rep, Ratio>& d) noexcept;
+    time_point& operator+=(const std::chrono::duration<Rep, Ratio>& d) noexcept;
 
     template <typename Rep, typename Ratio>
-    time_point& operator-=(
-        const std::chrono::duration<Rep, Ratio>& d) noexcept;
+    time_point& operator-=(const std::chrono::duration<Rep, Ratio>& d) noexcept;
 
-    friend duration operator-(
-        const time_point& a,
-        const time_point& b) noexcept {
+    friend duration
+    operator-(const time_point& a, const time_point& b) noexcept {
       return duration(
           (a.seconds_ - b.seconds_) * 10'000'000 +
           (a.nanoseconds_ - b.nanoseconds_) / 100);
@@ -92,8 +86,7 @@ class monotonic_clock {
 
     template <typename Rep, typename Ratio>
     friend time_point operator+(
-        const time_point& a,
-        std::chrono::duration<Rep, Ratio> d) noexcept {
+        const time_point& a, std::chrono::duration<Rep, Ratio> d) noexcept {
       time_point tp = a;
       tp += d;
       return tp;
@@ -101,8 +94,7 @@ class monotonic_clock {
 
     template <typename Rep, typename Ratio>
     friend time_point operator-(
-        const time_point& a,
-        std::chrono::duration<Rep, Ratio> d) noexcept {
+        const time_point& a, std::chrono::duration<Rep, Ratio> d) noexcept {
       time_point tp = a;
       tp -= d;
       return tp;
@@ -133,7 +125,7 @@ class monotonic_clock {
       return !(a < b);
     }
 
-   private:
+  private:
     void normalize() noexcept;
 
     std::int64_t seconds_;
@@ -145,8 +137,7 @@ class monotonic_clock {
 
 inline monotonic_clock::time_point
 monotonic_clock::time_point::from_seconds_and_nanoseconds(
-    std::int64_t seconds,
-    long long nanoseconds) noexcept {
+    std::int64_t seconds, long long nanoseconds) noexcept {
   time_point tp;
   tp.seconds_ = seconds;
   tp.nanoseconds_ = nanoseconds;
@@ -192,7 +183,7 @@ inline void monotonic_clock::time_point::normalize() noexcept {
   }
 }
 
-} // namespace linuxos
-} // namespace unifex
+}  // namespace linuxos
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/linux/safe_file_descriptor.hpp
+++ b/include/unifex/linux/safe_file_descriptor.hpp
@@ -23,13 +23,13 @@ namespace unifex {
 namespace linuxos {
 
 class safe_file_descriptor {
- public:
+public:
   safe_file_descriptor() noexcept : fd_(-1) {}
 
   explicit safe_file_descriptor(int fd) noexcept : fd_(fd) {}
 
   safe_file_descriptor(safe_file_descriptor&& other) noexcept
-      : fd_(std::exchange(other.fd_, -1)) {}
+    : fd_(std::exchange(other.fd_, -1)) {}
 
   ~safe_file_descriptor() {
     if (valid()) {
@@ -42,21 +42,17 @@ class safe_file_descriptor {
     return *this;
   }
 
-  bool valid() const noexcept {
-    return fd_ >= 0;
-  }
+  bool valid() const noexcept { return fd_ >= 0; }
 
-  int get() const noexcept {
-    return fd_;
-  }
+  int get() const noexcept { return fd_; }
 
   void close() noexcept;
 
- private:
+private:
   int fd_;
 };
 
-} // namespace linuxos
-} // namespace unifex
+}  // namespace linuxos
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -33,13 +33,9 @@ class context;
 struct task_base {
   using execute_fn = void(task_base*) noexcept;
 
-  explicit task_base(execute_fn* execute) noexcept
-  : execute_(execute)
-  {}
+  explicit task_base(execute_fn* execute) noexcept : execute_(execute) {}
 
-  void execute() noexcept {
-    this->execute_(this);
-  }
+  void execute() noexcept { this->execute_(this); }
 
   task_base* next_ = nullptr;
   execute_fn* execute_;
@@ -56,7 +52,7 @@ template <typename Receiver>
 class _op<Receiver>::type final : task_base {
   using stop_token_type = stop_token_type_t<Receiver&>;
 
- public:
+public:
   template <typename Receiver2>
   explicit type(Receiver2&& receiver, context* loop)
     : task_base(&type::execute_impl)
@@ -65,7 +61,7 @@ class _op<Receiver>::type final : task_base {
 
   void start() noexcept;
 
- private:
+private:
   static void execute_impl(task_base* t) noexcept {
     auto& self = *static_cast<type*>(t);
     if constexpr (is_stop_never_possible_v<stop_token_type>) {
@@ -86,19 +82,21 @@ class _op<Receiver>::type final : task_base {
 class context {
   template <class Receiver>
   friend struct _op;
- public:
+
+public:
   class scheduler {
     class schedule_task {
-      friend constexpr auto tag_invoke(
-          tag_t<blocking>,
-          const schedule_task&) noexcept {
+      friend constexpr auto
+      tag_invoke(tag_t<blocking>, const schedule_task&) noexcept {
         return blocking_kind::never;
       }
 
-     public:
+    public:
       template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
+          template <typename...>
+          class Variant,
+          template <typename...>
+          class Tuple>
       using value_types = Variant<Tuple<>>;
 
       template <template <typename...> class Variant>
@@ -114,9 +112,7 @@ class context {
     private:
       friend scheduler;
 
-      explicit schedule_task(context* loop) noexcept
-        : loop_(loop)
-      {}
+      explicit schedule_task(context* loop) noexcept : loop_(loop) {}
 
       context* const loop_;
     };
@@ -125,10 +121,8 @@ class context {
 
     explicit scheduler(context* loop) noexcept : loop_(loop) {}
 
-   public:
-    schedule_task schedule() const noexcept {
-      return schedule_task{loop_};
-    }
+  public:
+    schedule_task schedule() const noexcept { return schedule_task{loop_}; }
 
     friend bool operator==(scheduler a, scheduler b) noexcept {
       return a.loop_ == b.loop_;
@@ -137,19 +131,17 @@ class context {
       return a.loop_ != b.loop_;
     }
 
-   private:
+  private:
     context* loop_;
   };
 
-  scheduler get_scheduler() {
-    return scheduler{this};
-  }
+  scheduler get_scheduler() { return scheduler{this}; }
 
   void run();
 
   void stop();
 
- private:
+private:
   void enqueue(task_base* task);
 
   std::mutex mutex_;
@@ -164,9 +156,9 @@ inline void _op<Receiver>::type::start() noexcept {
   loop_->enqueue(this);
 }
 
-} // namespace _manual_event_loop
+}  // namespace _manual_event_loop
 
 using manual_event_loop = _manual_event_loop::context;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/manual_lifetime_union.hpp
+++ b/include/unifex/manual_lifetime_union.hpp
@@ -27,26 +27,27 @@ namespace unifex {
 
 template <typename... Ts>
 class manual_lifetime_union {
- public:
+public:
   manual_lifetime_union() = default;
 
   template <typename T, typename... Args>
   [[maybe_unused]] T& construct(Args&&... args) noexcept(
       std::is_nothrow_constructible_v<T, Args...>) {
     return unifex::activate_union_member(
-      *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)),
-      static_cast<Args&&>(args)...);
+        *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)),
+        static_cast<Args&&>(args)...);
   }
   template <typename T, typename Func>
-  [[maybe_unused]] T& construct_with(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
+  [[maybe_unused]] T&
+  construct_with(Func&& func) noexcept(is_nothrow_callable_v<Func>) {
     return unifex::activate_union_member_with(
-      *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)),
-      static_cast<Func&&>(func));
+        *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)),
+        static_cast<Func&&>(func));
   }
   template <typename T>
   void destruct() noexcept {
     unifex::deactivate_union_member(
-      *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)));
+        *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)));
   }
 
   template <typename T>
@@ -56,19 +57,21 @@ class manual_lifetime_union {
         ->get();
   }
   template <typename T>
-  decltype(auto) get() const & noexcept {
+  decltype(auto) get() const& noexcept {
     static_assert(is_one_of_v<T, Ts...>);
     return static_cast<manual_lifetime<T> const*>(
-        static_cast<void const*>(&storage_))->get();
+               static_cast<void const*>(&storage_))
+        ->get();
   }
   template <typename T>
   decltype(auto) get() && noexcept {
     static_assert(is_one_of_v<T, Ts...>);
     return std::move(
-      *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_))).get();
+               *static_cast<manual_lifetime<T>*>(static_cast<void*>(&storage_)))
+        .get();
   }
 
- private:
+private:
   std::aligned_union_t<0, manual_lifetime<Ts>...> storage_;
 };
 
@@ -82,7 +85,9 @@ template <typename T, typename... Ts, typename... Args>
 T& activate_union_member(manual_lifetime_union<Ts...>& box, Args&&... args) //
     noexcept(std::is_nothrow_constructible_v<T, Args...>) {
   auto* p = ::new (&box) manual_lifetime_union<Ts...>{};
-  scope_guard guard = [=]() noexcept { p->~manual_lifetime_union(); };
+  scope_guard guard = [=]() noexcept {
+    p->~manual_lifetime_union();
+  };
   auto& t = p->template construct<T>(static_cast<Args&&>(args)...);
   guard.release();
   return t;
@@ -95,7 +100,9 @@ template <typename T, typename... Ts, typename Func>
 T& activate_union_member_with(manual_lifetime_union<Ts...>& box, Func&& func)
     noexcept(is_nothrow_callable_v<Func>) {
   auto* p = ::new (&box) manual_lifetime_union<Ts...>{};
-  scope_guard guard = [=]() noexcept { p->~manual_lifetime_union(); };
+  scope_guard guard = [=]() noexcept {
+    p->~manual_lifetime_union();
+  };
   auto& t = p->template construct_with<T>(static_cast<Func&&>(func));
   guard.release();
   return t;
@@ -108,6 +115,6 @@ void deactivate_union_member(manual_lifetime_union<Ts...>& box) noexcept {
   box.~manual_lifetime_union();
 }
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -17,12 +17,12 @@
 
 #include <unifex/config.hpp>
 #include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
 #include <unifex/utility.hpp>
 
 #include <functional>
@@ -30,219 +30,221 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _mat
-  {
-    template <typename Receiver>
-    struct _receiver {
-      class type;
-    };
-    template <typename Receiver>
-    using receiver_t = typename _receiver<remove_cvref_t<Receiver>>::type;
+namespace unifex {
+namespace _mat {
+template <typename Receiver>
+struct _receiver {
+  class type;
+};
+template <typename Receiver>
+using receiver_t = typename _receiver<remove_cvref_t<Receiver>>::type;
 
-    template <typename Receiver>
-    class _receiver<Receiver>::type {
-    public:
-      template(typename Receiver2)
-        (requires constructible_from<Receiver, Receiver2>)
-      explicit type(Receiver2&& receiver) noexcept(
-          std::is_nothrow_constructible_v<Receiver, Receiver2>)
-        : receiver_(static_cast<Receiver2&&>(receiver)) {}
+template <typename Receiver>
+class _receiver<Receiver>::type {
+public:
+  template(typename Receiver2)(
+      requires constructible_from<
+          Receiver,
+          Receiver2>) explicit type(Receiver2&&
+                                        receiver) noexcept(std::
+                                                               is_nothrow_constructible_v<
+                                                                   Receiver,
+                                                                   Receiver2>)
+    : receiver_(static_cast<Receiver2&&>(receiver)) {}
 
-      template(typename... Values)
-          (requires receiver_of<Receiver, decltype(unifex::set_value), Values...>)
-      void
-      set_value(Values&&... values) && noexcept(
-          is_nothrow_receiver_of_v<Receiver, decltype(unifex::set_value), Values...>) {
+  template(typename... Values)(requires receiver_of<Receiver, decltype(unifex::set_value), Values...>) void set_value(
+      Values&&... values) && noexcept(is_nothrow_receiver_of_v<Receiver, decltype(unifex::set_value), Values...>) {
+    unifex::set_value(
+        static_cast<Receiver&&>(receiver_),
+        unifex::set_value,
+        static_cast<Values&&>(values)...);
+  }
+
+  template(typename Error)(requires receiver_of<
+                           Receiver,
+                           decltype(unifex::set_error),
+                           Error>) void set_error(Error&& error) && noexcept {
+    if constexpr (is_nothrow_receiver_of_v<
+                      Receiver,
+                      decltype(unifex::set_error),
+                      Error>) {
+      unifex::set_value(
+          static_cast<Receiver&&>(receiver_),
+          unifex::set_error,
+          static_cast<Error&&>(error));
+    } else {
+      UNIFEX_TRY {
         unifex::set_value(
             static_cast<Receiver&&>(receiver_),
-            unifex::set_value,
-            static_cast<Values&&>(values)...);
+            unifex::set_error,
+            static_cast<Error&&>(error));
       }
-
-      template(typename Error)
-          (requires receiver_of<Receiver, decltype(unifex::set_error), Error>)
-      void set_error(Error&& error) && noexcept {
-        if constexpr (is_nothrow_receiver_of_v<
-                          Receiver,
-                          decltype(unifex::set_error),
-                          Error>) {
-          unifex::set_value(
-              static_cast<Receiver&&>(receiver_),
-              unifex::set_error,
-              static_cast<Error&&>(error));
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(
-                static_cast<Receiver&&>(receiver_),
-                unifex::set_error,
-                static_cast<Error&&>(error));
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                static_cast<Receiver&&>(receiver_), std::current_exception());
-          }
-        }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            static_cast<Receiver&&>(receiver_), std::current_exception());
       }
+    }
+  }
 
-      template(typename R = Receiver)
-          (requires receiver_of<R, decltype(unifex::set_done)>)
-      void set_done() && noexcept {
-        if constexpr (is_nothrow_receiver_of_v<Receiver, decltype(unifex::set_done)>) {
-          unifex::set_value(
-              static_cast<Receiver&&>(receiver_), unifex::set_done);
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(
-                static_cast<Receiver&&>(receiver_), unifex::set_done);
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                static_cast<Receiver&&>(receiver_), std::current_exception());
-          }
-        }
+  template(typename R = Receiver)(
+      requires receiver_of<
+          R,
+          decltype(unifex::set_done)>) void set_done() && noexcept {
+    if constexpr (is_nothrow_receiver_of_v<
+                      Receiver,
+                      decltype(unifex::set_done)>) {
+      unifex::set_value(static_cast<Receiver&&>(receiver_), unifex::set_done);
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(static_cast<Receiver&&>(receiver_), unifex::set_done);
       }
-
-      template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))
-          (requires is_receiver_query_cpo_v<CPO> AND
-              is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r) noexcept(is_nothrow_callable_v<
-                                           CPO,
-                                           const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            static_cast<Receiver&&>(receiver_), std::current_exception());
       }
+    }
+  }
 
-      template <
-          typename Func,
-          UNIFEX_DECLARE_NON_DEDUCED_TYPE(CPO, tag_t<visit_continuations>),
-          UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type)>
-      friend void tag_invoke(
-          UNIFEX_USE_NON_DEDUCED_TYPE(CPO, tag_t<visit_continuations>),
-          const UNIFEX_USE_NON_DEDUCED_TYPE(R, type)& r,
-          Func&& func) noexcept(std::is_nothrow_invocable_v<
-                                        Func&,
-                                        const Receiver&>) {
-        std::invoke(func, std::as_const(r.receiver_));
-      }
+  template(typename CPO, UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type))(
+      requires is_receiver_query_cpo_v<CPO> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const UNIFEX_USE_NON_DEDUCED_TYPE(R, type) & r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(std::as_const(r.receiver_));
+  }
 
-    private:
-      Receiver receiver_;
-    };
+  template <
+      typename Func,
+      UNIFEX_DECLARE_NON_DEDUCED_TYPE(CPO, tag_t<visit_continuations>),
+      UNIFEX_DECLARE_NON_DEDUCED_TYPE(R, type)>
+  friend void tag_invoke(
+      UNIFEX_USE_NON_DEDUCED_TYPE(CPO, tag_t<visit_continuations>),
+      const UNIFEX_USE_NON_DEDUCED_TYPE(R, type) & r,
+      Func&&
+          func) noexcept(std::is_nothrow_invocable_v<Func&, const Receiver&>) {
+    std::invoke(func, std::as_const(r.receiver_));
+  }
 
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple,
-        typename... ValueTuples>
-    struct error_variant {
-      template <typename... Errors>
-      using apply = Variant<
-          ValueTuples...,
-          Tuple<decltype(set_error), Errors>...,
-          Tuple<decltype(set_done)>>;
-    };
+private:
+  Receiver receiver_;
+};
 
-    template <
-        typename Source,
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    struct value_types {
-      template <typename... Values>
-      using value_tuple = Tuple<decltype(set_value), Values...>;
+template <
+    template <typename...>
+    class Variant,
+    template <typename...>
+    class Tuple,
+    typename... ValueTuples>
+struct error_variant {
+  template <typename... Errors>
+  using apply = Variant<
+      ValueTuples...,
+      Tuple<decltype(set_error), Errors>...,
+      Tuple<decltype(set_done)>>;
+};
 
-      template <typename... ValueTuples>
-      using value_variant = typename Source::template error_types<
-          error_variant<Variant, Tuple, ValueTuples...>::
-              template apply>;
+template <
+    typename Source,
+    template <typename...>
+    class Variant,
+    template <typename...>
+    class Tuple>
+struct value_types {
+  template <typename... Values>
+  using value_tuple = Tuple<decltype(set_value), Values...>;
 
-      using type =
-          sender_value_types_t<Source, value_variant, value_tuple>;
-    };
+  template <typename... ValueTuples>
+  using value_variant = typename Source::template error_types<
+      error_variant<Variant, Tuple, ValueTuples...>::template apply>;
 
-    template <typename Source>
-    struct _sender {
-      class type;
-    };
-    template <typename Source>
-    using sender = typename _sender<remove_cvref_t<Source>>::type;
+  using type = sender_value_types_t<Source, value_variant, value_tuple>;
+};
 
-    template <typename Source>
-    class _sender<Source>::type {
-      using sender = type;
-    public:
-      template <
-          template <typename...>
-          class Variant,
-          template <typename...>
-          class Tuple>
-      using value_types =
-          typename value_types<Source, Variant, Tuple>::type;
+template <typename Source>
+struct _sender {
+  class type;
+};
+template <typename Source>
+using sender = typename _sender<remove_cvref_t<Source>>::type;
 
-      template <template <typename...> class Variant>
-      using error_types = Variant<std::exception_ptr>;
+template <typename Source>
+class _sender<Source>::type {
+  using sender = type;
 
-      static constexpr bool sends_done = false;
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename value_types<Source, Variant, Tuple>::type;
 
-      template(typename Source2)
-          (requires constructible_from<Source, Source2>)
-      explicit type(Source2&& source) noexcept(
-          std::is_nothrow_constructible_v<Source, Source2>)
-        : source_(static_cast<Source2&&>(source)) {}
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-      template(typename Self, typename Receiver)
-          (requires same_as<remove_cvref_t<Self>, type> AND
-            receiver<Receiver> AND
-            sender_to<member_t<Self, Source>, receiver_t<Receiver>>)
-      friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(
-          is_nothrow_connectable_v<member_t<Self, Source>, receiver_t<Receiver>> &&
-              std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
-          -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
-        return unifex::connect(
-            static_cast<Self&&>(self).source_,
-            receiver_t<Receiver>{static_cast<Receiver&&>(r)});
-      }
+  static constexpr bool sends_done = false;
 
-    private:
-      Source source_;
-    };
-  }  // namespace _mat
+  template(typename Source2)(
+      requires constructible_from<
+          Source,
+          Source2>) explicit type(Source2&&
+                                      source) noexcept(std::
+                                                           is_nothrow_constructible_v<
+                                                               Source,
+                                                               Source2>)
+    : source_(static_cast<Source2&&>(source)) {}
 
-  namespace _mat_cpo {
-    inline const struct _fn {
-    private:
-      template <typename Source>
-      using _result_t =
-        typename conditional_t<
-          tag_invocable<_fn, Source>,
-          meta_tag_invoke_result<_fn>,
-          meta_quote1<_mat::sender>>::template apply<Source>;
-    public:
-      template(typename Source)
-        (requires tag_invocable<_fn, Source>)
-      auto operator()(Source&& source) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, Source>)
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND sender_to<
+          member_t<Self, Source>,
+          receiver_t<
+              Receiver>>) friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(is_nothrow_connectable_v<member_t<Self, Source>, receiver_t<Receiver>>&&
+                                                                                                         std::is_nothrow_constructible_v<
+                                                                                                             remove_cvref_t<
+                                                                                                                 Receiver>,
+                                                                                                             Receiver>)
+      -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
+    return unifex::connect(
+        static_cast<Self&&>(self).source_,
+        receiver_t<Receiver>{static_cast<Receiver&&>(r)});
+  }
+
+private:
+  Source source_;
+};
+}  // namespace _mat
+
+namespace _mat_cpo {
+inline const struct _fn {
+private:
+  template <typename Source>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Source>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_mat::sender>>::template apply<Source>;
+
+public:
+  template(typename Source)(requires tag_invocable<_fn, Source>) auto
+  operator()(Source&& source) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Source>) -> _result_t<Source> {
+    return unifex::tag_invoke(_fn{}, (Source &&) source);
+  }
+  template(typename Source)(requires(!tag_invocable<_fn, Source>)) auto
+  operator()(Source&& source) const
+      noexcept(std::is_nothrow_constructible_v<_mat::sender<Source>, Source>)
           -> _result_t<Source> {
-        return unifex::tag_invoke(_fn{}, (Source&&) source);
-      }
-      template(typename Source)
-        (requires (!tag_invocable<_fn, Source>))
-      auto operator()(Source&& source) const
-          noexcept(std::is_nothrow_constructible_v<_mat::sender<Source>, Source>)
-          -> _result_t<Source> {
-        return _mat::sender<Source>{(Source&&) source};
-      }
-      constexpr auto operator()() const
-          noexcept(is_nothrow_callable_v<
-            tag_t<bind_back>, _fn>)
+    return _mat::sender<Source>{(Source &&) source};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
           -> bind_back_result_t<_fn> {
-        return bind_back(*this);
-      }
-    } materialize{};
-  } // namespace _mat_cpo
+    return bind_back(*this);
+  }
+} materialize{};
+}  // namespace _mat_cpo
 
-  using _mat_cpo::materialize;
+using _mat_cpo::materialize;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/memory_resource.hpp
+++ b/include/unifex/memory_resource.hpp
@@ -18,9 +18,9 @@
 #include <unifex/config.hpp>
 
 #if !UNIFEX_NO_MEMORY_RESOURCE
-#include UNIFEX_MEMORY_RESOURCE_HEADER
+#  include UNIFEX_MEMORY_RESOURCE_HEADER
 
 namespace unifex {
-    namespace pmr = UNIFEX_MEMORY_RESOURCE_NAMESPACE;
+namespace pmr = UNIFEX_MEMORY_RESOURCE_NAMESPACE;
 }
 #endif

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -21,7 +21,6 @@
 #include <unifex/ready_done_sender.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
 #include <unifex/stream_concepts.hpp>
 
 #include <type_traits>
@@ -57,26 +56,25 @@ struct _op<Receiver>::type {
 
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
   manual_lifetime<
-      typename stop_token_type::
-          template callback_type<cancel_callback>>
-    stopCallback_;
+      typename stop_token_type::template callback_type<cancel_callback>>
+      stopCallback_;
 
-  template(typename Receiver2)
-    (requires constructible_from<Receiver, Receiver2>)
-  type(Receiver2&& receiver)
+  template(typename Receiver2)(requires constructible_from<Receiver, Receiver2>)
+      type(Receiver2&& receiver)
     : receiver_((Receiver2 &&) receiver) {}
 
   void start() noexcept {
     UNIFEX_ASSERT(get_stop_token(receiver_).stop_possible());
-    stopCallback_.construct(
-        get_stop_token(receiver_), cancel_callback{*this});
+    stopCallback_.construct(get_stop_token(receiver_), cancel_callback{*this});
   }
 };
 
 struct sender {
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<>;
 
   template <template <typename...> class Variant>
@@ -94,14 +92,15 @@ struct stream {
   friend constexpr sender tag_invoke(tag_t<next>, stream&) noexcept {
     return {};
   }
-  friend constexpr ready_done_sender tag_invoke(tag_t<cleanup>, stream&) noexcept {
+  friend constexpr ready_done_sender
+  tag_invoke(tag_t<cleanup>, stream&) noexcept {
     return {};
   }
 };
-} // namespace _never
+}  // namespace _never
 
 using never_sender = _never::sender;
 using never_stream = _never::stream;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/new_thread_context.hpp
+++ b/include/unifex/new_thread_context.hpp
@@ -39,18 +39,17 @@ using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
 template <typename Receiver>
 class _op<Receiver>::type final {
- public:
+public:
   template <typename Receiver2>
   explicit type(context* ctx, Receiver2&& r)
-    : ctx_(ctx), receiver_((Receiver2&&)r) {}
+    : ctx_(ctx)
+    , receiver_((Receiver2 &&) r) {}
 
-  ~type() {
-      UNIFEX_ASSERT(!thread_.joinable());
-  }
+  ~type() { UNIFEX_ASSERT(!thread_.joinable()); }
 
   void start() & noexcept;
 
- private:
+private:
   void run() noexcept;
 
   context* ctx_;
@@ -67,8 +66,11 @@ private:
 
   class schedule_sender {
   public:
-    template <template <typename...> class Variant,
-             template <typename...> class Tuple>
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <typename...> class Variant>
@@ -76,12 +78,11 @@ private:
 
     static constexpr bool sends_done = true;
 
-    explicit schedule_sender(context* ctx) noexcept
-      : context_(ctx) {}
+    explicit schedule_sender(context* ctx) noexcept : context_(ctx) {}
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& r) const {
-      return operation<Receiver>{context_, (Receiver&&)r};
+      return operation<Receiver>{context_, (Receiver &&) r};
     }
 
   private:
@@ -110,9 +111,9 @@ public:
   context() = default;
 
   ~context() {
-    // The activeThreadCount_ counter is initialised to 1 so it will never get to
-    // zero until after enter the destructor and decrement the last count here.
-    // We do this so that the retire_thread() call doesn't end up calling
+    // The activeThreadCount_ counter is initialised to 1 so it will never get
+    // to zero until after enter the destructor and decrement the last count
+    // here. We do this so that the retire_thread() call doesn't end up calling
     // into the cv_.notify_one() until we are about to start waiting on the
     // cv.
     activeThreadCount_.fetch_sub(1, std::memory_order_relaxed);
@@ -126,9 +127,7 @@ public:
     }
   }
 
-  scheduler get_scheduler() noexcept {
-    return scheduler{this};
-  }
+  scheduler get_scheduler() noexcept { return scheduler{this}; }
 
 private:
   void retire_thread(std::thread t) noexcept {
@@ -170,7 +169,8 @@ inline void _op<Receiver>::type::start() & noexcept {
     // we ensure the count increment happens before the count decrement that
     // is performed when the thread is being retired.
     ctx_->activeThreadCount_.fetch_add(1, std::memory_order_relaxed);
-  } UNIFEX_CATCH (...) {
+  }
+  UNIFEX_CATCH(...) {
     unifex::set_error(std::move(receiver_), std::current_exception());
   }
 }
@@ -191,8 +191,8 @@ inline void _op<Receiver>::type::run() noexcept {
     // inside start().
     //
     // TODO: This can be replaced with an atomic<bool>::wait() once we have
-    // access to C++20 atomics. This would eliminate the unnecessary synchronisation
-    // performed by the unlock() at end-of-scope here.
+    // access to C++20 atomics. This would eliminate the unnecessary
+    // synchronisation performed by the unlock() at end-of-scope here.
     std::lock_guard opLock{mut_};
     thisThread = std::move(thread_);
   }
@@ -202,7 +202,8 @@ inline void _op<Receiver>::type::run() noexcept {
   } else {
     UNIFEX_TRY {
       unifex::set_value(std::move(receiver_));
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(std::move(receiver_), std::current_exception());
     }
   }
@@ -210,10 +211,10 @@ inline void _op<Receiver>::type::run() noexcept {
   ctx->retire_thread(std::move(thisThread));
 }
 
-} // namespace _new_thread
+}  // namespace _new_thread
 
 using new_thread_context = _new_thread::context;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/next_adapt_stream.hpp
+++ b/include/unifex/next_adapt_stream.hpp
@@ -24,46 +24,42 @@
 
 namespace unifex {
 namespace _next_adapt {
-  template <typename Stream, typename AdaptFunc>
-  struct _stream {
-    struct type;
-  };
-  template <typename Stream, typename AdaptFunc>
-  using stream =
-      typename _stream<
-          remove_cvref_t<Stream>,
-          remove_cvref_t<AdaptFunc>>::type;
+template <typename Stream, typename AdaptFunc>
+struct _stream {
+  struct type;
+};
+template <typename Stream, typename AdaptFunc>
+using stream =
+    typename _stream<remove_cvref_t<Stream>, remove_cvref_t<AdaptFunc>>::type;
 
-  template <typename Stream, typename AdaptFunc>
-  struct _stream<Stream, AdaptFunc>::type {
-    Stream innerStream_;
-    AdaptFunc adapter_;
+template <typename Stream, typename AdaptFunc>
+struct _stream<Stream, AdaptFunc>::type {
+  Stream innerStream_;
+  AdaptFunc adapter_;
 
-    friend auto tag_invoke(tag_t<next>, type& s)
+  friend auto tag_invoke(tag_t<next>, type& s)
       -> std::invoke_result_t<AdaptFunc&, next_sender_t<Stream>> {
-      return std::invoke(s.adapter_, next(s.innerStream_));
-    }
+    return std::invoke(s.adapter_, next(s.innerStream_));
+  }
 
-    friend auto tag_invoke(tag_t<cleanup>, type& s)
-      -> cleanup_sender_t<Stream> {
-      return cleanup(s.innerStream_);
-    }
-  };
-} // namespace _next_adapt
+  friend auto tag_invoke(tag_t<cleanup>, type& s) -> cleanup_sender_t<Stream> {
+    return cleanup(s.innerStream_);
+  }
+};
+}  // namespace _next_adapt
 
 namespace _next_adapt_cpo {
-  inline const struct _fn {
-    template <typename Stream, typename AdaptFunc>
-    auto operator()(Stream&& stream, AdaptFunc&& adapt) const {
-      return _next_adapt::stream<Stream, AdaptFunc>{
-          (Stream &&) stream,
-          (AdaptFunc &&) adapt};
-    }
-  } next_adapt_stream{};
-} // namespace _next_adapt_cpo
+inline const struct _fn {
+  template <typename Stream, typename AdaptFunc>
+  auto operator()(Stream&& stream, AdaptFunc&& adapt) const {
+    return _next_adapt::stream<Stream, AdaptFunc>{
+        (Stream &&) stream, (AdaptFunc &&) adapt};
+  }
+} next_adapt_stream{};
+}  // namespace _next_adapt_cpo
 
 using _next_adapt_cpo::next_adapt_stream;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/null_receiver.hpp
+++ b/include/unifex/null_receiver.hpp
@@ -21,18 +21,16 @@
 
 namespace unifex {
 namespace _null {
-  struct receiver {
-    void set_value() noexcept {}
-    [[noreturn]] void set_done() noexcept {
-      std::terminate();
-    }
-    template <typename Error>
-    [[noreturn]] void set_error(Error&&) noexcept {
-      std::terminate();
-    }
-  };
-} // namespace _null
+struct receiver {
+  void set_value() noexcept {}
+  [[noreturn]] void set_done() noexcept { std::terminate(); }
+  template <typename Error>
+  [[noreturn]] void set_error(Error&&) noexcept {
+    std::terminate();
+  }
+};
+}  // namespace _null
 using null_receiver = _null::receiver;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/on_stream.hpp
+++ b/include/unifex/on_stream.hpp
@@ -16,46 +16,44 @@
 #pragma once
 
 #include <unifex/adapt_stream.hpp>
+#include <unifex/bind_back.hpp>
 #include <unifex/on.hpp>
 #include <unifex/scheduler_concepts.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _on_stream {
-  inline const struct _fn {
-    template (typename StreamSender, typename Scheduler)
-      (requires scheduler<Scheduler>)
-    auto operator()(Scheduler&& scheduler, StreamSender&& stream) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return on(s, (decltype(sender)) sender);
-          });
-    }
-    template (typename StreamSender, typename Scheduler)
-      (requires scheduler<Scheduler>)
-    auto operator()(StreamSender&& stream, Scheduler&& scheduler) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return on(s, (decltype(sender)) sender);
-          });
-    }
-    template(typename Scheduler)
-      (requires scheduler<Scheduler>)
-    constexpr auto operator()(Scheduler&& scheduler) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Scheduler>)
-        -> bind_back_result_t<_fn, Scheduler> {
-      return bind_back(*this, (Scheduler&&)scheduler);
-    }
-  } on_stream {};
-} // namespace _on_stream
+inline const struct _fn {
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(Scheduler&& scheduler, StreamSender&& stream) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return on(s, (decltype(sender))sender);
+        });
+  }
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(StreamSender&& stream, Scheduler&& scheduler) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return on(s, (decltype(sender))sender);
+        });
+  }
+  template(typename Scheduler)(requires scheduler<Scheduler>) constexpr auto
+  operator()(Scheduler&& scheduler) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Scheduler>)
+          -> bind_back_result_t<_fn, Scheduler> {
+    return bind_back(*this, (Scheduler &&) scheduler);
+  }
+} on_stream{};
+}  // namespace _on_stream
 
 using _on_stream::on_stream;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/optional.hpp
+++ b/include/unifex/optional.hpp
@@ -18,30 +18,29 @@
 #include <unifex/config.hpp>
 
 #if defined(UNIFEX_USE_ABSEIL)
-#include <absl/types/optional.h>
+#  include <absl/types/optional.h>
 #else
-#include <optional>
+#  include <optional>
 #endif
 
 #include <unifex/utility.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
+namespace unifex {
 #if defined(UNIFEX_USE_ABSEIL)
-using absl::optional;
+using absl::bad_optional_access;
+using absl::make_optional;
 using absl::nullopt;
 using absl::nullopt_t;
-using absl::make_optional;
-using absl::bad_optional_access;
+using absl::optional;
 #else
-using std::optional;
+using std::bad_optional_access;
+using std::make_optional;
 using std::nullopt;
 using std::nullopt_t;
-using std::make_optional;
-using std::bad_optional_access;
+using std::optional;
 #endif
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/overload.hpp
+++ b/include/unifex/overload.hpp
@@ -61,7 +61,7 @@ inline constexpr typename _cpo_t<CPO, Sig>::type _cpo{};
 template <typename Sig>
 struct _sig {};
 
-} // namespace _overload
+}  // namespace _overload
 
 template <typename Sig>
 inline constexpr _overload::_sig<Sig> const sig{};
@@ -75,6 +75,6 @@ overload(CPO const&, _overload::_sig<Sig> = {}) noexcept {
   return _overload::_cpo<CPO, Sig>;
 }
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/pipe_concepts.hpp
+++ b/include/unifex/pipe_concepts.hpp
@@ -26,18 +26,14 @@ namespace _pipe_cpo {
 inline const struct open_pipe_cpo {
   template <typename Executor>
   auto operator()(Executor&& executor) const
-      noexcept(is_nothrow_tag_invocable_v<
-               open_pipe_cpo,
-               Executor>)
-          -> tag_invoke_result_t<
-              open_pipe_cpo,
-              Executor> {
+      noexcept(is_nothrow_tag_invocable_v<open_pipe_cpo, Executor>)
+          -> tag_invoke_result_t<open_pipe_cpo, Executor> {
     return unifex::tag_invoke(*this, (Executor &&) executor);
   }
 } open_pipe{};
-} // namespace _pipe_cpo
+}  // namespace _pipe_cpo
 
 using _pipe_cpo::open_pipe;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -48,8 +48,10 @@ struct next_sender {
   stream& stream_;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<int>>;
 
   template <template <typename...> class Variant>
@@ -57,9 +59,7 @@ struct next_sender {
 
   static constexpr bool sends_done = true;
 
-  friend constexpr auto tag_invoke(
-      tag_t<blocking>,
-      const stream&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const stream&) noexcept {
     return blocking_kind::always_inline;
   }
 
@@ -95,10 +95,10 @@ void _op<Receiver>::type::start() noexcept {
     unifex::set_done(std::move(receiver_));
   }
 }
-} // namespace _range
+}  // namespace _range
 
 using range_stream = _range::stream;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/blocking.hpp>
 #include <unifex/config.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/receiver_concepts.hpp>
 
 #include <type_traits>
@@ -25,48 +25,48 @@
 
 namespace unifex {
 namespace _ready_done {
-  template <typename Receiver>
-  struct _op {
-    struct type;
-  };
-  template <typename Receiver>
-  using operation = typename _op<remove_cvref_t<Receiver>>::type;
+template <typename Receiver>
+struct _op {
+  struct type;
+};
+template <typename Receiver>
+using operation = typename _op<remove_cvref_t<Receiver>>::type;
+
+template <typename Receiver>
+struct _op<Receiver>::type {
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+
+  void start() noexcept {
+    unifex::set_done(static_cast<Receiver&&>(receiver_));
+  }
+};
+
+struct sender {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+
+  static constexpr bool sends_done = true;
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender&) {
+    return blocking_kind::always_inline;
+  }
 
   template <typename Receiver>
-  struct _op<Receiver>::type {
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-
-    void start() noexcept {
-      unifex::set_done(static_cast<Receiver&&>(receiver_));
-    }
-  };
-
-  struct sender {
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<>;
-
-    static constexpr bool sends_done = true;
-
-    friend constexpr auto tag_invoke(
-        tag_t<blocking>,
-        const sender&) {
-      return blocking_kind::always_inline;
-    }
-
-    template <typename Receiver>
-    operation<Receiver> connect(Receiver&& receiver) const& {
-      return operation<Receiver>{(Receiver &&) receiver};
-    }
-  };
-} // namespace _ready_done
+  operation<Receiver> connect(Receiver&& receiver) const& {
+    return operation<Receiver>{(Receiver &&) receiver};
+  }
+};
+}  // namespace _ready_done
 
 using ready_done_sender = _ready_done::sender;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/std_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/std_concepts.hpp>
 #include <unifex/detail/unifex_fwd.hpp>
 
 #include <exception>
@@ -28,144 +28,137 @@
 
 namespace unifex {
 namespace _rec_cpo {
-  inline const struct _set_value_fn {
-  private:
-    template <typename Receiver, typename... Values>
-    using set_value_member_result_t =
+inline const struct _set_value_fn {
+private:
+  template <typename Receiver, typename... Values>
+  using set_value_member_result_t =
       decltype(UNIFEX_DECLVAL(Receiver).set_value(UNIFEX_DECLVAL(Values)...));
-    template <typename Receiver, typename... Values>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_set_value_fn, Receiver, Values...>,
-        meta_tag_invoke_result<_set_value_fn>,
-        meta_quote1_<set_value_member_result_t>>::template apply<Receiver, Values...>;
-  public:
-    template(typename Receiver, typename... Values)
-      (requires tag_invocable<_set_value_fn, Receiver, Values...>)
-    auto operator()(Receiver&& r, Values&&... values) const
-        noexcept(
-            is_nothrow_tag_invocable_v<_set_value_fn, Receiver, Values...>)
-        -> _result_t<Receiver, Values...> {
-      return unifex::tag_invoke(
-          _set_value_fn{}, (Receiver &&) r, (Values &&) values...);
-    }
-    template(typename Receiver, typename... Values)
-      (requires (!tag_invocable<_set_value_fn, Receiver, Values...>))
-    auto operator()(Receiver&& r, Values&&... values) const
-        noexcept(noexcept(
-            static_cast<Receiver&&>(r).set_value((Values &&) values...)))
-        -> _result_t<Receiver, Values...> {
-      return static_cast<Receiver&&>(r).set_value((Values &&) values...);
-    }
-  } set_value{};
+  template <typename Receiver, typename... Values>
+  using _result_t = typename conditional_t<
+      tag_invocable<_set_value_fn, Receiver, Values...>,
+      meta_tag_invoke_result<_set_value_fn>,
+      meta_quote1_<set_value_member_result_t>>::
+      template apply<Receiver, Values...>;
 
-  inline const struct _set_next_fn {
-  private:
-    template <typename Receiver, typename... Values>
-    using set_next_member_result_t =
+public:
+  template(typename Receiver, typename... Values)(
+      requires tag_invocable<_set_value_fn, Receiver, Values...>) auto
+  operator()(Receiver&& r, Values&&... values) const
+      noexcept(is_nothrow_tag_invocable_v<_set_value_fn, Receiver, Values...>)
+          -> _result_t<Receiver, Values...> {
+    return unifex::tag_invoke(
+        _set_value_fn{}, (Receiver &&) r, (Values &&) values...);
+  }
+  template(typename Receiver, typename... Values)(
+      requires(!tag_invocable<_set_value_fn, Receiver, Values...>)) auto
+  operator()(Receiver&& r, Values&&... values) const
+      noexcept(noexcept(static_cast<Receiver&&>(r).set_value((Values &&)
+                                                                 values...)))
+          -> _result_t<Receiver, Values...> {
+    return static_cast<Receiver&&>(r).set_value((Values &&) values...);
+  }
+} set_value{};
+
+inline const struct _set_next_fn {
+private:
+  template <typename Receiver, typename... Values>
+  using set_next_member_result_t =
       decltype(UNIFEX_DECLVAL(Receiver&).set_next(UNIFEX_DECLVAL(Values)...));
-    template <typename Receiver, typename... Values>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_set_next_fn, Receiver&, Values...>,
-        meta_tag_invoke_result<_set_next_fn>,
-        meta_quote1_<set_next_member_result_t>>::template apply<Receiver, Values...>;
-  public:
-    template(typename Receiver, typename... Values)
-      (requires tag_invocable<_set_next_fn, Receiver, Values...>)
-    auto operator()(Receiver& r, Values&&... values) const
-        noexcept(
-            is_nothrow_tag_invocable_v<_set_next_fn, Receiver, Values...>)
-        -> _result_t<Receiver, Values...> {
-      return unifex::tag_invoke(
-          _set_next_fn{}, r, (Values &&) values...);
-    }
-    template(typename Receiver, typename... Values)
-      (requires (!tag_invocable<_set_next_fn, Receiver&, Values...>))
-    auto operator()(Receiver& r, Values&&... values) const
-        noexcept(noexcept(
-            r.set_next((Values &&) values...)))
-        -> _result_t<Receiver, Values...> {
-      return r.set_next((Values &&) values...);
-    }
-  } set_next{};
+  template <typename Receiver, typename... Values>
+  using _result_t = typename conditional_t<
+      tag_invocable<_set_next_fn, Receiver&, Values...>,
+      meta_tag_invoke_result<_set_next_fn>,
+      meta_quote1_<set_next_member_result_t>>::
+      template apply<Receiver, Values...>;
 
-  inline const struct _set_error_fn {
-  private:
-    template <typename Receiver, typename Error>
-    using set_error_member_result_t =
+public:
+  template(typename Receiver, typename... Values)(
+      requires tag_invocable<_set_next_fn, Receiver, Values...>) auto
+  operator()(Receiver& r, Values&&... values) const
+      noexcept(is_nothrow_tag_invocable_v<_set_next_fn, Receiver, Values...>)
+          -> _result_t<Receiver, Values...> {
+    return unifex::tag_invoke(_set_next_fn{}, r, (Values &&) values...);
+  }
+  template(typename Receiver, typename... Values)(
+      requires(!tag_invocable<_set_next_fn, Receiver&, Values...>)) auto
+  operator()(Receiver& r, Values&&... values) const
+      noexcept(noexcept(r.set_next((Values &&) values...)))
+          -> _result_t<Receiver, Values...> {
+    return r.set_next((Values &&) values...);
+  }
+} set_next{};
+
+inline const struct _set_error_fn {
+private:
+  template <typename Receiver, typename Error>
+  using set_error_member_result_t =
       decltype(UNIFEX_DECLVAL(Receiver).set_error(UNIFEX_DECLVAL(Error)));
-    template <typename Receiver, typename Error>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_set_error_fn, Receiver, Error>,
-        meta_tag_invoke_result<_set_error_fn>,
-        meta_quote2<set_error_member_result_t>>::template apply<Receiver, Error>;
-  public:
-    template(typename Receiver, typename Error)
-      (requires tag_invocable<_set_error_fn, Receiver, Error>)
-    auto operator()(Receiver&& r, Error&& error) const noexcept
-        -> _result_t<Receiver, Error> {
-      static_assert(
-          is_nothrow_tag_invocable_v<_set_error_fn, Receiver, Error>,
-          "set_error() invocation is required to be noexcept.");
-      static_assert(
-        std::is_void_v<tag_invoke_result_t<_set_error_fn, Receiver, Error>>
-      );
-      return unifex::tag_invoke(
-          _set_error_fn{}, (Receiver &&) r, (Error&&) error);
-    }
-    template(typename Receiver, typename Error)
-      (requires (!tag_invocable<_set_error_fn, Receiver, Error>))
-    auto operator()(Receiver&& r, Error&& error) const noexcept
-        -> _result_t<Receiver, Error> {
-      static_assert(
-          noexcept(static_cast<Receiver&&>(r).set_error((Error &&) error)),
-          "receiver.set_error() method must be nothrow invocable");
-      return static_cast<Receiver&&>(r).set_error((Error&&) error);
-    }
-  } set_error{};
+  template <typename Receiver, typename Error>
+  using _result_t = typename conditional_t<
+      tag_invocable<_set_error_fn, Receiver, Error>,
+      meta_tag_invoke_result<_set_error_fn>,
+      meta_quote2<set_error_member_result_t>>::template apply<Receiver, Error>;
 
-  inline const struct _set_done_fn {
-  private:
-    template <typename Receiver>
-    using set_done_member_result_t =
+public:
+  template(typename Receiver, typename Error)(
+      requires tag_invocable<_set_error_fn, Receiver, Error>) auto
+  operator()(Receiver&& r, Error&& error) const noexcept
+      -> _result_t<Receiver, Error> {
+    static_assert(
+        is_nothrow_tag_invocable_v<_set_error_fn, Receiver, Error>,
+        "set_error() invocation is required to be noexcept.");
+    static_assert(
+        std::is_void_v<tag_invoke_result_t<_set_error_fn, Receiver, Error>>);
+    return unifex::tag_invoke(
+        _set_error_fn{}, (Receiver &&) r, (Error &&) error);
+  }
+  template(typename Receiver, typename Error)(
+      requires(!tag_invocable<_set_error_fn, Receiver, Error>)) auto
+  operator()(Receiver&& r, Error&& error) const noexcept
+      -> _result_t<Receiver, Error> {
+    static_assert(
+        noexcept(static_cast<Receiver&&>(r).set_error((Error &&) error)),
+        "receiver.set_error() method must be nothrow invocable");
+    return static_cast<Receiver&&>(r).set_error((Error &&) error);
+  }
+} set_error{};
+
+inline const struct _set_done_fn {
+private:
+  template <typename Receiver>
+  using set_done_member_result_t =
       decltype(UNIFEX_DECLVAL(Receiver).set_done());
-    template <typename Receiver>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_set_done_fn, Receiver>,
-        meta_tag_invoke_result<_set_done_fn>,
-        meta_quote1<set_done_member_result_t>>::template apply<Receiver>;
-  public:
-    template(typename Receiver)
-      (requires tag_invocable<_set_done_fn, Receiver>)
-    auto operator()(Receiver&& r) const noexcept
-        -> _result_t<Receiver> {
-      static_assert(
-          is_nothrow_tag_invocable_v<_set_done_fn, Receiver>,
-          "set_done() invocation is required to be noexcept.");
-      static_assert(
-        std::is_void_v<tag_invoke_result_t<_set_done_fn, Receiver>>
-      );
-      return unifex::tag_invoke(_set_done_fn{}, (Receiver &&) r);
-    }
-    template(typename Receiver)
-      (requires (!tag_invocable<_set_done_fn, Receiver>))
-    auto operator()(Receiver&& r) const noexcept
-        -> _result_t<Receiver> {
-      static_assert(
-          noexcept(static_cast<Receiver&&>(r).set_done()),
-          "receiver.set_done() method must be nothrow invocable");
-      return static_cast<Receiver&&>(r).set_done();
-    }
-  } set_done{};
-} // namespace _rec_cpo
+  template <typename Receiver>
+  using _result_t = typename conditional_t<
+      tag_invocable<_set_done_fn, Receiver>,
+      meta_tag_invoke_result<_set_done_fn>,
+      meta_quote1<set_done_member_result_t>>::template apply<Receiver>;
 
-using _rec_cpo::set_value;
-using _rec_cpo::set_next;
-using _rec_cpo::set_error;
+public:
+  template(typename Receiver)(
+      requires tag_invocable<_set_done_fn, Receiver>) auto
+  operator()(Receiver&& r) const noexcept -> _result_t<Receiver> {
+    static_assert(
+        is_nothrow_tag_invocable_v<_set_done_fn, Receiver>,
+        "set_done() invocation is required to be noexcept.");
+    static_assert(std::is_void_v<tag_invoke_result_t<_set_done_fn, Receiver>>);
+    return unifex::tag_invoke(_set_done_fn{}, (Receiver &&) r);
+  }
+  template(typename Receiver)(
+      requires(!tag_invocable<_set_done_fn, Receiver>)) auto
+  operator()(Receiver&& r) const noexcept -> _result_t<Receiver> {
+    static_assert(
+        noexcept(static_cast<Receiver&&>(r).set_done()),
+        "receiver.set_done() method must be nothrow invocable");
+    return static_cast<Receiver&&>(r).set_done();
+  }
+} set_done{};
+}  // namespace _rec_cpo
+
 using _rec_cpo::set_done;
+using _rec_cpo::set_error;
+using _rec_cpo::set_next;
+using _rec_cpo::set_value;
 
 template <typename T>
 inline constexpr bool is_receiver_cpo_v = is_one_of_v<
@@ -174,7 +167,6 @@ inline constexpr bool is_receiver_cpo_v = is_one_of_v<
     _rec_cpo::_set_next_fn,
     _rec_cpo::_set_error_fn,
     _rec_cpo::_set_done_fn>;
-
 
 // HACK: Approximation for CPOs that should be forwarded through receivers
 // as query operations.
@@ -193,59 +185,54 @@ using is_receiver_cpo = std::bool_constant<is_receiver_cpo_v<T>>;
 #if UNIFEX_CXX_CONCEPTS
 // Defined the receiver concepts without the macros for improved diagnostics
 template <typename R, typename E = std::exception_ptr>
-concept //
-  receiver = //
+concept         //
+    receiver =  //
     move_constructible<remove_cvref_t<R>> &&
     constructible_from<remove_cvref_t<R>, R> &&
-    requires(remove_cvref_t<R>&& r, E&& e)
-    {
-      { set_done(std::move(r)) } noexcept;
-      { set_error(std::move(r), (E&&) e) } noexcept;
-    };
+    requires(remove_cvref_t<R>&& r, E&& e) {
+  { set_done(std::move(r)) }
+  noexcept;
+  { set_error(std::move(r), (E &&) e) }
+  noexcept;
+};
 
 template <typename R, typename... An>
-concept //
-  receiver_of = //
-    receiver<R> &&
-    requires(remove_cvref_t<R>&& r, An&&... an) //
-    {
-      set_value(std::move(r), (An&&) an...);
-    };
+concept                                                         //
+    receiver_of =                                               //
+    receiver<R> && requires(remove_cvref_t<R>&& r, An&&... an)  //
+{
+  set_value(std::move(r), (An &&) an...);
+};
 #else
 template <typename R, typename E>
 UNIFEX_CONCEPT_FRAGMENT(
-  _receiver,
-    requires(remove_cvref_t<R>&& r, E&& e) //
-    (
-      noexcept(set_done(std::move(r))),
-      noexcept(set_error(std::move(r), (E&&) e))
-    ));
+    _receiver,
+    requires(remove_cvref_t<R>&& r, E&& e)  //
+    (noexcept(set_done(std::move(r))),
+     noexcept(set_error(std::move(r), (E &&) e))));
 
 template <typename R, typename E = std::exception_ptr>
-UNIFEX_CONCEPT //
-  receiver = //
-    move_constructible<remove_cvref_t<R>> &&
-    constructible_from<remove_cvref_t<R>, R> &&
-    UNIFEX_FRAGMENT(unifex::_receiver, R, E);
+UNIFEX_CONCEPT  //
+    receiver =  //
+    move_constructible<remove_cvref_t<R>>&&
+        constructible_from<remove_cvref_t<R>, R>&&
+            UNIFEX_FRAGMENT(unifex::_receiver, R, E);
 
 template <typename T, typename... An>
-UNIFEX_CONCEPT_FRAGMENT( //
-  _receiver_of, //
-    requires(remove_cvref_t<T>&& t, An&&... an) //
-    (
-      set_value(std::move(t), (An&&) an...)
-    ));
+UNIFEX_CONCEPT_FRAGMENT(                         //
+    _receiver_of,                                //
+    requires(remove_cvref_t<T>&& t, An&&... an)  //
+    (set_value(std::move(t), (An &&) an...)));
 
 template <typename R, typename... An>
-UNIFEX_CONCEPT //
-  receiver_of = //
-    receiver<R> &&
+UNIFEX_CONCEPT     //
+    receiver_of =  //
+    receiver<R>&&
     UNIFEX_FRAGMENT(unifex::_receiver_of, R, An...);
 #endif
 
 template <typename R, typename... An>
-  inline constexpr bool is_nothrow_receiver_of_v =
-    receiver_of<R, An...> &&
+inline constexpr bool is_nothrow_receiver_of_v = receiver_of<R, An...>&&
     is_nothrow_callable_v<decltype(set_value), R, An...>;
 
 //////////////////
@@ -259,6 +246,6 @@ template <typename R, typename... An>
 inline constexpr bool is_nothrow_next_receiver_v =
     is_nothrow_callable_v<decltype(set_next), R&, An...>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -16,18 +16,18 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/exception.hpp>
+#include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/stream_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
-#include <unifex/unstoppable_token.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
-#include <unifex/exception.hpp>
+#include <unifex/stream_concepts.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
+#include <unifex/unstoppable_token.hpp>
 #include <unifex/utility.hpp>
 
 #include <exception>
@@ -38,32 +38,51 @@
 
 namespace unifex {
 namespace _reduce {
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _op {
   struct type;
 };
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-using operation =
-    typename _op<
-        remove_cvref_t<StreamSender>,
-        remove_cvref_t<State>,
-        remove_cvref_t<ReducerFunc>,
-        remove_cvref_t<Receiver>>::type;
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+using operation = typename _op<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<State>,
+    remove_cvref_t<ReducerFunc>,
+    remove_cvref_t<Receiver>>::type;
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _error_cleanup_receiver {
   struct type;
 };
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-using error_cleanup_receiver =
-    typename _error_cleanup_receiver<
-        remove_cvref_t<StreamSender>,
-        remove_cvref_t<State>,
-        remove_cvref_t<ReducerFunc>,
-        remove_cvref_t<Receiver>>::type;
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+using error_cleanup_receiver = typename _error_cleanup_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<State>,
+    remove_cvref_t<ReducerFunc>,
+    remove_cvref_t<Receiver>>::type;
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-struct _error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+struct _error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::
+    type {
   operation<StreamSender, State, ReducerFunc, Receiver>& op_;
   std::exception_ptr ex_;
 
@@ -83,38 +102,51 @@ struct _error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type
     unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::move(ex));
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const type& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
-  friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
+  friend unstoppable_token
+  tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
     return {};
   }
 
   template <typename Func>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
     std::invoke(func, r.op_.receiver_);
   }
 };
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _done_cleanup_receiver {
   struct type;
 };
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-using done_cleanup_receiver =
-    typename _done_cleanup_receiver<
-        remove_cvref_t<StreamSender>,
-        remove_cvref_t<State>,
-        remove_cvref_t<ReducerFunc>,
-        remove_cvref_t<Receiver>>::type;
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+using done_cleanup_receiver = typename _done_cleanup_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<State>,
+    remove_cvref_t<ReducerFunc>,
+    remove_cvref_t<Receiver>>::type;
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::
+    type {
   operation<StreamSender, State, ReducerFunc, Receiver>& op_;
 
   template <typename Error>
@@ -128,60 +160,71 @@ struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type 
     auto& op = op_;
     unifex::deactivate_union_member(op.doneCleanup_);
     unifex::set_value(
-        static_cast<Receiver&&>(op.receiver_),
-        std::forward<State>(op.state_));
+        static_cast<Receiver&&>(op.receiver_), std::forward<State>(op.state_));
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const type& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
-  friend unstoppable_token tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
+  friend unstoppable_token
+  tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
     return {};
   }
 
   template <typename Func>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
     std::invoke(func, r.op_.receiver_);
   }
 };
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _next_receiver {
   struct type;
 };
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
-using next_receiver =
-    typename _next_receiver<
-        remove_cvref_t<StreamSender>,
-        remove_cvref_t<State>,
-        remove_cvref_t<ReducerFunc>,
-        remove_cvref_t<Receiver>>::type;
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
+using next_receiver = typename _next_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<State>,
+    remove_cvref_t<ReducerFunc>,
+    remove_cvref_t<Receiver>>::type;
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
-  using error_cleanup_receiver_t = error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
-  using done_cleanup_receiver_t = done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
-  using next_receiver_t = next_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using next_receiver_t =
+      next_receiver<StreamSender, State, ReducerFunc, Receiver>;
   operation<StreamSender, State, ReducerFunc, Receiver>& op_;
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const type& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.op_.receiver_));
   }
 
   template <typename Func>
-  friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const type& r,
-      Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
     std::invoke(func, r.op_.receiver_);
   }
 
@@ -191,14 +234,13 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
     unifex::deactivate_union_member(op.next_);
     UNIFEX_TRY {
       op.state_ = std::invoke(
-          op.reducer_,
-          std::forward<State>(op.state_),
-          (Values &&) values...);
+          op.reducer_, std::forward<State>(op.state_), (Values &&) values...);
       unifex::activate_union_member_with(op.next_, [&] {
         return unifex::connect(next(op.stream_), next_receiver_t{op});
       });
       unifex::start(op.next_.get());
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::activate_union_member_with(op.errorCleanup_, [&] {
         return unifex::connect(
             cleanup(op.stream_),
@@ -212,8 +254,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
     auto& op = op_;
     unifex::deactivate_union_member(op.next_);
     unifex::activate_union_member_with(op.doneCleanup_, [&] {
-      return unifex::connect(
-          cleanup(op.stream_), done_cleanup_receiver_t{op});
+      return unifex::connect(cleanup(op.stream_), done_cleanup_receiver_t{op});
     });
     unifex::start(op.doneCleanup_.get());
   }
@@ -223,8 +264,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
     unifex::deactivate_union_member(op.next_);
     unifex::activate_union_member_with(op.errorCleanup_, [&] {
       return unifex::connect(
-          cleanup(op.stream_),
-          error_cleanup_receiver_t{op, std::move(ex)});
+          cleanup(op.stream_), error_cleanup_receiver_t{op, std::move(ex)});
     });
     unifex::start(op.errorCleanup_.get());
   }
@@ -235,20 +275,30 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
   }
 };
 
-template <typename StreamSender, typename State, typename ReducerFunc, typename Receiver>
+template <
+    typename StreamSender,
+    typename State,
+    typename ReducerFunc,
+    typename Receiver>
 struct _op<StreamSender, State, ReducerFunc, Receiver>::type {
   UNIFEX_NO_UNIQUE_ADDRESS StreamSender stream_;
   UNIFEX_NO_UNIQUE_ADDRESS State state_;
   UNIFEX_NO_UNIQUE_ADDRESS ReducerFunc reducer_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  using next_receiver_t = next_receiver<StreamSender, State, ReducerFunc, Receiver>;
-  using error_cleanup_receiver_t = error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
-  using done_cleanup_receiver_t = done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using next_receiver_t =
+      next_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
 
-  using next_op = manual_lifetime<next_operation_t<StreamSender, next_receiver_t>>;
-  using error_op = manual_lifetime<cleanup_operation_t<StreamSender, error_cleanup_receiver_t>>;
-  using done_op = manual_lifetime<cleanup_operation_t<StreamSender, done_cleanup_receiver_t>>;
+  using next_op =
+      manual_lifetime<next_operation_t<StreamSender, next_receiver_t>>;
+  using error_op = manual_lifetime<
+      cleanup_operation_t<StreamSender, error_cleanup_receiver_t>>;
+  using done_op = manual_lifetime<
+      cleanup_operation_t<StreamSender, done_cleanup_receiver_t>>;
 
   union {
     next_op next_;
@@ -256,18 +306,22 @@ struct _op<StreamSender, State, ReducerFunc, Receiver>::type {
     done_op doneCleanup_;
   };
 
-  template <typename StreamSender2, typename State2, typename ReducerFunc2, typename Receiver2>
+  template <
+      typename StreamSender2,
+      typename State2,
+      typename ReducerFunc2,
+      typename Receiver2>
   explicit type(
       StreamSender2&& stream,
       State2&& state,
       ReducerFunc2&& reducer,
       Receiver2&& receiver)
-    : stream_(std::forward<StreamSender2>(stream)),
-      state_(std::forward<State2>(state)),
-      reducer_(std::forward<ReducerFunc2>(reducer)),
-      receiver_(std::forward<Receiver2>(receiver)) {}
+    : stream_(std::forward<StreamSender2>(stream))
+    , state_(std::forward<State2>(state))
+    , reducer_(std::forward<ReducerFunc2>(reducer))
+    , receiver_(std::forward<Receiver2>(receiver)) {}
 
-  ~type() {} // Due to the union member, this is load-bearing. DO NOT DELETE.
+  ~type() {}  // Due to the union member, this is load-bearing. DO NOT DELETE.
 
   void start() noexcept {
     UNIFEX_TRY {
@@ -275,7 +329,8 @@ struct _op<StreamSender, State, ReducerFunc, Receiver>::type {
         return unifex::connect(next(stream_), next_receiver_t{*this});
       });
       unifex::start(next_.get());
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
@@ -300,34 +355,43 @@ struct _sender<StreamSender, State, ReducerFunc>::type {
   ReducerFunc reducer_;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<State>>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<next_sender_t<StreamSender>, type_list>,
-          sender_error_types_t<cleanup_sender_t<StreamSender>, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<next_sender_t<StreamSender>, type_list>,
+      sender_error_types_t<cleanup_sender_t<StreamSender>, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = false;
 
   template <typename Receiver>
   using operation_t = operation<StreamSender, State, ReducerFunc, Receiver>;
   template <typename Receiver>
-  using next_receiver_t = next_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using next_receiver_t =
+      next_receiver<StreamSender, State, ReducerFunc, Receiver>;
   template <typename Receiver>
-  using error_cleanup_receiver_t = error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
   template <typename Receiver>
-  using done_cleanup_receiver_t = done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>;
 
-  template (typename Self, typename Receiver)
-      (requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND
-          sender_to<next_sender_t<StreamSender>, next_receiver_t<Receiver>> AND
-          sender_to<cleanup_sender_t<StreamSender>, error_cleanup_receiver_t<Receiver>> AND
-          sender_to<cleanup_sender_t<StreamSender>, done_cleanup_receiver_t<Receiver>>)
-  friend operation_t<Receiver> tag_invoke(tag_t<connect>, Self&& self, Receiver&& receiver) {
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND sender_to<
+          next_sender_t<StreamSender>,
+          next_receiver_t<Receiver>> AND
+          sender_to<
+              cleanup_sender_t<StreamSender>,
+              error_cleanup_receiver_t<Receiver>> AND
+              sender_to<
+                  cleanup_sender_t<StreamSender>,
+                  done_cleanup_receiver_t<
+                      Receiver>>) friend operation_t<Receiver> tag_invoke(tag_t<connect>, Self&& self, Receiver&& receiver) {
     return operation_t<Receiver>{
         static_cast<Self&&>(self).stream_,
         static_cast<Self&&>(self).initialState_,
@@ -335,34 +399,33 @@ struct _sender<StreamSender, State, ReducerFunc>::type {
         (Receiver &&) receiver};
   }
 };
-} // namespace _reduce
+}  // namespace _reduce
 
 namespace _reduce_cpo {
-  inline const struct _fn {
-    template <typename StreamSender, typename State, typename ReducerFunc>
-    auto operator()(
-        StreamSender&& stream,
-        State&& initialState,
-        ReducerFunc&& reducer) const
-        noexcept(std::is_nothrow_constructible_v<
-            _reduce::sender<StreamSender, State, ReducerFunc>,
-            StreamSender, State, ReducerFunc>)
-        -> _reduce::sender<StreamSender, State, ReducerFunc> {
-      return _reduce::sender<StreamSender, State, ReducerFunc>{
-          (StreamSender &&) stream,
-          (State &&) initialState,
-          (ReducerFunc &&) reducer};
-    }
-    template <typename State, typename ReducerFunc>
-    constexpr auto operator()(State&& initialState, ReducerFunc&& reducer) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, State, ReducerFunc>)
-        -> bind_back_result_t<_fn, State, ReducerFunc> {
-      return bind_back(*this, (State&&)initialState, (ReducerFunc&&)reducer);
-    }
-  } reduce_stream{};
-} // namespace _reduce_cpo
+inline const struct _fn {
+  template <typename StreamSender, typename State, typename ReducerFunc>
+  auto operator()(
+      StreamSender&& stream, State&& initialState, ReducerFunc&& reducer) const
+      noexcept(std::is_nothrow_constructible_v<
+               _reduce::sender<StreamSender, State, ReducerFunc>,
+               StreamSender,
+               State,
+               ReducerFunc>)
+          -> _reduce::sender<StreamSender, State, ReducerFunc> {
+    return _reduce::sender<StreamSender, State, ReducerFunc>{
+        (StreamSender &&) stream,
+        (State &&) initialState,
+        (ReducerFunc &&) reducer};
+  }
+  template <typename State, typename ReducerFunc>
+  constexpr auto operator()(State&& initialState, ReducerFunc&& reducer) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, State, ReducerFunc>)
+          -> bind_back_result_t<_fn, State, ReducerFunc> {
+    return bind_back(*this, (State &&) initialState, (ReducerFunc &&) reducer);
+  }
+} reduce_stream{};
+}  // namespace _reduce_cpo
 using _reduce_cpo::reduce_stream;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -16,18 +16,18 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
-#include <unifex/manual_lifetime.hpp>
 #include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
-#include <utility>
 #include <exception>
 #include <functional>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -55,13 +55,11 @@ struct _sndr {
 template <typename Source, typename Predicate, typename Receiver>
 class _rcvr<Source, Predicate, Receiver>::type {
   using operation = operation_type<Source, Predicate, Receiver>;
-public:
-  explicit type(operation* op) noexcept
-  : op_(op) {}
 
-  type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
-  {}
+public:
+  explicit type(operation* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
 
   void set_value() noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
@@ -73,30 +71,32 @@ public:
     op->isSourceOpConstructed_ = false;
     op->sourceOp_.destruct();
 
-    if constexpr (std::is_nothrow_invocable_v<Predicate&> && is_nothrow_connectable_v<Source&, type> && is_nothrow_tag_invocable_v<tag_t<unifex::set_value>, Receiver>) {
+    if constexpr (
+        std::is_nothrow_invocable_v<Predicate&> &&
+        is_nothrow_connectable_v<Source&, type> &&
+        is_nothrow_tag_invocable_v<tag_t<unifex::set_value>, Receiver>) {
       // call predicate and complete with void if it returns true
-      if(op->predicate_()) {
+      if (op->predicate_()) {
         unifex::set_value(std::move(op->receiver_));
         return;
       }
-      auto& sourceOp = op->sourceOp_.construct_with([&]() noexcept {
-          return unifex::connect(op->source_, type{op});
-        });
+      auto& sourceOp = op->sourceOp_.construct_with(
+          [&]() noexcept { return unifex::connect(op->source_, type{op}); });
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
       UNIFEX_TRY {
         // call predicate and complete with void if it returns true
-        if(op->predicate_()) {
+        if (op->predicate_()) {
           unifex::set_value(std::move(op->receiver_));
           return;
         }
-        auto& sourceOp = op->sourceOp_.construct_with([&] {
-            return unifex::connect(op->source_, type{op});
-          });
+        auto& sourceOp = op->sourceOp_.construct_with(
+            [&] { return unifex::connect(op->source_, type{op}); });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
-      } UNIFEX_CATCH (...) {
+      }
+      UNIFEX_CATCH(...) {
         unifex::set_error(std::move(op->receiver_), std::current_exception());
       }
     }
@@ -107,19 +107,20 @@ public:
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  template(typename Error)
-    (requires receiver<Receiver, Error>)
-  void set_error(Error&& error) noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
+    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
   }
 
 private:
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO> AND
-          is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const type& r)
-      noexcept(std::is_nothrow_invocable_v<CPO, const Receiver&>)
+  template(typename CPO)(
+      requires is_receiver_query_cpo_v<CPO> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const type& r) noexcept(std::
+                                                                                        is_nothrow_invocable_v<
+                                                                                            CPO,
+                                                                                            const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_rcvr());
   }
@@ -128,9 +129,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&& func) noexcept(std::is_nothrow_invocable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     std::invoke(func, r.get_rcvr());
   }
 
@@ -148,18 +150,23 @@ class _op<Source, Predicate, Receiver>::type {
 
 public:
   template <typename Source2, typename Predicate2, typename Receiver2>
-  explicit type(Source2&& source, Predicate2&& predicate, Receiver2&& dest)
-      noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2> &&
-               std::is_nothrow_constructible_v<Predicate, Predicate2> &&
-               std::is_nothrow_constructible_v<Source, Source2> &&
-               is_nothrow_connectable_v<Source&, _receiver_t>)
-  : source_((Source2&&)source)
-  , predicate_((Predicate2&&)predicate)
-  , receiver_((Receiver2&&)dest)
-  {
-    sourceOp_.construct_with([&] {
-        return unifex::connect(source_, _receiver_t{this});
-      });
+  explicit type(
+      Source2&& source,
+      Predicate2&& predicate,
+      Receiver2&&
+          dest) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>&&
+                             std::is_nothrow_constructible_v<
+                                 Predicate,
+                                 Predicate2>&& std::
+                                 is_nothrow_constructible_v<Source, Source2>&&
+                                     is_nothrow_connectable_v<
+                                         Source&,
+                                         _receiver_t>)
+    : source_((Source2 &&) source)
+    , predicate_((Predicate2 &&) predicate)
+    , receiver_((Receiver2 &&) dest) {
+    sourceOp_.construct_with(
+        [&] { return unifex::connect(source_, _receiver_t{this}); });
   }
 
   ~type() {
@@ -169,9 +176,7 @@ public:
     }
   }
 
-  void start() & noexcept {
-    unifex::start(sourceOp_.get());
-  }
+  void start() & noexcept { unifex::start(sourceOp_.get()); }
 
 private:
   friend _receiver_t;
@@ -187,47 +192,54 @@ private:
 
 template <typename Source, typename Predicate>
 class _sndr<Source, Predicate>::type {
-
 public:
-  template <template <typename...> class Variant,
-          template <typename...> class Tuple>
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<>>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Source, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Source, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = true;
 
   template <typename Source2, typename Predicate2>
-  explicit type(Source2&& source, Predicate2&& predicate)
-    noexcept(
-      std::is_nothrow_constructible_v<Source, Source2> &&
-      std::is_nothrow_constructible_v<Predicate, Predicate2>)
-  : source_((Source2&&)source)
-  , predicate_((Predicate2&&)predicate)
-  {}
+  explicit type(Source2&& source, Predicate2&& predicate) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
+          std::is_nothrow_constructible_v<Predicate, Predicate2>)
+    : source_((Source2 &&) source)
+    , predicate_((Predicate2 &&) predicate) {}
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND
-        constructible_from<remove_cvref_t<Receiver>, Receiver> AND
-        sender_to<
-            Source&,
-            receiver_t<Source, Predicate, remove_cvref_t<Receiver>>>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-       noexcept(
-        std::is_nothrow_constructible_v<Source, decltype((static_cast<Sender&&>(s).source_))> &&
-        std::is_nothrow_constructible_v<Predicate, decltype((static_cast<Sender&&>(s).predicate_))> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-        is_nothrow_connectable_v<Source&, receiver_t<Source, Predicate, remove_cvref_t<Receiver>>>)
-        -> operation_type<Source, Predicate, remove_cvref_t<Receiver>> {
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND constructible_from<remove_cvref_t<Receiver>, Receiver> AND sender_to<Source&, receiver_t<Source, Predicate, remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              Source,
+                              decltype((static_cast<Sender&&>(s).source_))>&&
+                              std::is_nothrow_constructible_v<
+                                  Predicate,
+                                  decltype((
+                                      static_cast<Sender&&>(s).predicate_))>&&
+                                  std::is_nothrow_constructible_v<
+                                      remove_cvref_t<Receiver>,
+                                      Receiver>&&
+                                      is_nothrow_connectable_v<
+                                          Source&,
+                                          receiver_t<
+                                              Source,
+                                              Predicate,
+                                              remove_cvref_t<Receiver>>>)
+      -> operation_type<Source, Predicate, remove_cvref_t<Receiver>> {
     return operation_type<Source, Predicate, remove_cvref_t<Receiver>>{
-      static_cast<Sender&&>(s).source_,
-      static_cast<Sender&&>(s).predicate_,
-      (Receiver&&)r
-    };
+        static_cast<Sender&&>(s).source_,
+        static_cast<Sender&&>(s).predicate_,
+        (Receiver &&) r};
   }
 
 private:
@@ -235,38 +247,46 @@ private:
   UNIFEX_NO_UNIQUE_ADDRESS Predicate predicate_;
 };
 
-} // namespace _repeat_effect_until
+}  // namespace _repeat_effect_until
 
 template <class Source, class Predicate>
-using repeat_effect_until_sender = typename _repeat_effect_until::_sndr<Source, Predicate>::type;
+using repeat_effect_until_sender =
+    typename _repeat_effect_until::_sndr<Source, Predicate>::type;
 
 inline const struct repeat_effect_until_cpo {
   template <typename Source, typename Predicate>
-  auto operator()(Source&& source, Predicate&& predicate) const
-      noexcept(is_nothrow_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate>)
+  auto operator()(Source&& source, Predicate&& predicate) const noexcept(
+      is_nothrow_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate>)
       -> tag_invoke_result_t<repeat_effect_until_cpo, Source, Predicate> {
-    return tag_invoke(*this, (Source&&)source, (Predicate&&)predicate);
+    return tag_invoke(*this, (Source &&) source, (Predicate &&) predicate);
   }
 
-  template(typename Source, typename Predicate)
-    (requires (!tag_invocable<repeat_effect_until_cpo, Source, Predicate>) AND
-        constructible_from<remove_cvref_t<Source>, Source> AND
-        constructible_from<std::decay_t<Predicate>, Predicate>)
-  auto operator()(Source&& source, Predicate&& predicate) const
+  template(typename Source, typename Predicate)(
+      requires(!tag_invocable<repeat_effect_until_cpo, Source, Predicate>)
+          AND constructible_from<remove_cvref_t<Source>, Source> AND
+              constructible_from<std::decay_t<Predicate>, Predicate>) auto
+  operator()(Source&& source, Predicate&& predicate) const
       noexcept(std::is_nothrow_constructible_v<
-                   repeat_effect_until_sender<remove_cvref_t<Source>, std::decay_t<Predicate>>,
-                   Source,
-                   Predicate>)
-      -> repeat_effect_until_sender<remove_cvref_t<Source>, std::decay_t<Predicate>> {
-    return repeat_effect_until_sender<remove_cvref_t<Source>, std::decay_t<Predicate>>{
-        (Source&&)source, (Predicate&&)predicate};
+               repeat_effect_until_sender<
+                   remove_cvref_t<Source>,
+                   std::decay_t<Predicate>>,
+               Source,
+               Predicate>)
+          -> repeat_effect_until_sender<
+              remove_cvref_t<Source>,
+              std::decay_t<Predicate>> {
+    return repeat_effect_until_sender<
+        remove_cvref_t<Source>,
+        std::decay_t<Predicate>>{(Source &&) source, (Predicate &&) predicate};
   }
   template <typename Predicate>
   constexpr auto operator()(Predicate&& predicate) const
       noexcept(is_nothrow_callable_v<
-        tag_t<bind_back>, repeat_effect_until_cpo, Predicate>)
-      -> bind_back_result_t<repeat_effect_until_cpo, Predicate> {
-    return bind_back(*this, (Predicate&&)predicate);
+               tag_t<bind_back>,
+               repeat_effect_until_cpo,
+               Predicate>)
+          -> bind_back_result_t<repeat_effect_until_cpo, Predicate> {
+    return bind_back(*this, (Predicate &&) predicate);
   }
 } repeat_effect_until{};
 
@@ -277,29 +297,28 @@ inline const struct repeat_effect_cpo {
   template <typename Source>
   auto operator()(Source&& source) const
       noexcept(is_nothrow_tag_invocable_v<repeat_effect_cpo, Source>)
-      -> tag_invoke_result_t<repeat_effect_cpo, Source> {
-    return tag_invoke(*this, (Source&&)source);
+          -> tag_invoke_result_t<repeat_effect_cpo, Source> {
+    return tag_invoke(*this, (Source &&) source);
   }
 
-  template(typename Source)
-    (requires (!tag_invocable<repeat_effect_cpo, Source>) AND
-        constructible_from<remove_cvref_t<Source>, Source>)
-  auto operator()(Source&& source) const
+  template(typename Source)(
+      requires(!tag_invocable<repeat_effect_cpo, Source>)
+          AND constructible_from<remove_cvref_t<Source>, Source>) auto
+  operator()(Source&& source) const
       noexcept(std::is_nothrow_constructible_v<
-                   repeat_effect_until_sender<remove_cvref_t<Source>, forever>,
-                   Source>)
-      -> repeat_effect_until_sender<remove_cvref_t<Source>, forever> {
+               repeat_effect_until_sender<remove_cvref_t<Source>, forever>,
+               Source>)
+          -> repeat_effect_until_sender<remove_cvref_t<Source>, forever> {
     return repeat_effect_until_sender<remove_cvref_t<Source>, forever>{
-        (Source&&)source, forever{}};
+        (Source &&) source, forever{}};
   }
   constexpr auto operator()() const
-      noexcept(is_nothrow_callable_v<
-        tag_t<bind_back>, repeat_effect_cpo>)
-      -> bind_back_result_t<repeat_effect_cpo> {
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, repeat_effect_cpo>)
+          -> bind_back_result_t<repeat_effect_cpo> {
     return bind_back(*this);
   }
 } repeat_effect{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -16,19 +16,19 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
-#include <unifex/manual_lifetime.hpp>
-#include <unifex/manual_lifetime_union.hpp>
 #include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/manual_lifetime_union.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
-#include <utility>
 #include <exception>
 #include <functional>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -62,12 +62,10 @@ class _trigger_receiver<Source, Func, Receiver, Trigger>::type {
   using trigger_receiver = type;
 
 public:
-  explicit type(operation<Source, Func, Receiver>* op) noexcept
-    : op_(op) {}
+  explicit type(operation<Source, Func, Receiver>* op) noexcept : op_(op) {}
 
   type(trigger_receiver&& other) noexcept
-    : op_(std::exchange(other.op_, nullptr))
-  {}
+    : op_(std::exchange(other.op_, nullptr)) {}
 
   void set_value() && noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
@@ -79,37 +77,38 @@ public:
     using source_receiver_t = source_receiver<Source, Func, Receiver>;
 
     if constexpr (is_nothrow_connectable_v<Source&, source_receiver_t>) {
-      auto& sourceOp = unifex::activate_union_member_with(op->sourceOp_, [&]() noexcept {
-          return unifex::connect(op->source_, source_receiver_t{op});
-        });
+      auto& sourceOp =
+          unifex::activate_union_member_with(op->sourceOp_, [&]() noexcept {
+            return unifex::connect(op->source_, source_receiver_t{op});
+          });
       op->isSourceOpConstructed_ = true;
       unifex::start(sourceOp);
     } else {
       UNIFEX_TRY {
         auto& sourceOp = unifex::activate_union_member_with(op->sourceOp_, [&] {
-            return unifex::connect(op->source_, source_receiver_t{op});
-          });
+          return unifex::connect(op->source_, source_receiver_t{op});
+        });
         op->isSourceOpConstructed_ = true;
         unifex::start(sourceOp);
-      } UNIFEX_CATCH (...) {
-        unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            (Receiver &&) op->receiver_, std::current_exception());
       }
     }
   }
 
-  template(typename R = Receiver)
-    (requires receiver<R>)
-  void set_done() && noexcept {
+  template(typename R = Receiver)(
+      requires receiver<R>) void set_done() && noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
 
     auto* const op = op_;
     destroy_trigger_op();
-    unifex::set_done((Receiver&&)op->receiver_);
+    unifex::set_done((Receiver &&) op->receiver_);
   }
 
-  template(typename Error)
-    (requires receiver<Receiver, Error>)
-  void set_error(Error error) && noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error error) && noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
 
     auto* const op = op_;
@@ -118,16 +117,14 @@ public:
     // to be valid after we destroy the operation-state that sent it.
     destroy_trigger_op();
 
-    unifex::set_error((Receiver&&)op->receiver_, (Error&&)error);
+    unifex::set_error((Receiver &&) op->receiver_, (Error &&) error);
   }
 
 private:
-
-  template(typename CPO)
-    (requires is_receiver_query_cpo_v<CPO> AND
-        is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const trigger_receiver& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const trigger_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
@@ -136,9 +133,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const trigger_receiver& r,
-      VisitFunc&& func) noexcept(std::is_nothrow_invocable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     std::invoke(func, r.get_receiver());
   }
 
@@ -158,20 +156,16 @@ private:
 template <typename Source, typename Func, typename Receiver>
 class _source_receiver<Source, Func, Receiver>::type {
   using source_receiver = type;
+
 public:
-  explicit type(operation<Source, Func, Receiver>* op) noexcept
-  : op_(op) {}
+  explicit type(operation<Source, Func, Receiver>* op) noexcept : op_(op) {}
 
-  type(type&& other) noexcept
-  : op_(std::exchange(other.op_, {}))
-  {}
+  type(type&& other) noexcept : op_(std::exchange(other.op_, {})) {}
 
-  template(typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values)
-      noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
+  template(typename... Values)(requires receiver_of<Receiver, Values...>) void set_value(
+      Values&&... values) noexcept(is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
+    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
   }
 
   void set_done() noexcept {
@@ -179,9 +173,9 @@ public:
     unifex::set_done(std::move(op_->receiver_));
   }
 
-  template(typename Error)
-    (requires std::is_invocable_v<Func&, Error>)
-  void set_error(Error error) noexcept {
+  template(typename Error)(requires std::is_invocable_v<
+                           Func&,
+                           Error>) void set_error(Error error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
     auto* const op = op_;
 
@@ -189,39 +183,43 @@ public:
     unifex::deactivate_union_member(op->sourceOp_);
 
     using trigger_sender_t = std::invoke_result_t<Func&, Error>;
-    using trigger_receiver_t = trigger_receiver<Source, Func, Receiver, trigger_sender_t>;
-    using trigger_op_t = unifex::connect_result_t<trigger_sender_t, trigger_receiver_t>;
+    using trigger_receiver_t =
+        trigger_receiver<Source, Func, Receiver, trigger_sender_t>;
+    using trigger_op_t =
+        unifex::connect_result_t<trigger_sender_t, trigger_receiver_t>;
 
-    if constexpr (std::is_nothrow_invocable_v<Func&, Error> &&
-                  is_nothrow_connectable_v<trigger_sender_t, trigger_receiver_t>) {
+    if constexpr (
+        std::is_nothrow_invocable_v<Func&, Error> &&
+        is_nothrow_connectable_v<trigger_sender_t, trigger_receiver_t>) {
       auto& triggerOp = unifex::activate_union_member_with<trigger_op_t>(
-        op->triggerOps_,
-        [&]() noexcept {
-          return unifex::connect(
-            std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
-        });
+          op->triggerOps_, [&]() noexcept {
+            return unifex::connect(
+                std::invoke(op->func_, (Error &&) error),
+                trigger_receiver_t{op});
+          });
       unifex::start(triggerOp);
     } else {
       UNIFEX_TRY {
         auto& triggerOp = unifex::activate_union_member_with<trigger_op_t>(
-          op->triggerOps_,
-            [&]() {
+            op->triggerOps_, [&]() {
               return unifex::connect(
-                std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
+                  std::invoke(op->func_, (Error &&) error),
+                  trigger_receiver_t{op});
             });
-          unifex::start(triggerOp);
-      } UNIFEX_CATCH (...) {
-        unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
+        unifex::start(triggerOp);
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            (Receiver &&) op->receiver_, std::current_exception());
       }
     }
   }
 
 private:
-  template(typename CPO)
-    (requires is_receiver_query_cpo_v<CPO> AND
-        is_callable_v<CPO, const Receiver&>)
-  friend auto tag_invoke(CPO cpo, const source_receiver& r)
-      noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO> AND is_callable_v<CPO, const Receiver&>) friend auto tag_invoke(
+      CPO cpo,
+      const source_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(r.get_receiver());
   }
@@ -230,9 +228,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const source_receiver& r,
-      VisitFunc&& func) noexcept(std::is_nothrow_invocable_v<
-                                VisitFunc&,
-                                const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     std::invoke(func, r.get_receiver());
   }
 
@@ -248,19 +247,20 @@ template <typename Source, typename Func, typename Receiver>
 class _op<Source, Func, Receiver>::type {
   using operation = type;
   using source_receiver_t = source_receiver<Source, Func, Receiver>;
+
 public:
   template <typename Source2, typename Func2, typename Receiver2>
-  explicit type(Source2&& source, Func2&& func, Receiver2&& receiver)
-      noexcept(std::is_nothrow_constructible_v<Source, Source2> &&
-               std::is_nothrow_constructible_v<Func, Func2> &&
-               std::is_nothrow_constructible_v<Receiver, Receiver2> &&
-               is_nothrow_connectable_v<Source&, source_receiver_t>)
-  : source_((Source2&&)source)
-  , func_((Func2&&)func)
-  , receiver_((Receiver&&)receiver) {
+  explicit type(Source2&& source, Func2&& func, Receiver2&& receiver) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
+          std::is_nothrow_constructible_v<Func, Func2>&&
+              std::is_nothrow_constructible_v<Receiver, Receiver2>&&
+                  is_nothrow_connectable_v<Source&, source_receiver_t>)
+    : source_((Source2 &&) source)
+    , func_((Func2 &&) func)
+    , receiver_((Receiver &&) receiver) {
     unifex::activate_union_member_with(sourceOp_, [&] {
-        return unifex::connect(source_, source_receiver_t{this});
-      });
+      return unifex::connect(source_, source_receiver_t{this});
+    });
   }
 
   ~type() {
@@ -269,14 +269,16 @@ public:
     }
   }
 
-  void start() & noexcept {
-    unifex::start(sourceOp_.get());
-  }
+  void start() & noexcept { unifex::start(sourceOp_.get()); }
 
 private:
   friend source_receiver_t;
 
-  template <typename Source2, typename Func2, typename Receiver2, typename Trigger>
+  template <
+      typename Source2,
+      typename Func2,
+      typename Receiver2,
+      typename Trigger>
   friend struct _trigger_receiver;
 
   using source_op_t = connect_result_t<Source&, source_receiver_t>;
@@ -285,12 +287,12 @@ private:
   using trigger_sender_t = std::invoke_result_t<Func&, remove_cvref_t<Error>>;
 
   template <typename Error>
-  using trigger_receiver_t = trigger_receiver<Source, Func, Receiver, trigger_sender_t<Error>>;
+  using trigger_receiver_t =
+      trigger_receiver<Source, Func, Receiver, trigger_sender_t<Error>>;
 
   template <typename Error>
-  using trigger_op_t = connect_result_t<
-      trigger_sender_t<Error>,
-      trigger_receiver_t<Error>>;
+  using trigger_op_t =
+      connect_result_t<trigger_sender_t<Error>, trigger_receiver_t<Error>>;
 
   template <typename... Errors>
   using trigger_op_union = manual_lifetime_union<trigger_op_t<Errors>...>;
@@ -310,12 +312,14 @@ struct _sender {
   class type;
 };
 template <typename Source, typename Func>
-using sender = typename _sender<remove_cvref_t<Source>, std::decay_t<Func>>::type;
+using sender =
+    typename _sender<remove_cvref_t<Source>, std::decay_t<Func>>::type;
 
-template<typename Sender>
-struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {};
+template <typename Sender>
+struct sends_done_impl
+  : std::bool_constant<sender_traits<Sender>::sends_done> {};
 
-template<typename... Senders>
+template <typename... Senders>
 using any_sends_done = std::disjunction<sends_done_impl<Senders>...>;
 
 template <typename Source, typename Func>
@@ -326,101 +330,126 @@ class _sender<Source, Func>::type {
   using trigger_sender = std::invoke_result_t<Func&, remove_cvref_t<Error>>;
 
   template <typename... Errors>
-  using make_error_type_list =
-      typename concat_type_lists_unique<
-          sender_error_types_t<trigger_sender<Errors>, type_list>...,
-          type_list<std::exception_ptr>>::type;
+  using make_error_type_list = typename concat_type_lists_unique<
+      sender_error_types_t<trigger_sender<Errors>, type_list>...,
+      type_list<std::exception_ptr>>::type;
 
   template <typename... Errors>
   using sends_done_impl = any_sends_done<Source, trigger_sender<Errors>...>;
 
 public:
-  template <template <typename...> class Variant,
-            template <typename...> class Tuple>
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = sender_value_types_t<Source, Variant, Tuple>;
 
   template <template <typename...> class Variant>
   using error_types =
-      typename sender_error_types_t<Source, make_error_type_list>::template
-          apply<Variant>;
+      typename sender_error_types_t<Source, make_error_type_list>::
+          template apply<Variant>;
 
   static constexpr bool sends_done =
-    sender_error_types_t<Source, sends_done_impl>::value;
+      sender_error_types_t<Source, sends_done_impl>::value;
 
   template <typename Source2, typename Func2>
-  explicit type(Source2&& source, Func2&& func)
-    noexcept(std::is_nothrow_constructible_v<Source, Source2> &&
-             std::is_nothrow_constructible_v<Func, Func2>)
-    : source_((Source2&&)source)
-    , func_((Func2&&)func)
-  {}
+  explicit type(Source2&& source, Func2&& func) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
+          std::is_nothrow_constructible_v<Func, Func2>)
+    : source_((Source2 &&) source)
+    , func_((Func2 &&) func) {}
 
   // TODO: The connect() methods are currently under-constrained.
-  // Ideally they should also check that func() invoked with each of the errors can be connected
-  // with the corresponding trigger_receiver.
+  // Ideally they should also check that func() invoked with each of the errors
+  // can be connected with the corresponding trigger_receiver.
 
-  template(typename Self, typename Receiver)
-      (requires same_as<remove_cvref_t<Self>, type> AND
-          receiver<Receiver> AND
-          constructible_from<Source, member_t<Self, Source>> AND
-          constructible_from<Func, member_t<Self, Func>> AND
-          constructible_from<remove_cvref_t<Receiver>, Receiver> AND
-          sender_to<Source&, source_receiver<Source, Func, remove_cvref_t<Receiver>>>)
-  friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r)
-      noexcept(
-        std::is_nothrow_constructible_v<Source, member_t<Self, Source>> &&
-        std::is_nothrow_constructible_v<Func, member_t<Self, Func>> &&
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-        is_nothrow_connectable_v<Source&, source_receiver<Source, Func, remove_cvref_t<Receiver>>>)
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND constructible_from<
+          Source,
+          member_t<
+              Self,
+              Source>> AND constructible_from<Func, member_t<Self, Func>> AND
+          constructible_from<remove_cvref_t<Receiver>, Receiver> AND sender_to<
+              Source&,
+              source_receiver<
+                  Source,
+                  Func,
+                  remove_cvref_t<
+                      Receiver>>>) friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(std::
+                                                                                                                  is_nothrow_constructible_v<
+                                                                                                                      Source,
+                                                                                                                      member_t<
+                                                                                                                          Self,
+                                                                                                                          Source>>&&
+                                                                                                                      std::is_nothrow_constructible_v<
+                                                                                                                          Func,
+                                                                                                                          member_t<
+                                                                                                                              Self,
+                                                                                                                              Func>>&&
+                                                                                                                          std::is_nothrow_constructible_v<
+                                                                                                                              remove_cvref_t<
+                                                                                                                                  Receiver>,
+                                                                                                                              Receiver>&&
+                                                                                                                              is_nothrow_connectable_v<
+                                                                                                                                  Source&,
+                                                                                                                                  source_receiver<
+                                                                                                                                      Source,
+                                                                                                                                      Func,
+                                                                                                                                      remove_cvref_t<
+                                                                                                                                          Receiver>>>)
       -> operation<Source, Func, Receiver> {
     return operation<Source, Func, Receiver>{
-        static_cast<Self&&>(self).source_, static_cast<Self&&>(self).func_, (Receiver&&)r};
+        static_cast<Self&&>(self).source_,
+        static_cast<Self&&>(self).func_,
+        (Receiver &&) r};
   }
 
 private:
   Source source_;
   Func func_;
 };
-} // namespace _retry_when
+}  // namespace _retry_when
 
 namespace _retry_when_cpo {
-  inline const struct _fn {
-  private:
-    template <typename Source, typename Func>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Source, Func>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote2<_retry_when::sender>>::template apply<Source, Func>;
-  public:
-    template(typename Source, typename Func)
-      (requires tag_invocable<_fn, Source, Func>)
-    auto operator()(Source&& source, Func&& func) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func>)
-        -> _result_t<Source, Func> {
-      return unifex::tag_invoke(_fn{}, (Source&&)source, (Func&&)func);
-    }
-    template(typename Source, typename Func)
-      (requires (!tag_invocable<_fn, Source, Func>) AND
-          constructible_from<remove_cvref_t<Source>, Source> AND
-          constructible_from<remove_cvref_t<Func>, Func>)
-    auto operator()(Source&& source, Func&& func) const
-        noexcept(std::is_nothrow_constructible_v<
-          _retry_when::sender<Source, Func>, Source, Func>)
-        -> _result_t<Source, Func> {
-      return _retry_when::sender<Source, Func>{(Source&&)source, (Func&&)func};
-    }
-    template <typename Func>
-    constexpr auto operator()(Func&& func) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func>)
-        -> bind_back_result_t<_fn, Func> {
-      return bind_back(*this, (Func&&)func);
-    }
-  } retry_when{};
-} // namespace _retry_when_cpo
+inline const struct _fn {
+private:
+  template <typename Source, typename Func>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Source, Func>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_retry_when::sender>>::template apply<Source, Func>;
+
+public:
+  template(typename Source, typename Func)(
+      requires tag_invocable<_fn, Source, Func>) auto
+  operator()(Source&& source, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func>)
+          -> _result_t<Source, Func> {
+    return unifex::tag_invoke(_fn{}, (Source &&) source, (Func &&) func);
+  }
+  template(typename Source, typename Func)(
+      requires(!tag_invocable<_fn, Source, Func>)
+          AND constructible_from<remove_cvref_t<Source>, Source> AND
+              constructible_from<remove_cvref_t<Func>, Func>) auto
+  operator()(Source&& source, Func&& func) const
+      noexcept(std::is_nothrow_constructible_v<
+               _retry_when::sender<Source, Func>,
+               Source,
+               Func>) -> _result_t<Source, Func> {
+    return _retry_when::sender<Source, Func>{
+        (Source &&) source, (Func &&) func};
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&) func);
+  }
+} retry_when{};
+}  // namespace _retry_when_cpo
 using _retry_when_cpo::retry_when;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -15,81 +15,69 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/then.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _subschedule {
-  namespace _detail {
-    template <typename T>
-    struct _return_value {
-      struct type {
-        T value;
+namespace _detail {
+template <typename T>
+struct _return_value {
+  struct type {
+    T value;
 
-        T operator()() && {
-          return std::move(value);
-        }
+    T operator()() && { return std::move(value); }
 
-        T operator()() & {
-          return value;
-        }
+    T operator()() & { return value; }
 
-        T operator()() const& {
-          return value;
-        }
-      };
-    };
-  } // _detail
+    T operator()() const& { return value; }
+  };
+};
+}  // namespace _detail
 
-  inline const struct _fn {
-  private:
-    template <typename T>
-    using _return_value =
+inline const struct _fn {
+private:
+  template <typename T>
+  using _return_value =
       typename _detail::_return_value<remove_cvref_t<T>>::type;
 
-    template <typename Scheduler>
-    using _default_result_t = _then::sender<
-        callable_result_t<decltype(schedule), Scheduler&>,
-        _return_value<Scheduler>>;
-    template <typename Scheduler>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Scheduler>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote1<_default_result_t>>::template apply<Scheduler>;
-  public:
-    template(typename Scheduler)
-      (requires tag_invocable<_fn, Scheduler>)
-    auto operator()(Scheduler&& sched) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
-        -> _result_t<Scheduler> {
-      return unifex::tag_invoke(_fn{}, (Scheduler &&) sched);
-    }
-    template(typename Scheduler)
-      (requires (!tag_invocable<_fn, Scheduler>))
-    auto operator()(Scheduler&& sched) const
-        -> _result_t<Scheduler> {
-      auto&& scheduleOp = schedule(sched);
-      return _result_t<Scheduler>{
-        static_cast<decltype(scheduleOp)>(scheduleOp),
-        {(Scheduler &&) sched}
-      };
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
-  } schedule_with_subscheduler{};
-} // namespace _subschedule
+  template <typename Scheduler>
+  using _default_result_t = _then::sender<
+      callable_result_t<decltype(schedule), Scheduler&>,
+      _return_value<Scheduler>>;
+  template <typename Scheduler>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Scheduler>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_default_result_t>>::template apply<Scheduler>;
+
+public:
+  template(typename Scheduler)(requires tag_invocable<_fn, Scheduler>) auto
+  operator()(Scheduler&& sched) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
+          -> _result_t<Scheduler> {
+    return unifex::tag_invoke(_fn{}, (Scheduler &&) sched);
+  }
+  template(typename Scheduler)(requires(!tag_invocable<_fn, Scheduler>)) auto
+  operator()(Scheduler&& sched) const -> _result_t<Scheduler> {
+    auto&& scheduleOp = schedule(sched);
+    return _result_t<Scheduler>{
+        static_cast<decltype(scheduleOp)>(scheduleOp), {(Scheduler &&) sched}};
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
+} schedule_with_subscheduler{};
+}  // namespace _subschedule
 
 using _subschedule::schedule_with_subscheduler;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -16,190 +16,186 @@
 
 #pragma once
 
+#include <unifex/blocking.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/sender_for.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/utility.hpp>
-#include <unifex/sender_for.hpp>
-#include <unifex/blocking.hpp>
 
-#include <type_traits>
 #include <exception>
+#include <type_traits>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _schedule {
-  struct _fn;
+struct _fn;
 
-  template <typename Scheduler>
-  UNIFEX_CONCEPT_FRAGMENT( //
-    _with_tag_invoke_helper, //
-      requires () (0) &&
-      tag_invocable<_fn, Scheduler> &&
-      sender<tag_invoke_result_t<_fn, Scheduler>>);
-  template <typename Scheduler>
-  UNIFEX_CONCEPT //
-    _with_tag_invoke = //
-      UNIFEX_FRAGMENT(_schedule::_with_tag_invoke_helper, Scheduler);
+template <typename Scheduler>
+UNIFEX_CONCEPT_FRAGMENT(      //
+    _with_tag_invoke_helper,  //
+    requires()(0) && tag_invocable<_fn, Scheduler> &&
+        sender<tag_invoke_result_t<_fn, Scheduler>>);
+template <typename Scheduler>
+UNIFEX_CONCEPT          //
+    _with_tag_invoke =  //
+    UNIFEX_FRAGMENT(_schedule::_with_tag_invoke_helper, Scheduler);
 
-  template <typename Scheduler>
-  using _member_schedule_result_t =
+template <typename Scheduler>
+using _member_schedule_result_t =
     decltype(UNIFEX_DECLVAL(Scheduler).schedule());
 
+template <typename Scheduler>
+UNIFEX_CONCEPT_FRAGMENT(    //
+    _has_member_schedule_,  //
+    requires()(0) && sender<_member_schedule_result_t<Scheduler>>);
+template <typename Scheduler>
+UNIFEX_CONCEPT               //
+    _with_member_schedule =  //
+    UNIFEX_FRAGMENT(_schedule::_has_member_schedule_, Scheduler);
+
+struct sender;
+
+struct _impl {
+private:
   template <typename Scheduler>
-  UNIFEX_CONCEPT_FRAGMENT( //
-    _has_member_schedule_, //
-      requires() (0) &&
-      sender<_member_schedule_result_t<Scheduler>>);
+  static auto _select() noexcept {
+    if constexpr (_with_tag_invoke<Scheduler>) {
+      return meta_tag_invoke_result<_fn>{};
+    } else if constexpr (_with_member_schedule<Scheduler>) {
+      return meta_quote1<_member_schedule_result_t>{};
+    } else {
+      return type_always<void>{};
+    }
+  }
   template <typename Scheduler>
-  UNIFEX_CONCEPT //
-    _with_member_schedule = //
-      UNIFEX_FRAGMENT(_schedule::_has_member_schedule_, Scheduler);
+  using _result_t =
+      typename decltype(_impl::_select<Scheduler>())::template apply<Scheduler>;
 
-  struct sender;
+public:
+  template(typename Scheduler)(
+      requires _with_tag_invoke<Scheduler>) constexpr auto
+  operator()(Scheduler&& s) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
+          -> _result_t<Scheduler> {
+    return tag_invoke(schedule, static_cast<Scheduler&&>(s));
+  }
+  template(typename Scheduler)(
+      requires(!_with_tag_invoke<Scheduler>)
+          AND _with_member_schedule<Scheduler>) constexpr auto
+  operator()(Scheduler&& s) const
+      noexcept(noexcept(static_cast<Scheduler&&>(s).schedule()))
+          -> _result_t<Scheduler> {
+    return static_cast<Scheduler&&>(s).schedule();
+  }
+};
 
-  struct _impl {
-  private:
-    template <typename Scheduler>
-    static auto _select() noexcept {
-      if constexpr (_with_tag_invoke<Scheduler>) {
-        return meta_tag_invoke_result<_fn>{};
-      } else if constexpr (_with_member_schedule<Scheduler>) {
-        return meta_quote1<_member_schedule_result_t>{};
-      } else {
-        return type_always<void>{};
-      }
-    }
-    template <typename Scheduler>
-    using _result_t =
-        typename decltype(_impl::_select<Scheduler>())::template apply<Scheduler>;
-  public:
-    template(typename Scheduler)
-      (requires _with_tag_invoke<Scheduler>)
-    constexpr auto operator()(Scheduler&& s) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Scheduler>)
-        -> _result_t<Scheduler> {
-      return tag_invoke(schedule, static_cast<Scheduler&&>(s));
-    }
-    template(typename Scheduler)
-      (requires (!_with_tag_invoke<Scheduler>) AND
-        _with_member_schedule<Scheduler>)
-    constexpr auto operator()(Scheduler&& s) const noexcept(
-        noexcept(static_cast<Scheduler&&>(s).schedule()))
-        -> _result_t<Scheduler> {
-      return static_cast<Scheduler&&>(s).schedule();
-    }
-  };
-
-  template <typename S>
-  using _schedule_result_t = decltype(_impl{}(UNIFEX_DECLVAL(S&&)));
-} // namespace _schedule
+template <typename S>
+using _schedule_result_t = decltype(_impl{}(UNIFEX_DECLVAL(S &&)));
+}  // namespace _schedule
 
 // Define the scheduler concept without the macros for better diagnostics
 #if UNIFEX_CXX_CONCEPTS
 template <typename S>
-concept //
-  scheduler = //
+concept          //
+    scheduler =  //
     requires(S&& s) {
-      _schedule::_impl{}((S&&) s);
-    } &&
-    copy_constructible<remove_cvref_t<S>> &&
+  _schedule::_impl{}((S &&) s);
+}
+&&copy_constructible<remove_cvref_t<S>>&&
     equality_comparable<remove_cvref_t<S>>;
 #else
 template <typename S>
-UNIFEX_CONCEPT_FRAGMENT( //
-  _scheduler,
-    requires(S&& s) (
-      _schedule::_impl{}((S&&) s)
-    ));
+UNIFEX_CONCEPT_FRAGMENT(  //
+    _scheduler,
+    requires(S&& s)(_schedule::_impl{}((S &&) s)));
 template <typename S>
-UNIFEX_CONCEPT //
-  scheduler = //
+UNIFEX_CONCEPT   //
+    scheduler =  //
     UNIFEX_FRAGMENT(unifex::_scheduler, S) &&
-    copy_constructible<remove_cvref_t<S>> &&
-    equality_comparable<remove_cvref_t<S>>;
+    copy_constructible<remove_cvref_t<S>>&& equality_comparable<
+        remove_cvref_t<S>>;
 #endif
 
 namespace _get_scheduler {
-  struct _fn {
-    template (typename SchedulerProvider)
-        (requires tag_invocable<_fn, const SchedulerProvider&>)
-    auto operator()(const SchedulerProvider& context) const noexcept
-        -> tag_invoke_result_t<_fn, const SchedulerProvider&> {
-      static_assert(is_nothrow_tag_invocable_v<_fn, const SchedulerProvider&>);
-      static_assert(
-          scheduler<tag_invoke_result_t<_fn, const SchedulerProvider&>>);
-      return tag_invoke(*this, context);
-    }
+struct _fn {
+  template(typename SchedulerProvider)(
+      requires tag_invocable<_fn, const SchedulerProvider&>) auto
+  operator()(const SchedulerProvider& context) const noexcept
+      -> tag_invoke_result_t<_fn, const SchedulerProvider&> {
+    static_assert(is_nothrow_tag_invocable_v<_fn, const SchedulerProvider&>);
+    static_assert(
+        scheduler<tag_invoke_result_t<_fn, const SchedulerProvider&>>);
+    return tag_invoke(*this, context);
+  }
 
-    template (typename T)
-      (requires (!same_as<_fn, remove_cvref_t<T>>))
-    constexpr kv<_fn, remove_cvref_t<T>> operator=(T&& t) const &
-        noexcept(std::is_nothrow_constructible_v<remove_cvref_t<T>, T>) {
-      return {*this, (T&&) t};
-    }
-  };
-} // namespace _get_scheduler
-inline constexpr _get_scheduler::_fn get_scheduler {};
+  template(typename T)(requires(
+      !same_as<_fn, remove_cvref_t<T>>)) constexpr kv<_fn, remove_cvref_t<T>>
+  operator=(T&& t) const& noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<T>, T>) {
+    return {*this, (T &&) t};
+  }
+};
+}  // namespace _get_scheduler
+inline constexpr _get_scheduler::_fn get_scheduler{};
 
 template <typename SchedulerProvider>
 using get_scheduler_result_t =
-    decltype(get_scheduler(UNIFEX_DECLVAL(SchedulerProvider&&)));
+    decltype(get_scheduler(UNIFEX_DECLVAL(SchedulerProvider &&)));
 
 // Define the scheduler concept without the macros for better diagnostics
 #if UNIFEX_CXX_CONCEPTS
 template <typename SP>
-concept //
-  scheduler_provider = //
+concept                   //
+    scheduler_provider =  //
     requires(SP&& sp) {
-      get_scheduler((SP&&) sp);
-    };
+  get_scheduler((SP &&) sp);
+};
 #else
 template <typename SP>
-UNIFEX_CONCEPT_FRAGMENT( //
-  _scheduler_provider,
-    requires(SP&& sp) (
-      get_scheduler((SP&&) sp)
-    ));
+UNIFEX_CONCEPT_FRAGMENT(  //
+    _scheduler_provider,
+    requires(SP&& sp)(get_scheduler((SP &&) sp)));
 template <typename SP>
-UNIFEX_CONCEPT //
-  scheduler_provider = //
+UNIFEX_CONCEPT            //
+    scheduler_provider =  //
     UNIFEX_FRAGMENT(unifex::_scheduler_provider, SP);
 #endif
 
-namespace _schedule
-{
-  struct _fn {
-  private:
-    template <typename Scheduler>
-    static auto impl_(Scheduler sched)
-        noexcept(noexcept(make_sender_for<schedule>(
-            _impl{}((Scheduler&&) sched), get_scheduler = Scheduler(sched)))) {
-      return make_sender_for<schedule>(
-          _impl{}((Scheduler&&) sched), get_scheduler = Scheduler(sched));
-    }
-  public:
-    template (typename Scheduler)
-      (requires scheduler<Scheduler>)
-    auto operator()(Scheduler&& sched) const
-        noexcept(noexcept(_fn::impl_((Scheduler&&) sched)))
-        -> decltype(_fn::impl_((Scheduler&&) sched)) {
-      return _fn::impl_((Scheduler&&) sched);
-    }
+namespace _schedule {
+struct _fn {
+private:
+  template <typename Scheduler>
+  static auto
+  impl_(Scheduler sched) noexcept(noexcept(make_sender_for<schedule>(
+      _impl{}((Scheduler &&) sched), get_scheduler = Scheduler(sched)))) {
+    return make_sender_for<schedule>(
+        _impl{}((Scheduler &&) sched), get_scheduler = Scheduler(sched));
+  }
 
-    constexpr sender operator()() const noexcept;
-  };
-} // namespace _schedule
-inline constexpr _schedule::_fn schedule {};
+public:
+  template(typename Scheduler)(requires scheduler<Scheduler>) auto
+  operator()(Scheduler&& sched) const
+      noexcept(noexcept(_fn::impl_((Scheduler &&) sched)))
+          -> decltype(_fn::impl_((Scheduler &&) sched)) {
+    return _fn::impl_((Scheduler &&) sched);
+  }
+
+  constexpr sender operator()() const noexcept;
+};
+}  // namespace _schedule
+inline constexpr _schedule::_fn schedule{};
 
 template <typename S>
-using schedule_result_t = decltype(schedule(UNIFEX_DECLVAL(S&&)));
+using schedule_result_t = decltype(schedule(UNIFEX_DECLVAL(S &&)));
 
 namespace _schedule {
 struct sender {
   template <
-    template <typename...> class Variant,
-    template <typename...> class Tuple>
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = Variant<Tuple<>>;
 
   template <template <typename...> class Variant>
@@ -207,13 +203,13 @@ struct sender {
 
   static constexpr bool sends_done = true;
 
-  template(typename Receiver)
-    (requires receiver<Receiver>)
-  friend auto tag_invoke(tag_t<connect>, sender, Receiver &&r)
+  template(typename Receiver)(
+      requires receiver<
+          Receiver>) friend auto tag_invoke(tag_t<connect>, sender, Receiver&& r)
       -> connect_result_t<
-            schedule_result_t<
-                get_scheduler_result_t<const remove_cvref_t<Receiver>&>>,
-            Receiver> {
+          schedule_result_t<
+              get_scheduler_result_t<const remove_cvref_t<Receiver>&>>,
+          Receiver> {
     auto scheduler = get_scheduler(std::as_const(r));
     return connect(schedule(std::move(scheduler)), (Receiver &&) r);
   }
@@ -222,264 +218,265 @@ struct sender {
 inline constexpr sender _fn::operator()() const noexcept {
   return {};
 }
-} // namespace _schedule
+}  // namespace _schedule
 
 namespace _schedule_after {
-  template <typename Duration>
-  struct _sender {
-    class type;
-  };
-  template <typename Duration>
-  using sender = typename _sender<Duration>::type;
+template <typename Duration>
+struct _sender {
+  class type;
+};
+template <typename Duration>
+using sender = typename _sender<Duration>::type;
 
-  inline const struct _fn {
-  private:
-    template <typename TimeScheduler, typename Duration>
-    using _schedule_after_member_result_t =
-      decltype(UNIFEX_DECLVAL(TimeScheduler).schedule_after(UNIFEX_DECLVAL(Duration)));
-    template <typename TimeScheduler, typename Duration>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, TimeScheduler, Duration>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote2<_schedule_after_member_result_t>>
-          ::template apply<TimeScheduler, Duration>;
-  public:
-    template(typename TimeScheduler, typename Duration)
-      (requires tag_invocable<_fn, TimeScheduler, Duration>)
-    constexpr auto operator()(TimeScheduler&& s, Duration&& d) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, Duration>)
-        -> _result_t<TimeScheduler, Duration> {
-      return tag_invoke(*this, (TimeScheduler &&) s, (Duration &&) d);
-    }
-
-    template(typename TimeScheduler, typename Duration)
-      (requires (!tag_invocable<_fn, TimeScheduler, Duration>))
-    constexpr auto operator()(TimeScheduler&& s, Duration&& d) const noexcept(
-        noexcept(static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d)))
-        -> _result_t<TimeScheduler, Duration> {
-      return static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d);
-    }
-
-    template <typename Duration>
-    constexpr sender<Duration> operator()(Duration d) const {
-      return sender<Duration>{std::move(d)};
-    }
-  } schedule_after{};
-
+inline const struct _fn {
+private:
   template <typename TimeScheduler, typename Duration>
-  using schedule_after_result_t =
-      decltype(schedule_after(UNIFEX_DECLVAL(TimeScheduler&&), UNIFEX_DECLVAL(Duration&&)));
+  using _schedule_after_member_result_t =
+      decltype(UNIFEX_DECLVAL(TimeScheduler)
+                   .schedule_after(UNIFEX_DECLVAL(Duration)));
+  template <typename TimeScheduler, typename Duration>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, TimeScheduler, Duration>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_schedule_after_member_result_t>>::
+      template apply<TimeScheduler, Duration>;
+
+public:
+  template(typename TimeScheduler, typename Duration)(
+      requires tag_invocable<_fn, TimeScheduler, Duration>) constexpr auto
+  operator()(TimeScheduler&& s, Duration&& d) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, Duration>)
+          -> _result_t<TimeScheduler, Duration> {
+    return tag_invoke(*this, (TimeScheduler &&) s, (Duration &&) d);
+  }
+
+  template(typename TimeScheduler, typename Duration)(
+      requires(!tag_invocable<_fn, TimeScheduler, Duration>)) constexpr auto
+  operator()(TimeScheduler&& s, Duration&& d) const noexcept(
+      noexcept(static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d)))
+      -> _result_t<TimeScheduler, Duration> {
+    return static_cast<TimeScheduler&&>(s).schedule_after((Duration &&) d);
+  }
 
   template <typename Duration>
-  class _sender<Duration>::type {
-  public:
-    template <template <typename...> class Variant, template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  constexpr sender<Duration> operator()(Duration d) const {
+    return sender<Duration>{std::move(d)};
+  }
+} schedule_after{};
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+template <typename TimeScheduler, typename Duration>
+using schedule_after_result_t = decltype(schedule_after(
+    UNIFEX_DECLVAL(TimeScheduler &&), UNIFEX_DECLVAL(Duration&&)));
 
-    static constexpr bool sends_done = true;
+template <typename Duration>
+class _sender<Duration>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    explicit type(Duration d)
-      : duration_(d)
-    {}
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-  private:
-    friend _fn;
+  static constexpr bool sends_done = true;
 
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, const type& s, Receiver&& r)
-        -> connect_result_t<
-            schedule_after_result_t<std::decay_t<
-                get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
-                const Duration&>,
-            Receiver> {
-      auto scheduler = get_scheduler(std::as_const(r));
-      return connect(schedule_after(scheduler, std::as_const(s.duration_)), (Receiver&&) r);
-    }
+  explicit type(Duration d) : duration_(d) {}
 
-    Duration duration_;
-  };
-} // namespace _schedule_after
+private:
+  friend _fn;
+
+  template(typename Receiver)(requires receiver<Receiver>) friend auto tag_invoke(
+      tag_t<connect>, const type& s, Receiver&& r)
+      -> connect_result_t<
+          schedule_after_result_t<
+              std::decay_t<
+                  get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
+              const Duration&>,
+          Receiver> {
+    auto scheduler = get_scheduler(std::as_const(r));
+    return connect(
+        schedule_after(scheduler, std::as_const(s.duration_)), (Receiver &&) r);
+  }
+
+  Duration duration_;
+};
+}  // namespace _schedule_after
 using _schedule_after::schedule_after;
 
 namespace _schedule_at {
-  template <typename TimePoint>
-  struct _sender {
-    class type;
-  };
-  template <typename TimePoint>
-  using sender = typename _sender<TimePoint>::type;
+template <typename TimePoint>
+struct _sender {
+  class type;
+};
+template <typename TimePoint>
+using sender = typename _sender<TimePoint>::type;
 
-  inline const struct _fn {
-  private:
-    template <typename TimeScheduler, typename TimePoint>
-    using _schedule_at_member_result_t =
-      decltype(UNIFEX_DECLVAL(TimeScheduler).schedule_at(UNIFEX_DECLVAL(TimePoint)));
-    template <typename TimeScheduler, typename TimePoint>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, TimeScheduler, TimePoint>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote2<_schedule_at_member_result_t>>
-          ::template apply<TimeScheduler, TimePoint>;
-  public:
-    template(typename TimeScheduler, typename TimePoint)
-      (requires tag_invocable<_fn, TimeScheduler, TimePoint>)
-    constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, TimePoint>)
-        -> _result_t<TimeScheduler, TimePoint> {
-      return tag_invoke(*this, (TimeScheduler &&) s, (TimePoint &&) tp);
-    }
-
-    template(typename TimeScheduler, typename TimePoint)
-      (requires (!tag_invocable<_fn, TimeScheduler, TimePoint>))
-    constexpr auto operator()(TimeScheduler&& s, TimePoint&& tp) const noexcept(
-        noexcept(static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp)))
-        -> _result_t<TimeScheduler, TimePoint> {
-      return static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp);
-    }
-
-    template <typename TimePoint>
-    constexpr sender<TimePoint> operator()(TimePoint tp) const {
-      return sender<TimePoint>{std::move(tp)};
-    }
-  } schedule_at {};
-
+inline const struct _fn {
+private:
   template <typename TimeScheduler, typename TimePoint>
-  using schedule_at_result_t =
-      decltype(schedule_at(
-          UNIFEX_DECLVAL(TimeScheduler&&),
-          UNIFEX_DECLVAL(TimePoint&&)));
+  using _schedule_at_member_result_t =
+      decltype(UNIFEX_DECLVAL(TimeScheduler)
+                   .schedule_at(UNIFEX_DECLVAL(TimePoint)));
+  template <typename TimeScheduler, typename TimePoint>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, TimeScheduler, TimePoint>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_schedule_at_member_result_t>>::
+      template apply<TimeScheduler, TimePoint>;
+
+public:
+  template(typename TimeScheduler, typename TimePoint)(
+      requires tag_invocable<_fn, TimeScheduler, TimePoint>) constexpr auto
+  operator()(TimeScheduler&& s, TimePoint&& tp) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler, TimePoint>)
+          -> _result_t<TimeScheduler, TimePoint> {
+    return tag_invoke(*this, (TimeScheduler &&) s, (TimePoint &&) tp);
+  }
+
+  template(typename TimeScheduler, typename TimePoint)(
+      requires(!tag_invocable<_fn, TimeScheduler, TimePoint>)) constexpr auto
+  operator()(TimeScheduler&& s, TimePoint&& tp) const noexcept(
+      noexcept(static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp)))
+      -> _result_t<TimeScheduler, TimePoint> {
+    return static_cast<TimeScheduler&&>(s).schedule_at((TimePoint &&) tp);
+  }
 
   template <typename TimePoint>
-  class _sender<TimePoint>::type {
-  public:
-    template <template <typename...> class Variant, template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  constexpr sender<TimePoint> operator()(TimePoint tp) const {
+    return sender<TimePoint>{std::move(tp)};
+  }
+} schedule_at{};
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+template <typename TimeScheduler, typename TimePoint>
+using schedule_at_result_t = decltype(schedule_at(
+    UNIFEX_DECLVAL(TimeScheduler &&), UNIFEX_DECLVAL(TimePoint&&)));
 
-    static constexpr bool sends_done = true;
+template <typename TimePoint>
+class _sender<TimePoint>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    explicit type(TimePoint tp)
-      : time_point_(tp)
-    {}
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-  private:
-    friend _fn;
+  static constexpr bool sends_done = true;
 
-    template(typename Receiver)
-      (requires receiver<Receiver>)
-    friend auto tag_invoke(tag_t<connect>, const type& s, Receiver&& r)
-        -> connect_result_t<
-            schedule_at_result_t<std::decay_t<
-                get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
-                const TimePoint&>,
-            Receiver> {
-      auto scheduler = get_scheduler(std::as_const(r));
-      return connect(schedule_at(scheduler, std::as_const(s.time_point_)), (Receiver&&) r);
-    }
+  explicit type(TimePoint tp) : time_point_(tp) {}
 
-    TimePoint time_point_;
-  };
-} // namespace _schedule_at
+private:
+  friend _fn;
+
+  template(typename Receiver)(requires receiver<Receiver>) friend auto tag_invoke(
+      tag_t<connect>, const type& s, Receiver&& r)
+      -> connect_result_t<
+          schedule_at_result_t<
+              std::decay_t<
+                  get_scheduler_result_t<const remove_cvref_t<Receiver>&>>&,
+              const TimePoint&>,
+          Receiver> {
+    auto scheduler = get_scheduler(std::as_const(r));
+    return connect(
+        schedule_at(scheduler, std::as_const(s.time_point_)), (Receiver &&) r);
+  }
+
+  TimePoint time_point_;
+};
+}  // namespace _schedule_at
 using _schedule_at::schedule_at;
 
 namespace _now {
-  inline const struct _fn {
-  private:
-    template <typename TimeScheduler>
-    using _now_member_result_t =
-      decltype(UNIFEX_DECLVAL(TimeScheduler).now());
-    template <typename TimeScheduler>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, TimeScheduler>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote1<_now_member_result_t>>::template apply<TimeScheduler>;
-  public:
-    template(typename TimeScheduler)
-      (requires tag_invocable<_fn, TimeScheduler>)
-    constexpr auto operator()(TimeScheduler&& s) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler>)
-        -> _result_t<TimeScheduler> {
-      return tag_invoke(*this, (TimeScheduler &&) s);
-    }
+inline const struct _fn {
+private:
+  template <typename TimeScheduler>
+  using _now_member_result_t = decltype(UNIFEX_DECLVAL(TimeScheduler).now());
+  template <typename TimeScheduler>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, TimeScheduler>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote1<_now_member_result_t>>::template apply<TimeScheduler>;
 
-    template(typename TimeScheduler)
-      (requires (!tag_invocable<_fn, TimeScheduler>))
-    constexpr auto operator()(TimeScheduler&& s) const noexcept(
-        noexcept(static_cast<TimeScheduler&&>(s).now()))
-        -> _result_t<TimeScheduler> {
-      return static_cast<TimeScheduler&&>(s).now();
-    }
-  } now {};
-} // namespace _now
+public:
+  template(typename TimeScheduler)(
+      requires tag_invocable<_fn, TimeScheduler>) constexpr auto
+  operator()(TimeScheduler&& s) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, TimeScheduler>)
+          -> _result_t<TimeScheduler> {
+    return tag_invoke(*this, (TimeScheduler &&) s);
+  }
+
+  template(typename TimeScheduler)(
+      requires(!tag_invocable<_fn, TimeScheduler>)) constexpr auto
+  operator()(TimeScheduler&& s) const
+      noexcept(noexcept(static_cast<TimeScheduler&&>(s).now()))
+          -> _result_t<TimeScheduler> {
+    return static_cast<TimeScheduler&&>(s).now();
+  }
+} now{};
+}  // namespace _now
 using _now::now;
 
 namespace _current {
 #if !UNIFEX_NO_COROUTINES
-  template <typename Scheduler>
-  struct _awaiter {
-    Scheduler sched_;
+template <typename Scheduler>
+struct _awaiter {
+  Scheduler sched_;
 
-    static constexpr bool await_ready() noexcept {
-      return true;
-    }
-    void await_suspend(coro::coroutine_handle<>) const noexcept {
-    }
-    Scheduler await_resume() {
-      return (Scheduler&&) sched_;
-    }
-    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
-      return blocking_kind::always_inline;
-    }
-  };
-  template <typename Scheduler>
-  _awaiter(Scheduler) -> _awaiter<Scheduler>;
-#endif // !UNIFEX_NO_COROUTINES
+  static constexpr bool await_ready() noexcept { return true; }
+  void await_suspend(coro::coroutine_handle<>) const noexcept {}
+  Scheduler await_resume() { return (Scheduler &&) sched_; }
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
+    return blocking_kind::always_inline;
+  }
+};
+template <typename Scheduler>
+_awaiter(Scheduler) -> _awaiter<Scheduler>;
+#endif  // !UNIFEX_NO_COROUTINES
 
-  struct _scheduler {
+struct _scheduler {
 #if !UNIFEX_NO_COROUTINES
-  private:
-    // `co_await current_scheduler()` to fetch a coroutine's current scheduler.
-    template (typename Tag, typename Promise)
-      (requires same_as<Tag, tag_t<await_transform>> AND scheduler_provider<Promise&>)
-    friend auto tag_invoke(Tag, Promise& promise, _scheduler) noexcept {
-      return _awaiter{get_scheduler(promise)};
-    }
-#endif // !UNIFEX_NO_COROUTINES
+private:
+  // `co_await current_scheduler()` to fetch a coroutine's current scheduler.
+  template(typename Tag, typename Promise)(
+      requires same_as<Tag, tag_t<await_transform>> AND scheduler_provider<
+          Promise&>) friend auto tag_invoke(Tag, Promise& promise, _scheduler) noexcept {
+    return _awaiter{get_scheduler(promise)};
+  }
+#endif  // !UNIFEX_NO_COROUTINES
 
-  public:
-    auto schedule() const noexcept {
-        return unifex::schedule();
-    }
-    template <typename Duration>
-    auto schedule_after(Duration d) const {
-        return unifex::schedule_after(std::move(d));
-    }
-    template <typename TimePoint>
-    auto schedule_at(TimePoint tp) const {
-        return unifex::schedule_at(std::move(tp));
-    }
-    friend constexpr bool operator==(_scheduler, _scheduler) noexcept {
-        return true;
-    }
-    friend constexpr bool operator!=(_scheduler, _scheduler) noexcept {
-        return false;
-    }
-    constexpr _scheduler operator()() const noexcept {
-      return {};
-    }
-  };
-} // namespace _current
-inline constexpr _current::_scheduler current_scheduler {};
+public:
+  auto schedule() const noexcept {
+    return unifex::schedule();
+  }
+  template <typename Duration>
+  auto schedule_after(Duration d) const {
+    return unifex::schedule_after(std::move(d));
+  }
+  template <typename TimePoint>
+  auto schedule_at(TimePoint tp) const {
+    return unifex::schedule_at(std::move(tp));
+  }
+  friend constexpr bool operator==(_scheduler, _scheduler) noexcept {
+    return true;
+  }
+  friend constexpr bool operator!=(_scheduler, _scheduler) noexcept {
+    return false;
+  }
+  constexpr _scheduler operator()() const noexcept {
+    return {};
+  }
+};
+}  // namespace _current
+inline constexpr _current::_scheduler current_scheduler{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/scope_guard.hpp
+++ b/include/unifex/scope_guard.hpp
@@ -32,16 +32,11 @@ private:
   bool released_ = false;
 
 public:
-  scope_guard(Func&& func) noexcept
-      : func_((Func &&) func) {}
+  scope_guard(Func&& func) noexcept : func_((Func &&) func) {}
 
-  ~scope_guard() {
-    reset();
-  }
+  ~scope_guard() { reset(); }
 
-  void release() noexcept {
-    released_ = true;
-  }
+  void release() noexcept { released_ = true; }
 
   void reset() noexcept {
     static_assert(noexcept(((Func &&) func_)()));
@@ -54,6 +49,6 @@ public:
 template <typename Func>
 scope_guard(Func&& func) -> scope_guard<Func>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/detail/unifex_fwd.hpp>
+#include <unifex/receiver_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/receiver_concepts.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 
 #if !UNIFEX_NO_COROUTINES
-#include <unifex/coroutine_concepts.hpp>
+#  include <unifex/coroutine_concepts.hpp>
 #endif
 
 #include <exception>
@@ -41,284 +41,277 @@ struct sender_traits;
 
 /// \cond
 namespace detail {
-  template <template <template <typename...> class, template <typename...> class> class>
-  struct _has_value_types;
+template <template <template <typename...> class, template <typename...> class>
+          class>
+struct _has_value_types;
 
-  template <template <template <typename...> class> class>
-  struct _has_error_types;
+template <template <template <typename...> class> class>
+struct _has_error_types;
 
-  template <typename S>
-  UNIFEX_CONCEPT_FRAGMENT(  //
-    _has_sender_types_impl, //
-      requires() (          //
-        typename (std::bool_constant<S::sends_done>),
-        typename (_has_value_types<S::template value_types>),
-        typename (_has_error_types<S::template error_types>)
-      ));
-  template <typename S>
-  UNIFEX_CONCEPT        //
-    _has_sender_types = //
-      UNIFEX_FRAGMENT(detail::_has_sender_types_impl, S);
+template <typename S>
+UNIFEX_CONCEPT_FRAGMENT(     //
+    _has_sender_types_impl,  //
+    requires()(              //
+        typename(std::bool_constant<S::sends_done>),
+        typename(_has_value_types<S::template value_types>),
+        typename(_has_error_types<S::template error_types>)));
+template <typename S>
+UNIFEX_CONCEPT           //
+    _has_sender_types =  //
+    UNIFEX_FRAGMENT(detail::_has_sender_types_impl, S);
 
-  template <typename S>
-  UNIFEX_CONCEPT_FRAGMENT(  //
-    _has_bulk_sender_types_impl, //
-      requires() (          //
-        typename (std::bool_constant<S::sends_done>),
-        typename (_has_value_types<S::template value_types>),
-        typename (_has_value_types<S::template next_types>),
-        typename (_has_error_types<S::template error_types>)
-      ));
-  template <typename S>
-  UNIFEX_CONCEPT        //
-    _has_bulk_sender_types = //
-      UNIFEX_FRAGMENT(detail::_has_bulk_sender_types_impl, S);
+template <typename S>
+UNIFEX_CONCEPT_FRAGMENT(          //
+    _has_bulk_sender_types_impl,  //
+    requires()(                   //
+        typename(std::bool_constant<S::sends_done>),
+        typename(_has_value_types<S::template value_types>),
+        typename(_has_value_types<S::template next_types>),
+        typename(_has_error_types<S::template error_types>)));
+template <typename S>
+UNIFEX_CONCEPT                //
+    _has_bulk_sender_types =  //
+    UNIFEX_FRAGMENT(detail::_has_bulk_sender_types_impl, S);
 
-  struct _void_sender_traits {
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+struct _void_sender_traits {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
-  };
+  static constexpr bool sends_done = true;
+};
 
-  template <typename S>
-  struct _typed_sender_traits {
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = typename S::template value_types<Variant, Tuple>;
+template <typename S>
+struct _typed_sender_traits {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename S::template value_types<Variant, Tuple>;
 
-    template <template <typename...> class Variant>
-    using error_types = typename S::template error_types<Variant>;
+  template <template <typename...> class Variant>
+  using error_types = typename S::template error_types<Variant>;
 
-    static constexpr bool sends_done = S::sends_done;
-  };
+  static constexpr bool sends_done = S::sends_done;
+};
 
-  template <typename S>
-  struct _typed_bulk_sender_traits : _typed_sender_traits<S> {
-    template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
-    using next_types = typename S::template next_types<Variant, Tuple>;
-  };
+template <typename S>
+struct _typed_bulk_sender_traits : _typed_sender_traits<S> {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using next_types = typename S::template next_types<Variant, Tuple>;
+};
 
-  struct _no_sender_traits {
-    using _unspecialized = void;
-  };
+struct _no_sender_traits {
+  using _unspecialized = void;
+};
 
 // Workaround for unknown MSVC (19.28.29333) bug
 #ifdef _MSC_VER
-  template <typename S>
-  inline constexpr bool _has_sender_traits =
-      !std::is_base_of_v<_no_sender_traits, sender_traits<S>>;
+template <typename S>
+inline constexpr bool _has_sender_traits =
+    !std::is_base_of_v<_no_sender_traits, sender_traits<S>>;
 #elif UNIFEX_CXX_CONCEPTS
-  template <typename S>
-  concept _has_sender_traits =
-      !requires {
-        typename sender_traits<S>::_unspecialized;
-      };
+template <typename S>
+concept _has_sender_traits = !requires {
+  typename sender_traits<S>::_unspecialized;
+};
 #else
-  template <typename S>
-  UNIFEX_CONCEPT_FRAGMENT(  //
-    _not_has_sender_traits, //
-      requires() (          //
-        typename (typename sender_traits<S>::_unspecialized)
-      ));
-  template <typename S>
-  UNIFEX_CONCEPT         //
-    _has_sender_traits = //
-      (!UNIFEX_FRAGMENT(detail::_not_has_sender_traits, S));
+template <typename S>
+UNIFEX_CONCEPT_FRAGMENT(     //
+    _not_has_sender_traits,  //
+    requires()(              //
+        typename(typename sender_traits<S>::_unspecialized)));
+template <typename S>
+UNIFEX_CONCEPT            //
+    _has_sender_traits =  //
+    (!UNIFEX_FRAGMENT(detail::_not_has_sender_traits, S));
 #endif
 
-  template <typename S>
-  constexpr auto _select_sender_traits() noexcept {
-    if constexpr (_has_bulk_sender_types<S>) {
-      return _typed_bulk_sender_traits<S>{};
-    } else if constexpr (_has_sender_types<S>) {
-      return _typed_sender_traits<S>{};
-    } else if constexpr (std::is_base_of_v<sender_base, S>) {
-      return sender_base{};
-    } else {
-      return _no_sender_traits{};
-    }
+template <typename S>
+constexpr auto _select_sender_traits() noexcept {
+  if constexpr (_has_bulk_sender_types<S>) {
+    return _typed_bulk_sender_traits<S>{};
+  } else if constexpr (_has_sender_types<S>) {
+    return _typed_sender_traits<S>{};
+  } else if constexpr (std::is_base_of_v<sender_base, S>) {
+    return sender_base{};
+  } else {
+    return _no_sender_traits{};
   }
-} // namespace detail
+}
+}  // namespace detail
 
 template <typename S>
 struct sender_traits : decltype(detail::_select_sender_traits<S>()) {};
 
 template <typename S>
-UNIFEX_CONCEPT //
-  sender =     //
-    move_constructible<remove_cvref_t<S>> &&
-    detail::_has_sender_traits<remove_cvref_t<S>>;
+UNIFEX_CONCEPT  //
+    sender =    //
+    move_constructible<remove_cvref_t<S>>&&
+        detail::_has_sender_traits<remove_cvref_t<S>>;
 
 template <typename S>
-UNIFEX_CONCEPT   //
-  typed_sender = //
-    sender<S> && //
-    detail::_has_sender_types<sender_traits<remove_cvref_t<S>>>;
+UNIFEX_CONCEPT      //
+    typed_sender =  //
+    sender<S>&&     //
+        detail::_has_sender_types<sender_traits<remove_cvref_t<S>>>;
 
 template <typename S>
-UNIFEX_CONCEPT        //
-  typed_bulk_sender = //
-    sender<S> &&      //
-    detail::_has_bulk_sender_types<sender_traits<remove_cvref_t<S>>>;
+UNIFEX_CONCEPT           //
+    typed_bulk_sender =  //
+    sender<S>&&          //
+        detail::_has_bulk_sender_types<sender_traits<remove_cvref_t<S>>>;
 
 namespace _start_cpo {
-  inline const struct _fn {
-    template(typename Operation)
-      (requires tag_invocable<_fn, Operation&>)
-    auto operator()(Operation& op) const noexcept
-        -> tag_invoke_result_t<_fn, Operation&> {
-      static_assert(
-          is_nothrow_tag_invocable_v<_fn, Operation&>,
-          "start() customisation must be noexcept");
-      return unifex::tag_invoke(_fn{}, op);
-    }
-    template(typename Operation)
-      (requires (!tag_invocable<_fn, Operation&>))
-    auto operator()(Operation& op) const noexcept -> decltype(op.start()) {
-      static_assert(
-          noexcept(op.start()),
-          "start() customisation must be noexcept");
-      return op.start();
-    }
-  } start{};
-} // namespace _start_cpo
+inline const struct _fn {
+  template(typename Operation)(requires tag_invocable<_fn, Operation&>) auto
+  operator()(Operation& op) const noexcept
+      -> tag_invoke_result_t<_fn, Operation&> {
+    static_assert(
+        is_nothrow_tag_invocable_v<_fn, Operation&>,
+        "start() customisation must be noexcept");
+    return unifex::tag_invoke(_fn{}, op);
+  }
+  template(typename Operation)(requires(!tag_invocable<_fn, Operation&>)) auto
+  operator()(Operation& op) const noexcept -> decltype(op.start()) {
+    static_assert(
+        noexcept(op.start()), "start() customisation must be noexcept");
+    return op.start();
+  }
+} start{};
+}  // namespace _start_cpo
 using _start_cpo::start;
 
 namespace _connect {
-  template <typename Sender, typename Receiver>
-  using _member_connect_result_t =
-      decltype((UNIFEX_DECLVAL(Sender&&)).connect(
-          UNIFEX_DECLVAL(Receiver&&)));
+template <typename Sender, typename Receiver>
+using _member_connect_result_t =
+    decltype((UNIFEX_DECLVAL(Sender &&)).connect(UNIFEX_DECLVAL(Receiver &&)));
 
-  template <typename Sender, typename Receiver>
-  UNIFEX_CONCEPT_FRAGMENT( //
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT_FRAGMENT(   //
     _has_member_connect_,  //
-      requires() (         //
-        typename(_member_connect_result_t<Sender, Receiver>)
-      ));
+    requires()(            //
+        typename(_member_connect_result_t<Sender, Receiver>)));
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT              //
+    _with_member_connect =  //
+    sender<Sender>&&
+        UNIFEX_FRAGMENT(_connect::_has_member_connect_, Sender, Receiver);
+
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT          //
+    _with_tag_invoke =  //
+    sender<Sender>&& tag_invocable<_cpo::_fn, Sender, Receiver>;
+
+namespace _cpo {
+struct _fn {
+private:
   template <typename Sender, typename Receiver>
-  UNIFEX_CONCEPT //
-    _with_member_connect = //
-      sender<Sender> &&
-      UNIFEX_FRAGMENT(_connect::_has_member_connect_, Sender, Receiver);
+  static auto _select() {
+    if constexpr (_with_tag_invoke<Sender, Receiver>) {
+      return meta_tag_invoke_result<_fn>{};
+    } else if constexpr (_with_member_connect<Sender, Receiver>) {
+      return meta_quote2<_member_connect_result_t>{};
+    } else {
+      return type_always<void>{};
+    }
+  }
 
   template <typename Sender, typename Receiver>
-  UNIFEX_CONCEPT //
-    _with_tag_invoke = //
-      sender<Sender> && tag_invocable<_cpo::_fn, Sender, Receiver>;
+  using _result_t = typename decltype(_fn::_select<Sender, Receiver>())::
+      template apply<Sender, Receiver>;
 
-  namespace _cpo {
-    struct _fn {
-     private:
-      template <typename Sender, typename Receiver>
-      static auto _select() {
-        if constexpr (_with_tag_invoke<Sender, Receiver>) {
-          return meta_tag_invoke_result<_fn>{};
-        } else if constexpr (_with_member_connect<Sender, Receiver>) {
-          return meta_quote2<_member_connect_result_t>{};
-        } else {
-          return type_always<void>{};
-        }
-      }
-
-      template <typename Sender, typename Receiver>
-      using _result_t = typename decltype(_fn::_select<Sender, Receiver>())
-          ::template apply<Sender, Receiver>;
-
-     public:
-      template(typename Sender, typename Receiver)
-        (requires receiver<Receiver> AND
-            _with_tag_invoke<Sender, Receiver>)
-      auto operator()(Sender&& s, Receiver&& r) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Receiver>) ->
-          _result_t<Sender, Receiver> {
-        return unifex::tag_invoke(_fn{}, (Sender &&) s, (Receiver &&) r);
-      }
-      template(typename Sender, typename Receiver)
-        (requires receiver<Receiver> AND
-            (!_with_tag_invoke<Sender, Receiver>) AND
-            _with_member_connect<Sender, Receiver>)
-      auto operator()(Sender&& s, Receiver&& r) const
-          noexcept(noexcept(((Sender &&) s).connect((Receiver &&) r))) ->
-          _result_t<Sender, Receiver> {
-        return ((Sender &&) s).connect((Receiver &&) r);
-      }
-    };
-  } // namespace _cpo
-} // namespace _connect
-inline const _connect::_cpo::_fn connect {};
+public:
+  template(typename Sender, typename Receiver)(
+      requires receiver<Receiver> AND _with_tag_invoke<Sender, Receiver>) auto
+  operator()(Sender&& s, Receiver&& r) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Receiver>)
+          -> _result_t<Sender, Receiver> {
+    return unifex::tag_invoke(_fn{}, (Sender &&) s, (Receiver &&) r);
+  }
+  template(typename Sender, typename Receiver)(
+      requires receiver<Receiver> AND(!_with_tag_invoke<Sender, Receiver>)
+          AND _with_member_connect<Sender, Receiver>) auto
+  operator()(Sender&& s, Receiver&& r) const
+      noexcept(noexcept(((Sender &&) s).connect((Receiver &&) r)))
+          -> _result_t<Sender, Receiver> {
+    return ((Sender &&) s).connect((Receiver &&) r);
+  }
+};
+}  // namespace _cpo
+}  // namespace _connect
+inline const _connect::_cpo::_fn connect{};
 
 #if UNIFEX_CXX_CONCEPTS
 // Define the sender_to concept without macros for
 // improved diagnostics:
 template <typename Sender, typename Receiver>
-concept //
-  sender_to = //
-    sender<Sender> &&
-    receiver<Receiver> &&
-    requires (Sender&& s, Receiver&& r) {
-      connect((Sender&&) s, (Receiver&&) r);
-    };
+concept          //
+    sender_to =  //
+    sender<Sender> && receiver<Receiver> && requires(Sender&& s, Receiver&& r) {
+  connect((Sender &&) s, (Receiver &&) r);
+};
 #else
 template <typename Sender, typename Receiver>
-UNIFEX_CONCEPT_FRAGMENT( //
-  _sender_to, //
-    requires (Sender&& s, Receiver&& r) ( //
-      connect((Sender&&) s, (Receiver&&) r)
-    ));
+UNIFEX_CONCEPT_FRAGMENT(                 //
+    _sender_to,                          //
+    requires(Sender&& s, Receiver&& r)(  //
+        connect((Sender &&) s, (Receiver &&) r)));
 template <typename Sender, typename Receiver>
-UNIFEX_CONCEPT //
-  sender_to =
-    sender<Sender> &&
-    receiver<Receiver> &&
-    UNIFEX_FRAGMENT(_sender_to, Sender, Receiver);
+UNIFEX_CONCEPT  //
+    sender_to = sender<Sender>&& receiver<Receiver>&&
+        UNIFEX_FRAGMENT(_sender_to, Sender, Receiver);
 #endif
 
 template <typename Sender, typename Receiver>
 using connect_result_t =
-  decltype(connect(UNIFEX_DECLVAL(Sender), UNIFEX_DECLVAL(Receiver)));
+    decltype(connect(UNIFEX_DECLVAL(Sender), UNIFEX_DECLVAL(Receiver)));
 
 /// \cond
 template <typename Sender, typename Receiver>
-using operation_t [[deprecated("Use connect_result_t instead of operation_t")]] =
-    connect_result_t<Sender, Receiver>;
+using operation_t
+    [[deprecated("Use connect_result_t instead of operation_t")]] =
+        connect_result_t<Sender, Receiver>;
 
 template <typename Sender, typename Receiver>
-[[deprecated("Use sender_to instead of is_connectable_v")]]
-inline constexpr bool is_connectable_v =
-  is_callable_v<decltype(connect), Sender, Receiver>;
+[[deprecated(
+    "Use sender_to instead of is_connectable_v")]] inline constexpr bool
+    is_connectable_v = is_callable_v<decltype(connect), Sender, Receiver>;
 
 template <typename Sender, typename Receiver>
 using is_connectable [[deprecated]] =
-  is_callable<decltype(connect), Sender, Receiver>;
+    is_callable<decltype(connect), Sender, Receiver>;
 /// \endcond
 
 template <typename Sender, typename Receiver>
 inline constexpr bool is_nothrow_connectable_v =
-  is_nothrow_callable_v<decltype(connect), Sender, Receiver>;
+    is_nothrow_callable_v<decltype(connect), Sender, Receiver>;
 
 template <typename Sender, typename Receiver>
-using is_nothrow_connectable = is_nothrow_callable<decltype(connect), Sender, Receiver>;
+using is_nothrow_connectable =
+    is_nothrow_callable<decltype(connect), Sender, Receiver>;
 
 template <
     typename Sender,
-    template <typename...> class Variant,
-    template <typename...> class Tuple>
+    template <typename...>
+    class Variant,
+    template <typename...>
+    class Tuple>
 using sender_value_types_t =
     typename sender_traits<Sender>::template value_types<Variant, Tuple>;
 
-template <
-    typename Sender,
-    template <typename...> class Variant>
+template <typename Sender, template <typename...> class Variant>
 using sender_error_types_t =
     typename sender_traits<Sender>::template error_types<Variant>;
 
@@ -351,22 +344,24 @@ private:
   struct impl {
     using type = void;
   };
+
 public:
   using type = impl;
 };
 
 template <typename Sender>
 using sender_single_value_return_type_t =
-    typename sender_value_types_t<Sender, single_overload, single_value_type>::type::type;
+    typename sender_value_types_t<Sender, single_overload, single_value_type>::
+        type::type;
 
 template <typename Sender>
-using sender_single_value_result_t =
-    non_void_t<wrap_reference_t<decay_rvalue_t<sender_single_value_return_type_t<Sender>>>>;
+using sender_single_value_result_t = non_void_t<wrap_reference_t<
+    decay_rvalue_t<sender_single_value_return_type_t<Sender>>>>;
 
 template <typename Sender>
 constexpr bool is_sender_nofail_v =
     sender_error_types_t<Sender, is_empty_list>::value;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -22,10 +22,10 @@
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
 #include <unifex/std_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -33,421 +33,387 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _seq
-  {
-    constexpr blocking_kind _blocking_kind(
-        blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
-      if (predBlocking == blocking_kind::never) {
-        return blocking_kind::never;
-      } else if (
-          predBlocking == blocking_kind::always_inline &&
-          succBlocking == blocking_kind::always_inline) {
-        return blocking_kind::always_inline;
-      } else if (
-          (predBlocking == blocking_kind::always_inline ||
-          predBlocking == blocking_kind::always) &&
-          (succBlocking == blocking_kind::always_inline ||
-          succBlocking == blocking_kind::always)) {
-        return blocking_kind::always;
-      } else {
-        return blocking_kind::maybe;
+namespace unifex {
+namespace _seq {
+constexpr blocking_kind _blocking_kind(
+    blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
+  if (predBlocking == blocking_kind::never) {
+    return blocking_kind::never;
+  } else if (
+      predBlocking == blocking_kind::always_inline &&
+      succBlocking == blocking_kind::always_inline) {
+    return blocking_kind::always_inline;
+  } else if (
+      (predBlocking == blocking_kind::always_inline ||
+       predBlocking == blocking_kind::always) &&
+      (succBlocking == blocking_kind::always_inline ||
+       succBlocking == blocking_kind::always)) {
+    return blocking_kind::always;
+  } else {
+    return blocking_kind::maybe;
+  }
+}
+
+template <typename Predecessor, typename Successor, typename Receiver>
+struct _op {
+  class type;
+};
+template <typename Predecessor, typename Successor, typename Receiver>
+using operation =
+    typename _op<Predecessor, Successor, remove_cvref_t<Receiver>>::type;
+
+template <typename Predecessor, typename Successor, typename Receiver>
+struct _successor_receiver {
+  class type;
+};
+template <typename Predecessor, typename Successor, typename Receiver>
+using successor_receiver = typename _successor_receiver<
+    Predecessor,
+    Successor,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename Predecessor, typename Successor, typename Receiver>
+class _successor_receiver<Predecessor, Successor, Receiver>::type final {
+  using successor_receiver = type;
+  using operation_type = operation<Predecessor, Successor, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+private:
+  template(typename CPO, typename R, typename... Args)(
+      requires is_receiver_cpo_v<CPO> AND same_as<R, successor_receiver> AND is_callable_v<
+          CPO,
+          Receiver,
+          Args...>) friend auto tag_invoke(CPO cpo, R&& r, Args&&... args) noexcept(is_nothrow_callable_v<CPO, Receiver, Args...>)
+      -> callable_result_t<CPO, Receiver, Args...> {
+    return static_cast<CPO&&>(cpo)(
+        r.get_receiver_rvalue(), static_cast<Args&&>(args)...);
+  }
+
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, successor_receiver> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_const_receiver());
+  }
+
+  template <typename Func>
+  friend void tag_invoke(
+      tag_t<visit_continuations>, const successor_receiver& r, Func&& func) {
+    std::invoke(func, r.get_const_receiver());
+  }
+
+  Receiver&& get_receiver_rvalue() noexcept {
+    return static_cast<Receiver&&>(op_->receiver_);
+  }
+
+  const Receiver& get_const_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <typename Predecessor, typename Successor, typename Receiver>
+struct _predecessor_receiver {
+  class type;
+};
+template <typename Predecessor, typename Successor, typename Receiver>
+using predecessor_receiver = typename _predecessor_receiver<
+    Predecessor,
+    Successor,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename Predecessor, typename Successor, typename Receiver>
+class _predecessor_receiver<Predecessor, Successor, Receiver>::type final {
+  using predecessor_receiver = type;
+  using operation_type = operation<Predecessor, Successor, Receiver>;
+
+public:
+  explicit type(operation_type* op) noexcept : op_(op) {}
+
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
+
+  void set_value() && noexcept {
+    // Take a copy of op_ before destroying predOp_ as this may end up
+    // destroying *this.
+    using successor_receiver_t =
+        successor_receiver<Predecessor, Successor, Receiver>;
+
+    auto* op = op_;
+    op->status_ = operation_type::status::empty;
+    unifex::deactivate_union_member(op->predOp_);
+    if constexpr (is_nothrow_connectable_v<Successor, successor_receiver_t>) {
+      unifex::activate_union_member_with(op->succOp_, [&]() noexcept {
+        return unifex::connect(
+            static_cast<Successor&&>(op->successor_), successor_receiver_t{op});
+      });
+      op->status_ = operation_type::status::successor_operation_constructed;
+      unifex::start(op->succOp_.get());
+    } else {
+      UNIFEX_TRY {
+        unifex::activate_union_member_with(op->succOp_, [&] {
+          return unifex::connect(
+              static_cast<Successor&&>(op->successor_),
+              successor_receiver_t{op});
+        });
+        op->status_ = operation_type::status::successor_operation_constructed;
+        unifex::start(op->succOp_.get());
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(
+            static_cast<Receiver&&>(op->receiver_), std::current_exception());
       }
     }
+  }
 
-    template <typename Predecessor, typename Successor, typename Receiver>
-    struct _op {
-      class type;
-    };
-    template <typename Predecessor, typename Successor, typename Receiver>
-    using operation = typename _op<
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
+    unifex::set_error(
+        static_cast<Receiver&&>(op_->receiver_), static_cast<Error&&>(error));
+  }
+
+  void set_done() && noexcept {
+    unifex::set_done(static_cast<Receiver&&>(op_->receiver_));
+  }
+
+private:
+  template(typename CPO, typename R)(
+      requires is_receiver_query_cpo_v<CPO> AND same_as<R, predecessor_receiver> AND is_callable_v<
+          CPO,
+          const Receiver&>) friend auto tag_invoke(CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return static_cast<CPO&&>(cpo)(r.get_const_receiver());
+  }
+
+  template <typename Func>
+  friend void tag_invoke(
+      tag_t<visit_continuations>, const predecessor_receiver& r, Func&& func) {
+    std::invoke(func, r.get_const_receiver());
+  }
+
+  const Receiver& get_const_receiver() const noexcept { return op_->receiver_; }
+
+  operation_type* op_;
+};
+
+template <typename Predecessor, typename Successor, typename Receiver>
+class _op<Predecessor, Successor, Receiver>::type {
+  using operation = type;
+
+public:
+  template <typename Successor2, typename Receiver2>
+  explicit type(
+      Predecessor&& predecessor, Successor2&& successor, Receiver2&& receiver)
+    : successor_(static_cast<Successor2&&>(successor))
+    , receiver_(static_cast<Receiver&&>(receiver))
+    , status_(status::predecessor_operation_constructed) {
+    unifex::activate_union_member_with(predOp_, [&] {
+      return unifex::connect(
+          static_cast<Predecessor&&>(predecessor),
+          predecessor_receiver<Predecessor, Successor, Receiver>{this});
+    });
+  }
+
+  ~type() {
+    switch (status_) {
+      case status::predecessor_operation_constructed:
+        unifex::deactivate_union_member(predOp_);
+        break;
+      case status::successor_operation_constructed:
+        unifex::deactivate_union_member(succOp_);
+        break;
+      case status::empty: break;
+    }
+  }
+
+  void start() & noexcept {
+    UNIFEX_ASSERT(status_ == status::predecessor_operation_constructed);
+    unifex::start(predOp_.get());
+  }
+
+private:
+  friend predecessor_receiver<Predecessor, Successor, Receiver>;
+  friend successor_receiver<Predecessor, Successor, Receiver>;
+
+  Successor successor_;
+  Receiver receiver_;
+  enum class status {
+    empty,
+    predecessor_operation_constructed,
+    successor_operation_constructed
+  };
+  status status_;
+  union {
+    manual_lifetime<connect_result_t<
         Predecessor,
+        predecessor_receiver<Predecessor, Successor, Receiver>>>
+        predOp_;
+    manual_lifetime<connect_result_t<
         Successor,
-        remove_cvref_t<Receiver>>::type;
+        successor_receiver<Predecessor, Successor, Receiver>>>
+        succOp_;
+  };
+};
 
-    template <typename Predecessor, typename Successor, typename Receiver>
-    struct _successor_receiver {
-      class type;
-    };
-    template <typename Predecessor, typename Successor, typename Receiver>
-    using successor_receiver =
-        typename _successor_receiver<
-            Predecessor,
-            Successor,
-            remove_cvref_t<Receiver>>::type;
+template <typename Predecessor, typename Successor>
+struct _sndr {
+  struct type;
+};
+template <typename Predecessor, typename Successor>
+using _sender =
+    typename _sndr<remove_cvref_t<Predecessor>, remove_cvref_t<Successor>>::
+        type;
 
-    template <typename Predecessor, typename Successor, typename Receiver>
-    class _successor_receiver<Predecessor, Successor, Receiver>::type final {
-      using successor_receiver = type;
-      using operation_type = operation<Predecessor, Successor, Receiver>;
+template <typename Predecessor, typename Successor>
+struct _sndr<Predecessor, Successor>::type {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Successor, Variant, Tuple>;
 
-    public:
-      explicit type(operation_type* op) noexcept
-        : op_(op) {}
+  template <template <typename...> class Variant>
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      sender_error_types_t<Successor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done ||
+      sender_traits<Successor>::sends_done;
 
-    private:
-      template(typename CPO, typename R, typename... Args)
-          (requires
-              is_receiver_cpo_v<CPO> AND
-              same_as<R, successor_receiver> AND
-              is_callable_v<CPO, Receiver, Args...>)
-      friend auto tag_invoke(
-          CPO cpo,
-          R&& r,
-          Args&&... args) noexcept(is_nothrow_callable_v<
-                                           CPO,
-                                           Receiver,
-                                           Args...>)
-          -> callable_result_t<CPO, Receiver, Args...> {
-        return static_cast<CPO&&>(cpo)(
-            r.get_receiver_rvalue(), static_cast<Args&&>(args)...);
-      }
-
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, successor_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const R& r) noexcept(is_nothrow_callable_v<
-                                           CPO,
-                                           const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_const_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const successor_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.get_const_receiver());
-      }
-
-      Receiver&& get_receiver_rvalue() noexcept {
-        return static_cast<Receiver&&>(op_->receiver_);
-      }
-
-      const Receiver& get_const_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <typename Predecessor, typename Successor, typename Receiver>
-    struct _predecessor_receiver {
-      class type;
-    };
-    template <typename Predecessor, typename Successor, typename Receiver>
-    using predecessor_receiver =
-        typename _predecessor_receiver<
-            Predecessor,
-            Successor,
-            remove_cvref_t<Receiver>>::type;
-
-    template <typename Predecessor, typename Successor, typename Receiver>
-    class _predecessor_receiver<Predecessor, Successor, Receiver>::type final {
-      using predecessor_receiver = type;
-      using operation_type = operation<Predecessor, Successor, Receiver>;
-
-    public:
-      explicit type(operation_type* op) noexcept
-        : op_(op) {}
-
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
-
-      void set_value() && noexcept {
-        // Take a copy of op_ before destroying predOp_ as this may end up
-        // destroying *this.
-        using successor_receiver_t =
-            successor_receiver<Predecessor, Successor, Receiver>;
-
-        auto* op = op_;
-        op->status_ = operation_type::status::empty;
-        unifex::deactivate_union_member(op->predOp_);
-        if constexpr (is_nothrow_connectable_v<Successor, successor_receiver_t>) {
-          unifex::activate_union_member_with(op->succOp_, [&]() noexcept {
-            return unifex::connect(
-                static_cast<Successor&&>(op->successor_), successor_receiver_t{op});
-          });
-          op->status_ = operation_type::status::successor_operation_constructed;
-          unifex::start(op->succOp_.get());
-        } else {
-          UNIFEX_TRY {
-            unifex::activate_union_member_with(op->succOp_, [&] {
-              return unifex::connect(
-                  static_cast<Successor&&>(op->successor_), successor_receiver_t{op});
-            });
-            op->status_ = operation_type::status::successor_operation_constructed;
-            unifex::start(op->succOp_.get());
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                static_cast<Receiver&&>(op->receiver_),
-                std::current_exception());
-          }
-        }
-      }
-
-      template(typename Error)
-          (requires receiver<Receiver, Error>)
-      void set_error(Error&& error) && noexcept {
-        unifex::set_error(
-            static_cast<Receiver&&>(op_->receiver_),
-            static_cast<Error&&>(error));
-      }
-
-      void set_done() && noexcept {
-        unifex::set_done(static_cast<Receiver&&>(op_->receiver_));
-      }
-
-    private:
-      template(typename CPO, typename R)
-          (requires is_receiver_query_cpo_v<CPO> AND
-            same_as<R, predecessor_receiver> AND
-            is_callable_v<CPO, const Receiver&>)
-      friend auto tag_invoke(
-          CPO cpo,
-          const R& r) noexcept(is_nothrow_callable_v<
-                                           CPO,
-                                           const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return static_cast<CPO&&>(cpo)(r.get_const_receiver());
-      }
-
-      template <typename Func>
-      friend void tag_invoke(
-          tag_t<visit_continuations>,
-          const predecessor_receiver& r,
-          Func&& func) {
-        std::invoke(func, r.get_const_receiver());
-      }
-
-      const Receiver& get_const_receiver() const noexcept {
-        return op_->receiver_;
-      }
-
-      operation_type* op_;
-    };
-
-    template <typename Predecessor, typename Successor, typename Receiver>
-    class _op<Predecessor, Successor, Receiver>::type {
-      using operation = type;
-    public:
-      template <typename Successor2, typename Receiver2>
-      explicit type(
-          Predecessor&& predecessor,
-          Successor2&& successor,
-          Receiver2&& receiver)
-        : successor_(static_cast<Successor2&&>(successor))
-        , receiver_(static_cast<Receiver&&>(receiver))
-        , status_(status::predecessor_operation_constructed) {
-        unifex::activate_union_member_with(predOp_, [&] {
-          return unifex::connect(
-              static_cast<Predecessor&&>(predecessor),
-              predecessor_receiver<Predecessor, Successor, Receiver>{this});
-        });
-      }
-
-      ~type() {
-        switch (status_) {
-          case status::predecessor_operation_constructed:
-            unifex::deactivate_union_member(predOp_);
-            break;
-          case status::successor_operation_constructed:
-            unifex::deactivate_union_member(succOp_);
-            break;
-          case status::empty: break;
-        }
-      }
-
-      void start() & noexcept {
-        UNIFEX_ASSERT(status_ == status::predecessor_operation_constructed);
-        unifex::start(predOp_.get());
-      }
-
-    private:
-      friend predecessor_receiver<
-          Predecessor,
+  template(typename Predecessor2, typename Successor2)(
+      requires constructible_from<Predecessor, Predecessor2> AND constructible_from<
           Successor,
-          Receiver>;
-      friend successor_receiver<
-          Predecessor,
+          Successor2>) explicit type(Predecessor2&& predecessor, Successor2&& successor) noexcept(std::
+                                                                                                      is_nothrow_constructible_v<
+                                                                                                          Predecessor,
+                                                                                                          Predecessor2>&&
+                                                                                                          std::is_nothrow_constructible_v<
+                                                                                                              Successor,
+                                                                                                              Successor2>)
+    : predecessor_(static_cast<Predecessor&&>(predecessor))
+    , successor_(static_cast<Successor&&>(successor)) {}
+
+  friend auto tag_invoke(tag_t<blocking>, const type& self) {
+    if constexpr (
+        blocking_kind::maybe != cblocking<Predecessor>() &&
+        blocking_kind::maybe != cblocking<Successor>()) {
+      return blocking_kind::constant<_seq::_blocking_kind(
+          cblocking<Predecessor>(), cblocking<Successor>())>();
+    } else {
+      return _seq::_blocking_kind(
+          blocking(self.predecessor_), blocking(self.successor_));
+    }
+  }
+
+  template(typename Receiver, typename Sender)(
+      requires same_as<remove_cvref_t<Sender>, type> AND constructible_from<
           Successor,
-          Receiver>;
-
-      Successor successor_;
-      Receiver receiver_;
-      enum class status {
-        empty,
-        predecessor_operation_constructed,
-        successor_operation_constructed
-      };
-      status status_;
-      union {
-        manual_lifetime<connect_result_t<
-            Predecessor,
-            predecessor_receiver<Predecessor, Successor, Receiver>>>
-            predOp_;
-        manual_lifetime<connect_result_t<
-            Successor,
-            successor_receiver<Predecessor, Successor, Receiver>>>
-            succOp_;
-      };
-    };
-
-    template <typename Predecessor, typename Successor>
-    struct _sndr {
-      struct type;
-    };
-    template <typename Predecessor, typename Successor>
-    using _sender = typename _sndr<
-        remove_cvref_t<Predecessor>,
-        remove_cvref_t<Successor>>::type;
-
-    template <typename Predecessor, typename Successor>
-    struct _sndr<Predecessor, Successor>::type {
-      template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
-      using value_types =
-          sender_value_types_t<Successor, Variant, Tuple>;
-
-      template <template <typename...> class Variant>
-      using error_types =
-          typename concat_type_lists_unique_t<
-              sender_error_types_t<Predecessor, type_list>,
-              sender_error_types_t<Successor, type_list>,
-              type_list<std::exception_ptr>>::template apply<Variant>;
-
-      static constexpr bool sends_done =
-        sender_traits<Predecessor>::sends_done ||
-        sender_traits<Successor>::sends_done;
-
-      template(typename Predecessor2, typename Successor2)
-          (requires constructible_from<Predecessor, Predecessor2> AND
-              constructible_from<Successor, Successor2>)
-      explicit type(Predecessor2&& predecessor, Successor2&& successor)
-          noexcept(std::is_nothrow_constructible_v<Predecessor, Predecessor2> &&
-              std::is_nothrow_constructible_v<Successor, Successor2>)
-        : predecessor_(static_cast<Predecessor&&>(predecessor))
-        , successor_(static_cast<Successor&&>(successor)) {}
-
-      friend auto tag_invoke(tag_t<blocking>, const type& self) {
-        if constexpr (
-            blocking_kind::maybe != cblocking<Predecessor>() &&
-            blocking_kind::maybe != cblocking<Successor>()) {
-          return blocking_kind::constant<
-              _seq::_blocking_kind(cblocking<Predecessor>(), cblocking<Successor>())>();
-        } else {
-          return _seq::_blocking_kind(
-              blocking(self.predecessor_),
-              blocking(self.successor_));
-        }
-      }
-
-      template(typename Receiver, typename Sender)
-          (requires same_as<remove_cvref_t<Sender>, type> AND
-            constructible_from<Successor, member_t<Sender, Successor>> AND
-            sender_to<
+          member_t<Sender, Successor>> AND
+          sender_to<
               member_t<Sender, Predecessor>,
-              predecessor_receiver<member_t<Sender, Predecessor>, Successor, Receiver>> AND
-            sender_to<
-              Successor,
-              successor_receiver<member_t<Sender, Predecessor>, Successor, Receiver>>)
-      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& sender, Receiver&& receiver)
-          -> operation<member_t<Sender, Predecessor>, Successor, Receiver> {
-        return operation<member_t<Sender, Predecessor>, Successor,  Receiver>{
-            static_cast<Sender&&>(sender).predecessor_,
-            static_cast<Sender&&>(sender).successor_,
-            (Receiver &&) receiver};
-      }
+              predecessor_receiver<
+                  member_t<Sender, Predecessor>,
+                  Successor,
+                  Receiver>> AND
+              sender_to<
+                  Successor,
+                  successor_receiver<
+                      member_t<Sender, Predecessor>,
+                      Successor,
+                      Receiver>>) friend auto tag_invoke(tag_t<unifex::connect>, Sender&& sender, Receiver&& receiver)
+      -> operation<member_t<Sender, Predecessor>, Successor, Receiver> {
+    return operation<member_t<Sender, Predecessor>, Successor, Receiver>{
+        static_cast<Sender&&>(sender).predecessor_,
+        static_cast<Sender&&>(sender).successor_,
+        (Receiver &&) receiver};
+  }
 
-    private:
-      UNIFEX_NO_UNIQUE_ADDRESS Predecessor predecessor_;
-      UNIFEX_NO_UNIQUE_ADDRESS Successor successor_;
-    };
+private:
+  UNIFEX_NO_UNIQUE_ADDRESS Predecessor predecessor_;
+  UNIFEX_NO_UNIQUE_ADDRESS Successor successor_;
+};
 
-    namespace _cpo {
-      struct _fn {
-        // Sequencing a single sender is just the same as returning the sender
-        // itself.
-        template <typename First>
-        remove_cvref_t<First> operator()(First&& first) const
-            noexcept(std::is_nothrow_constructible_v<remove_cvref_t<First>, First>) {
-          return static_cast<First&&>(first);
-        }
+namespace _cpo {
+struct _fn {
+  // Sequencing a single sender is just the same as returning the sender
+  // itself.
+  template <typename First>
+  remove_cvref_t<First> operator()(First&& first) const
+      noexcept(std::is_nothrow_constructible_v<remove_cvref_t<First>, First>) {
+    return static_cast<First&&>(first);
+  }
 
-        template(typename First, typename Second)
-          (requires sender<First> AND sender<Second> AND //
-            tag_invocable<_fn, First, Second>)
-        auto operator()(First&& first, Second&& second) const
-            noexcept(is_nothrow_tag_invocable_v<_fn, First, Second>)
-            -> tag_invoke_result_t<_fn, First, Second> {
-          return unifex::tag_invoke(
-              _fn{}, static_cast<First&&>(first), static_cast<Second&&>(second));
-        }
+  template(typename First, typename Second)(
+      requires sender<First> AND sender<Second> AND  //
+          tag_invocable<_fn, First, Second>) auto
+  operator()(First&& first, Second&& second) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, First, Second>)
+          -> tag_invoke_result_t<_fn, First, Second> {
+    return unifex::tag_invoke(
+        _fn{}, static_cast<First&&>(first), static_cast<Second&&>(second));
+  }
 
-        template(typename First, typename Second)
-          (requires sender<First> AND sender<Second> AND //
-            (!tag_invocable<_fn, First, Second>))
-        auto operator()(First&& first, Second&& second) const
-            noexcept(std::is_nothrow_constructible_v<
-                    _seq::_sender<First, Second>,
-                    First,
-                    Second>)
-                -> _seq::_sender<First, Second> {
-          return _seq::_sender<First, Second>{
-              static_cast<First&&>(first),
-              static_cast<Second&&>(second)};
-        }
+  template(typename First, typename Second)(
+      requires sender<First> AND sender<Second> AND  //
+      (!tag_invocable<_fn, First, Second>)) auto
+  operator()(First&& first, Second&& second) const
+      noexcept(std::is_nothrow_constructible_v<
+               _seq::_sender<First, Second>,
+               First,
+               Second>) -> _seq::_sender<First, Second> {
+    return _seq::_sender<First, Second>{
+        static_cast<First&&>(first), static_cast<Second&&>(second)};
+  }
 
-        template(typename First, typename Second, typename Third, typename... Rest)
-          (requires sender<First> AND sender<Second> AND sender<Third> AND
-            (sender<Rest> &&...) AND tag_invocable<_fn, First, Second, Third, Rest...>)
-        auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
-            noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Third, Rest...>)
-            -> tag_invoke_result_t<_fn, First, Second, Third, Rest...> {
-          return unifex::tag_invoke(
-              _fn{},
-              static_cast<First&&>(first),
-              static_cast<Second&&>(second),
-              static_cast<Third&&>(third),
-              static_cast<Rest&&>(rest)...);
-        }
+  template(typename First, typename Second, typename Third, typename... Rest)(
+      requires sender<First> AND sender<Second> AND
+          sender<Third> AND(sender<Rest>&&...)
+              AND tag_invocable<_fn, First, Second, Third, Rest...>) auto
+  operator()(
+      First&& first, Second&& second, Third&& third, Rest&&... rest) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, First, Second, Third, Rest...>)
+          -> tag_invoke_result_t<_fn, First, Second, Third, Rest...> {
+    return unifex::tag_invoke(
+        _fn{},
+        static_cast<First&&>(first),
+        static_cast<Second&&>(second),
+        static_cast<Third&&>(third),
+        static_cast<Rest&&>(rest)...);
+  }
 
-        template(typename First, typename Second, typename Third, typename... Rest)
-          (requires sender<First> AND sender<Second> AND sender<Third> AND
-            (sender<Rest> &&...) AND (!tag_invocable<_fn, First, Second, Third, Rest...>))
-        auto operator()(First&& first, Second&& second, Third&& third, Rest&&... rest) const
-            noexcept(is_nothrow_callable_v<_fn, First, Second> &&
-                is_nothrow_callable_v<
-                    _fn,
-                    callable_result_t<_fn, First, Second>,
-                    Third,
-                    Rest...>)
-            -> callable_result_t<
-                _fn,
-                callable_result_t<_fn, First, Second>,
-                Third,
-                Rest...> {
-          // Fall-back to pair-wise invocation of the sequence() CPO.
-          return (*this)(
-              (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
-              static_cast<Third&&>(third),
-              static_cast<Rest&&>(rest)...);
-        }
-      };
-    } // _cpo
-  } // namespace _seq
+  template(typename First, typename Second, typename Third, typename... Rest)(
+      requires sender<First> AND sender<Second> AND
+          sender<Third> AND(sender<Rest>&&...)
+              AND(!tag_invocable<_fn, First, Second, Third, Rest...>)) auto
+  operator()(First&& first, Second&& second, Third&& third, Rest&&... rest)
+      const noexcept(
+          is_nothrow_callable_v<_fn, First, Second>&& is_nothrow_callable_v<
+              _fn,
+              callable_result_t<_fn, First, Second>,
+              Third,
+              Rest...>)
+          -> callable_result_t<
+              _fn,
+              callable_result_t<_fn, First, Second>,
+              Third,
+              Rest...> {
+    // Fall-back to pair-wise invocation of the sequence() CPO.
+    return (*this)(
+        (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
+        static_cast<Third&&>(third),
+        static_cast<Rest&&>(rest)...);
+  }
+};
+}  // namespace _cpo
+}  // namespace _seq
 
-  inline constexpr _seq::_cpo::_fn sequence {};
+inline constexpr _seq::_cpo::_fn sequence{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/single_thread_context.hpp
+++ b/include/unifex/single_thread_context.hpp
@@ -35,18 +35,14 @@ public:
     thread_.join();
   }
 
-  auto get_scheduler() noexcept {
-    return loop_.get_scheduler();
-  }
+  auto get_scheduler() noexcept { return loop_.get_scheduler(); }
 
-  std::thread::id get_thread_id() const noexcept {
-    return thread_.get_id();
-  }
+  std::thread::id get_thread_id() const noexcept { return thread_.get_id(); }
 };
-} // namespace _single_thread
+}  // namespace _single_thread
 
 using single_thread_context = _single_thread::context;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/span.hpp
+++ b/include/unifex/span.hpp
@@ -30,7 +30,7 @@ inline constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
 
 template <typename T, std::size_t Extent = dynamic_extent>
 struct span {
- public:
+public:
   using value_type = T;
   using size_type = std::size_t;
   using reference = std::add_lvalue_reference_t<T>;
@@ -42,7 +42,7 @@ struct span {
   explicit constexpr span(T* data) noexcept : data_(data) {}
 
   explicit constexpr span(const span<T, dynamic_extent>& other) noexcept
-      : data_(other.data()) {
+    : data_(other.data()) {
     UNIFEX_ASSERT(other.size() >= Extent);
   }
 
@@ -58,23 +58,26 @@ struct span {
 
   template <std::size_t OtherExtent>
   constexpr span(const span<T, OtherExtent>& other) noexcept
-      : data_(other.data()) {
+    : data_(other.data()) {
     static_assert(
         OtherExtent >= Extent,
         "Cannot construct a larger span from a smaller one");
   }
 
-  template(typename U)
-    (requires (!std::is_const_v<U>) AND same_as<const U, T>)
-  explicit constexpr span(const span<U, dynamic_extent>& other) noexcept
-      : data_(other.data()) {
+  template(typename U)(
+      requires(!std::is_const_v<U>) AND same_as<
+          const U,
+          T>) explicit constexpr span(const span<U, dynamic_extent>&
+                                          other) noexcept
+    : data_(other.data()) {
     UNIFEX_ASSERT(other.size() >= Extent);
   }
 
-  template(std::size_t OtherExtent, typename U)
-      (requires (!std::is_const_v<U>) AND same_as<const U, T>)
-  constexpr span(const span<U, OtherExtent>& other) noexcept
-      : data_(other.data()) {
+  template(std::size_t OtherExtent, typename U)(
+      requires(!std::is_const_v<U>)
+          AND same_as<const U, T>) constexpr span(const span<U, OtherExtent>&
+                                                      other) noexcept
+    : data_(other.data()) {
     static_assert(
         OtherExtent >= Extent,
         "Cannot construct a larger span from a smaller one");
@@ -85,25 +88,15 @@ struct span {
     return data_[index];
   }
 
-  constexpr T* data() const noexcept {
-    return data_;
-  }
+  constexpr T* data() const noexcept { return data_; }
 
-  constexpr std::size_t size() const noexcept {
-    return Extent;
-  }
+  constexpr std::size_t size() const noexcept { return Extent; }
 
-  constexpr bool empty() const noexcept {
-    return Extent == 0;
-  }
+  constexpr bool empty() const noexcept { return Extent == 0; }
 
-  T* begin() const noexcept {
-    return data();
-  }
+  T* begin() const noexcept { return data(); }
 
-  T* end() const noexcept {
-    return data() + size();
-  }
+  T* end() const noexcept { return data() + size(); }
 
   template <std::size_t N>
   span<T, N> first() const noexcept {
@@ -138,13 +131,13 @@ struct span {
 
   span<T, dynamic_extent> after(std::size_t count) const noexcept;
 
- private:
+private:
   T* data_;
 };
 
 template <typename T>
 struct span<T, dynamic_extent> {
- public:
+public:
   using value_type = T;
   using size_type = std::size_t;
   using reference = std::add_lvalue_reference_t<T>;
@@ -153,45 +146,40 @@ struct span<T, dynamic_extent> {
   constexpr span() noexcept : data_(nullptr), size_(0) {}
 
   constexpr span(T* data, std::size_t size) noexcept
-      : data_(data), size_(size) {}
+    : data_(data)
+    , size_(size) {}
 
   template <std::size_t N>
-  constexpr span(T (&arr)[N]) noexcept : data_(arr), size_(N) {}
+  constexpr span(T (&arr)[N]) noexcept : data_(arr)
+                                       , size_(N) {}
 
   template <std::size_t N>
   constexpr span(std::array<T, N>& arr) noexcept
-      : data_(arr.data()), size_(N) {}
+    : data_(arr.data())
+    , size_(N) {}
 
-  template(typename U, std::size_t OtherExtent)
-      (requires same_as<U, T> ||
-          (!std::is_const_v<U> && same_as<const U, T>))
-  constexpr span(const span<U, OtherExtent>& other) noexcept
-      : data_(other.data()), size_(other.size()) {}
+  template(typename U, std::size_t OtherExtent)(
+      requires same_as<U, T> ||
+      (!std::is_const_v<U> &&
+       same_as<const U, T>)) constexpr span(const span<U, OtherExtent>&
+                                                other) noexcept
+    : data_(other.data())
+    , size_(other.size()) {}
 
   T& operator[](std::size_t index) const noexcept {
     UNIFEX_ASSERT(index < size());
     return data_[index];
   }
 
-  T* data() const noexcept {
-    return data_;
-  }
+  T* data() const noexcept { return data_; }
 
-  bool empty() const noexcept {
-    return size_ == 0;
-  }
+  bool empty() const noexcept { return size_ == 0; }
 
-  std::size_t size() const noexcept {
-    return size_;
-  }
+  std::size_t size() const noexcept { return size_; }
 
-  T* begin() const noexcept {
-    return data();
-  }
+  T* begin() const noexcept { return data(); }
 
-  T* end() const noexcept {
-    return data() + size();
-  }
+  T* end() const noexcept { return data() + size(); }
 
   template <std::size_t N>
   span<T, N> first() const noexcept {
@@ -241,47 +229,47 @@ struct span<T, dynamic_extent> {
     return span<T, dynamic_extent>{data() + count, size() - count};
   }
 
- private:
+private:
   T* data_;
   std::size_t size_;
 };
 
 template <typename T, std::size_t Extent>
-inline span<T, dynamic_extent> span<T, Extent>::first(std::size_t count) const
-    noexcept {
+inline span<T, dynamic_extent>
+span<T, Extent>::first(std::size_t count) const noexcept {
   UNIFEX_ASSERT(count <= Extent);
   return span<T, dynamic_extent>{data(), count};
 }
 
 template <typename T, std::size_t Extent>
-inline span<T, dynamic_extent> span<T, Extent>::last(std::size_t count) const
-    noexcept {
+inline span<T, dynamic_extent>
+span<T, Extent>::last(std::size_t count) const noexcept {
   UNIFEX_ASSERT(count <= Extent);
   return span<T, dynamic_extent>{data() + (Extent - count), count};
 }
 
 template <typename T, std::size_t Extent>
-inline span<T, dynamic_extent> span<T, Extent>::after(std::size_t count) const
-    noexcept {
+inline span<T, dynamic_extent>
+span<T, Extent>::after(std::size_t count) const noexcept {
   UNIFEX_ASSERT(count <= Extent);
   return span<T, dynamic_extent>{data() + count, Extent - count};
 }
 
 template <typename T, std::size_t N>
-span(T (&)[N])->span<T, N>;
+span(T (&)[N]) -> span<T, N>;
 
 template <typename T, std::size_t N>
-span(std::array<T, N>&)->span<T, N>;
+span(std::array<T, N>&) -> span<T, N>;
 
 template <typename T, std::size_t N>
-span(const std::array<T, N>&)->span<const T, N>;
+span(const std::array<T, N>&) -> span<const T, N>;
 
 template <typename T>
-span(T*, std::size_t)->span<T>;
+span(T*, std::size_t) -> span<T>;
 
 template <typename T, std::size_t Extent>
-span<const std::byte, Extent * sizeof(T)> as_bytes(
-    const span<T, Extent>& s) noexcept {
+span<const std::byte, Extent * sizeof(T)>
+as_bytes(const span<T, Extent>& s) noexcept {
   constexpr std::size_t maxSize = std::size_t(-1) / sizeof(T);
   static_assert(Extent <= maxSize);
   return span<const std::byte, Extent * sizeof(T)>{
@@ -292,29 +280,27 @@ template <typename T>
 span<const std::byte> as_bytes(const span<T>& s) noexcept {
   [[maybe_unused]] constexpr std::size_t maxSize = std::size_t(-1) / sizeof(T);
   UNIFEX_ASSERT(s.size() <= maxSize);
-  return span<const std::byte>{reinterpret_cast<const std::byte*>(s.data()),
-                                  s.size() * sizeof(T)};
+  return span<const std::byte>{
+      reinterpret_cast<const std::byte*>(s.data()), s.size() * sizeof(T)};
 }
 
-template(typename T, std::size_t Extent)
-    (requires (!std::is_const_v<T>))
-span<std::byte, Extent * sizeof(T)> as_writable_bytes(
-    const span<T, Extent>& s) noexcept {
+template(typename T, std::size_t Extent)(requires(!std::is_const_v<T>))
+    span<std::byte, Extent * sizeof(T)> as_writable_bytes(
+        const span<T, Extent>& s) noexcept {
   constexpr std::size_t maxSize = std::size_t(-1) / sizeof(T);
   static_assert(Extent <= maxSize);
   return span<std::byte, Extent * sizeof(T)>{
       reinterpret_cast<std::byte*>(s.data())};
 }
 
-template(typename T)
-    (requires (!std::is_const_v<T>))
-span<std::byte> as_writable_bytes(const span<T>& s) noexcept {
+template(typename T)(requires(!std::is_const_v<T>))
+    span<std::byte> as_writable_bytes(const span<T>& s) noexcept {
   [[maybe_unused]] constexpr std::size_t maxSize = std::size_t(-1) / sizeof(T);
   UNIFEX_ASSERT(s.size() <= maxSize);
-  return span<std::byte>{reinterpret_cast<std::byte*>(s.data()),
-                            s.size() * sizeof(T)};
+  return span<std::byte>{
+      reinterpret_cast<std::byte*>(s.data()), s.size() * sizeof(T)};
 }
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/spin_wait.hpp
+++ b/include/unifex/spin_wait.hpp
@@ -22,7 +22,7 @@
 namespace unifex {
 
 class spin_wait {
- public:
+public:
   spin_wait() noexcept = default;
 
   void wait() noexcept {
@@ -36,12 +36,12 @@ class spin_wait {
     }
   }
 
- private:
+private:
   static constexpr std::uint32_t yield_threshold = 20;
 
   std::uint32_t count_ = 0;
 };
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -22,163 +22,155 @@
 #include <unifex/stop_token_concepts.hpp>
 #include <unifex/detail/intrusive_queue.hpp>
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <type_traits>
 #include <vector>
-#include <atomic>
-#include <mutex>
-#include <condition_variable>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _static_thread_pool {
-  struct task_base {
-    task_base* next;
-    void (*execute)(task_base*) noexcept;
-  };
+struct task_base {
+  task_base* next;
+  void (*execute)(task_base*) noexcept;
+};
 
-  template <typename Receiver>
-  struct _op {
-    class type;
-  };
-  template <typename Receiver>
-  using operation = typename _op<remove_cvref_t<Receiver>>::type;
+template <typename Receiver>
+struct _op {
+  class type;
+};
+template <typename Receiver>
+using operation = typename _op<remove_cvref_t<Receiver>>::type;
 
-  class context {
+class context {
+  template <typename Receiver>
+  friend struct _op;
+
+public:
+  context();
+  context(std::uint32_t threadCount);
+  ~context();
+
+  class scheduler {
     template <typename Receiver>
     friend struct _op;
-  public:
-    context();
-    context(std::uint32_t threadCount);
-    ~context();
+    class schedule_sender {
+    public:
+      template <
+          template <typename...>
+          class Variant,
+          template <typename...>
+          class Tuple>
+      using value_types = Variant<Tuple<>>;
 
-    class scheduler {
+      template <template <typename...> class Variant>
+      using error_types = Variant<>;
+
+      static constexpr bool sends_done = true;
+
+    private:
       template <typename Receiver>
-      friend struct _op;
-      class schedule_sender {
-      public:
-        template <
-            template <typename...> class Variant,
-            template <typename...> class Tuple>
-        using value_types = Variant<Tuple<>>;
-
-        template <template <typename...> class Variant>
-        using error_types = Variant<>;
-
-        static constexpr bool sends_done = true;
-
-      private:
-        template <typename Receiver>
-        operation<Receiver> make_operation_(Receiver&& r) const {
-          return operation<Receiver>{pool_, (Receiver &&) r};
-        }
-
-        template(typename Receiver)
-          (requires receiver_of<Receiver>)
-        friend operation<Receiver>
-        tag_invoke(tag_t<connect>, schedule_sender s, Receiver&& r) {
-          return s.make_operation_((Receiver &&) r);
-        }
-
-        friend class context::scheduler;
-
-        explicit schedule_sender(context& pool) noexcept
-          : pool_(pool) {}
-
-        context& pool_;
-      };
-
-      schedule_sender make_sender_() const {
-        return schedule_sender{pool_};
+      operation<Receiver> make_operation_(Receiver&& r) const {
+        return operation<Receiver>{pool_, (Receiver &&) r};
       }
 
-      friend schedule_sender
-      tag_invoke(tag_t<schedule>, const scheduler& s) noexcept {
-        return s.make_sender_();
+      template(typename Receiver)(requires receiver_of<Receiver>) friend operation<
+          Receiver> tag_invoke(tag_t<connect>, schedule_sender s, Receiver&& r) {
+        return s.make_operation_((Receiver &&) r);
       }
 
-      friend class context;
-      explicit scheduler(context& pool) noexcept
-        : pool_(pool) {}
+      friend class context::scheduler;
 
-      friend bool operator==(scheduler a, scheduler b) noexcept {
-        return &a.pool_ == &b.pool_;
-      }
-      friend bool operator!=(scheduler a, scheduler b) noexcept {
-        return &a.pool_ != &b.pool_;
-      }
+      explicit schedule_sender(context& pool) noexcept : pool_(pool) {}
 
       context& pool_;
     };
 
-    scheduler get_scheduler() noexcept { return scheduler{*this}; }
+    schedule_sender make_sender_() const { return schedule_sender{pool_}; }
 
-    void request_stop() noexcept;
+    friend schedule_sender
+    tag_invoke(tag_t<schedule>, const scheduler& s) noexcept {
+      return s.make_sender_();
+    }
 
-  private:
-    class thread_state {
-    public:
-      task_base* try_pop();
-      task_base* pop();
-      bool try_push(task_base* task);
-      void push(task_base* task);
-      void request_stop();
+    friend class context;
+    explicit scheduler(context& pool) noexcept : pool_(pool) {}
 
-    private:
-      std::mutex mut_;
-      std::condition_variable cv_;
-      intrusive_queue<task_base, &task_base::next> queue_;
-      bool stopRequested_ = false;
-    };
-
-    void run(std::uint32_t index) noexcept;
-    void join() noexcept;
-
-    void enqueue(task_base* task) noexcept;
-
-    std::uint32_t threadCount_;
-    std::vector<std::thread> threads_;
-    std::vector<thread_state> threadStates_;
-    std::atomic<std::uint32_t> nextThread_;
-  };
-
-  template <typename Receiver>
-  class _op<Receiver>::type : task_base {
-    friend context::scheduler::schedule_sender;
+    friend bool operator==(scheduler a, scheduler b) noexcept {
+      return &a.pool_ == &b.pool_;
+    }
+    friend bool operator!=(scheduler a, scheduler b) noexcept {
+      return &a.pool_ != &b.pool_;
+    }
 
     context& pool_;
-    Receiver receiver_;
-
-    explicit type(context& pool, Receiver&& r)
-      : pool_(pool)
-      , receiver_((Receiver &&) r) {
-      this->execute = [](task_base* t) noexcept {
-        auto& op = *static_cast<type*>(t);
-        if constexpr (!is_stop_never_possible_v<
-                          stop_token_type_t<Receiver>>) {
-          if (get_stop_token(op.receiver_).stop_requested()) {
-            unifex::set_done((Receiver &&) op.receiver_);
-            return;
-          }
-        }
-        unifex::set_value((Receiver &&) op.receiver_);
-      };
-    }
-
-    void enqueue_(task_base* op) const {
-      pool_.enqueue(op);
-    }
-
-    friend void tag_invoke(tag_t<start>, type& op) noexcept {
-      op.enqueue_(&op);
-    }
   };
 
-} // _static_thread_pool
+  scheduler get_scheduler() noexcept { return scheduler{*this}; }
+
+  void request_stop() noexcept;
+
+private:
+  class thread_state {
+  public:
+    task_base* try_pop();
+    task_base* pop();
+    bool try_push(task_base* task);
+    void push(task_base* task);
+    void request_stop();
+
+  private:
+    std::mutex mut_;
+    std::condition_variable cv_;
+    intrusive_queue<task_base, &task_base::next> queue_;
+    bool stopRequested_ = false;
+  };
+
+  void run(std::uint32_t index) noexcept;
+  void join() noexcept;
+
+  void enqueue(task_base* task) noexcept;
+
+  std::uint32_t threadCount_;
+  std::vector<std::thread> threads_;
+  std::vector<thread_state> threadStates_;
+  std::atomic<std::uint32_t> nextThread_;
+};
+
+template <typename Receiver>
+class _op<Receiver>::type : task_base {
+  friend context::scheduler::schedule_sender;
+
+  context& pool_;
+  Receiver receiver_;
+
+  explicit type(context& pool, Receiver&& r)
+    : pool_(pool)
+    , receiver_((Receiver &&) r) {
+    this->execute = [](task_base* t) noexcept {
+      auto& op = *static_cast<type*>(t);
+      if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+        if (get_stop_token(op.receiver_).stop_requested()) {
+          unifex::set_done((Receiver &&) op.receiver_);
+          return;
+        }
+      }
+      unifex::set_value((Receiver &&) op.receiver_);
+    };
+  }
+
+  void enqueue_(task_base* op) const { pool_.enqueue(op); }
+
+  friend void tag_invoke(tag_t<start>, type& op) noexcept { op.enqueue_(&op); }
+};
+
+}  // namespace _static_thread_pool
 
 using static_thread_pool = _static_thread_pool::context;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/std_concepts.hpp
+++ b/include/unifex/std_concepts.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include <unifex/detail/concept_macros.hpp>
 #include <unifex/swap.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/detail/concept_macros.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -26,284 +26,214 @@
 
 namespace unifex {
 
-  template <typename A, typename B>
-  UNIFEX_CONCEPT
-    same_as =
-      UNIFEX_IS_SAME(A, B) &&
-      UNIFEX_IS_SAME(B, A);
+template <typename A, typename B>
+UNIFEX_CONCEPT same_as = UNIFEX_IS_SAME(A, B) && UNIFEX_IS_SAME(B, A);
 
-  template <typename From, typename To>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename From, typename To>
+UNIFEX_CONCEPT_FRAGMENT(
     _explicitly_convertible_to,
-      requires(From(*from)()) //
-      (
-        static_cast<To>(from())
-      ));
-  template <typename From, typename To>
-  UNIFEX_CONCEPT
-    convertible_to =
-      std::is_convertible_v<std::add_rvalue_reference_t<From>, To> &&
-      UNIFEX_FRAGMENT(unifex::_explicitly_convertible_to, From, To);
+    requires(From (*from)())  //
+    (static_cast<To>(from())));
+template <typename From, typename To>
+UNIFEX_CONCEPT convertible_to =
+    std::is_convertible_v<std::add_rvalue_reference_t<From>, To>&&
+        UNIFEX_FRAGMENT(unifex::_explicitly_convertible_to, From, To);
 
-  /// \cond
-  namespace detail {
-    template <typename T>
-    using _cref_t = std::remove_reference_t<T> const &;
+/// \cond
+namespace detail {
+template <typename T>
+using _cref_t = std::remove_reference_t<T> const&;
 
-    template <class T>
-    UNIFEX_CONCEPT_FRAGMENT(
-      _boolean_testable_impl,
-        requires(T && t)
-        (
-          requires(convertible_to<decltype(! (T &&) t), bool>)
-        ));
-    template <class T>
-    UNIFEX_CONCEPT
-      _boolean_testable =
-        UNIFEX_FRAGMENT(_boolean_testable_impl, T) &&
-        convertible_to<T, bool>;
+template <class T>
+UNIFEX_CONCEPT_FRAGMENT(
+    _boolean_testable_impl,
+    requires(T&& t)(requires(convertible_to<decltype(!(T &&) t), bool>)));
+template <class T>
+UNIFEX_CONCEPT _boolean_testable =
+    UNIFEX_FRAGMENT(_boolean_testable_impl, T) && convertible_to<T, bool>;
 
-    UNIFEX_DIAGNOSTIC_PUSH
-    UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
+UNIFEX_DIAGNOSTIC_PUSH
+UNIFEX_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
 
-    template <typename T, typename U>
-    UNIFEX_CONCEPT_FRAGMENT(
-      _weakly_equality_comparable_with,
-        requires(_cref_t<T> t, _cref_t<U> u) //
-        (
-          requires(_boolean_testable<decltype(t == u)>),
-          requires(_boolean_testable<decltype(t != u)>),
-          requires(_boolean_testable<decltype(u == t)>),
-          requires(_boolean_testable<decltype(u != t)>)
-        ));
-    template <typename T, typename U>
-    UNIFEX_CONCEPT
-      weakly_equality_comparable_with_ =
-        UNIFEX_FRAGMENT(detail::_weakly_equality_comparable_with, T, U);
+template <typename T, typename U>
+UNIFEX_CONCEPT_FRAGMENT(
+    _weakly_equality_comparable_with,
+    requires(_cref_t<T> t, _cref_t<U> u)  //
+    (requires(_boolean_testable<decltype(t == u)>),
+     requires(_boolean_testable<decltype(t != u)>),
+     requires(_boolean_testable<decltype(u == t)>),
+     requires(_boolean_testable<decltype(u != t)>)));
+template <typename T, typename U>
+UNIFEX_CONCEPT weakly_equality_comparable_with_ =
+    UNIFEX_FRAGMENT(detail::_weakly_equality_comparable_with, T, U);
 
-    UNIFEX_DIAGNOSTIC_POP
-  } // namespace detail
-  /// \endcond
+UNIFEX_DIAGNOSTIC_POP
+}  // namespace detail
+/// \endcond
 
-  template <typename T, typename U>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T, typename U>
+UNIFEX_CONCEPT_FRAGMENT(
     _derived_from,
-      requires()(0) &&
-      convertible_to<T const volatile *, U const volatile *>);
-  template <typename T, typename U>
-  UNIFEX_CONCEPT
-    derived_from =
-      UNIFEX_IS_BASE_OF(U, T) &&
-      UNIFEX_FRAGMENT(unifex::_derived_from, T, U);
+    requires()(0) && convertible_to<T const volatile*, U const volatile*>);
+template <typename T, typename U>
+UNIFEX_CONCEPT derived_from = UNIFEX_IS_BASE_OF(U, T) &&
+    UNIFEX_FRAGMENT(unifex::_derived_from, T, U);
 
-  template <typename T, typename U>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T, typename U>
+UNIFEX_CONCEPT_FRAGMENT(
     _assignable_from,
-      requires(T t, U && u) //
-      (
-        t = (U &&) u,
-        requires(same_as<T, decltype(t = (U &&) u)>)
-      ));
-  template <typename T, typename U>
-  UNIFEX_CONCEPT
-    assignable_from =
-      std::is_lvalue_reference_v<T> &&
-      UNIFEX_FRAGMENT(unifex::_assignable_from, T, U);
+    requires(T t, U&& u)  //
+    (t = (U &&) u, requires(same_as<T, decltype(t = (U &&) u)>)));
+template <typename T, typename U>
+UNIFEX_CONCEPT assignable_from = std::is_lvalue_reference_v<T>&&
+    UNIFEX_FRAGMENT(unifex::_assignable_from, T, U);
 
-  template <typename T>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T>
+UNIFEX_CONCEPT_FRAGMENT(
     _swappable,
-      requires(T & t, T & u) //
-      (
-        unifex::swap(t, u)
-      ));
-  template <typename T>
-  UNIFEX_CONCEPT
-    swappable =
-      UNIFEX_FRAGMENT(unifex::_swappable, T);
+    requires(T& t, T& u)  //
+    (unifex::swap(t, u)));
+template <typename T>
+UNIFEX_CONCEPT swappable = UNIFEX_FRAGMENT(unifex::_swappable, T);
 
-  template <typename T, typename U>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T, typename U>
+UNIFEX_CONCEPT_FRAGMENT(
     _swappable_with,
-      requires(T && t, U && u) //
-      (
-        unifex::swap((T &&) t, (T &&) t),
-        unifex::swap((U &&) u, (U &&) u),
-        unifex::swap((U &&) u, (T &&) t),
-        unifex::swap((T &&) t, (U &&) u)
-      ));
-  template <typename T, typename U>
-  UNIFEX_CONCEPT
-    swappable_with =
-      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
-      UNIFEX_FRAGMENT(unifex::_swappable_with, T, U);
+    requires(T&& t, U&& u)  //
+    (unifex::swap((T &&) t, (T &&) t),
+     unifex::swap((U &&) u, (U &&) u),
+     unifex::swap((U &&) u, (T &&) t),
+     unifex::swap((T &&) t, (U &&) u)));
+template <typename T, typename U>
+UNIFEX_CONCEPT swappable_with =
+    // common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+    UNIFEX_FRAGMENT(unifex::_swappable_with, T, U);
 
-  ////////////////////////////////////////////////////////////////////////////////////////////
-  // Comparison concepts
-  ////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Comparison concepts
+////////////////////////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    equality_comparable =
-      detail::weakly_equality_comparable_with_<T, T>;
+template <typename T>
+UNIFEX_CONCEPT equality_comparable =
+    detail::weakly_equality_comparable_with_<T, T>;
 
-  // template <typename T, typename U>
-  // UNIFEX_CONCEPT_FRAGMENT(
-  //   _equality_comparable_with,
-  //     requires()(0) &&
-  //     equality_comparable<
-  //       common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>);
-  template <typename T, typename U>
-  UNIFEX_CONCEPT
-    equality_comparable_with =
-      equality_comparable<T> &&
-      equality_comparable<U> &&
-      detail::weakly_equality_comparable_with_<T, U>;// &&
-      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
-      //UNIFEX_FRAGMENT(unifex::_equality_comparable_with, T, U);
+// template <typename T, typename U>
+// UNIFEX_CONCEPT_FRAGMENT(
+//   _equality_comparable_with,
+//     requires()(0) &&
+//     equality_comparable<
+//       common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>);
+template <typename T, typename U>
+UNIFEX_CONCEPT equality_comparable_with =
+    equality_comparable<T>&& equality_comparable<U>&&
+        detail::weakly_equality_comparable_with_<T, U>;  // &&
+// common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+// UNIFEX_FRAGMENT(unifex::_equality_comparable_with, T, U);
 
-  template <typename T>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T>
+UNIFEX_CONCEPT_FRAGMENT(
     _totally_ordered,
-      requires(detail::_cref_t<T> t, detail::_cref_t<T> u) //
-      (
-        requires(detail::_boolean_testable<decltype(t < u)>),
-        requires(detail::_boolean_testable<decltype(t > u)>),
-        requires(detail::_boolean_testable<decltype(u <= t)>),
-        requires(detail::_boolean_testable<decltype(u >= t)>)
-      ));
-  template <typename T>
-  UNIFEX_CONCEPT
-    totally_ordered =
-      equality_comparable<T> &&
-      UNIFEX_FRAGMENT(unifex::_totally_ordered, T);
+    requires(detail::_cref_t<T> t, detail::_cref_t<T> u)  //
+    (requires(detail::_boolean_testable<decltype(t < u)>),
+     requires(detail::_boolean_testable<decltype(t > u)>),
+     requires(detail::_boolean_testable<decltype(u <= t)>),
+     requires(detail::_boolean_testable<decltype(u >= t)>)));
+template <typename T>
+UNIFEX_CONCEPT totally_ordered = equality_comparable<T>&&
+    UNIFEX_FRAGMENT(unifex::_totally_ordered, T);
 
-  template <typename T, typename U>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T, typename U>
+UNIFEX_CONCEPT_FRAGMENT(
     _totally_ordered_with,
-      requires(detail::_cref_t<T> t, detail::_cref_t<U> u) //
-      (
-        requires(detail::_boolean_testable<decltype(t < u)>),
-        requires(detail::_boolean_testable<decltype(t > u)>),
-        requires(detail::_boolean_testable<decltype(t <= u)>),
-        requires(detail::_boolean_testable<decltype(t >= u)>),
-        requires(detail::_boolean_testable<decltype(u < t)>),
-        requires(detail::_boolean_testable<decltype(u > t)>),
-        requires(detail::_boolean_testable<decltype(u <= t)>),
-        requires(detail::_boolean_testable<decltype(u >= t)>)
-      ));
-      //&& totally_ordered<
-      //   common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>
-  template <typename T, typename U>
-  UNIFEX_CONCEPT
-    totally_ordered_with =
-      totally_ordered<T> &&
-      totally_ordered<U> &&
-      equality_comparable_with<T, U> &&
-      //common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
-      UNIFEX_FRAGMENT(unifex::_totally_ordered_with, T, U);
+    requires(detail::_cref_t<T> t, detail::_cref_t<U> u)  //
+    (requires(detail::_boolean_testable<decltype(t < u)>),
+     requires(detail::_boolean_testable<decltype(t > u)>),
+     requires(detail::_boolean_testable<decltype(t <= u)>),
+     requires(detail::_boolean_testable<decltype(t >= u)>),
+     requires(detail::_boolean_testable<decltype(u < t)>),
+     requires(detail::_boolean_testable<decltype(u > t)>),
+     requires(detail::_boolean_testable<decltype(u <= t)>),
+     requires(detail::_boolean_testable<decltype(u >= t)>)));
+//&& totally_ordered<
+//   common_reference_t<detail::_cref_t<T>, detail::_cref_t<U>>>
+template <typename T, typename U>
+UNIFEX_CONCEPT totally_ordered_with = totally_ordered<T>&& totally_ordered<U>&&
+    equality_comparable_with<T, U>&&
+        // common_reference_with<detail::_cref_t<T>, detail::_cref_t<U>> &&
+        UNIFEX_FRAGMENT(unifex::_totally_ordered_with, T, U);
 
-  ////////////////////////////////////////////////////////////////////////////////////////////
-  // Object concepts
-  ////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Object concepts
+////////////////////////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    destructible =
-      std::is_nothrow_destructible_v<T>;
+template <typename T>
+UNIFEX_CONCEPT destructible = std::is_nothrow_destructible_v<T>;
 
-  template <typename T, typename... Args>
-  UNIFEX_CONCEPT
-    constructible_from =
-      destructible<T> &&
-      UNIFEX_IS_CONSTRUCTIBLE(T, Args...);
+template <typename T, typename... Args>
+UNIFEX_CONCEPT constructible_from = destructible<T>&&
+UNIFEX_IS_CONSTRUCTIBLE(T, Args...);
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    default_constructible =
-      constructible_from<T>;
+template <typename T>
+UNIFEX_CONCEPT default_constructible = constructible_from<T>;
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    move_constructible =
-      constructible_from<T, T> &&
-      convertible_to<T, T>;
+template <typename T>
+UNIFEX_CONCEPT move_constructible =
+    constructible_from<T, T>&& convertible_to<T, T>;
 
-  template <typename T>
-  UNIFEX_CONCEPT_FRAGMENT(
+template <typename T>
+UNIFEX_CONCEPT_FRAGMENT(
     _copy_constructible,
-      requires()(0) &&
-      constructible_from<T, T &> &&
-      constructible_from<T, T const &> &&
-      constructible_from<T, T const> &&
-      convertible_to<T &, T> &&
-      convertible_to<T const &, T> &&
-      convertible_to<T const, T>);
-  template <typename T>
-  UNIFEX_CONCEPT
-    copy_constructible =
-      move_constructible<T> &&
-      UNIFEX_FRAGMENT(unifex::_copy_constructible, T);
+    requires()(0) && constructible_from<T, T&> &&
+        constructible_from<T, T const&> && constructible_from<T, T const> &&
+        convertible_to<T&, T> && convertible_to<T const&, T> &&
+        convertible_to<T const, T>);
+template <typename T>
+UNIFEX_CONCEPT copy_constructible = move_constructible<T>&&
+    UNIFEX_FRAGMENT(unifex::_copy_constructible, T);
 
-  template <typename T>
-  UNIFEX_CONCEPT_FRAGMENT(
-    _move_assignable,
-      requires()(0) &&
-      assignable_from<T &, T>);
-  template <typename T>
-  UNIFEX_CONCEPT
-    movable =
-      std::is_object_v<T> &&
-      move_constructible<T> &&
-      UNIFEX_FRAGMENT(unifex::_move_assignable, T) &&
-      swappable<T>;
+template <typename T>
+UNIFEX_CONCEPT_FRAGMENT(
+    _move_assignable, requires()(0) && assignable_from<T&, T>);
+template <typename T>
+UNIFEX_CONCEPT movable = std::is_object_v<T>&& move_constructible<T>&&
+                             UNIFEX_FRAGMENT(unifex::_move_assignable, T) &&
+    swappable<T>;
 
-  template <typename T>
-  UNIFEX_CONCEPT_FRAGMENT(
-    _copy_assignable,
-      requires()(0) &&
-      assignable_from<T &, T const &>);
-  template <typename T>
-  UNIFEX_CONCEPT
-    copyable =
-      copy_constructible<T> &&
-      movable<T> &&
-      UNIFEX_FRAGMENT(unifex::_copy_assignable, T);
+template <typename T>
+UNIFEX_CONCEPT_FRAGMENT(
+    _copy_assignable, requires()(0) && assignable_from<T&, T const&>);
+template <typename T>
+UNIFEX_CONCEPT copyable = copy_constructible<T>&& movable<T>&&
+    UNIFEX_FRAGMENT(unifex::_copy_assignable, T);
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    semiregular =
-      copyable<T> &&
-      default_constructible<T>;
-      // Axiom: copies are independent. See Fundamentals of Generic Programming
-      // http://www.stepanovpapers.com/DeSt98.pdf
+template <typename T>
+UNIFEX_CONCEPT semiregular = copyable<T>&& default_constructible<T>;
+// Axiom: copies are independent. See Fundamentals of Generic Programming
+// http://www.stepanovpapers.com/DeSt98.pdf
 
-  template <typename T>
-  UNIFEX_CONCEPT
-    regular =
-      semiregular<T> &&
-      equality_comparable<T>;
+template <typename T>
+UNIFEX_CONCEPT regular = semiregular<T>&& equality_comparable<T>;
 
-  template <typename Fn, typename... As>
-  UNIFEX_CONCEPT  //
-    invocable = //
-      std::is_invocable_v<Fn, As...>;
+template <typename Fn, typename... As>
+UNIFEX_CONCEPT   //
+    invocable =  //
+    std::is_invocable_v<Fn, As...>;
 
 #if UNIFEX_CXX_CONCEPTS
-  template <typename Fn, typename... As>
-  concept //
-    callable = //
-      requires (Fn&& fn, As&&... as) {
-        ((Fn&&) fn)((As&&) as...);
-      };
+template <typename Fn, typename... As>
+concept         //
+    callable =  //
+    requires(Fn&& fn, As&&... as) {
+  ((Fn &&) fn)((As &&) as...);
+};
 #else
-  template <typename Fn, typename... As>
-  UNIFEX_CONCEPT //
-    callable = //
-      sizeof(decltype(_is_callable::_try_call(static_cast<Fn(*)(As...)>(nullptr)))) ==
-      sizeof(_is_callable::yes_type);
+template <typename Fn, typename... As>
+UNIFEX_CONCEPT  //
+    callable =  //
+    sizeof(decltype(_is_callable::_try_call(static_cast<Fn (*)(As...)>(
+        nullptr)))) == sizeof(_is_callable::yes_type);
 #endif
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -16,10 +16,10 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/blocking.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -36,19 +36,20 @@ private:
         void start() & noexcept {
           UNIFEX_TRY {
             if (get_stop_token(std::as_const(rec_)).stop_requested()) {
-              unifex::set_done((Receiver&&) rec_);
+              unifex::set_done((Receiver &&) rec_);
             } else {
-              unifex::set_value((Receiver&&) rec_);
+              unifex::set_value((Receiver &&) rec_);
             }
-          } UNIFEX_CATCH (...) {
-            unifex::set_error((Receiver&&) rec_, std::current_exception());
+          }
+          UNIFEX_CATCH(...) {
+            unifex::set_error((Receiver &&) rec_, std::current_exception());
           }
         }
       };
     };
 
   public:
-  #if !UNIFEX_NO_COROUTINES
+#if !UNIFEX_NO_COROUTINES
     // Provide an awaiter interface in addition to the sender interface
     // because as an awaiter we can take advantage of symmetric transfer
     // to save stack space:
@@ -56,35 +57,36 @@ private:
       return false;
     }
     template <typename Promise>
-    coro::coroutine_handle<> await_suspend(coro::coroutine_handle<Promise> coro) const noexcept {
+    coro::coroutine_handle<>
+    await_suspend(coro::coroutine_handle<Promise> coro) const noexcept {
       if (get_stop_token(coro.promise()).stop_requested()) {
         return coro.promise().unhandled_done();
       }
-      return coro; // don't suspend
+      return coro;  // don't suspend
     }
     void await_resume() const noexcept {
     }
-  #endif
+#endif
 
-    template<
-      template<typename...> class Variant,
-      template<typename...> class Tuple>
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
-    template<
-      template<typename...> class Variant>
+    template <template <typename...> class Variant>
     using error_types = Variant<std::exception_ptr>;
 
     static constexpr bool sends_done = true;
 
-    template (typename Receiver)
-      (requires receiver_of<Receiver>)
-    auto connect(Receiver&& rec) const
-      -> typename _op<remove_cvref_t<Receiver>>::type {
-      return typename _op<remove_cvref_t<Receiver>>::type{(Receiver&&) rec};
+    template(typename Receiver)(requires receiver_of<Receiver>) auto connect(
+        Receiver&& rec) const -> typename _op<remove_cvref_t<Receiver>>::type {
+      return typename _op<remove_cvref_t<Receiver>>::type{(Receiver &&) rec};
     }
 
-    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _sender&) noexcept {
+    friend constexpr auto
+    tag_invoke(tag_t<unifex::blocking>, const _sender&) noexcept {
       return blocking_kind::always_inline;
     }
   };
@@ -94,7 +96,7 @@ public:
     return {};
   }
 };
-} // namespace _stop_if
+}  // namespace _stop_if
 
 namespace _stop {
 struct _fn {
@@ -102,14 +104,14 @@ struct _fn {
     return just_done();
   }
 };
-} // namespace _stop
+}  // namespace _stop
 
 // Await this to cancel and unwind if stop has been requested:
-inline constexpr _stop_if::_fn stop_if_requested {};
+inline constexpr _stop_if::_fn stop_if_requested{};
 
 // Await this to cancel unconditionally:
-inline constexpr _stop::_fn stop {};
+inline constexpr _stop::_fn stop{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_token_concepts.hpp
+++ b/include/unifex/stop_token_concepts.hpp
@@ -34,6 +34,6 @@ inline constexpr bool is_stop_never_possible_v<
 template <typename T>
 using is_stop_never_possible = std::bool_constant<is_stop_never_possible_v<T>>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -15,378 +15,368 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/bind_back.hpp>
-#include <unifex/optional.hpp>
 
+#include <unifex/variant.hpp>
 #include <atomic>
 #include <functional>
 #include <tuple>
 #include <type_traits>
-#include <unifex/variant.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  namespace _stop_when
-  {
-    template <typename Source, typename Trigger, typename Receiver>
-    struct _op {
-      class type;
-    };
-    template <typename Source, typename Trigger, typename Receiver>
-    using stop_when_operation = typename _op<Source, Trigger, Receiver>::type;
+namespace unifex {
+namespace _stop_when {
+template <typename Source, typename Trigger, typename Receiver>
+struct _op {
+  class type;
+};
+template <typename Source, typename Trigger, typename Receiver>
+using stop_when_operation = typename _op<Source, Trigger, Receiver>::type;
 
-    template <typename Source, typename Trigger, typename Receiver>
-    struct _srcvr {
-      class type;
-    };
+template <typename Source, typename Trigger, typename Receiver>
+struct _srcvr {
+  class type;
+};
 
-    template <typename Source, typename Trigger, typename Receiver>
-    using stop_when_source_receiver =
-        typename _srcvr<Source, Trigger, Receiver>::type;
+template <typename Source, typename Trigger, typename Receiver>
+using stop_when_source_receiver =
+    typename _srcvr<Source, Trigger, Receiver>::type;
 
-    template <typename Source, typename Trigger, typename Receiver>
-    class _srcvr<Source, Trigger, Receiver>::type {
-      using operation_state = stop_when_operation<Source, Trigger, Receiver>;
+template <typename Source, typename Trigger, typename Receiver>
+class _srcvr<Source, Trigger, Receiver>::type {
+  using operation_state = stop_when_operation<Source, Trigger, Receiver>;
 
-    public:
-      explicit type(operation_state* op) noexcept : op_(op) {}
+public:
+  explicit type(operation_state* op) noexcept : op_(op) {}
 
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
 
-      template <typename... Values>
-      void set_value(Values&&... values) && {
-        op_->result_.template emplace<
-            std::tuple<tag_t<unifex::set_value>, std::decay_t<Values>...>>(
-            unifex::set_value, (Values &&) values...);
-        op_->notify_source_complete();
-      }
+  template <typename... Values>
+  void set_value(Values&&... values) && {
+    op_->result_.template emplace<
+        std::tuple<tag_t<unifex::set_value>, std::decay_t<Values>...>>(
+        unifex::set_value, (Values &&) values...);
+    op_->notify_source_complete();
+  }
 
-      template <typename Error>
-      void set_error(Error&& error) && noexcept {
-        op_->result_.template emplace<
-            std::tuple<tag_t<unifex::set_error>, std::decay_t<Error>>>(
-            unifex::set_error, (Error &&) error);
-        op_->notify_source_complete();
-      }
+  template <typename Error>
+  void set_error(Error&& error) && noexcept {
+    op_->result_.template emplace<
+        std::tuple<tag_t<unifex::set_error>, std::decay_t<Error>>>(
+        unifex::set_error, (Error &&) error);
+    op_->notify_source_complete();
+  }
 
-      void set_done() && noexcept {
-        op_->result_.template emplace<std::tuple<tag_t<unifex::set_done>>>(
-            unifex::set_done);
-        op_->notify_source_complete();
-      }
+  void set_done() && noexcept {
+    op_->result_.template emplace<std::tuple<tag_t<unifex::set_done>>>(
+        unifex::set_done);
+    op_->notify_source_complete();
+  }
 
-    private:
-      friend inplace_stop_token tag_invoke(
-          tag_t<unifex::get_stop_token>,
-          const type& r) noexcept {
-        return r.get_stop_token();
-      }
+private:
+  friend inplace_stop_token
+  tag_invoke(tag_t<unifex::get_stop_token>, const type& r) noexcept {
+    return r.get_stop_token();
+  }
 
-      template(typename CPO)
-          (requires is_receiver_query_cpo_v<CPO>)
-      friend auto tag_invoke(CPO cpo, const type& r)
-          noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(r.get_receiver());
-      }
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(r.get_receiver());
+  }
 
-      inplace_stop_token get_stop_token() const noexcept {
-        return op_->stopSource_.get_token();
-      }
+  inplace_stop_token get_stop_token() const noexcept {
+    return op_->stopSource_.get_token();
+  }
 
-      const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
 
-      operation_state* op_;
-    };
+  operation_state* op_;
+};
 
-    template <typename Source, typename Trigger, typename Receiver>
-    struct _trcvr {
-      class type;
-    };
+template <typename Source, typename Trigger, typename Receiver>
+struct _trcvr {
+  class type;
+};
 
-    template <typename Source, typename Trigger, typename Receiver>
-    using stop_when_trigger_receiver =
-        typename _trcvr<Source, Trigger, Receiver>::type;
+template <typename Source, typename Trigger, typename Receiver>
+using stop_when_trigger_receiver =
+    typename _trcvr<Source, Trigger, Receiver>::type;
 
-    template <typename Source, typename Trigger, typename Receiver>
-    class _trcvr<Source, Trigger, Receiver>::type {
-      using operation_state = stop_when_operation<Source, Trigger, Receiver>;
+template <typename Source, typename Trigger, typename Receiver>
+class _trcvr<Source, Trigger, Receiver>::type {
+  using operation_state = stop_when_operation<Source, Trigger, Receiver>;
 
-    public:
-      explicit type(operation_state* op) noexcept : op_(op) {}
+public:
+  explicit type(operation_state* op) noexcept : op_(op) {}
 
-      type(type&& other) noexcept
-        : op_(std::exchange(other.op_, nullptr)) {}
+  type(type&& other) noexcept : op_(std::exchange(other.op_, nullptr)) {}
 
-      void set_value() && noexcept { op_->notify_trigger_complete(); }
+  void set_value() && noexcept { op_->notify_trigger_complete(); }
 
-      template <typename Error>
-      void set_error(Error&&) && noexcept {
-        op_->notify_trigger_complete();
-      }
+  template <typename Error>
+  void set_error(Error&&) && noexcept {
+    op_->notify_trigger_complete();
+  }
 
-      void set_done() && noexcept { op_->notify_trigger_complete(); }
+  void set_done() && noexcept { op_->notify_trigger_complete(); }
 
-    private:
-      friend inplace_stop_token tag_invoke(
-          tag_t<unifex::get_stop_token>,
-          const type& r) noexcept {
-        return r.get_stop_token();
-      }
+private:
+  friend inplace_stop_token
+  tag_invoke(tag_t<unifex::get_stop_token>, const type& r) noexcept {
+    return r.get_stop_token();
+  }
 
-      template(typename CPO)
-          (requires is_receiver_query_cpo_v<CPO>)
-      friend auto tag_invoke(CPO cpo, const type& r)
-          noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
-          -> callable_result_t<CPO, const Receiver&> {
-        return std::move(cpo)(r.get_receiver());
-      }
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
+      -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(r.get_receiver());
+  }
 
-      inplace_stop_token get_stop_token() const noexcept {
-        return op_->stopSource_.get_token();
-      }
+  inplace_stop_token get_stop_token() const noexcept {
+    return op_->stopSource_.get_token();
+  }
 
-      const Receiver& get_receiver() const noexcept { return op_->receiver_; }
+  const Receiver& get_receiver() const noexcept { return op_->receiver_; }
 
-      operation_state* op_;
-    };
+  operation_state* op_;
+};
 
-    template <typename Source, typename Trigger, typename Receiver>
-    class _op<Source, Trigger, Receiver>::type {
-      using source_receiver =
-          stop_when_source_receiver<Source, Trigger, Receiver>;
-      using trigger_receiver =
-          stop_when_trigger_receiver<Source, Trigger, Receiver>;
+template <typename Source, typename Trigger, typename Receiver>
+class _op<Source, Trigger, Receiver>::type {
+  using source_receiver = stop_when_source_receiver<Source, Trigger, Receiver>;
+  using trigger_receiver =
+      stop_when_trigger_receiver<Source, Trigger, Receiver>;
 
-    public:
-      template <typename Receiver2>
-      explicit type(
-          Source&& source,
-          Trigger&& trigger,
-          Receiver2&& receiver)
-          noexcept(is_nothrow_connectable_v<Source, source_receiver> &&
-                   is_nothrow_connectable_v<Trigger, trigger_receiver> &&
-                   std::is_nothrow_constructible_v<Receiver, Receiver2>)
-        : receiver_((Receiver2 &&) receiver)
-        , sourceOp_(unifex::connect((Source &&) source, source_receiver{this}))
-        , triggerOp_(
-              unifex::connect((Trigger &&) trigger, trigger_receiver{this})) {}
+public:
+  template <typename Receiver2>
+  explicit type(
+      Source&& source,
+      Trigger&& trigger,
+      Receiver2&&
+          receiver) noexcept(is_nothrow_connectable_v<Source, source_receiver>&&
+                                 is_nothrow_connectable_v<
+                                     Trigger,
+                                     trigger_receiver>&&
+                                     std::is_nothrow_constructible_v<
+                                         Receiver,
+                                         Receiver2>)
+    : receiver_((Receiver2 &&) receiver)
+    , sourceOp_(unifex::connect((Source &&) source, source_receiver{this}))
+    , triggerOp_(
+          unifex::connect((Trigger &&) trigger, trigger_receiver{this})) {}
 
-      void start() & noexcept {
-        stopCallback_.emplace(get_stop_token(receiver_), cancel_callback{this});
+  void start() & noexcept {
+    stopCallback_.emplace(get_stop_token(receiver_), cancel_callback{this});
 
-        unifex::start(sourceOp_);
-        unifex::start(triggerOp_);
-      }
+    unifex::start(sourceOp_);
+    unifex::start(triggerOp_);
+  }
 
-    private:
-      friend class _srcvr<Source, Trigger, Receiver>::type;
-      friend class _trcvr<Source, Trigger, Receiver>::type;
+private:
+  friend class _srcvr<Source, Trigger, Receiver>::type;
+  friend class _trcvr<Source, Trigger, Receiver>::type;
 
-      class cancel_callback {
-      public:
-        explicit cancel_callback(type* op) noexcept : op_(op) {}
+  class cancel_callback {
+  public:
+    explicit cancel_callback(type* op) noexcept : op_(op) {}
 
-        void operator()() noexcept { op_->stopSource_.request_stop(); }
+    void operator()() noexcept { op_->stopSource_.request_stop(); }
 
-      private:
-        type* op_;
-      };
+  private:
+    type* op_;
+  };
 
-      void notify_source_complete() noexcept {
-        this->notify_trigger_complete();
-      }
+  void notify_source_complete() noexcept { this->notify_trigger_complete(); }
 
-      void notify_trigger_complete() noexcept {
-        stopSource_.request_stop();
-        if (activeOpCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-          stopCallback_.reset();
-          deliver_result();
-        }
-      }
+  void notify_trigger_complete() noexcept {
+    stopSource_.request_stop();
+    if (activeOpCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      stopCallback_.reset();
+      deliver_result();
+    }
+  }
 
-      void deliver_result() noexcept {
-        UNIFEX_TRY {
-          unifex::visit(
-              [this](auto&& tuple) {
-                if constexpr (
-                    std::tuple_size<
-                        std::remove_reference_t<decltype(tuple)>>::value != 0) {
-                  std::apply(
-                      [&](auto set_xxx, auto&&... args) {
-                        set_xxx(
-                            std::move(receiver_),
-                            static_cast<decltype(args)>(args)...);
-                      },
-                      static_cast<decltype(tuple)>(tuple));
-                } else {
-                  // Should be unreachable
-                  std::terminate();
-                }
-              },
-              std::move(result_));
-        } UNIFEX_CATCH (...) {
-          unifex::set_error(std::move(receiver_), std::current_exception());
-        }
-      }
+  void deliver_result() noexcept {
+    UNIFEX_TRY {
+      unifex::visit(
+          [this](auto&& tuple) {
+            if constexpr (
+                std::tuple_size<
+                    std::remove_reference_t<decltype(tuple)>>::value != 0) {
+              std::apply(
+                  [&](auto set_xxx, auto&&... args) {
+                    set_xxx(
+                        std::move(receiver_),
+                        static_cast<decltype(args)>(args)...);
+                  },
+                  static_cast<decltype(tuple)>(tuple));
+            } else {
+              // Should be unreachable
+              std::terminate();
+            }
+          },
+          std::move(result_));
+    }
+    UNIFEX_CATCH(...) {
+      unifex::set_error(std::move(receiver_), std::current_exception());
+    }
+  }
 
-      template <typename... Values>
-      using value_decayed_tuple =
-          std::tuple<tag_t<unifex::set_value>, std::decay_t<Values>...>;
+  template <typename... Values>
+  using value_decayed_tuple =
+      std::tuple<tag_t<unifex::set_value>, std::decay_t<Values>...>;
 
-      template <typename... Errors>
-      using error_tuples = type_list<
-          std::tuple<tag_t<unifex::set_error>, std::decay_t<Errors>>...>;
+  template <typename... Errors>
+  using error_tuples =
+      type_list<std::tuple<tag_t<unifex::set_error>, std::decay_t<Errors>>...>;
 
-      using result_variant =
-          typename concat_type_lists_t<
-              type_list<std::tuple<>, std::tuple<tag_t<unifex::set_done>>>,
-              sender_value_types_t<remove_cvref_t<Source>, type_list, value_decayed_tuple>,
-              sender_error_types_t<remove_cvref_t<Source>, error_tuples>>::template
-                  apply<variant>;
+  using result_variant = typename concat_type_lists_t<
+      type_list<std::tuple<>, std::tuple<tag_t<unifex::set_done>>>,
+      sender_value_types_t<
+          remove_cvref_t<Source>,
+          type_list,
+          value_decayed_tuple>,
+      sender_error_types_t<remove_cvref_t<Source>, error_tuples>>::
+      template apply<variant>;
 
-      UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-      std::atomic<int> activeOpCount_ = 2;
-      inplace_stop_source stopSource_;
-      optional<typename stop_token_type_t<
-          Receiver>::template callback_type<cancel_callback>>
-          stopCallback_;
-      UNIFEX_NO_UNIQUE_ADDRESS result_variant result_;
-      UNIFEX_NO_UNIQUE_ADDRESS connect_result_t<Source, source_receiver> sourceOp_;
-      UNIFEX_NO_UNIQUE_ADDRESS
-      connect_result_t<Trigger, trigger_receiver> triggerOp_;
-    };
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  std::atomic<int> activeOpCount_ = 2;
+  inplace_stop_source stopSource_;
+  optional<typename stop_token_type_t<Receiver>::template callback_type<
+      cancel_callback>>
+      stopCallback_;
+  UNIFEX_NO_UNIQUE_ADDRESS result_variant result_;
+  UNIFEX_NO_UNIQUE_ADDRESS connect_result_t<Source, source_receiver> sourceOp_;
+  UNIFEX_NO_UNIQUE_ADDRESS
+  connect_result_t<Trigger, trigger_receiver> triggerOp_;
+};
 
-    template <typename Source, typename Trigger>
-    struct _sndr {
-      class type;
-    };
+template <typename Source, typename Trigger>
+struct _sndr {
+  class type;
+};
 
-    template <typename Source, typename Trigger>
-    using stop_when_sender = typename _sndr<Source, Trigger>::type;
+template <typename Source, typename Trigger>
+using stop_when_sender = typename _sndr<Source, Trigger>::type;
 
-    template <typename Source, typename Trigger>
-    class _sndr<Source, Trigger>::type {
-      using stop_when_sender = type;
+template <typename Source, typename Trigger>
+class _sndr<Source, Trigger>::type {
+  using stop_when_sender = type;
 
-      template <typename... Values>
-      using decayed_type_list = type_list<type_list<std::decay_t<Values>...>>;
+  template <typename... Values>
+  using decayed_type_list = type_list<type_list<std::decay_t<Values>...>>;
 
-      template <
-          template <typename...> class Outer,
-          template <typename...> class Inner>
-      struct compose_nested {
-        template <typename... Lists>
-        using apply = Outer<typename Lists::template apply<Inner>...>;
-      };
+  template <
+      template <typename...>
+      class Outer,
+      template <typename...>
+      class Inner>
+  struct compose_nested {
+    template <typename... Lists>
+    using apply = Outer<typename Lists::template apply<Inner>...>;
+  };
 
-    public:
-      template <
-          template <typename...> class Variant,
-          template <typename...> class Tuple>
-      using value_types = typename sender_traits<Source>::
-          template value_types<concat_type_lists_unique_t, decayed_type_list>::
-              template apply<compose_nested<Variant, Tuple>::template apply>;
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename sender_traits<Source>::
+      template value_types<concat_type_lists_unique_t, decayed_type_list>::
+          template apply<compose_nested<Variant, Tuple>::template apply>;
 
-      template <template <typename...> class Variant>
-      using error_types =
-          typename concat_type_lists_unique_t<
-              sender_error_types_t<Source, decayed_tuple<type_list>::template apply>,
-              type_list<std::exception_ptr>>::template apply<Variant>;
+  template <template <typename...> class Variant>
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Source, decayed_tuple<type_list>::template apply>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
-      static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-      template <typename Source2, typename Trigger2>
-      explicit type(Source2&& source, Trigger2&& trigger) noexcept(
-          std::is_nothrow_constructible_v<Source, Source2> &&
+  template <typename Source2, typename Trigger2>
+  explicit type(Source2&& source, Trigger2&& trigger) noexcept(
+      std::is_nothrow_constructible_v<Source, Source2>&&
           std::is_nothrow_constructible_v<Trigger, Trigger2>)
-        : source_((Source2 &&) source)
-        , trigger_((Trigger2 &&) trigger) {}
+    : source_((Source2 &&) source)
+    , trigger_((Trigger2 &&) trigger) {}
 
-      template(typename Self, typename Receiver)
-          (requires
-              same_as<remove_cvref_t<Self>, type> AND
-              receiver<Receiver> AND
-              sender_to<
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND sender_to<
+          member_t<Self, Source>,
+          stop_when_source_receiver<
+              member_t<Self, Source>,
+              member_t<Self, Trigger>,
+              remove_cvref_t<Receiver>>> AND
+          sender_to<
+              member_t<Self, Trigger>,
+              stop_when_trigger_receiver<
                   member_t<Self, Source>,
-                  stop_when_source_receiver<
-                      member_t<Self, Source>,
-                      member_t<Self, Trigger>,
-                      remove_cvref_t<Receiver>>> AND
-              sender_to<
                   member_t<Self, Trigger>,
-                  stop_when_trigger_receiver<
-                      member_t<Self, Source>,
-                      member_t<Self, Trigger>,
-                      remove_cvref_t<Receiver>>>)
-      friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r)
-          -> stop_when_operation<
-                member_t<Self, Source>,
-                member_t<Self, Trigger>,
-                remove_cvref_t<Receiver>> {
-        return stop_when_operation<
-            member_t<Self, Source>,
-            member_t<Self, Trigger>,
-            remove_cvref_t<Receiver>>{
-                ((Self &&) self).source_,
-                ((Self &&) self).trigger_,
-                (Receiver &&) r};
-      }
+                  remove_cvref_t<
+                      Receiver>>>) friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r)
+      -> stop_when_operation<
+          member_t<Self, Source>,
+          member_t<Self, Trigger>,
+          remove_cvref_t<Receiver>> {
+    return stop_when_operation<
+        member_t<Self, Source>,
+        member_t<Self, Trigger>,
+        remove_cvref_t<Receiver>>{
+        ((Self &&) self).source_, ((Self &&) self).trigger_, (Receiver &&) r};
+  }
 
-    private:
-      UNIFEX_NO_UNIQUE_ADDRESS Source source_;
-      UNIFEX_NO_UNIQUE_ADDRESS Trigger trigger_;
-    };
-  }  // namespace _stop_when
+private:
+  UNIFEX_NO_UNIQUE_ADDRESS Source source_;
+  UNIFEX_NO_UNIQUE_ADDRESS Trigger trigger_;
+};
+}  // namespace _stop_when
 
-  namespace _stop_when_cpo
-  {
-    struct _fn {
-      template(typename Source, typename Trigger)
-          (requires tag_invocable<_fn, Source, Trigger>)
-      auto operator()(Source&& source, Trigger&& trigger) const
-          noexcept(is_nothrow_tag_invocable_v<_fn, Source, Trigger>)
+namespace _stop_when_cpo {
+struct _fn {
+  template(typename Source, typename Trigger)(
+      requires tag_invocable<_fn, Source, Trigger>) auto
+  operator()(Source&& source, Trigger&& trigger) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Source, Trigger>)
           -> tag_invoke_result_t<_fn, Source, Trigger> {
-        return unifex::tag_invoke(
-            *this, (Source &&) source, (Trigger &&) trigger);
-      }
+    return unifex::tag_invoke(*this, (Source &&) source, (Trigger &&) trigger);
+  }
 
-      template(typename Source, typename Trigger)
-          (requires (!tag_invocable<_fn, Source, Trigger>))
-      auto operator()(Source&& source, Trigger&& trigger) const noexcept(
-          std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source> &&
+  template(typename Source, typename Trigger)(
+      requires(!tag_invocable<_fn, Source, Trigger>)) auto
+  operator()(Source&& source, Trigger&& trigger) const noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>&&
           std::is_nothrow_constructible_v<remove_cvref_t<Trigger>, Trigger>)
-          -> _stop_when::stop_when_sender<
-              remove_cvref_t<Source>,
-              remove_cvref_t<Trigger>> {
-        return _stop_when::stop_when_sender<
-            remove_cvref_t<Source>,
-            remove_cvref_t<Trigger>>(
+      -> _stop_when::
+          stop_when_sender<remove_cvref_t<Source>, remove_cvref_t<Trigger>> {
+    return _stop_when::
+        stop_when_sender<remove_cvref_t<Source>, remove_cvref_t<Trigger>>(
             (Source &&) source, (Trigger &&) trigger);
-      }
-      template <typename Trigger>
-      constexpr auto operator()(Trigger&& trigger) const
-          noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Trigger>)
+  }
+  template <typename Trigger>
+  constexpr auto operator()(Trigger&& trigger) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Trigger>)
           -> bind_back_result_t<_fn, Trigger> {
-        return bind_back(*this, (Trigger&&)trigger);
-      }
-    };
+    return bind_back(*this, (Trigger &&) trigger);
+  }
+};
 
-  }  // namespace _stop_when_cpo
+}  // namespace _stop_when_cpo
 
-  inline constexpr _stop_when_cpo::_fn stop_when{};
+inline constexpr _stop_when_cpo::_fn stop_when{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stream_concepts.hpp
+++ b/include/unifex/stream_concepts.hpp
@@ -15,70 +15,64 @@
  */
 #pragma once
 
-#include <unifex/tag_invoke.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _streams {
-  inline const struct _next_fn {
-  private:
-    template <typename Stream>
-    using _member_next_result_t = decltype(UNIFEX_DECLVAL(Stream).next());
-    template <typename Stream>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_next_fn, Stream>,
-        meta_tag_invoke_result<_next_fn>,
-        meta_quote1<_member_next_result_t>>::template apply<Stream>;
-  public:
-    template(typename Stream)
-      (requires tag_invocable<_next_fn, Stream&>)
-    auto operator()(Stream& stream) const
-        noexcept(is_nothrow_tag_invocable_v<_next_fn, Stream&>)
-        -> _result_t<Stream&> {
-      return unifex::tag_invoke(_next_fn{}, stream);
-    }
-    template(typename Stream)
-      (requires (!tag_invocable<_next_fn, Stream&>))
-    auto operator()(Stream& stream) const
-        noexcept(noexcept(stream.next()))
-        -> _result_t<Stream&> {
-      return stream.next();
-    }
-  } next{};
+inline const struct _next_fn {
+private:
+  template <typename Stream>
+  using _member_next_result_t = decltype(UNIFEX_DECLVAL(Stream).next());
+  template <typename Stream>
+  using _result_t = typename conditional_t<
+      tag_invocable<_next_fn, Stream>,
+      meta_tag_invoke_result<_next_fn>,
+      meta_quote1<_member_next_result_t>>::template apply<Stream>;
 
-  inline const struct _cleanup_fn {
-  private:
-    template <typename Stream>
-    using _member_cleanup_result_t = decltype(UNIFEX_DECLVAL(Stream).cleanup());
-    template <typename Stream>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_cleanup_fn, Stream>,
-        meta_tag_invoke_result<_cleanup_fn>,
-        meta_quote1<_member_cleanup_result_t>>::template apply<Stream>;
-  public:
-    template(typename Stream)
-      (requires tag_invocable<_cleanup_fn, Stream&>)
-    auto operator()(Stream& stream) const
-        noexcept(is_nothrow_tag_invocable_v<_cleanup_fn, Stream&>)
-        -> _result_t<Stream&> {
-      return unifex::tag_invoke(_cleanup_fn{}, stream);
-    }
-    template(typename Stream)
-      (requires (!tag_invocable<_cleanup_fn, Stream&>))
-    auto operator()(Stream& stream) const
-        noexcept(noexcept(stream.cleanup()))
-        -> _result_t<Stream&> {
-      return stream.cleanup();
-    }
-  } cleanup{};
-} // namespace _streams
+public:
+  template(typename Stream)(requires tag_invocable<_next_fn, Stream&>) auto
+  operator()(Stream& stream) const
+      noexcept(is_nothrow_tag_invocable_v<_next_fn, Stream&>)
+          -> _result_t<Stream&> {
+    return unifex::tag_invoke(_next_fn{}, stream);
+  }
+  template(typename Stream)(requires(!tag_invocable<_next_fn, Stream&>)) auto
+  operator()(Stream& stream) const noexcept(noexcept(stream.next()))
+      -> _result_t<Stream&> {
+    return stream.next();
+  }
+} next{};
 
-using _streams::next;
+inline const struct _cleanup_fn {
+private:
+  template <typename Stream>
+  using _member_cleanup_result_t = decltype(UNIFEX_DECLVAL(Stream).cleanup());
+  template <typename Stream>
+  using _result_t = typename conditional_t<
+      tag_invocable<_cleanup_fn, Stream>,
+      meta_tag_invoke_result<_cleanup_fn>,
+      meta_quote1<_member_cleanup_result_t>>::template apply<Stream>;
+
+public:
+  template(typename Stream)(requires tag_invocable<_cleanup_fn, Stream&>) auto
+  operator()(Stream& stream) const
+      noexcept(is_nothrow_tag_invocable_v<_cleanup_fn, Stream&>)
+          -> _result_t<Stream&> {
+    return unifex::tag_invoke(_cleanup_fn{}, stream);
+  }
+  template(typename Stream)(requires(!tag_invocable<_cleanup_fn, Stream&>)) auto
+  operator()(Stream& stream) const noexcept(noexcept(stream.cleanup()))
+      -> _result_t<Stream&> {
+    return stream.cleanup();
+  }
+} cleanup{};
+}  // namespace _streams
+
 using _streams::cleanup;
+using _streams::next;
 
 template <typename Stream>
 using next_sender_t = decltype(next(std::declval<Stream&>()));
@@ -90,8 +84,9 @@ template <typename Stream, typename Receiver>
 using next_operation_t = connect_result_t<next_sender_t<Stream>, Receiver>;
 
 template <typename Stream, typename Receiver>
-using cleanup_operation_t = connect_result_t<cleanup_sender_t<Stream>, Receiver>;
+using cleanup_operation_t =
+    connect_result_t<cleanup_sender_t<Stream>, Receiver>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/submit.hpp
+++ b/include/unifex/submit.hpp
@@ -15,17 +15,17 @@
  */
 #pragma once
 
-#include <unifex/blocking.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/async_trace.hpp>
-#include <unifex/tag_invoke.hpp>
 #include <unifex/config.hpp>
-#include <unifex/get_allocator.hpp>
-#include <unifex/scope_guard.hpp>
-#include <unifex/std_concepts.hpp>
+#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/get_allocator.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scope_guard.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
 #include <unifex/utility.hpp>
 
 #include <memory>
@@ -38,8 +38,7 @@ template <typename Allocator, typename T>
 using rebind_alloc_t =
     typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
 template <typename Allocator, typename T>
-using rebind_traits_t =
-    std::allocator_traits<rebind_alloc_t<Allocator, T>>;
+using rebind_traits_t = std::allocator_traits<rebind_alloc_t<Allocator, T>>;
 
 template <typename Sender, typename Receiver>
 struct _op {
@@ -53,17 +52,17 @@ class _op<Sender, Receiver>::type {
   struct wrapped_receiver {
     type* op_;
 
-    template(typename... Values)
-      (requires receiver_of<Receiver, Values...>)
-    void set_value(Values&&... values) && noexcept {
+    template(typename... Values)(
+        requires receiver_of<
+            Receiver,
+            Values...>) void set_value(Values&&... values) && noexcept {
       auto allocator = get_allocator(get_receiver());
       unifex::set_value(std::move(get_receiver()), (Values &&) values...);
       destroy(std::move(allocator));
     }
 
-    template(typename Error)
-      (requires receiver<Receiver, Error>)
-    void set_error(Error&& error) && noexcept {
+    template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+        Error&& error) && noexcept {
       auto allocator = get_allocator(get_receiver());
       unifex::set_error(std::move(get_receiver()), (Error &&) error);
       destroy(std::move(allocator));
@@ -83,23 +82,19 @@ class _op<Sender, Receiver>::type {
       rebind_traits_t<Allocator, type>::deallocate(typedAllocator, op, 1);
     }
 
-    Receiver& get_receiver() const noexcept {
-      return op_->receiver_;
-    }
+    Receiver& get_receiver() const noexcept { return op_->receiver_; }
 
-    template(typename CPO)
-        (requires is_receiver_query_cpo_v<CPO>)
-    friend auto tag_invoke(CPO cpo, const wrapped_receiver& r) noexcept(
-        is_nothrow_callable_v<CPO, const Receiver&>)
+    template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+        CPO cpo,
+        const wrapped_receiver&
+            r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
         -> callable_result_t<CPO, const Receiver&> {
       return std::move(cpo)(std::as_const(r.get_receiver()));
     }
 
     template <typename Func>
     friend void tag_invoke(
-        tag_t<visit_continuations>,
-        const wrapped_receiver& r,
-        Func&& func) {
+        tag_t<visit_continuations>, const wrapped_receiver& r, Func&& func) {
       std::invoke(func, std::as_const(r.get_receiver()));
     }
   };
@@ -108,107 +103,101 @@ public:
   template <typename Receiver2>
   explicit type(Sender&& sender, Receiver2&& receiver)
     : receiver_((Receiver2 &&) receiver)
-    , inner_(unifex::connect((Sender &&) sender, wrapped_receiver{this}))
-  {}
+    , inner_(unifex::connect((Sender &&) sender, wrapped_receiver{this})) {}
 
-  void start() & noexcept {
-    unifex::start(inner_);
-  }
+  void start() & noexcept { unifex::start(inner_); }
 
 private:
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-  /*UNIFEX_NO_UNIQUE_ADDRESS*/ connect_result_t<Sender, wrapped_receiver> inner_;
+  /*UNIFEX_NO_UNIQUE_ADDRESS*/ connect_result_t<Sender, wrapped_receiver>
+      inner_;
 };
-} // namespace _submit
+}  // namespace _submit
 
 namespace _submit_cpo {
-  using _submit::rebind_alloc_t;
-  using _submit::rebind_traits_t;
-  template <typename Sender, typename Receiver>
-  using _member_submit_result_t =
-      decltype((UNIFEX_DECLVAL(Sender&&)).submit(UNIFEX_DECLVAL(Receiver&&)));
+using _submit::rebind_alloc_t;
+using _submit::rebind_traits_t;
+template <typename Sender, typename Receiver>
+using _member_submit_result_t =
+    decltype((UNIFEX_DECLVAL(Sender &&)).submit(UNIFEX_DECLVAL(Receiver &&)));
 
-  template <typename Sender, typename Receiver>
-  UNIFEX_CONCEPT_FRAGMENT( //
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT_FRAGMENT(  //
     _has_member_submit_,  //
-      requires() (         //
-        typename(_member_submit_result_t<Sender, Receiver>)
-      ));
-  template <typename Sender, typename Receiver>
-  UNIFEX_CONCEPT //
-    _has_member_submit = //
-      UNIFEX_FRAGMENT(_submit_cpo::_has_member_submit_, Sender, Receiver);
+    requires()(           //
+        typename(_member_submit_result_t<Sender, Receiver>)));
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT            //
+    _has_member_submit =  //
+    UNIFEX_FRAGMENT(_submit_cpo::_has_member_submit_, Sender, Receiver);
 
-  inline const struct _fn {
-    template(typename Sender, typename Receiver)
-        (requires sender<Sender> AND receiver<Receiver> AND
-          tag_invocable<_fn, Sender, Receiver>)
-    void operator()(Sender&& sender, Receiver&& receiver) const {
-      static_assert(
+inline const struct _fn {
+  template(typename Sender, typename Receiver)(
+      requires sender<Sender> AND receiver<Receiver> AND
+          tag_invocable<_fn, Sender, Receiver>) void
+  operator()(Sender&& sender, Receiver&& receiver) const {
+    static_assert(
         std::is_void_v<tag_invoke_result_t<_fn, Sender, Receiver>>,
         "Customisations of submit() must have a void return value");
-      unifex::tag_invoke(*this, (Sender&&) sender, (Receiver&&) receiver);
-    }
-    template(typename Sender, typename Receiver)
-        (requires sender<Sender> AND receiver<Receiver> AND
-          (!tag_invocable<_fn, Sender, Receiver>) AND
-          _has_member_submit<Sender, Receiver>)
-    void operator()(Sender&& sender, Receiver&& receiver) const {
-      ((Sender&&) sender).submit((Receiver&&) receiver);
-    }
-    template(typename Sender, typename Receiver)
-        (requires sender<Sender> AND receiver<Receiver> AND
-          (!tag_invocable<_fn, Sender, Receiver>) AND
-          (!_has_member_submit<Sender, Receiver>) AND
-          sender_to<Sender, Receiver>)
-    void operator()(Sender&& sender, Receiver&& receiver) const {
-      // Default implementation in terms of connect/start
-      switch (blocking(sender)) {
-        case blocking_kind::always:
-        case blocking_kind::always_inline:
-        {
-          // The sender will complete synchronously so we can avoid allocating the
-          // state on the heap.
-          auto op = unifex::connect((Sender &&) sender, (Receiver &&) receiver);
-          unifex::start(op);
-          break;
-        }
-        default:
-        {
-          // Otherwise need to heap-allocate the operation-state
-          using op_t = _submit::operation<Sender, Receiver>;
-          op_t* op = nullptr;
+    unifex::tag_invoke(*this, (Sender &&) sender, (Receiver &&) receiver);
+  }
+  template(typename Sender, typename Receiver)(
+      requires sender<Sender> AND
+          receiver<Receiver> AND(!tag_invocable<_fn, Sender, Receiver>)
+              AND _has_member_submit<Sender, Receiver>) void
+  operator()(Sender&& sender, Receiver&& receiver) const {
+    ((Sender &&) sender).submit((Receiver &&) receiver);
+  }
+  template(typename Sender, typename Receiver)(
+      requires sender<Sender> AND
+          receiver<Receiver> AND(!tag_invocable<_fn, Sender, Receiver>)
+              AND(!_has_member_submit<Sender, Receiver>)
+                  AND sender_to<Sender, Receiver>) void
+  operator()(Sender&& sender, Receiver&& receiver) const {
+    // Default implementation in terms of connect/start
+    switch (blocking(sender)) {
+      case blocking_kind::always:
+      case blocking_kind::always_inline: {
+        // The sender will complete synchronously so we can avoid allocating the
+        // state on the heap.
+        auto op = unifex::connect((Sender &&) sender, (Receiver &&) receiver);
+        unifex::start(op);
+        break;
+      }
+      default: {
+        // Otherwise need to heap-allocate the operation-state
+        using op_t = _submit::operation<Sender, Receiver>;
+        op_t* op = nullptr;
 
-          {
-            // Use the receiver's associated allocator to allocate this state.
-            auto allocator = get_allocator(receiver);
-            using allocator_t = decltype(allocator);
+        {
+          // Use the receiver's associated allocator to allocate this state.
+          auto allocator = get_allocator(receiver);
+          using allocator_t = decltype(allocator);
 
-            rebind_alloc_t<allocator_t, op_t> typedAllocator{allocator};
-            op = rebind_traits_t<allocator_t, op_t>::allocate(typedAllocator, 1);
-            scope_guard freeOnError = [&]() noexcept {
-              rebind_traits_t<allocator_t, op_t>::deallocate(typedAllocator, op, 1);
-            };
-            rebind_traits_t<allocator_t, op_t>::construct(
-                typedAllocator, op, (Sender&&)sender, (Receiver&&)receiver);
-            freeOnError.release();
-          }
-          op->start();
+          rebind_alloc_t<allocator_t, op_t> typedAllocator{allocator};
+          op = rebind_traits_t<allocator_t, op_t>::allocate(typedAllocator, 1);
+          scope_guard freeOnError = [&]() noexcept {
+            rebind_traits_t<allocator_t, op_t>::deallocate(
+                typedAllocator, op, 1);
+          };
+          rebind_traits_t<allocator_t, op_t>::construct(
+              typedAllocator, op, (Sender &&) sender, (Receiver &&) receiver);
+          freeOnError.release();
         }
+        op->start();
       }
     }
-    template(typename Receiver)
-        (requires receiver<Receiver>)
-    constexpr auto operator()(Receiver&& receiver) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Receiver>)
-        -> bind_back_result_t<_fn, Receiver> {
-      return bind_back(*this, (Receiver&&)receiver);
-    }
-  } submit{};
-} // namespace _submit_cpo
+  }
+  template(typename Receiver)(requires receiver<Receiver>) constexpr auto
+  operator()(Receiver&& receiver) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Receiver>)
+          -> bind_back_result_t<_fn, Receiver> {
+    return bind_back(*this, (Receiver &&) receiver);
+  }
+} submit{};
+}  // namespace _submit_cpo
 using _submit_cpo::submit;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/swap.hpp
+++ b/include/unifex/swap.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/detail/concept_macros.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/detail/concept_macros.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -30,68 +30,66 @@ template <typename T, typename U, typename = void>
 extern bool const is_nothrow_swappable_with_v;
 
 namespace _swap {
-    struct nope;
+struct nope;
 
-    // Intentionally create an ambiguity with std::swap, which is
-    // (possibly) unconstrained.
-    template <typename T>
-    nope* swap(T &, T &) = delete;
+// Intentionally create an ambiguity with std::swap, which is
+// (possibly) unconstrained.
+template <typename T>
+nope* swap(T&, T&) = delete;
 
-    template <typename T, std::size_t N>
-    nope* swap(T (&)[N], T (&)[N]) = delete;
+template <typename T, std::size_t N>
+nope* swap(T (&)[N], T (&)[N]) = delete;
 
 #ifdef CPP_WORKAROUND_MSVC_895622
-    nope swap();
+nope swap();
 #endif
 
-    template <typename T, typename U>
-    decltype(swap(std::declval<T>(), std::declval<U>())) try_adl_swap_(int);
+template <typename T, typename U>
+decltype(swap(std::declval<T>(), std::declval<U>())) try_adl_swap_(int);
 
-    template <typename T, typename U>
-    nope* try_adl_swap_(long);
+template <typename T, typename U>
+nope* try_adl_swap_(long);
 
-    template <typename T, typename U = T>
-    inline constexpr bool is_adl_swappable_v =
-        !UNIFEX_IS_SAME(decltype(_swap::try_adl_swap_<T, U>(42)), nope*);
+template <typename T, typename U = T>
+inline constexpr bool is_adl_swappable_v =
+    !UNIFEX_IS_SAME(decltype(_swap::try_adl_swap_<T, U>(42)), nope*);
 
-    struct _fn {
-        // Dispatch to user-defined swap found via ADL:
-        UNIFEX_TEMPLATE(typename T, typename U)
-            (requires is_adl_swappable_v<T, U>)
-        constexpr void operator()(T &&t, U &&u) const
-            noexcept(noexcept(swap((T &&) t, (U &&) u))) {
-            swap((T &&) t, (U &&) u);
-        }
+struct _fn {
+  // Dispatch to user-defined swap found via ADL:
+  UNIFEX_TEMPLATE(typename T, typename U)
+  (requires is_adl_swappable_v<T, U>)constexpr void
+  operator()(T&& t, U&& u) const noexcept(noexcept(swap((T &&) t, (U &&) u))) {
+    swap((T &&) t, (U &&) u);
+  }
 
-        // For intrinsically swappable (i.e., movable) types for which
-        // a swap overload cannot be found via ADL, swap by moving.
-        UNIFEX_TEMPLATE(typename T)
-            (requires (!is_adl_swappable_v<T &>))
-        constexpr auto operator()(T &a, T &b) const
-            noexcept(noexcept(a = T(static_cast<T&&>(b)))) ->
-            decltype(static_cast<void>(a = T(static_cast<T&&>(b)))) {
-            T tmp = static_cast<T &&>(a);
-            a = static_cast<T &&>(b);
-            b = static_cast<T &&>(tmp);
-        }
+  // For intrinsically swappable (i.e., movable) types for which
+  // a swap overload cannot be found via ADL, swap by moving.
+  UNIFEX_TEMPLATE(typename T)
+  (requires(!is_adl_swappable_v<T&>)) constexpr auto
+  operator()(T& a, T& b) const noexcept(noexcept(a = T(static_cast<T&&>(b))))
+      -> decltype(static_cast<void>(a = T(static_cast<T&&>(b)))) {
+    T tmp = static_cast<T&&>(a);
+    a = static_cast<T&&>(b);
+    b = static_cast<T&&>(tmp);
+  }
 
-        // For arrays of intrinsically swappable (i.e., movable) types
-        // for which a swap overload cannot be found via ADL, swap array
-        // elements by moving.
-        UNIFEX_TEMPLATE(typename T, typename U, std::size_t N)
-            (requires (!is_adl_swappable_v<T (&)[N], U (&)[N]>) &&
-                is_swappable_with_v<T &, U &>)
-        constexpr void operator()(T (&t)[N], U (&u)[N]) const
-            noexcept(is_nothrow_swappable_with_v<T &, U &>) {
-            for(std::size_t i = 0; i < N; ++i)
-                (*this)(t[i], u[i]);
-        }
-    };
-} // namespace _swap
+  // For arrays of intrinsically swappable (i.e., movable) types
+  // for which a swap overload cannot be found via ADL, swap array
+  // elements by moving.
+  UNIFEX_TEMPLATE(typename T, typename U, std::size_t N)
+  (requires(!is_adl_swappable_v<T (&)[N], U (&)[N]>) &&
+   is_swappable_with_v<T&, U&>)constexpr void
+  operator()(T (&t)[N], U (&u)[N]) const
+      noexcept(is_nothrow_swappable_with_v<T&, U&>) {
+    for (std::size_t i = 0; i < N; ++i)
+      (*this)(t[i], u[i]);
+  }
+};
+}  // namespace _swap
 
 namespace _swap_cpo {
-inline constexpr _swap::_fn swap {};
-} // namespace _swap_cpo
+inline constexpr _swap::_fn swap{};
+}  // namespace _swap_cpo
 using _swap_cpo::swap;
 
 template <typename, typename, typename>
@@ -99,15 +97,19 @@ inline constexpr bool is_swappable_with_v = false;
 
 template <typename T, typename U>
 inline constexpr bool is_swappable_with_v<
-    T, U, decltype(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)))> = true;
+    T,
+    U,
+    decltype(swap(UNIFEX_DECLVAL(T &&), UNIFEX_DECLVAL(U&&)))> = true;
 
 template <typename, typename, typename>
 inline constexpr bool is_nothrow_swappable_with_v = false;
 
 template <typename T, typename U>
 inline constexpr bool is_nothrow_swappable_with_v<
-    T, U, decltype(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)))> = 
+    T,
+    U,
+    decltype(swap(UNIFEX_DECLVAL(T &&), UNIFEX_DECLVAL(U&&)))> =
     noexcept(swap(UNIFEX_DECLVAL(T&&), UNIFEX_DECLVAL(U&&)));
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -15,22 +15,22 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
+#include <unifex/exception.hpp>
 #include <unifex/manual_event_loop.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/blocking.hpp>
 #include <unifex/with_query_value.hpp>
-#include <unifex/bind_back.hpp>
-#include <unifex/exception.hpp>
-#include <unifex/optional.hpp>
 
+#include <cassert>
 #include <condition_variable>
 #include <exception>
 #include <mutex>
 #include <type_traits>
 #include <utility>
-#include <cassert>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -66,11 +66,12 @@ struct _receiver {
     template <typename... Values>
     void set_value(Values&&... values) && noexcept {
       UNIFEX_TRY {
-        unifex::activate_union_member(promise_.value_, (Values&&)values...);
+        unifex::activate_union_member(promise_.value_, (Values &&) values...);
         promise_.state_ = promise<T>::state::value;
       }
-      UNIFEX_CATCH (...) {
-        unifex::activate_union_member(promise_.exception_, std::current_exception());
+      UNIFEX_CATCH(...) {
+        unifex::activate_union_member(
+            promise_.exception_, std::current_exception());
         promise_.state_ = promise<T>::state::error;
       }
 
@@ -84,12 +85,13 @@ struct _receiver {
     }
 
     void set_error(std::error_code ec) && noexcept {
-      std::move(*this).set_error(make_exception_ptr(std::system_error{ec, "sync_wait"}));
+      std::move(*this).set_error(
+          make_exception_ptr(std::system_error{ec, "sync_wait"}));
     }
 
     template <typename Error>
     void set_error(Error&& e) && noexcept {
-      std::move(*this).set_error(make_exception_ptr((Error&&)e));
+      std::move(*this).set_error(make_exception_ptr((Error &&) e));
     }
 
     void set_done() && noexcept {
@@ -97,15 +99,12 @@ struct _receiver {
       signal_complete();
     }
 
-    friend auto
-    tag_invoke(tag_t<get_scheduler>, const type& r) noexcept {
+    friend auto tag_invoke(tag_t<get_scheduler>, const type& r) noexcept {
       return r.ctx_.get_scheduler();
     }
 
   private:
-    void signal_complete() noexcept {
-      ctx_.stop();
-    }
+    void signal_complete() noexcept { ctx_.stop(); }
   };
 };
 
@@ -113,69 +112,61 @@ template <typename T>
 using receiver_t = typename _receiver<T>::type;
 
 template <typename Result, typename Sender>
-UNIFEX_CLANG_DISABLE_OPTIMIZATION
-optional<Result> _impl(Sender&& sender) {
+UNIFEX_CLANG_DISABLE_OPTIMIZATION optional<Result> _impl(Sender&& sender) {
   using promise_t = _sync_wait::promise<Result>;
   promise_t promise;
   manual_event_loop ctx;
 
   // Store state for the operation on the stack.
-  auto operation = connect(
-      (Sender&&)sender,
-      _sync_wait::receiver_t<Result>{promise, ctx});
+  auto operation =
+      connect((Sender &&) sender, _sync_wait::receiver_t<Result>{promise, ctx});
 
   start(operation);
 
   ctx.run();
 
   switch (promise.state_) {
-    case promise_t::state::done:
-      return nullopt;
-    case promise_t::state::value:
-      return std::move(promise.value_).get();
+    case promise_t::state::done: return nullopt;
+    case promise_t::state::value: return std::move(promise.value_).get();
     case promise_t::state::error:
       std::rethrow_exception(promise.exception_.get());
-    default:
-      std::terminate();
+    default: std::terminate();
   }
 }
-} // namespace _sync_wait
+}  // namespace _sync_wait
 
 namespace _sync_wait_cpo {
-  struct _fn {
-    template(typename Sender)
-      (requires typed_sender<Sender>)
-    auto operator()(Sender&& sender) const
-        -> optional<sender_single_value_result_t<remove_cvref_t<Sender>>> {
-      using Result = sender_single_value_result_t<remove_cvref_t<Sender>>;
-      return _sync_wait::_impl<Result>((Sender&&) sender);
-    }
-    constexpr auto operator()() const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn>)
-        -> bind_back_result_t<_fn> {
-      return bind_back(*this);
-    }
-  };
-} // namespace _sync_wait_cpo
+struct _fn {
+  template(typename Sender)(requires typed_sender<Sender>) auto
+  operator()(Sender&& sender) const
+      -> optional<sender_single_value_result_t<remove_cvref_t<Sender>>> {
+    using Result = sender_single_value_result_t<remove_cvref_t<Sender>>;
+    return _sync_wait::_impl<Result>((Sender &&) sender);
+  }
+  constexpr auto operator()() const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn>)
+          -> bind_back_result_t<_fn> {
+    return bind_back(*this);
+  }
+};
+}  // namespace _sync_wait_cpo
 
-inline constexpr _sync_wait_cpo::_fn sync_wait {};
+inline constexpr _sync_wait_cpo::_fn sync_wait{};
 
 namespace _sync_wait_r_cpo {
-  template <typename Result>
-  struct _fn {
-    template(typename Sender)
-      (requires sender<Sender>)
-    decltype(auto) operator()(Sender&& sender) const {
-      using Result2 = non_void_t<wrap_reference_t<decay_rvalue_t<Result>>>;
-      return _sync_wait::_impl<Result2>((Sender&&) sender);
-    }
-  };
-} // namespace _sync_wait_r_cpo
+template <typename Result>
+struct _fn {
+  template(typename Sender)(requires sender<Sender>) decltype(auto)
+  operator()(Sender&& sender) const {
+    using Result2 = non_void_t<wrap_reference_t<decay_rvalue_t<Result>>>;
+    return _sync_wait::_impl<Result2>((Sender &&) sender);
+  }
+};
+}  // namespace _sync_wait_r_cpo
 
 template <typename Result>
-inline constexpr _sync_wait_r_cpo::_fn<Result> sync_wait_r {};
+inline constexpr _sync_wait_r_cpo::_fn<Result> sync_wait_r{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -16,96 +16,97 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/detail/unifex_fwd.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/detail/concept_macros.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
-  namespace _tag_invoke {
-    void tag_invoke();
+namespace _tag_invoke {
+void tag_invoke();
 
-    struct _fn {
-      template <typename CPO, typename... Args>
-      constexpr auto operator()(CPO cpo, Args&&... args) const
-          noexcept(noexcept(tag_invoke((CPO &&) cpo, (Args &&) args...)))
+struct _fn {
+  template <typename CPO, typename... Args>
+  constexpr auto operator()(CPO cpo, Args&&... args) const
+      noexcept(noexcept(tag_invoke((CPO &&) cpo, (Args &&) args...)))
           -> decltype(tag_invoke((CPO &&) cpo, (Args &&) args...)) {
-        return tag_invoke((CPO &&) cpo, (Args &&) args...);
-      }
-    };
+    return tag_invoke((CPO &&) cpo, (Args &&) args...);
+  }
+};
 
-    template <typename CPO, typename... Args>
-    using tag_invoke_result_t = decltype(
-        tag_invoke(UNIFEX_DECLVAL(CPO &&), UNIFEX_DECLVAL(Args &&)...));
+template <typename CPO, typename... Args>
+using tag_invoke_result_t =
+    decltype(tag_invoke(UNIFEX_DECLVAL(CPO &&), UNIFEX_DECLVAL(Args&&)...));
 
-    using yes_type = char;
-    using no_type = char(&)[2];
+using yes_type = char;
+using no_type = char (&)[2];
 
-    template <typename CPO, typename... Args>
-    auto try_tag_invoke(int) //
-        noexcept(noexcept(tag_invoke(
-            UNIFEX_DECLVAL(CPO &&), UNIFEX_DECLVAL(Args &&)...)))
-        -> decltype(static_cast<void>(tag_invoke(
-            UNIFEX_DECLVAL(CPO &&), UNIFEX_DECLVAL(Args &&)...)), yes_type{});
+template <typename CPO, typename... Args>
+auto try_tag_invoke(int)  //
+    noexcept(
+        noexcept(tag_invoke(UNIFEX_DECLVAL(CPO&&), UNIFEX_DECLVAL(Args&&)...)))
+        -> decltype(
+            static_cast<void>(
+                tag_invoke(UNIFEX_DECLVAL(CPO &&), UNIFEX_DECLVAL(Args&&)...)),
+            yes_type{});
 
-    template <typename CPO, typename... Args>
-    no_type try_tag_invoke(...) noexcept(false);
+template <typename CPO, typename... Args>
+no_type try_tag_invoke(...) noexcept(false);
 
-    template <template <typename...> class T, typename... Args>
-    struct defer {
-      using type = T<Args...>;
-    };
+template <template <typename...> class T, typename... Args>
+struct defer {
+  using type = T<Args...>;
+};
 
-    namespace _cpo {
-      inline constexpr _fn tag_invoke{};
-    }
-  } // namespace _tag_invoke
-  using namespace _tag_invoke::_cpo;
+namespace _cpo {
+inline constexpr _fn tag_invoke{};
+}
+}  // namespace _tag_invoke
+using namespace _tag_invoke::_cpo;
 
-  template <auto& CPO>
-  using tag_t = remove_cvref_t<decltype(CPO)>;
+template <auto& CPO>
+using tag_t = remove_cvref_t<decltype(CPO)>;
 
-  // Manually implement the traits here rather than defining them in terms of
-  // the corresponding std::invoke_result/is_invocable/is_nothrow_invocable
-  // traits to improve compile-times. We don't need all of the generality of the
-  // std:: traits and the tag_invoke traits are used heavily through libunifex
-  // so optimising them for compile time makes a big difference.
+// Manually implement the traits here rather than defining them in terms of
+// the corresponding std::invoke_result/is_invocable/is_nothrow_invocable
+// traits to improve compile-times. We don't need all of the generality of the
+// std:: traits and the tag_invoke traits are used heavily through libunifex
+// so optimising them for compile time makes a big difference.
 
-  using _tag_invoke::tag_invoke_result_t;
+using _tag_invoke::tag_invoke_result_t;
 
-  template <typename CPO, typename... Args>
-  inline constexpr bool is_tag_invocable_v =
-      (sizeof(_tag_invoke::try_tag_invoke<CPO, Args...>(0)) ==
-       sizeof(_tag_invoke::yes_type));
+template <typename CPO, typename... Args>
+inline constexpr bool is_tag_invocable_v =
+    (sizeof(_tag_invoke::try_tag_invoke<CPO, Args...>(0)) ==
+     sizeof(_tag_invoke::yes_type));
 
-  template <typename CPO, typename... Args>
-  struct tag_invoke_result
-    : conditional_t<
-          is_tag_invocable_v<CPO, Args...>,
-          _tag_invoke::defer<tag_invoke_result_t, CPO, Args...>,
-          detail::_empty<>>
-  {};
+template <typename CPO, typename... Args>
+struct tag_invoke_result
+  : conditional_t<
+        is_tag_invocable_v<CPO, Args...>,
+        _tag_invoke::defer<tag_invoke_result_t, CPO, Args...>,
+        detail::_empty<>> {};
 
-  template <typename CPO, typename... Args>
-  using is_tag_invocable = std::bool_constant<is_tag_invocable_v<CPO, Args...>>;
+template <typename CPO, typename... Args>
+using is_tag_invocable = std::bool_constant<is_tag_invocable_v<CPO, Args...>>;
 
-  template <typename CPO, typename... Args>
-  inline constexpr bool is_nothrow_tag_invocable_v =
-      noexcept(_tag_invoke::try_tag_invoke<CPO, Args...>(0));
+template <typename CPO, typename... Args>
+inline constexpr bool is_nothrow_tag_invocable_v =
+    noexcept(_tag_invoke::try_tag_invoke<CPO, Args...>(0));
 
-  template <typename CPO, typename... Args>
-  using is_nothrow_tag_invocable =
-      std::bool_constant<is_nothrow_tag_invocable_v<CPO, Args...>>;
+template <typename CPO, typename... Args>
+using is_nothrow_tag_invocable =
+    std::bool_constant<is_nothrow_tag_invocable_v<CPO, Args...>>;
 
-  template <typename CPO, typename... Args>
-  UNIFEX_CONCEPT tag_invocable =
-      (sizeof(_tag_invoke::try_tag_invoke<CPO, Args...>(0)) ==
-       sizeof(_tag_invoke::yes_type));
+template <typename CPO, typename... Args>
+UNIFEX_CONCEPT tag_invocable =
+    (sizeof(_tag_invoke::try_tag_invoke<CPO, Args...>(0)) ==
+     sizeof(_tag_invoke::yes_type));
 
-  template <typename Fn>
-  using meta_tag_invoke_result =
-      meta_quote1_<tag_invoke_result_t>::bind_front<Fn>;
-} // namespace unifex
+template <typename Fn>
+using meta_tag_invoke_result =
+    meta_quote1_<tag_invoke_result_t>::bind_front<Fn>;
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/take_until.hpp
+++ b/include/unifex/take_until.hpp
@@ -16,18 +16,18 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/stream_concepts.hpp>
-#include <unifex/manual_lifetime.hpp>
-#include <unifex/unstoppable_token.hpp>
-#include <unifex/inplace_stop_token.hpp>
-#include <unifex/get_stop_token.hpp>
 #include <unifex/bind_back.hpp>
 #include <unifex/exception.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/inplace_stop_token.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/stream_concepts.hpp>
+#include <unifex/unstoppable_token.hpp>
 
-#include <exception>
 #include <atomic>
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -40,14 +40,13 @@ struct _stream {
   struct type;
 };
 template <typename SourceStream, typename TriggerStream>
-using stream =
-    typename _stream<
-        remove_cvref_t<SourceStream>,
-        remove_cvref_t<TriggerStream>>::type;
+using stream = typename _stream<
+    remove_cvref_t<SourceStream>,
+    remove_cvref_t<TriggerStream>>::type;
 
 template <typename SourceStream, typename TriggerStream>
 struct _stream<SourceStream, TriggerStream>::type {
- private:
+private:
   using take_until_stream = type;
   struct trigger_next_receiver {
     take_until_stream& stream_;
@@ -68,12 +67,10 @@ struct _stream<SourceStream, TriggerStream>::type {
       stream.trigger_next_done();
     }
 
-    inplace_stop_source& get_stop_source() const {
-      return stream_.stopSource_;
-    }
+    inplace_stop_source& get_stop_source() const { return stream_.stopSource_; }
 
-    friend inplace_stop_token tag_invoke(
-        tag_t<get_stop_token>, const trigger_next_receiver& r) noexcept {
+    friend inplace_stop_token
+    tag_invoke(tag_t<get_stop_token>, const trigger_next_receiver& r) noexcept {
       return r.get_stop_source().get_token();
     }
   };
@@ -85,25 +82,26 @@ struct _stream<SourceStream, TriggerStream>::type {
   struct cancel_callback {
     inplace_stop_source& stopSource_;
 
-    void operator()() noexcept {
-      stopSource_.request_stop();
-    }
+    void operator()() noexcept { stopSource_.request_stop(); }
   };
 
   struct next_sender {
     take_until_stream& stream_;
 
-    template <template <typename...> class Variant,
-             template <typename...> class Tuple>
-    using value_types =
-      typename sender_traits<next_sender_t<SourceStream>>::
-        template value_types<Variant, Tuple>;
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = typename sender_traits<
+        next_sender_t<SourceStream>>::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      sender_error_types_t<next_sender_t<SourceStream>, Variant>;
+        sender_error_types_t<next_sender_t<SourceStream>, Variant>;
 
-    static constexpr bool sends_done = sender_traits<next_sender_t<SourceStream>>::sends_done;
+    static constexpr bool sends_done =
+        sender_traits<next_sender_t<SourceStream>>::sends_done;
 
     template <typename Receiver>
     struct _op {
@@ -114,7 +112,7 @@ struct _stream<SourceStream, TriggerStream>::type {
           template <typename... Values>
           void set_value(Values&&... values) && noexcept {
             op_.stopCallback_.destruct();
-            unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
+            unifex::set_value(std::move(op_.receiver_), (Values &&) values...);
           }
 
           void set_done() && noexcept {
@@ -127,7 +125,7 @@ struct _stream<SourceStream, TriggerStream>::type {
           void set_error(Error&& error) && noexcept {
             op_.stopCallback_.destruct();
             op_.stream_.stopSource_.request_stop();
-            unifex::set_error(std::move(op_.receiver_), (Error&&)error);
+            unifex::set_error(std::move(op_.receiver_), (Error &&) error);
           }
 
           inplace_stop_source& get_stop_source() const {
@@ -139,10 +137,10 @@ struct _stream<SourceStream, TriggerStream>::type {
             return r.get_stop_source().get_token();
           }
 
-          template(typename CPO)
-              (requires is_receiver_query_cpo_v<CPO>)
-          friend auto tag_invoke(CPO cpo, const receiver_wrapper& r) noexcept(
-              is_nothrow_callable_v<CPO, const Receiver&>)
+          template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+              CPO cpo,
+              const receiver_wrapper&
+                  r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
               -> callable_result_t<CPO, const Receiver&> {
             return std::move(cpo)(std::as_const(r.op_.receiver_));
           }
@@ -158,19 +156,17 @@ struct _stream<SourceStream, TriggerStream>::type {
 
         take_until_stream& stream_;
         Receiver receiver_;
-        manual_lifetime<typename stop_token_type_t<Receiver&>::
-                        template callback_type<cancel_callback>>
-          stopCallback_;
+        manual_lifetime<typename stop_token_type_t<
+            Receiver&>::template callback_type<cancel_callback>>
+            stopCallback_;
         next_operation_t<SourceStream, receiver_wrapper> innerOp_;
 
         template <typename Receiver2>
         explicit type(take_until_stream& stream, Receiver2&& receiver)
           : stream_(stream)
-          , receiver_((Receiver2&&)receiver)
+          , receiver_((Receiver2 &&) receiver)
           , innerOp_(unifex::connect(
-                next(stream.source_),
-                receiver_wrapper{*this}))
-        {}
+                next(stream.source_), receiver_wrapper{*this})) {}
 
         void start() noexcept {
           if (!stream_.triggerNextStarted_) {
@@ -179,18 +175,17 @@ struct _stream<SourceStream, TriggerStream>::type {
             UNIFEX_TRY {
               stream_.triggerNextOp_.construct_with([&] {
                 return unifex::connect(
-                  next(stream_.trigger_),
-                  trigger_next_receiver{stream_});
+                    next(stream_.trigger_), trigger_next_receiver{stream_});
               });
               unifex::start(stream_.triggerNextOp_.get());
-            } UNIFEX_CATCH (...) {
+            }
+            UNIFEX_CATCH(...) {
               stream_.trigger_next_done();
             }
           }
 
           stopCallback_.construct(
-            get_stop_token(receiver_),
-            cancel_callback{stream_.stopSource_});
+              get_stop_token(receiver_), cancel_callback{stream_.stopSource_});
           unifex::start(innerOp_);
         }
       };
@@ -200,24 +195,24 @@ struct _stream<SourceStream, TriggerStream>::type {
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
-      return operation<Receiver>{
-        stream_,
-        (Receiver&&)receiver};
+      return operation<Receiver>{stream_, (Receiver &&) receiver};
     }
   };
 
   struct cleanup_sender {
     take_until_stream& stream_;
 
-    template <template <typename...> class Variant,
-             template <typename...> class Tuple>
-    using value_types =
-      typename sender_traits<cleanup_sender_t<SourceStream>>::
-        template value_types<Variant, Tuple>;
+    template <
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
+    using value_types = typename sender_traits<
+        cleanup_sender_t<SourceStream>>::template value_types<Variant, Tuple>;
 
     template <template <typename...> class Variant>
     using error_types =
-      sender_error_types_t<cleanup_sender_t<SourceStream>, Variant>;
+        sender_error_types_t<cleanup_sender_t<SourceStream>, Variant>;
 
     static constexpr bool sends_done = true;
 
@@ -235,7 +230,7 @@ struct _stream<SourceStream, TriggerStream>::type {
 
           template <typename Error>
           void set_error(Error&& error) && noexcept {
-            std::move(*this).set_error(make_exception_ptr((Error&&)error));
+            std::move(*this).set_error(make_exception_ptr((Error &&) error));
           }
 
           void set_error(std::exception_ptr error) && noexcept {
@@ -244,10 +239,10 @@ struct _stream<SourceStream, TriggerStream>::type {
             op.source_cleanup_error(std::move(error));
           }
 
-          template(typename CPO)
-              (requires is_receiver_query_cpo_v<CPO>)
-          friend auto tag_invoke(CPO cpo, const source_receiver& r) noexcept(
-              is_nothrow_callable_v<CPO, const Receiver&>)
+          template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+              CPO cpo,
+              const source_receiver&
+                  r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
               -> callable_result_t<CPO, const Receiver&> {
             return std::move(cpo)(std::as_const(r.op_.receiver_));
           }
@@ -272,7 +267,7 @@ struct _stream<SourceStream, TriggerStream>::type {
 
           template <typename Error>
           void set_error(Error&& error) && noexcept {
-            std::move(*this).set_error(make_exception_ptr((Error&&)error));
+            std::move(*this).set_error(make_exception_ptr((Error &&) error));
           }
 
           void set_error(std::exception_ptr error) && noexcept {
@@ -281,10 +276,10 @@ struct _stream<SourceStream, TriggerStream>::type {
             op.trigger_cleanup_error(std::move(error));
           }
 
-          template(typename CPO)
-              (requires is_receiver_query_cpo_v<CPO>)
-          friend auto tag_invoke(CPO cpo, const trigger_receiver& r) noexcept(
-              is_nothrow_callable_v<CPO, const Receiver&>)
+          template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+              CPO cpo,
+              const trigger_receiver&
+                  r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
               -> callable_result_t<CPO, const Receiver&> {
             return std::move(cpo)(std::as_const(r.op_.receiver_));
           }
@@ -305,32 +300,32 @@ struct _stream<SourceStream, TriggerStream>::type {
         UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
         manual_lifetime<cleanup_operation_t<SourceStream, source_receiver>>
-          sourceOp_;
+            sourceOp_;
         manual_lifetime<cleanup_operation_t<TriggerStream, trigger_receiver>>
-          triggerOp_;
+            triggerOp_;
 
         template <typename Receiver2>
         explicit type(take_until_stream& stream, Receiver2&& receiver)
           : stream_(stream)
-          , receiver_((Receiver2&&)receiver)
-        {}
+          , receiver_((Receiver2 &&) receiver) {}
 
         void start() noexcept {
           UNIFEX_TRY {
             sourceOp_.construct_with([&] {
               return unifex::connect(
-                cleanup(stream_.source_),
-                source_receiver{*this});
+                  cleanup(stream_.source_), source_receiver{*this});
             });
             unifex::start(sourceOp_.get());
-          } UNIFEX_CATCH (...) {
+          }
+          UNIFEX_CATCH(...) {
             source_cleanup_error(std::current_exception());
           }
 
           if (!stream_.cleanupReady_.load(std::memory_order_acquire)) {
             stream_.cleanupOperation_ = this;
             stream_.stopSource_.request_stop();
-            if (!stream_.cleanupReady_.exchange(true, std::memory_order_acq_rel)) {
+            if (!stream_.cleanupReady_.exchange(
+                    true, std::memory_order_acq_rel)) {
               // The trigger cleanup is not yet ready to run.
               // The trigger_next_receiver will start this when it completes.
               return;
@@ -345,11 +340,11 @@ struct _stream<SourceStream, TriggerStream>::type {
           UNIFEX_TRY {
             triggerOp_.construct_with([&] {
               return unifex::connect(
-                cleanup(stream_.trigger_),
-                trigger_receiver{*this});
+                  cleanup(stream_.trigger_), trigger_receiver{*this});
             });
             unifex::start(triggerOp_.get());
-          } UNIFEX_CATCH (...) {
+          }
+          UNIFEX_CATCH(...) {
             trigger_cleanup_error(std::current_exception());
             return;
           }
@@ -445,39 +440,36 @@ struct _stream<SourceStream, TriggerStream>::type {
   bool triggerNextStarted_ = false;
 
   manual_lifetime<next_operation_t<TriggerStream, trigger_next_receiver>>
-    triggerNextOp_;
+      triggerNextOp_;
 
   void trigger_next_done() noexcept {
-      if (!cleanupReady_.load(std::memory_order_acquire)) {
-        stopSource_.request_stop();
-        if (!cleanupReady_.exchange(true, std::memory_order_acq_rel)) {
-          // Successfully registered completion of next(trigger)
-          // before someone called cleanup(stream). We have passed
-          // responsibility for calling cleanup(trigger_) to the
-          // call to start() on the cleanup(stream) sender.
-          return;
-        }
+    if (!cleanupReady_.load(std::memory_order_acquire)) {
+      stopSource_.request_stop();
+      if (!cleanupReady_.exchange(true, std::memory_order_acq_rel)) {
+        // Successfully registered completion of next(trigger)
+        // before someone called cleanup(stream). We have passed
+        // responsibility for calling cleanup(trigger_) to the
+        // call to start() on the cleanup(stream) sender.
+        return;
       }
+    }
 
-      // Otherwise, the cleanup(stream) operation has already been started
-      // before the next(trigger) operation finished.
-      // We have the responsibility for launching cleanup(trigger).
-      UNIFEX_ASSERT(cleanupOperation_ != nullptr);
-      cleanupOperation_->start_trigger_cleanup();
+    // Otherwise, the cleanup(stream) operation has already been started
+    // before the next(trigger) operation finished.
+    // We have the responsibility for launching cleanup(trigger).
+    UNIFEX_ASSERT(cleanupOperation_ != nullptr);
+    cleanupOperation_->start_trigger_cleanup();
   }
 
 public:
-
   template <typename SourceStream2, typename TriggerStream2>
   explicit type(SourceStream2&& source, TriggerStream2&& trigger)
-  : source_((SourceStream2&&)source)
-  , trigger_((TriggerStream2&&)trigger)
-  {}
+    : source_((SourceStream2 &&) source)
+    , trigger_((TriggerStream2 &&) trigger) {}
 
   type(type&& other)
-  : source_(std::move(other.source_))
-  , trigger_(std::move(other.trigger_))
-  {}
+    : source_(std::move(other.source_))
+    , trigger_(std::move(other.trigger_)) {}
 
   friend next_sender tag_invoke(tag_t<next>, take_until_stream& s) {
     return {s};
@@ -487,28 +479,26 @@ public:
     return {s};
   }
 };
-} // namespace _take_until
+}  // namespace _take_until
 
 namespace _take_until_cpo {
-  inline const struct _fn {
-    template <typename SourceStream, typename TriggerStream>
-    auto operator()(SourceStream&& source, TriggerStream&& trigger) const {
-      return _take_until::stream<SourceStream, TriggerStream>{
-        (SourceStream&&)source,
-        (TriggerStream&&)trigger};
-    }
-    template <typename TriggerStream>
-    constexpr auto operator()(TriggerStream&& trigger) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, TriggerStream>)
-        -> bind_back_result_t<_fn, TriggerStream> {
-      return bind_back(*this, (TriggerStream&&)trigger);
-    }
-  } take_until {};
-} // namespace _take_until_cpo
+inline const struct _fn {
+  template <typename SourceStream, typename TriggerStream>
+  auto operator()(SourceStream&& source, TriggerStream&& trigger) const {
+    return _take_until::stream<SourceStream, TriggerStream>{
+        (SourceStream &&) source, (TriggerStream &&) trigger};
+  }
+  template <typename TriggerStream>
+  constexpr auto operator()(TriggerStream&& trigger) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, TriggerStream>)
+          -> bind_back_result_t<_fn, TriggerStream> {
+    return bind_back(*this, (TriggerStream &&) trigger);
+  }
+} take_until{};
+}  // namespace _take_until_cpo
 
 using _take_until_cpo::take_until;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -15,27 +15,27 @@
  */
 #pragma once
 
+#include <unifex/any_scheduler.hpp>
 #include <unifex/async_trace.hpp>
 #include <unifex/await_transform.hpp>
+#include <unifex/blocking.hpp>
 #include <unifex/connect_awaitable.hpp>
-#include <unifex/inplace_stop_token.hpp>
-#include <unifex/inline_scheduler.hpp>
-#include <unifex/manual_lifetime.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/coroutine_concepts.hpp>
+#include <unifex/inline_scheduler.hpp>
+#include <unifex/inplace_stop_token.hpp>
+#include <unifex/invoke.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/scope_guard.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/scope_guard.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/invoke.hpp>
-#include <unifex/continuations.hpp>
-#include <unifex/any_scheduler.hpp>
 #include <unifex/typed_via.hpp>
-#include <unifex/blocking.hpp>
 
 #if UNIFEX_NO_COROUTINES
-# error "Coroutine support is required to use this header"
+#  error "Coroutine support is required to use this header"
 #endif
 
 #include <exception>
@@ -48,32 +48,30 @@ namespace _task {
 using namespace _util;
 
 template <typename... Types>
-using _is_single_valued_tuple =
-    std::bool_constant<1 >= sizeof...(Types)>;
+using _is_single_valued_tuple = std::bool_constant<1 >= sizeof...(Types)>;
 
 template <typename... Types>
 using _is_single_valued_variant =
-    std::bool_constant<sizeof...(Types) == 1 && (Types::value &&...)>;
+    std::bool_constant<sizeof...(Types) == 1 && (Types::value && ...)>;
 
 template <typename Sender>
-UNIFEX_CONCEPT_FRAGMENT(     //
-  _single_typed_sender_impl, //
-    requires()(0) &&         //
-    sender_traits<remove_cvref_t<Sender>>
-      ::template value_types<
-        _is_single_valued_variant,
-        _is_single_valued_tuple>::value);
+UNIFEX_CONCEPT_FRAGMENT(        //
+    _single_typed_sender_impl,  //
+    requires()(0) &&            //
+        sender_traits<remove_cvref_t<Sender>>::template value_types<
+            _is_single_valued_variant,
+            _is_single_valued_tuple>::value);
 
 template <typename Sender>
-UNIFEX_CONCEPT _single_typed_sender =
-  typed_sender<Sender> && UNIFEX_FRAGMENT(_single_typed_sender_impl, Sender);
+UNIFEX_CONCEPT _single_typed_sender = typed_sender<Sender>&&
+    UNIFEX_FRAGMENT(_single_typed_sender_impl, Sender);
 
 struct coro_holder {
   explicit coro_holder(coro::coroutine_handle<> h) noexcept
-      : coro_(std::move(h)) {}
+    : coro_(std::move(h)) {}
 
   coro_holder(coro_holder&& other) noexcept
-      : coro_(std::exchange(other.coro_, {})) {}
+    : coro_(std::exchange(other.coro_, {})) {}
 
   ~coro_holder() {
     if (coro_) {
@@ -86,7 +84,7 @@ struct coro_holder {
     return *this;
   }
 
- protected:
+protected:
   coro::coroutine_handle<> coro_;
 };
 
@@ -97,21 +95,18 @@ struct _task {
 
 struct _promise_base {
   struct _final_suspend_awaiter_base {
-    bool await_ready() noexcept {
-      return false;
-    }
+    bool await_ready() noexcept { return false; }
     void await_resume() noexcept {}
 
-    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _final_suspend_awaiter_base&) noexcept {
+    friend constexpr auto tag_invoke(
+        tag_t<unifex::blocking>, const _final_suspend_awaiter_base&) noexcept {
       return blocking_kind::always_inline;
     }
   };
 
   void transform_schedule_sender_impl_(any_scheduler newSched);
 
-  coro::suspend_always initial_suspend() noexcept {
-    return {};
-  }
+  coro::suspend_always initial_suspend() noexcept { return {}; }
 
   coro::coroutine_handle<> unhandled_done() noexcept {
     return continuation_.done();
@@ -123,17 +118,21 @@ struct _promise_base {
     visit_continuations(p.continuation_, (Func &&) func);
   }
 
-  friend inplace_stop_token tag_invoke(tag_t<get_stop_token>, const _promise_base& p) noexcept {
+  friend inplace_stop_token
+  tag_invoke(tag_t<get_stop_token>, const _promise_base& p) noexcept {
     return p.stoken_;
   }
 
-  friend any_scheduler tag_invoke(tag_t<get_scheduler>, const _promise_base& p) noexcept {
+  friend any_scheduler
+  tag_invoke(tag_t<get_scheduler>, const _promise_base& p) noexcept {
     return p.sched_;
   }
 
   friend continuation_handle<> tag_invoke(
-      const tag_t<exchange_continuation>&, _promise_base& p, continuation_handle<> action) noexcept {
-    return std::exchange(p.continuation_, (continuation_handle<>&&) action);
+      const tag_t<exchange_continuation>&,
+      _promise_base& p,
+      continuation_handle<> action) noexcept {
+    return std::exchange(p.continuation_, (continuation_handle<> &&) action);
   }
 
   inline static constexpr inline_scheduler _default_scheduler{};
@@ -147,10 +146,14 @@ struct _promise_base {
 template <typename T>
 struct _return_value_or_void {
   struct type {
-    template(typename Value = T)
-        (requires convertible_to<Value, T> AND constructible_from<T, Value>)
-    void return_value(Value&& value) noexcept(
-        std::is_nothrow_constructible_v<T, Value>) {
+    template(typename Value = T)(
+        requires convertible_to<Value, T> AND constructible_from<
+            T,
+            Value>) void return_value(Value&&
+                                          value) noexcept(std::
+                                                              is_nothrow_constructible_v<
+                                                                  T,
+                                                                  Value>) {
       expected_.reset_value();
       unifex::activate_union_member(expected_.value_, (Value &&) value);
       expected_.state_ = _state::value;
@@ -175,7 +178,9 @@ struct _task_base {};
 
 template <typename T>
 struct _promise {
-  struct type : _promise_base, _return_value_or_void<T>::type {
+  struct type
+    : _promise_base
+    , _return_value_or_void<T>::type {
     using result_type = T;
 
     typename _task<T>::type get_return_object() noexcept {
@@ -185,10 +190,9 @@ struct _promise {
 
     auto final_suspend() noexcept {
       struct awaiter : _final_suspend_awaiter_base {
-
 #if (defined(_MSC_VER) && !defined(__clang__)) || defined(__EMSCRIPTEN__)
-        // MSVC doesn't seem to like symmetric transfer in this final awaiter and
-        // the Emscripten (WebAssembly) compiler doesn't support tail-calls
+        // MSVC doesn't seem to like symmetric transfer in this final awaiter
+        // and the Emscripten (WebAssembly) compiler doesn't support tail-calls
         void await_suspend(coro::coroutine_handle<type> h) noexcept {
           return h.promise().continuation_.handle().resume();
         }
@@ -203,54 +207,58 @@ struct _promise {
 
     void unhandled_exception() noexcept {
       this->expected_.reset_value();
-      unifex::activate_union_member(this->expected_.exception_, std::current_exception());
+      unifex::activate_union_member(
+          this->expected_.exception_, std::current_exception());
       this->expected_.state_ = _state::exception;
     }
 
     template <typename Value>
     decltype(auto) await_transform(Value&& value) {
       if constexpr (derived_from<remove_cvref_t<Value>, _task_base>) {
-        // We are co_await-ing a unifex::task, which completes inline because of task
-        // scheduler affinity. We don't need an additional transition.
-        return unifex::await_transform(*this, (Value&&) value);
-      } else if constexpr (tag_invocable<tag_t<unifex::await_transform>, type&, Value>
-          || detail::_awaitable<Value>) {
-        // Either await_transform has been customized or Value is an awaitable. Either
-        // way, we can dispatch to the await_transform CPO, then insert a transition back
-        // to the correct execution context if necessary.
-        return transform_awaitable_(unifex::await_transform(*this, (Value&&) value));
+        // We are co_await-ing a unifex::task, which completes inline because of
+        // task scheduler affinity. We don't need an additional transition.
+        return unifex::await_transform(*this, (Value &&) value);
+      } else if constexpr (
+          tag_invocable<tag_t<unifex::await_transform>, type&, Value> ||
+          detail::_awaitable<Value>) {
+        // Either await_transform has been customized or Value is an awaitable.
+        // Either way, we can dispatch to the await_transform CPO, then insert a
+        // transition back to the correct execution context if necessary.
+        return transform_awaitable_(
+            unifex::await_transform(*this, (Value &&) value));
       } else if constexpr (unifex::sender<Value>) {
-        return transform_sender_((Value&&) value);
+        return transform_sender_((Value &&) value);
       } else {
-        // Otherwise, we don't know how to await this type. Just return it and let the
-        // compiler issue a diagnostic.
-        return (Value&&) value;
+        // Otherwise, we don't know how to await this type. Just return it and
+        // let the compiler issue a diagnostic.
+        return (Value &&) value;
       }
     }
 
     template <typename Awaitable>
     decltype(auto) transform_awaitable_(Awaitable&& awaitable) {
       if constexpr (blocking_kind::always_inline == cblocking<Awaitable>()) {
-        return Awaitable{(Awaitable&&) awaitable};
+        return Awaitable{(Awaitable &&) awaitable};
       } else {
         return unifex::await_transform(
             *this,
-            typed_via(as_sender((Awaitable&&) awaitable), this->sched_));
+            typed_via(as_sender((Awaitable &&) awaitable), this->sched_));
       }
     }
 
     template <typename Sender>
     decltype(auto) transform_sender_(Sender&& sndr) {
       if constexpr (blocking_kind::always_inline == cblocking<Sender>()) {
-        return unifex::await_transform(*this, (Sender&&) sndr);
+        return unifex::await_transform(*this, (Sender &&) sndr);
       } else if constexpr (is_sender_for_v<remove_cvref_t<Sender>, schedule>) {
-        // If we are co_await'ing a sender that is the result of calling schedule,
-        // do something special
-        return transform_schedule_sender_((Sender&&) sndr);
+        // If we are co_await'ing a sender that is the result of calling
+        // schedule, do something special
+        return transform_schedule_sender_((Sender &&) sndr);
       } else {
-        // Otherwise, append a transition to the correct execution context and wrap the
-        // result in an awaiter:
-        return unifex::await_transform(*this, typed_via((Sender&&) sndr, this->sched_));
+        // Otherwise, append a transition to the correct execution context and
+        // wrap the result in an awaiter:
+        return unifex::await_transform(
+            *this, typed_via((Sender &&) sndr, this->sched_));
       }
     }
 
@@ -258,13 +266,14 @@ struct _promise {
     // - transitions execution context
     // - updates the coroutine's current scheduler
     // - schedules an async cleanup action that transitions back to the correct
-    //   context at the end of the coroutine (if one has not already been scheduled).
+    //   context at the end of the coroutine (if one has not already been
+    //   scheduled).
     template <typename ScheduleSender>
     decltype(auto) transform_schedule_sender_(ScheduleSender&& snd) {
-      // This sender is a scheduler provider. Get the scheduler. This get_scheduler
-      // call returns a reference to the scheduler stored within snd, which is an object
-      // whose lifetime spans a suspend point. So it's ok to build an any_scheduler_ref
-      // from it:
+      // This sender is a scheduler provider. Get the scheduler. This
+      // get_scheduler call returns a reference to the scheduler stored within
+      // snd, which is an object whose lifetime spans a suspend point. So it's
+      // ok to build an any_scheduler_ref from it:
       transform_schedule_sender_impl_(get_scheduler(snd));
 
       // Return the inner sender, appropriately wrapped in an awaitable:
@@ -282,13 +291,13 @@ struct _promise {
 
 struct tagged_coro_holder {
   explicit tagged_coro_holder(coro::coroutine_handle<> h) noexcept
-      : coro_((std::uintptr_t) h.address()) {
+    : coro_((std::uintptr_t)h.address()) {
     UNIFEX_ASSERT(coro_);
   }
 
   tagged_coro_holder(tagged_coro_holder&& other) noexcept
-      : coro_(std::exchange(other.coro_, 0)) {
-      UNIFEX_ASSERT(coro_ && ((coro_ & 1u) == 0u));
+    : coro_(std::exchange(other.coro_, 0)) {
+    UNIFEX_ASSERT(coro_ && ((coro_ & 1u) == 0u));
   }
 
   ~tagged_coro_holder() {
@@ -300,12 +309,12 @@ struct tagged_coro_holder {
     }
   }
 
- protected:
+protected:
   // Stored as an integer so we can use the low bit as a dirty bit
   std::uintptr_t coro_;
 };
 
-template<typename ThisPromise, typename OtherPromise>
+template <typename ThisPromise, typename OtherPromise>
 struct _awaiter {
   struct type : tagged_coro_holder {
     using result_type = typename ThisPromise::result_type;
@@ -313,11 +322,10 @@ struct _awaiter {
     explicit type(coro::coroutine_handle<> coro) noexcept
       : tagged_coro_holder(coro) {}
 
-    // The move constructor is only ever called /before/ the awaitable is awaited.
-    // In those cases, the other fields have not been initialized yet and so do not
-    // need to be moved.
-    type(type&& other) noexcept
-      : tagged_coro_holder(std::move(other)) {}
+    // The move constructor is only ever called /before/ the awaitable is
+    // awaited. In those cases, the other fields have not been initialized yet
+    // and so do not need to be moved.
+    type(type&& other) noexcept : tagged_coro_holder(std::move(other)) {}
 
     ~type() {
       if (coro_ & 1u) {
@@ -328,15 +336,14 @@ struct _awaiter {
       }
     }
 
-    bool await_ready() noexcept {
-      return false;
-    }
+    bool await_ready() noexcept { return false; }
 
-    coro::coroutine_handle<ThisPromise> await_suspend(
-        coro::coroutine_handle<OtherPromise> h) noexcept {
+    coro::coroutine_handle<ThisPromise>
+    await_suspend(coro::coroutine_handle<OtherPromise> h) noexcept {
       UNIFEX_ASSERT(coro_ && ((coro_ & 1u) == 0u));
-      auto thisCoro = coro::coroutine_handle<ThisPromise>::from_address((void*) coro_);
-      ++coro_; // mark the awaiter as needing cleanup
+      auto thisCoro =
+          coro::coroutine_handle<ThisPromise>::from_address((void*)coro_);
+      ++coro_;  // mark the awaiter as needing cleanup
       auto& promise = thisCoro.promise();
       promise.continuation_ = h;
       if constexpr (needs_scheduler_t::value) {
@@ -346,7 +353,8 @@ struct _awaiter {
         promise.sched_ = get_scheduler(h.promise());
       }
       if constexpr (needs_stop_token_t::value) {
-        promise.stoken_ = stopTokenAdapter_.subscribe(get_stop_token(h.promise()));
+        promise.stoken_ =
+            stopTokenAdapter_.subscribe(get_stop_token(h.promise()));
       } else {
         promise.stoken_ = get_stop_token(h.promise());
       }
@@ -359,7 +367,7 @@ struct _awaiter {
       if constexpr (needs_scheduler_t::value)
         sched_.destruct();
       auto thisCoro = coro::coroutine_handle<ThisPromise>::from_address(
-          (void*) std::exchange(--coro_, 0));
+          (void*)std::exchange(--coro_, 0));
       coro_holder destroyOnExit{thisCoro};
       return thisCoro.promise().result();
     }
@@ -372,39 +380,44 @@ struct _awaiter {
     using needs_stop_token_t =
         std::bool_constant<!same_as<stop_token_t, inplace_stop_token>>;
 
-    // Only store the scheduler and the stop_token in the awaiter if we need to type
-    // erase them. Otherwise, these members are "empty" and should take up no space
-    // because of the [[no_unique_address]] attribute.
-    // Note: for the compiler to fold the members away, they must have different types.
-    // Hence, the slightly odd-looking template parameter to the empty struct.
+    // Only store the scheduler and the stop_token in the awaiter if we need to
+    // type erase them. Otherwise, these members are "empty" and should take up
+    // no space because of the [[no_unique_address]] attribute. Note: for the
+    // compiler to fold the members away, they must have different types. Hence,
+    // the slightly odd-looking template parameter to the empty struct.
     UNIFEX_NO_UNIQUE_ADDRESS
     conditional_t<
         needs_scheduler_t::value,
         manual_lifetime<scheduler_t>,
-        detail::_empty<0>> sched_;
+        detail::_empty<0>>
+        sched_;
     UNIFEX_NO_UNIQUE_ADDRESS
     conditional_t<
         needs_stop_token_t::value,
         inplace_stop_token_adapter<stop_token_t>,
-        detail::_empty<1>> stopTokenAdapter_;
+        detail::_empty<1>>
+        stopTokenAdapter_;
   };
 };
 
 template <typename T>
-struct _task<T>::type : _task_base, coro_holder {
+struct _task<T>::type
+  : _task_base
+  , coro_holder {
   using promise_type = typename _promise<T>::type;
   friend promise_type;
 
-  template<
-    template<typename...> class Variant,
-    template<typename...> class Tuple>
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types =
-    Variant<
-      typename std::conditional_t<std::is_void_v<T>, type_list<>, type_list<T>>
-        ::template apply<Tuple>>;
+      Variant<typename std::
+                  conditional_t<std::is_void_v<T>, type_list<>, type_list<T>>::
+                      template apply<Tuple>>;
 
-  template<
-    template<typename...> class Variant>
+  template <template <typename...> class Variant>
   using error_types = Variant<std::exception_ptr>;
 
   static constexpr bool sends_done = true;
@@ -414,9 +427,9 @@ struct _task<T>::type : _task_base, coro_holder {
   type& operator=(type&& t) noexcept = default;
 
   template <typename Fn, typename... Args>
-  friend type tag_invoke(
-      tag_t<co_invoke>, type_identity<type>, Fn fn, Args... args) {
-    co_return co_await std::invoke((Fn&&) fn, (Args&&) args...);
+  friend type
+  tag_invoke(tag_t<co_invoke>, type_identity<type>, Fn fn, Args... args) {
+    co_return co_await std::invoke((Fn &&) fn, (Args &&) args...);
   }
 
 private:
@@ -426,22 +439,23 @@ private:
   explicit type(coro::coroutine_handle<promise_type> h) noexcept
     : coro_holder(h) {}
 
-  template<typename Promise>
-  friend awaiter<Promise> tag_invoke(tag_t<unifex::await_transform>, Promise&, type&& t) noexcept {
+  template <typename Promise>
+  friend awaiter<Promise>
+  tag_invoke(tag_t<unifex::await_transform>, Promise&, type&& t) noexcept {
     return awaiter<Promise>{std::exchange(t.coro_, {})};
   }
 
-  template<typename Receiver>
+  template <typename Receiver>
   friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-    return unifex::connect_awaitable((type&&) t, (Receiver&&) r);
+    return unifex::connect_awaitable((type &&) t, (Receiver &&) r);
   }
 };
 
-} // namespace _task
+}  // namespace _task
 
 template <typename T>
 using task = typename _task::_task<T>::type;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/then.hpp
+++ b/include/unifex/then.hpp
@@ -16,16 +16,16 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/stream_concepts.hpp>
-#include <unifex/type_traits.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/get_stop_token.hpp>
-#include <unifex/async_trace.hpp>
-#include <unifex/type_list.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/bind_back.hpp>
+#include <unifex/stream_concepts.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <exception>
 #include <functional>
@@ -37,15 +37,15 @@
 namespace unifex {
 namespace _then {
 namespace detail {
-  template <typename Result, typename = void>
-  struct result_overload {
-    using type = type_list<Result>;
-  };
-  template <typename Result>
-  struct result_overload<Result, std::enable_if_t<std::is_void_v<Result>>> {
-    using type = type_list<>;
-  };
-}
+template <typename Result, typename = void>
+struct result_overload {
+  using type = type_list<Result>;
+};
+template <typename Result>
+struct result_overload<Result, std::enable_if_t<std::is_void_v<Result>>> {
+  using type = type_list<>;
+};
+}  // namespace detail
 
 template <typename Receiver, typename Func>
 struct _receiver {
@@ -63,21 +63,22 @@ struct _receiver<Receiver, Func>::type {
   void set_value(Values&&... values) && noexcept {
     using result_type = std::invoke_result_t<Func, Values...>;
     if constexpr (std::is_void_v<result_type>) {
-      if constexpr (noexcept(std::invoke(
-                        (Func &&) func_, (Values &&) values...))) {
+      if constexpr (noexcept(
+                        std::invoke((Func &&) func_, (Values &&) values...))) {
         std::invoke((Func &&) func_, (Values &&) values...);
         unifex::set_value((Receiver &&) receiver_);
       } else {
         UNIFEX_TRY {
           std::invoke((Func &&) func_, (Values &&) values...);
           unifex::set_value((Receiver &&) receiver_);
-        } UNIFEX_CATCH (...) {
+        }
+        UNIFEX_CATCH(...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
       }
     } else {
-      if constexpr (noexcept(std::invoke(
-                        (Func &&) func_, (Values &&) values...))) {
+      if constexpr (noexcept(
+                        std::invoke((Func &&) func_, (Values &&) values...))) {
         unifex::set_value(
             (Receiver &&) receiver_,
             std::invoke((Func &&) func_, (Values &&) values...));
@@ -86,7 +87,8 @@ struct _receiver<Receiver, Func>::type {
           unifex::set_value(
               (Receiver &&) receiver_,
               std::invoke((Func &&) func_, (Values &&) values...));
-        } UNIFEX_CATCH (...) {
+        }
+        UNIFEX_CATCH(...) {
           unifex::set_error((Receiver &&) receiver_, std::current_exception());
         }
       }
@@ -98,20 +100,17 @@ struct _receiver<Receiver, Func>::type {
     unifex::set_error((Receiver &&) receiver_, (Error &&) error);
   }
 
-  void set_done() && noexcept {
-    unifex::set_done((Receiver &&) receiver_);
-  }
+  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
 
-  template(typename CPO, typename R)
-      (requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>)
-  friend auto tag_invoke(CPO cpo, const R& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO, typename R)(requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>) friend auto tag_invoke(
+      CPO cpo, const R& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
     std::invoke(visit, r.receiver_);
   }
 };
@@ -121,7 +120,8 @@ struct _sender {
   struct type;
 };
 template <typename Predecessor, typename Func>
-using sender = typename _sender<remove_cvref_t<Predecessor>, std::decay_t<Func>>::type;
+using sender =
+    typename _sender<remove_cvref_t<Predecessor>, std::decay_t<Func>>::type;
 
 template <typename Predecessor, typename Func>
 struct _sender<Predecessor, Func>::type {
@@ -129,30 +129,28 @@ struct _sender<Predecessor, Func>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
 
 private:
-
   // This helper transforms an argument list into either
   // - type_list<type_list<Result>> - if Result is non-void, or
   // - type_list<type_list<>>       - if Result is void
   template <typename... Args>
-  using result = type_list<
-    typename detail::result_overload<std::invoke_result_t<Func, Args...>>::type>;
+  using result = type_list<typename detail::result_overload<
+      std::invoke_result_t<Func, Args...>>::type>;
 
 public:
-
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
-  using value_types =
-      type_list_nested_apply_t<
-          sender_value_types_t<Predecessor, concat_type_lists_unique_t, result>,
-          Variant,
-          Tuple>;
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = type_list_nested_apply_t<
+      sender_value_types_t<Predecessor, concat_type_lists_unique_t, result>,
+      Variant,
+      Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Predecessor, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
   static constexpr bool sends_done = sender_traits<Predecessor>::sends_done;
 
@@ -163,61 +161,67 @@ public:
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND
-        sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r)
-    noexcept(
-      std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-      std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
-      is_nothrow_connectable_v<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>)
-      -> connect_result_t<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>> {
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>&&
+                              std::is_nothrow_constructible_v<
+                                  Func,
+                                  member_t<Sender, Func>>&&
+                                  is_nothrow_connectable_v<
+                                      member_t<Sender, Predecessor>,
+                                      receiver_t<remove_cvref_t<Receiver>>>)
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
     return unifex::connect(
-      static_cast<Sender&&>(s).pred_,
-      receiver_t<remove_cvref_t<Receiver>>{
-        static_cast<Sender&&>(s).func_,
-        static_cast<Receiver&&>(r)});
+        static_cast<Sender&&>(s).pred_,
+        receiver_t<remove_cvref_t<Receiver>>{
+            static_cast<Sender&&>(s).func_, static_cast<Receiver&&>(r)});
   }
 };
 
 namespace _cpo {
-  struct _fn {
-  private:
-    template <typename Sender, typename Func>
-    using _result_t =
-      typename conditional_t<
-        tag_invocable<_fn, Sender, Func>,
-        meta_tag_invoke_result<_fn>,
-        meta_quote2<_then::sender>>::template apply<Sender, Func>;
-  public:
-    template(typename Sender, typename Func)
-      (requires tag_invocable<_fn, Sender, Func>)
-    auto operator()(Sender&& predecessor, Func&& func) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
-        -> _result_t<Sender, Func> {
-      return unifex::tag_invoke(_fn{}, (Sender&&)predecessor, (Func&&)func);
-    }
-    template(typename Sender, typename Func)
-      (requires (!tag_invocable<_fn, Sender, Func>))
-    auto operator()(Sender&& predecessor, Func&& func) const
-        noexcept(std::is_nothrow_constructible_v<
-          _then::sender<Sender, Func>, Sender, Func>)
-        -> _result_t<Sender, Func> {
-      return _then::sender<Sender, Func>{(Sender &&) predecessor, (Func &&) func};
-    }
-    template <typename Func>
-    constexpr auto operator()(Func&& func) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func>)
-        -> bind_back_result_t<_fn, Func> {
-      return bind_back(*this, (Func &&) func);
-    }
-  };
-} // namespace _cpo
-} // namespace _then
+struct _fn {
+private:
+  template <typename Sender, typename Func>
+  using _result_t = typename conditional_t<
+      tag_invocable<_fn, Sender, Func>,
+      meta_tag_invoke_result<_fn>,
+      meta_quote2<_then::sender>>::template apply<Sender, Func>;
 
-inline constexpr _then::_cpo::_fn then {};
+public:
+  template(typename Sender, typename Func)(
+      requires tag_invocable<_fn, Sender, Func>) auto
+  operator()(Sender&& predecessor, Func&& func) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
+          -> _result_t<Sender, Func> {
+    return unifex::tag_invoke(_fn{}, (Sender &&) predecessor, (Func &&) func);
+  }
+  template(typename Sender, typename Func)(
+      requires(!tag_invocable<_fn, Sender, Func>)) auto
+  operator()(Sender&& predecessor, Func&& func) const noexcept(
+      std::
+          is_nothrow_constructible_v<_then::sender<Sender, Func>, Sender, Func>)
+      -> _result_t<Sender, Func> {
+    return _then::sender<Sender, Func>{(Sender &&) predecessor, (Func &&) func};
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&) func);
+  }
+};
+}  // namespace _cpo
+}  // namespace _then
 
-} // namespace unifex
+inline constexpr _then::_cpo::_fn then{};
+
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/then_execute.hpp
+++ b/include/unifex/then_execute.hpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #pragma once
+#pragma once
 
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/then.hpp>
@@ -24,16 +24,14 @@
 namespace unifex {
 
 namespace _then_execute_cpo {
-  struct _fn {
-    template <typename Scheduler, typename Predecessor, typename Func>
-    auto operator()(Scheduler&& s, Predecessor&& p, Func&& f) const {
-      return then(
-          typed_via((Predecessor &&) p, (Scheduler&&)s),
-          (Func &&) f);
-    }
-  };
-} // namespace _then_execute_cpo
-inline constexpr _then_execute_cpo::_fn then_execute {};
-} // namespace unifex
+struct _fn {
+  template <typename Scheduler, typename Predecessor, typename Func>
+  auto operator()(Scheduler&& s, Predecessor&& p, Func&& f) const {
+    return then(typed_via((Predecessor &&) p, (Scheduler &&) s), (Func &&) f);
+  }
+};
+}  // namespace _then_execute_cpo
+inline constexpr _then_execute_cpo::_fn then_execute{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/this.hpp
+++ b/include/unifex/this.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/detail/unifex_fwd.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -105,7 +105,7 @@ struct _replace_this<const this_&&> {
 
   template <typename T>
   static const T&& get(detail::_ignore, T& obj) noexcept {
-    return (const T&&) obj;
+    return (const T&&)obj;
   }
 };
 
@@ -119,14 +119,13 @@ template <typename Arg, typename T>
 using replace_this_t = typename replace_this<Arg>::template apply<Arg, T>;
 
 template <typename Arg>
-using replace_this_with_void_ptr_t =
-    conditional_t<is_this_v<Arg>, void*, Arg>;
+using replace_this_with_void_ptr_t = conditional_t<is_this_v<Arg>, void*, Arg>;
 
 template <bool...>
 struct _extract_this {
   template <typename TFirst, typename... TRest>
   TFirst&& operator()(TFirst&& first, TRest&&...) const noexcept {
-    return (TFirst&&) first;
+    return (TFirst &&) first;
   }
 };
 template <bool... IsThis>
@@ -141,6 +140,6 @@ struct _extract_this<false, IsThis...> {
 template <typename... Ts>
 using extract_this = _extract_this<is_this_v<Ts>...>;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/thread_unsafe_event_loop.hpp
+++ b/include/unifex/thread_unsafe_event_loop.hpp
@@ -18,10 +18,10 @@
 #include <unifex/config.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/stop_token_concepts.hpp>
-#include <unifex/optional.hpp>
 
 #include <chrono>
 #include <exception>
@@ -34,333 +34,323 @@ namespace unifex {
 class thread_unsafe_event_loop;
 
 namespace _thread_unsafe_event_loop {
-  using clock_t = std::chrono::steady_clock;
-  using time_point_t = clock_t::time_point;
+using clock_t = std::chrono::steady_clock;
+using time_point_t = clock_t::time_point;
 
-  class cancel_callback;
+class cancel_callback;
 
-  class operation_base {
-    friend cancel_callback;
-   protected:
-    using execute_fn = void(operation_base*) noexcept;
+class operation_base {
+  friend cancel_callback;
 
-    operation_base(thread_unsafe_event_loop& loop, execute_fn* execute) noexcept
-      : loop_(loop), execute_(execute) {}
+protected:
+  using execute_fn = void(operation_base*) noexcept;
 
-    operation_base(const operation_base&) = delete;
-    operation_base(operation_base&&) = delete;
+  operation_base(thread_unsafe_event_loop& loop, execute_fn* execute) noexcept
+    : loop_(loop)
+    , execute_(execute) {}
 
-   public:
-    void start() noexcept;
+  operation_base(const operation_base&) = delete;
+  operation_base(operation_base&&) = delete;
 
-   private:
-    friend thread_unsafe_event_loop;
+public:
+  void start() noexcept;
 
-    void execute() noexcept {
-      this->execute_(this);
-    }
+private:
+  friend thread_unsafe_event_loop;
 
-    thread_unsafe_event_loop& loop_;
-    operation_base* next_;
-    operation_base** prevPtr_;
-    execute_fn* execute_;
+  void execute() noexcept { this->execute_(this); }
 
-   protected:
-    time_point_t dueTime_;
-  };
+  thread_unsafe_event_loop& loop_;
+  operation_base* next_;
+  operation_base** prevPtr_;
+  execute_fn* execute_;
 
-  class cancel_callback {
-   public:
-    explicit cancel_callback(operation_base& op) noexcept
-      : op_(&op) {}
+protected:
+  time_point_t dueTime_;
+};
 
-    void operator()() noexcept;
+class cancel_callback {
+public:
+  explicit cancel_callback(operation_base& op) noexcept : op_(&op) {}
 
-   private:
-    operation_base* const op_;
-  };
+  void operator()() noexcept;
 
-  class scheduler;
+private:
+  operation_base* const op_;
+};
 
-  template <typename Duration>
-  struct _schedule_after_sender {
-    class type;
-  };
-  template <typename Duration>
-  using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
+class scheduler;
 
-  template <typename Duration, typename Receiver>
-  struct _after_op {
-    class type;
-  };
-  template <typename Duration, typename Receiver>
-  using after_operation = typename _after_op<Duration, remove_cvref_t<Receiver>>::type;
+template <typename Duration>
+struct _schedule_after_sender {
+  class type;
+};
+template <typename Duration>
+using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
 
-  template <typename Duration, typename Receiver>
-  class _after_op<Duration, Receiver>::type final : public operation_base {
-    friend schedule_after_sender<Duration>;
-   public:
-    void start() noexcept {
-      this->dueTime_ = clock_t::now() + duration_;
-      callback_.construct(
-          get_stop_token(receiver_), cancel_callback{*this});
-      operation_base::start();
-    }
+template <typename Duration, typename Receiver>
+struct _after_op {
+  class type;
+};
+template <typename Duration, typename Receiver>
+using after_operation =
+    typename _after_op<Duration, remove_cvref_t<Receiver>>::type;
 
-   private:
-    template <typename Receiver2>
-    explicit type(
-        Receiver2&& r,
-        Duration d,
-        thread_unsafe_event_loop& loop)
-        : operation_base(loop, &type::execute_impl)
-        , receiver_((Receiver2 &&) r)
-        , duration_(d) {}
+template <typename Duration, typename Receiver>
+class _after_op<Duration, Receiver>::type final : public operation_base {
+  friend schedule_after_sender<Duration>;
 
-    static void execute_impl(operation_base* p) noexcept {
-      auto& self = *static_cast<type*>(p);
-      self.callback_.destruct();
-      if constexpr (is_stop_never_possible_v<
-                        stop_token_type_t<Receiver&>>) {
-        unifex::set_value(std::move(self.receiver_));
+public:
+  void start() noexcept {
+    this->dueTime_ = clock_t::now() + duration_;
+    callback_.construct(get_stop_token(receiver_), cancel_callback{*this});
+    operation_base::start();
+  }
+
+private:
+  template <typename Receiver2>
+  explicit type(Receiver2&& r, Duration d, thread_unsafe_event_loop& loop)
+    : operation_base(loop, &type::execute_impl)
+    , receiver_((Receiver2 &&) r)
+    , duration_(d) {}
+
+  static void execute_impl(operation_base* p) noexcept {
+    auto& self = *static_cast<type*>(p);
+    self.callback_.destruct();
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver&>>) {
+      unifex::set_value(std::move(self.receiver_));
+    } else {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(std::move(self.receiver_));
       } else {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(std::move(self.receiver_));
-        } else {
-          unifex::set_value(std::move(self.receiver_));
-        }
-      }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Duration duration_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver&>::template callback_type<cancel_callback>>
-        callback_;
-  };
-
-  template <typename Duration>
-  class _schedule_after_sender<Duration>::type {
-    using schedule_after_sender = type;
-   public:
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<>;
-
-    static constexpr bool sends_done = true;
-
-    template <typename Receiver>
-    after_operation<Duration, remove_cvref_t<Receiver>> connect(Receiver&& r) const& {
-      return after_operation<Duration, remove_cvref_t<Receiver>>{
-          (Receiver &&) r, duration_, loop_};
-    }
-   private:
-    friend scheduler;
-
-    explicit type(
-        thread_unsafe_event_loop& loop,
-        Duration duration) noexcept
-        : loop_(loop), duration_(duration) {}
-
-    thread_unsafe_event_loop& loop_;
-    Duration duration_;
-  };
-
-  struct schedule_at_sender;
-
-  template <typename Receiver>
-  struct _at_op {
-    class type;
-  };
-  template <typename Receiver>
-  using at_operation = typename _at_op<remove_cvref_t<Receiver>>::type;
-
-  template <typename Receiver>
-  class _at_op<Receiver>::type final : public operation_base {
-   public:
-    void start() noexcept {
-      callback_.construct(
-          get_stop_token(receiver_), cancel_callback{*this});
-      operation_base::start();
-    }
-
-   private:
-    friend schedule_at_sender;
-
-    template <typename Receiver2>
-    explicit type(
-        Receiver2&& r,
-        time_point_t tp,
-        thread_unsafe_event_loop& loop)
-        : operation_base(loop, &type::execute_impl), receiver_((Receiver2 &&) r) {
-      this->dueTime_ = tp;
-    }
-
-    static void execute_impl(operation_base* p) noexcept {
-      auto& self = *static_cast<type*>(p);
-      self.callback_.destruct();
-      if constexpr (is_stop_never_possible_v<
-                        stop_token_type_t<Receiver&>>) {
         unifex::set_value(std::move(self.receiver_));
+      }
+    }
+  }
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Duration duration_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver&>::template callback_type<cancel_callback>>
+      callback_;
+};
+
+template <typename Duration>
+class _schedule_after_sender<Duration>::type {
+  using schedule_after_sender = type;
+
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+
+  static constexpr bool sends_done = true;
+
+  template <typename Receiver>
+  after_operation<Duration, remove_cvref_t<Receiver>>
+  connect(Receiver&& r) const& {
+    return after_operation<Duration, remove_cvref_t<Receiver>>{
+        (Receiver &&) r, duration_, loop_};
+  }
+
+private:
+  friend scheduler;
+
+  explicit type(thread_unsafe_event_loop& loop, Duration duration) noexcept
+    : loop_(loop)
+    , duration_(duration) {}
+
+  thread_unsafe_event_loop& loop_;
+  Duration duration_;
+};
+
+struct schedule_at_sender;
+
+template <typename Receiver>
+struct _at_op {
+  class type;
+};
+template <typename Receiver>
+using at_operation = typename _at_op<remove_cvref_t<Receiver>>::type;
+
+template <typename Receiver>
+class _at_op<Receiver>::type final : public operation_base {
+public:
+  void start() noexcept {
+    callback_.construct(get_stop_token(receiver_), cancel_callback{*this});
+    operation_base::start();
+  }
+
+private:
+  friend schedule_at_sender;
+
+  template <typename Receiver2>
+  explicit type(Receiver2&& r, time_point_t tp, thread_unsafe_event_loop& loop)
+    : operation_base(loop, &type::execute_impl)
+    , receiver_((Receiver2 &&) r) {
+    this->dueTime_ = tp;
+  }
+
+  static void execute_impl(operation_base* p) noexcept {
+    auto& self = *static_cast<type*>(p);
+    self.callback_.destruct();
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver&>>) {
+      unifex::set_value(std::move(self.receiver_));
+    } else {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(std::move(self.receiver_));
       } else {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(std::move(self.receiver_));
-        } else {
-          unifex::set_value(std::move(self.receiver_));
-        }
+        unifex::set_value(std::move(self.receiver_));
       }
     }
+  }
 
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver&>::template callback_type<cancel_callback>>
-        callback_;
-  };
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver&>::template callback_type<cancel_callback>>
+      callback_;
+};
 
-  struct schedule_at_sender {
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+struct schedule_at_sender {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    template <typename Receiver>
-    at_operation<remove_cvref_t<Receiver>> connect(Receiver&& r) const& {
-      return at_operation<remove_cvref_t<Receiver>>{
-          (Receiver &&) r, dueTime_, loop_};
-    }
+  template <typename Receiver>
+  at_operation<remove_cvref_t<Receiver>> connect(Receiver&& r) const& {
+    return at_operation<remove_cvref_t<Receiver>>{
+        (Receiver &&) r, dueTime_, loop_};
+  }
 
-   private:
-    friend scheduler;
+private:
+  friend scheduler;
 
-    explicit schedule_at_sender(
-        thread_unsafe_event_loop& loop,
-        time_point_t dueTime)
-        : loop_(loop), dueTime_(dueTime) {}
+  explicit schedule_at_sender(
+      thread_unsafe_event_loop& loop, time_point_t dueTime)
+    : loop_(loop)
+    , dueTime_(dueTime) {}
 
-    thread_unsafe_event_loop& loop_;
-    time_point_t dueTime_;
-  };
+  thread_unsafe_event_loop& loop_;
+  time_point_t dueTime_;
+};
 
-  class scheduler {
-   public:
-    auto schedule_at(time_point_t dueTime) const noexcept {
-      return schedule_at_sender{*loop_, dueTime};
-    }
+class scheduler {
+public:
+  auto schedule_at(time_point_t dueTime) const noexcept {
+    return schedule_at_sender{*loop_, dueTime};
+  }
 
-    template <typename Rep, typename Ratio>
-    auto schedule_after(std::chrono::duration<Rep, Ratio> d) const noexcept {
-      return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{*loop_, d};
-    }
+  template <typename Rep, typename Ratio>
+  auto schedule_after(std::chrono::duration<Rep, Ratio> d) const noexcept {
+    return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{*loop_, d};
+  }
 
-    auto schedule() const noexcept {
-      return schedule_after(std::chrono::milliseconds(0));
-    }
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-      return a.loop_ == b.loop_;
-    }
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-      return a.loop_ != b.loop_;
-    }
+  auto schedule() const noexcept {
+    return schedule_after(std::chrono::milliseconds(0));
+  }
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.loop_ == b.loop_;
+  }
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return a.loop_ != b.loop_;
+  }
 
-   private:
-    friend thread_unsafe_event_loop;
+private:
+  friend thread_unsafe_event_loop;
 
-    explicit scheduler(thread_unsafe_event_loop& loop) noexcept
-      : loop_(&loop) {}
+  explicit scheduler(thread_unsafe_event_loop& loop) noexcept : loop_(&loop) {}
 
-    thread_unsafe_event_loop* loop_;
-  };
+  thread_unsafe_event_loop* loop_;
+};
 
-  template <typename T>
-  struct _sync_wait_promise {
-    class type;
-  };
-  template <typename T>
-  using sync_wait_promise = typename _sync_wait_promise<T>::type;
+template <typename T>
+struct _sync_wait_promise {
+  class type;
+};
+template <typename T>
+using sync_wait_promise = typename _sync_wait_promise<T>::type;
 
-  template <typename T>
-  class _sync_wait_promise<T>::type {
-    using sync_wait_promise = type;
-    enum class state { incomplete, done, value, error };
+template <typename T>
+class _sync_wait_promise<T>::type {
+  using sync_wait_promise = type;
+  enum class state { incomplete, done, value, error };
 
-    class receiver {
-     public:
-      template <typename... Values>
-      void set_value(Values&&... values) && noexcept {
-        UNIFEX_TRY {
-          unifex::activate_union_member(promise_.value_, (Values &&) values...);
-          promise_.state_ = state::value;
-        } UNIFEX_CATCH (...) {
-          unifex::activate_union_member(promise_.exception_, std::current_exception());
-          promise_.state_ = state::error;
-        }
+  class receiver {
+  public:
+    template <typename... Values>
+    void set_value(Values&&... values) && noexcept {
+      UNIFEX_TRY {
+        unifex::activate_union_member(promise_.value_, (Values &&) values...);
+        promise_.state_ = state::value;
       }
-
-      void set_error(std::exception_ptr ex) && noexcept {
-        unifex::activate_union_member(promise_.exception_, std::move(ex));
+      UNIFEX_CATCH(...) {
+        unifex::activate_union_member(
+            promise_.exception_, std::current_exception());
         promise_.state_ = state::error;
       }
-
-      void set_done() && noexcept {
-        promise_.state_ = state::done;
-      }
-
-     private:
-      friend sync_wait_promise;
-
-      explicit receiver(sync_wait_promise& promise) noexcept
-        : promise_(promise) {}
-
-      sync_wait_promise& promise_;
-    };
-
-   public:
-    type() noexcept {}
-
-    ~type() {
-      if (state_ == state::value) {
-        unifex::deactivate_union_member(value_);
-      } else if (state_ == state::error) {
-        unifex::deactivate_union_member(exception_);
-      }
     }
 
-    receiver get_receiver() noexcept {
-      return receiver{*this};
+    void set_error(std::exception_ptr ex) && noexcept {
+      unifex::activate_union_member(promise_.exception_, std::move(ex));
+      promise_.state_ = state::error;
     }
 
-    optional<T> get() && {
-      switch (state_) {
-        case state::done:
-          return nullopt;
-        case state::value:
-          return std::move(value_).get();
-        case state::error:
-          std::rethrow_exception(exception_.get());
-        default:
-          UNIFEX_ASSERT(false);
-          std::terminate();
-      }
-    }
+    void set_done() && noexcept { promise_.state_ = state::done; }
 
-   private:
-    union {
-      manual_lifetime<T> value_;
-      manual_lifetime<std::exception_ptr> exception_;
-    };
+  private:
+    friend sync_wait_promise;
 
-    state state_ = state::incomplete;
+    explicit receiver(sync_wait_promise& promise) noexcept
+      : promise_(promise) {}
+
+    sync_wait_promise& promise_;
   };
-} // namespace _thread_unsafe_event_loop
+
+public:
+  type() noexcept {}
+
+  ~type() {
+    if (state_ == state::value) {
+      unifex::deactivate_union_member(value_);
+    } else if (state_ == state::error) {
+      unifex::deactivate_union_member(exception_);
+    }
+  }
+
+  receiver get_receiver() noexcept { return receiver{*this}; }
+
+  optional<T> get() && {
+    switch (state_) {
+      case state::done: return nullopt;
+      case state::value: return std::move(value_).get();
+      case state::error: std::rethrow_exception(exception_.get());
+      default: UNIFEX_ASSERT(false); std::terminate();
+    }
+  }
+
+private:
+  union {
+    manual_lifetime<T> value_;
+    manual_lifetime<std::exception_ptr> exception_;
+  };
+
+  state state_ = state::incomplete;
+};
+}  // namespace _thread_unsafe_event_loop
 
 class thread_unsafe_event_loop {
   using operation_base = _thread_unsafe_event_loop::operation_base;
@@ -374,13 +364,12 @@ class thread_unsafe_event_loop {
   void run_until_empty() noexcept;
 
   operation_base* head_ = nullptr;
- public:
+
+public:
   using clock_t = _thread_unsafe_event_loop::clock_t;
   using time_point_t = _thread_unsafe_event_loop::time_point_t;
 
-  scheduler get_scheduler() noexcept {
-    return scheduler{*this};
-  }
+  scheduler get_scheduler() noexcept { return scheduler{*this}; }
 
   template <
       typename Sender,
@@ -399,11 +388,11 @@ class thread_unsafe_event_loop {
 };
 
 namespace _thread_unsafe_event_loop {
-  inline void operation_base::start() noexcept {
-    loop_.enqueue(this);
-  }
+inline void operation_base::start() noexcept {
+  loop_.enqueue(this);
 }
+}  // namespace _thread_unsafe_event_loop
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -33,224 +33,228 @@ namespace unifex {
 class timed_single_thread_context;
 
 namespace _timed_single_thread_context {
-  using clock_t = std::chrono::steady_clock;
-  using time_point = typename clock_t::time_point;
+using clock_t = std::chrono::steady_clock;
+using time_point = typename clock_t::time_point;
 
-  struct task_base {
-    using execute_fn = void(task_base*) noexcept;
+struct task_base {
+  using execute_fn = void(task_base*) noexcept;
 
-    explicit task_base(timed_single_thread_context& context, execute_fn* execute) noexcept
-      : context_(&context), execute_(execute) {}
+  explicit task_base(
+      timed_single_thread_context& context, execute_fn* execute) noexcept
+    : context_(&context)
+    , execute_(execute) {}
 
-    timed_single_thread_context* const context_;
-    task_base* next_ = nullptr;
-    task_base** prevNextPtr_ = nullptr;
-    execute_fn* execute_;
-    time_point dueTime_;
+  timed_single_thread_context* const context_;
+  task_base* next_ = nullptr;
+  task_base** prevNextPtr_ = nullptr;
+  execute_fn* execute_;
+  time_point dueTime_;
 
-    void execute() noexcept {
-      execute_(this);
-    }
-  };
+  void execute() noexcept { execute_(this); }
+};
 
-  class cancel_callback {
-    task_base* const task_;
-   public:
-    explicit cancel_callback(task_base* task) noexcept
-      : task_(task) {}
+class cancel_callback {
+  task_base* const task_;
 
-    void operator()() noexcept;
-  };
+public:
+  explicit cancel_callback(task_base* task) noexcept : task_(task) {}
 
-  class scheduler;
+  void operator()() noexcept;
+};
 
-  template <typename Duration>
-  struct _schedule_after_sender {
-    class type;
-  };
-  template <typename Duration>
-  using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
+class scheduler;
 
-  template <typename Duration, typename Receiver>
-  struct _after_op {
-    class type;
-  };
-  template <typename Duration, typename Receiver>
-  using after_operation =
-      typename _after_op<Duration, remove_cvref_t<Receiver>>::type;
+template <typename Duration>
+struct _schedule_after_sender {
+  class type;
+};
+template <typename Duration>
+using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
 
-  template <typename Duration, typename Receiver>
-  class _after_op<Duration, Receiver>::type final : task_base {
-    friend schedule_after_sender<Duration>;
+template <typename Duration, typename Receiver>
+struct _after_op {
+  class type;
+};
+template <typename Duration, typename Receiver>
+using after_operation =
+    typename _after_op<Duration, remove_cvref_t<Receiver>>::type;
 
-    template <typename Receiver2>
-    explicit type(
-        timed_single_thread_context& context,
-        Duration duration,
-        Receiver2&& receiver)
-        : task_base(context, &type::execute_impl),
-          duration_(duration),
-          receiver_((Receiver2 &&) receiver) {
-      UNIFEX_ASSERT(context_ != nullptr);
-    }
+template <typename Duration, typename Receiver>
+class _after_op<Duration, Receiver>::type final : task_base {
+  friend schedule_after_sender<Duration>;
 
-    static void execute_impl(task_base* t) noexcept {
-      auto& self = *static_cast<type*>(t);
-      self.cancelCallback_.destruct();
-      if constexpr (is_stop_never_possible_v<
-                        stop_token_type_t<Receiver&>>) {
-        unifex::set_value(static_cast<Receiver&&>(self.receiver_));
+  template <typename Receiver2>
+  explicit type(
+      timed_single_thread_context& context,
+      Duration duration,
+      Receiver2&& receiver)
+    : task_base(context, &type::execute_impl)
+    , duration_(duration)
+    , receiver_((Receiver2 &&) receiver) {
+    UNIFEX_ASSERT(context_ != nullptr);
+  }
+
+  static void execute_impl(task_base* t) noexcept {
+    auto& self = *static_cast<type*>(t);
+    self.cancelCallback_.destruct();
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver&>>) {
+      unifex::set_value(static_cast<Receiver&&>(self.receiver_));
+    } else {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(static_cast<Receiver&&>(self.receiver_));
       } else {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(static_cast<Receiver&&>(self.receiver_));
-        } else {
-          unifex::set_value(static_cast<Receiver&&>(self.receiver_));
-        }
+        unifex::set_value(static_cast<Receiver&&>(self.receiver_));
       }
     }
+  }
 
-    Duration duration_;
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver&>::template callback_type<cancel_callback>>
-        cancelCallback_;
+  Duration duration_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver&>::template callback_type<cancel_callback>>
+      cancelCallback_;
 
-   public:
-    void start() noexcept;
-  };
+public:
+  void start() noexcept;
+};
 
-  template <typename Duration>
-  class _schedule_after_sender<Duration>::type {
-    friend scheduler;
+template <typename Duration>
+class _schedule_after_sender<Duration>::type {
+  friend scheduler;
 
-    explicit type(
-        timed_single_thread_context& context,
-        Duration duration) noexcept
-      : context_(&context), duration_(duration) {}
+  explicit type(
+      timed_single_thread_context& context, Duration duration) noexcept
+    : context_(&context)
+    , duration_(duration) {}
 
-    timed_single_thread_context* context_;
-    Duration duration_;
+  timed_single_thread_context* context_;
+  Duration duration_;
 
-   public:
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
 
-    static constexpr bool sends_done = true;
-
-    template <typename Receiver>
-    after_operation<Duration, Receiver> connect(Receiver&& receiver) const {
-      return after_operation<Duration, Receiver>{
-          *context_, duration_, (Receiver &&) receiver};
-    }
-  };
+  static constexpr bool sends_done = true;
 
   template <typename Receiver>
-  struct _at_op {
-    class type;
-  };
-  template <typename Receiver>
-  using at_operation = typename _at_op<remove_cvref_t<Receiver>>::type;
+  after_operation<Duration, Receiver> connect(Receiver&& receiver) const {
+    return after_operation<Duration, Receiver>{
+        *context_, duration_, (Receiver &&) receiver};
+  }
+};
 
-  template <typename Receiver>
-  class _at_op<Receiver>::type final : task_base {
-    static void execute_impl(task_base* p) noexcept {
-      auto& self = *static_cast<type*>(p);
-      self.cancelCallback_.destruct();
-      if constexpr (is_stop_never_possible_v<
-                        stop_token_type_t<Receiver&>>) {
-        unifex::set_value(static_cast<Receiver&&>(self.receiver_));
+template <typename Receiver>
+struct _at_op {
+  class type;
+};
+template <typename Receiver>
+using at_operation = typename _at_op<remove_cvref_t<Receiver>>::type;
+
+template <typename Receiver>
+class _at_op<Receiver>::type final : task_base {
+  static void execute_impl(task_base* p) noexcept {
+    auto& self = *static_cast<type*>(p);
+    self.cancelCallback_.destruct();
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver&>>) {
+      unifex::set_value(static_cast<Receiver&&>(self.receiver_));
+    } else {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(static_cast<Receiver&&>(self.receiver_));
       } else {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(static_cast<Receiver&&>(self.receiver_));
-        } else {
-          unifex::set_value(static_cast<Receiver&&>(self.receiver_));
-        }
+        unifex::set_value(static_cast<Receiver&&>(self.receiver_));
       }
     }
+  }
 
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver&>::template callback_type<cancel_callback>>
-        cancelCallback_;
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver&>::template callback_type<cancel_callback>>
+      cancelCallback_;
 
-   public:
-    template <typename Receiver2>
-    explicit type(
-        timed_single_thread_context& scheduler,
-        clock_t::time_point dueTime,
-        Receiver2&& receiver)
-        : task_base(scheduler, &type::execute_impl)
-        , receiver_((Receiver2 &&) receiver) {
-      this->dueTime_ = dueTime;
-    }
+public:
+  template <typename Receiver2>
+  explicit type(
+      timed_single_thread_context& scheduler,
+      clock_t::time_point dueTime,
+      Receiver2&& receiver)
+    : task_base(scheduler, &type::execute_impl)
+    , receiver_((Receiver2 &&) receiver) {
+    this->dueTime_ = dueTime;
+  }
 
-    void start() noexcept;
-  };
+  void start() noexcept;
+};
 
-  class schedule_at_sender {
-    friend scheduler;
+class schedule_at_sender {
+  friend scheduler;
 
-    explicit schedule_at_sender(
-        timed_single_thread_context& context,
-        time_point dueTime)
-      : context_(&context), dueTime_(dueTime) {}
+  explicit schedule_at_sender(
+      timed_single_thread_context& context, time_point dueTime)
+    : context_(&context)
+    , dueTime_(dueTime) {}
 
-    timed_single_thread_context* context_;
-    time_point dueTime_;
-   public:
-    template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  timed_single_thread_context* context_;
+  time_point dueTime_;
 
-    template <template <typename...> class Variant>
-    using error_types = Variant<>;
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    static constexpr bool sends_done = true;
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
 
-    template <typename Receiver>
-    at_operation<remove_cvref_t<Receiver>> connect(Receiver&& receiver) {
-      return at_operation<remove_cvref_t<Receiver>>{
-          *context_, dueTime_, (Receiver &&) receiver};
-    }
-  };
+  static constexpr bool sends_done = true;
 
-  class scheduler {
-    friend timed_single_thread_context;
+  template <typename Receiver>
+  at_operation<remove_cvref_t<Receiver>> connect(Receiver&& receiver) {
+    return at_operation<remove_cvref_t<Receiver>>{
+        *context_, dueTime_, (Receiver &&) receiver};
+  }
+};
 
-    explicit scheduler(timed_single_thread_context& context) noexcept
-      : context_(&context) {}
+class scheduler {
+  friend timed_single_thread_context;
 
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-      return a.context_ == b.context_;
-    }
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-      return a.context_ != b.context_;
-    }
+  explicit scheduler(timed_single_thread_context& context) noexcept
+    : context_(&context) {}
 
-    timed_single_thread_context* context_;
-   public:
-    template <typename Rep, typename Ratio>
-    auto schedule_after(std::chrono::duration<Rep, Ratio> delay) const noexcept
-        -> schedule_after_sender<std::chrono::duration<Rep, Ratio>> {
-      return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{
-          *context_, delay};
-    }
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.context_ == b.context_;
+  }
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return a.context_ != b.context_;
+  }
 
-    auto schedule_at(clock_t::time_point dueTime) const noexcept {
-      return schedule_at_sender{*context_, dueTime};
-    }
+  timed_single_thread_context* context_;
 
-    auto schedule() const noexcept {
-      return schedule_after(std::chrono::milliseconds{0});
-    }
-  };
-} // namespace _timed_single_thread_context
+public:
+  template <typename Rep, typename Ratio>
+  auto schedule_after(std::chrono::duration<Rep, Ratio> delay) const noexcept
+      -> schedule_after_sender<std::chrono::duration<Rep, Ratio>> {
+    return schedule_after_sender<std::chrono::duration<Rep, Ratio>>{
+        *context_, delay};
+  }
+
+  auto schedule_at(clock_t::time_point dueTime) const noexcept {
+    return schedule_at_sender{*context_, dueTime};
+  }
+
+  auto schedule() const noexcept {
+    return schedule_after(std::chrono::milliseconds{0});
+  }
+};
+}  // namespace _timed_single_thread_context
 
 class timed_single_thread_context {
   using scheduler = _timed_single_thread_context::scheduler;
@@ -274,38 +278,33 @@ class timed_single_thread_context {
   bool stop_ = false;
 
   std::thread thread_;
- public:
+
+public:
   using clock_t = _timed_single_thread_context::clock_t;
   using time_point = _timed_single_thread_context::time_point;
 
   timed_single_thread_context();
   ~timed_single_thread_context();
 
-  scheduler get_scheduler() noexcept {
-    return scheduler{*this};
-  }
+  scheduler get_scheduler() noexcept { return scheduler{*this}; }
 
-  std::thread::id get_thread_id() const noexcept {
-    return thread_.get_id();
-  }
+  std::thread::id get_thread_id() const noexcept { return thread_.get_id(); }
 };
 
 namespace _timed_single_thread_context {
-  template <typename Duration, typename Receiver>
-  inline void _after_op<Duration, Receiver>::type::start() noexcept {
-    this->dueTime_ = clock_t::now() + duration_;
-    cancelCallback_.construct(
-        get_stop_token(receiver_), cancel_callback{this});
-    context_->enqueue(this);
-  }
+template <typename Duration, typename Receiver>
+inline void _after_op<Duration, Receiver>::type::start() noexcept {
+  this->dueTime_ = clock_t::now() + duration_;
+  cancelCallback_.construct(get_stop_token(receiver_), cancel_callback{this});
+  context_->enqueue(this);
+}
 
-  template <typename Receiver>
-  inline void _at_op<Receiver>::type::start() noexcept {
-    cancelCallback_.construct(
-        get_stop_token(receiver_), cancel_callback{this});
-    this->context_->enqueue(this);
-  }
-} // namespace _timed_single_thread_context
-} // namespace unifex
+template <typename Receiver>
+inline void _at_op<Receiver>::type::start() noexcept {
+  cancelCallback_.construct(get_stop_token(receiver_), cancel_callback{this});
+  this->context_->enqueue(this);
+}
+}  // namespace _timed_single_thread_context
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -31,24 +31,20 @@ namespace _trampoline {
 class scheduler {
   std::size_t maxRecursionDepth_;
 
- public:
+public:
   scheduler() noexcept : maxRecursionDepth_(16) {}
 
-  explicit scheduler(std::size_t depth) noexcept
-      : maxRecursionDepth_(depth) {}
+  explicit scheduler(std::size_t depth) noexcept : maxRecursionDepth_(depth) {}
 
- private:
+private:
   struct operation_base {
     using execute_fn = void(operation_base*) noexcept;
 
     explicit operation_base(execute_fn* execute, std::size_t maxDepth) noexcept
-    : execute_(execute)
-    , maxRecursionDepth_(maxDepth)
-    {}
+      : execute_(execute)
+      , maxRecursionDepth_(maxDepth) {}
 
-    void execute() noexcept {
-      execute_(this);
-    }
+    void execute() noexcept { execute_(this); }
 
     void start() noexcept {
       auto* currentState = trampoline_state::current_;
@@ -62,8 +58,7 @@ class scheduler {
       } else {
         // Exceeded recursion limit.
         next_ = std::exchange(
-          currentState->head_,
-          static_cast<operation_base*>(this));
+            currentState->head_, static_cast<operation_base*>(this));
       }
     }
 
@@ -75,13 +70,9 @@ class scheduler {
   struct trampoline_state {
     static thread_local trampoline_state* current_;
 
-    trampoline_state() noexcept {
-      current_ = this;
-    }
+    trampoline_state() noexcept { current_ = this; }
 
-    ~trampoline_state() {
-      current_ = nullptr;
-    }
+    ~trampoline_state() { current_ = nullptr; }
 
     void drain() noexcept;
 
@@ -115,7 +106,7 @@ class scheduler {
           }
         }
       }
-      
+
     public:
       using operation_base::start;
     };
@@ -126,12 +117,13 @@ class scheduler {
   class schedule_sender {
   public:
     explicit schedule_sender(std::size_t maxDepth) noexcept
-      : maxRecursionDepth_(maxDepth)
-    {}
+      : maxRecursionDepth_(maxDepth) {}
 
     template <
-        template <typename...> class Variant,
-        template <typename...> class Tuple>
+        template <typename...>
+        class Variant,
+        template <typename...>
+        class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <typename...> class Variant>
@@ -152,17 +144,13 @@ public:
   schedule_sender schedule() const noexcept {
     return schedule_sender{maxRecursionDepth_};
   }
-  friend bool operator==(scheduler, scheduler) noexcept {
-    return true;
-  }
-  friend bool operator!=(scheduler, scheduler) noexcept {
-    return false;
-  }
+  friend bool operator==(scheduler, scheduler) noexcept { return true; }
+  friend bool operator!=(scheduler, scheduler) noexcept { return false; }
 };
-} // namespace _trampoline
+}  // namespace _trampoline
 
 using trampoline_scheduler = _trampoline::scheduler;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/transform_stream.hpp
+++ b/include/unifex/transform_stream.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
 #include <unifex/next_adapt_stream.hpp>
 #include <unifex/then.hpp>
-#include <unifex/bind_back.hpp>
 
 #include <functional>
 
@@ -25,25 +25,25 @@
 
 namespace unifex {
 namespace _tfx_stream {
-  struct _fn {
-    template <typename StreamSender, typename Func>
-    auto operator()(StreamSender&& stream, Func&& func) const {
-      return next_adapt_stream(
-          (StreamSender &&) stream, [func = (Func &&) func](auto&& sender) mutable {
-            return then((decltype(sender))sender, std::ref(func));
-          });
-    }
-    template <typename Func>
-    constexpr auto operator()(Func&& func) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Func>)
-        -> bind_back_result_t<_fn, Func> {
-      return bind_back(*this, (Func&&)func);
-    }
-  };
-} // namespace _tfx_stream
+struct _fn {
+  template <typename StreamSender, typename Func>
+  auto operator()(StreamSender&& stream, Func&& func) const {
+    return next_adapt_stream(
+        (StreamSender &&) stream,
+        [func = (Func &&) func](auto&& sender) mutable {
+          return then((decltype(sender))sender, std::ref(func));
+        });
+  }
+  template <typename Func>
+  constexpr auto operator()(Func&& func) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
+          -> bind_back_result_t<_fn, Func> {
+    return bind_back(*this, (Func &&) func);
+  }
+};
+}  // namespace _tfx_stream
 
-inline constexpr _tfx_stream::_fn transform_stream {};
-} // namespace unifex
+inline constexpr _tfx_stream::_fn transform_stream{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_index.hpp
+++ b/include/unifex/type_index.hpp
@@ -19,9 +19,9 @@
 #include <unifex/type_traits.hpp>
 
 #if UNIFEX_NO_RTTI
-#include <functional>
+#  include <functional>
 #else
-#include <typeindex>
+#  include <typeindex>
 #endif
 
 #include <unifex/detail/prologue.hpp>
@@ -31,19 +31,16 @@ namespace unifex {
 #if UNIFEX_NO_RTTI
 
 struct type_index final {
-  const char* name() const noexcept {
-    return index_;
-  }
+  const char* name() const noexcept { return index_; }
 
   std::size_t hash_code() const noexcept {
     return std::hash<const void*>{}(index_);
   }
 
- private:
+private:
   const char* index_;
 
-  explicit type_index(const char* index) noexcept
-    : index_(index) {}
+  explicit type_index(const char* index) noexcept : index_(index) {}
 
   friend bool operator==(type_index lhs, type_index rhs) noexcept {
     return lhs.index_ == rhs.index_;
@@ -76,11 +73,11 @@ struct type_index final {
   static type_index make() noexcept {
     static_assert(std::is_same_v<T, remove_cvref_t<T>>);
 
-#ifdef __FUNCSIG__
+#  ifdef __FUNCSIG__
     static constexpr auto index = __FUNCSIG__;
-#else
+#  else
     static constexpr auto index = __PRETTY_FUNCTION__;
-#endif
+#  endif
 
     return type_index{index};
   }
@@ -102,7 +99,7 @@ type_index type_id() noexcept {
 
 #endif
 
-} // namespace unifex
+}  // namespace unifex
 
 #if UNIFEX_NO_RTTI
 
@@ -115,7 +112,7 @@ struct hash<unifex::type_index> {
   }
 };
 
-} // namespace std
+}  // namespace std
 
 #endif
 

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -21,99 +21,113 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
-  // A template metaprogramming data-structure used to represent an
-  // ordered list of types.
-  template <typename... Ts>
-  struct type_list {
-    // Invoke the template metafunction with the type-list's elements
-    // as arguments.
-    template <template <typename...> class F>
-    using apply = F<Ts...>;
-  };
+namespace unifex {
+// A template metaprogramming data-structure used to represent an
+// ordered list of types.
+template <typename... Ts>
+struct type_list {
+  // Invoke the template metafunction with the type-list's elements
+  // as arguments.
+  template <template <typename...> class F>
+  using apply = F<Ts...>;
+};
 
-  // concat_type_lists<Lists...>
-  //
-  // Concatenates a variadic pack of type_list<Ts...> into a single
-  // type_list that contains the concatenation of the elements of the
-  // input type_lists.
-  //
-  // Result is produced via nested ::type.
-  template <typename... Lists>
-  struct concat_type_lists;
+// concat_type_lists<Lists...>
+//
+// Concatenates a variadic pack of type_list<Ts...> into a single
+// type_list that contains the concatenation of the elements of the
+// input type_lists.
+//
+// Result is produced via nested ::type.
+template <typename... Lists>
+struct concat_type_lists;
 
-  template <>
-  struct concat_type_lists<> {
-    using type = type_list<>;
-  };
+template <>
+struct concat_type_lists<> {
+  using type = type_list<>;
+};
 
-  template <typename List>
-  struct concat_type_lists<List> {
-    using type = List;
-  };
+template <typename List>
+struct concat_type_lists<List> {
+  using type = List;
+};
 
-  template <typename... Ts, typename... Us>
-  struct concat_type_lists<type_list<Ts...>, type_list<Us...>> {
-      using type = type_list<Ts..., Us...>;
-  };
+template <typename... Ts, typename... Us>
+struct concat_type_lists<type_list<Ts...>, type_list<Us...>> {
+  using type = type_list<Ts..., Us...>;
+};
 
-  template <typename... Ts, typename... Us, typename... Vs, typename... OtherLists>
-  struct concat_type_lists<type_list<Ts...>, type_list<Us...>, type_list<Vs...>, OtherLists...>
-    : concat_type_lists<type_list<Ts..., Us..., Vs...>, OtherLists...> {};
+template <
+    typename... Ts,
+    typename... Us,
+    typename... Vs,
+    typename... OtherLists>
+struct concat_type_lists<
+    type_list<Ts...>,
+    type_list<Us...>,
+    type_list<Vs...>,
+    OtherLists...>
+  : concat_type_lists<type_list<Ts..., Us..., Vs...>, OtherLists...> {};
 
-  template <typename... UniqueLists>
-  using concat_type_lists_t = typename concat_type_lists<UniqueLists...>::type;
+template <typename... UniqueLists>
+using concat_type_lists_t = typename concat_type_lists<UniqueLists...>::type;
 
-  // concat_type_lists_unique<UniqueLists...>
-  //
-  // Result is produced via '::type' which will contain a type_list<Ts...> that
-  // contains the unique elements from the input type_list types.
-  // Assumes that the input lists already
-  template <typename... UniqueLists>
-  struct concat_type_lists_unique;
+// concat_type_lists_unique<UniqueLists...>
+//
+// Result is produced via '::type' which will contain a type_list<Ts...> that
+// contains the unique elements from the input type_list types.
+// Assumes that the input lists already
+template <typename... UniqueLists>
+struct concat_type_lists_unique;
 
-  template <>
-  struct concat_type_lists_unique<> {
-    using type = type_list<>;
-  };
+template <>
+struct concat_type_lists_unique<> {
+  using type = type_list<>;
+};
 
-  template <typename UniqueList>
-  struct concat_type_lists_unique<UniqueList> {
-    using type = UniqueList;
-  };
+template <typename UniqueList>
+struct concat_type_lists_unique<UniqueList> {
+  using type = UniqueList;
+};
 
-  template <typename... Ts, typename... Us, typename... OtherLists>
-  struct concat_type_lists_unique<type_list<Ts...>, type_list<Us...>, OtherLists...>
-    : concat_type_lists_unique<
-          typename concat_type_lists<
-              type_list<Ts...>,
-              conditional_t<
+template <typename... Ts, typename... Us, typename... OtherLists>
+struct concat_type_lists_unique<
+    type_list<Ts...>,
+    type_list<Us...>,
+    OtherLists...>
+  : concat_type_lists_unique<
+        typename concat_type_lists<
+            type_list<Ts...>,
+            conditional_t<
                 is_one_of_v<Us, Ts...>,
                 type_list<>,
                 type_list<Us>>...>::type,
-          OtherLists...> {};
+        OtherLists...> {};
 
-  template <typename... UniqueLists>
-  using concat_type_lists_unique_t = typename concat_type_lists_unique<UniqueLists...>::type;
+template <typename... UniqueLists>
+using concat_type_lists_unique_t =
+    typename concat_type_lists_unique<UniqueLists...>::type;
 
-  namespace detail
-  {
-    template <
-      template <typename...> class Outer,
-      template <typename...> class Inner>
-    struct type_list_nested_apply_impl {
-      template <typename... Lists>
-      using apply = Outer<typename Lists::template apply<Inner>...>;
-    };
-  }
+namespace detail {
+template <
+    template <typename...>
+    class Outer,
+    template <typename...>
+    class Inner>
+struct type_list_nested_apply_impl {
+  template <typename... Lists>
+  using apply = Outer<typename Lists::template apply<Inner>...>;
+};
+}  // namespace detail
 
-  template <
+template <
     typename ListOfLists,
-    template <typename...> class Outer,
-    template <typename...> class Inner>
-  using type_list_nested_apply_t = typename ListOfLists::template apply<
+    template <typename...>
+    class Outer,
+    template <typename...>
+    class Inner>
+using type_list_nested_apply_t = typename ListOfLists::template apply<
     detail::type_list_nested_apply_impl<Outer, Inner>::template apply>;
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_traits.hpp
+++ b/include/unifex/type_traits.hpp
@@ -28,10 +28,10 @@ template <typename T>
 struct type_identity {
   using type = T;
 };
-} // namespace _ti
+}  // namespace _ti
 using _ti::type_identity;
 
-template<typename T>
+template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 
 template <typename... Ts>
@@ -47,20 +47,41 @@ using single_type_t = typename single_type<Ts...>::type;
 
 // We don't care about volatile, and not handling volatile is
 // less work for the compiler.
-template <class T> struct remove_cvref { using type = T; };
-template <class T> struct remove_cvref<T const> { using type = T; };
+template <class T>
+struct remove_cvref {
+  using type = T;
+};
+template <class T>
+struct remove_cvref<T const> {
+  using type = T;
+};
 // template <class T> struct remove_cvref<T volatile> { using type = T; };
 // template <class T> struct remove_cvref<T const volatile> { using type = T; };
-template <class T> struct remove_cvref<T&> { using type = T; };
-template <class T> struct remove_cvref<T const&> { using type = T; };
+template <class T>
+struct remove_cvref<T&> {
+  using type = T;
+};
+template <class T>
+struct remove_cvref<T const&> {
+  using type = T;
+};
 // template <class T> struct remove_cvref<T volatile&> { using type = T; };
-// template <class T> struct remove_cvref<T const volatile&> { using type = T; };
-template <class T> struct remove_cvref<T&&> { using type = T; };
-template <class T> struct remove_cvref<T const&&> { using type = T; };
+// template <class T> struct remove_cvref<T const volatile&> { using type = T;
+// };
+template <class T>
+struct remove_cvref<T&&> {
+  using type = T;
+};
+template <class T>
+struct remove_cvref<T const&&> {
+  using type = T;
+};
 // template <class T> struct remove_cvref<T volatile&&> { using type = T; };
-// template <class T> struct remove_cvref<T const volatile&&> { using type = T; };
+// template <class T> struct remove_cvref<T const volatile&&> { using type = T;
+// };
 
-template <class T> using remove_cvref_t = typename remove_cvref<T>::type;
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
 
 template <template <typename...> class T, typename X>
 inline constexpr bool instance_of_v = false;
@@ -73,7 +94,7 @@ using instance_of = std::bool_constant<instance_of_v<T, X>>;
 
 namespace _unit {
 struct unit {};
-}
+}  // namespace _unit
 using _unit::unit;
 
 template <bool B>
@@ -103,9 +124,8 @@ template <class Member, class Self>
 Member Self::*_memptr(const Self&);
 
 template <typename Self, typename Member>
-using member_t = decltype(
-    (UNIFEX_DECLVAL(Self&&) .*
-        unifex::_memptr<Member>(UNIFEX_DECLVAL(Self&&))));
+using member_t = decltype((
+    UNIFEX_DECLVAL(Self &&).*unifex::_memptr<Member>(UNIFEX_DECLVAL(Self &&))));
 
 template <typename T>
 using decay_rvalue_t =
@@ -131,35 +151,39 @@ inline constexpr bool is_one_of_v = (UNIFEX_IS_SAME(T, Ts) || ...);
 
 template <typename Fn, typename... As>
 using callable_result_t =
-    decltype(UNIFEX_DECLVAL(Fn&&)(UNIFEX_DECLVAL(As&&)...));
+    decltype(UNIFEX_DECLVAL(Fn &&)(UNIFEX_DECLVAL(As &&)...));
 
 namespace _is_callable {
-  struct yes_type { char dummy; };
-  struct no_type { char dummy[2]; };
-  static_assert(sizeof(yes_type) != sizeof(no_type));
+struct yes_type {
+  char dummy;
+};
+struct no_type {
+  char dummy[2];
+};
+static_assert(sizeof(yes_type) != sizeof(no_type));
 
-  template <
-      typename Fn,
-      typename... As,
-      typename = callable_result_t<Fn, As...>>
-  yes_type _try_call(Fn(*)(As...))
-      noexcept(noexcept(UNIFEX_DECLVAL(Fn&&)(UNIFEX_DECLVAL(As&&)...)));
-  no_type _try_call(...) noexcept(false);
-} // namespace _is_callable
+template <typename Fn, typename... As, typename = callable_result_t<Fn, As...>>
+yes_type _try_call(Fn (*)(As...)) noexcept(
+    noexcept(UNIFEX_DECLVAL(Fn&&)(UNIFEX_DECLVAL(As&&)...)));
+no_type _try_call(...) noexcept(false);
+}  // namespace _is_callable
 
 template <typename Fn, typename... As>
-inline constexpr bool is_callable_v =
-  sizeof(decltype(_is_callable::_try_call(static_cast<Fn(*)(As...)>(nullptr)))) == sizeof(_is_callable::yes_type);
+inline constexpr bool
+    is_callable_v = sizeof(decltype(_is_callable::_try_call(
+                        static_cast<Fn (*)(As...)>(nullptr)))) ==
+    sizeof(_is_callable::yes_type);
 
 template <typename Fn, typename... As>
 struct is_callable : std::bool_constant<is_callable_v<Fn, As...>> {};
 
 template <typename Fn, typename... As>
 inline constexpr bool is_nothrow_callable_v =
-    noexcept(_is_callable::_try_call(static_cast<Fn(*)(As...)>(nullptr)));
+    noexcept(_is_callable::_try_call(static_cast<Fn (*)(As...)>(nullptr)));
 
 template <typename Fn, typename... As>
-struct is_nothrow_callable : std::bool_constant<is_nothrow_callable_v<Fn, As...>> {};
+struct is_nothrow_callable
+  : std::bool_constant<is_nothrow_callable_v<Fn, As...>> {};
 
 template <typename T>
 struct type_always {
@@ -245,7 +269,6 @@ struct meta_quote1_ {
   };
 };
 
-
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/typed_via_stream.hpp
+++ b/include/unifex/typed_via_stream.hpp
@@ -23,38 +23,36 @@
 
 namespace unifex {
 namespace _typed_via_stream {
-  struct _fn {
-    template (typename StreamSender, typename Scheduler)
-        (requires scheduler<Scheduler>)
-    auto operator()(Scheduler&& scheduler, StreamSender&& stream) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
-          });
-    }
-    template (typename StreamSender, typename Scheduler)
-        (requires scheduler<Scheduler>)
-    auto operator()(StreamSender&& stream, Scheduler&& scheduler) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
-          });
-    }
-    template(typename Scheduler)
-        (requires scheduler<Scheduler>)
-    constexpr auto operator()(Scheduler&& scheduler) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Scheduler>)
-        -> bind_back_result_t<_fn, Scheduler> {
-      return bind_back(*this, (Scheduler&&)scheduler);
-    }
-  };
-} // namespace _typed_via_stream
+struct _fn {
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(Scheduler&& scheduler, StreamSender&& stream) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return typed_via((decltype(sender))sender, s);
+        });
+  }
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(StreamSender&& stream, Scheduler&& scheduler) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return typed_via((decltype(sender))sender, s);
+        });
+  }
+  template(typename Scheduler)(requires scheduler<Scheduler>) constexpr auto
+  operator()(Scheduler&& scheduler) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Scheduler>)
+          -> bind_back_result_t<_fn, Scheduler> {
+    return bind_back(*this, (Scheduler &&) scheduler);
+  }
+};
+}  // namespace _typed_via_stream
 
-inline constexpr _typed_via_stream::_fn typed_via_stream {};
+inline constexpr _typed_via_stream::_fn typed_via_stream{};
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/unstoppable_token.hpp
+++ b/include/unifex/unstoppable_token.hpp
@@ -24,14 +24,10 @@ struct unstoppable_token {
   struct callback_type {
     explicit callback_type(unstoppable_token, F&&) noexcept {}
   };
-  static constexpr bool stop_requested() noexcept {
-    return false;
-  }
-  static constexpr bool stop_possible() noexcept {
-    return false;
-  }
+  static constexpr bool stop_requested() noexcept { return false; }
+  static constexpr bool stop_possible() noexcept { return false; }
 };
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -43,15 +43,15 @@ struct _receiver<Receiver, Func>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  template(typename... Values)
-    (requires receiver_of< Receiver, Values...>) 
-  void set_value(Values&&... values) && {
+  template(typename... Values)(
+      requires receiver_of<
+          Receiver,
+          Values...>) void set_value(Values&&... values) && {
     unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
   }
 
-  template(typename Error)
-    (requires receiver<Receiver, Error>) 
-  void set_error(Error&& error) && noexcept {
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
     unifex::set_error((Receiver &&)(receiver_), (Error &&)(error));
   }
 
@@ -86,16 +86,16 @@ struct _receiver<Receiver, Func>::type {
     }
   }
 
-  template(typename CPO)
-    (requires is_receiver_query_cpo_v<CPO>) 
-  friend auto tag_invoke( CPO cpo, const type& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>) 
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return (CPO &&)(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
     std::invoke(visit, self.receiver_);
   }
 };
@@ -168,16 +168,23 @@ public:
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND 
-     sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) 
-    friend auto tag_invoke( tag_t<unifex::connect>, Sender&& s, Receiver&& r) 
-    noexcept(
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>&&
-        std::is_nothrow_constructible_v<Func, member_t<Sender, Func>>&&
-        is_nothrow_connectable_v<member_t<Sender, Predecessor>,
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>&&
+                              std::is_nothrow_constructible_v<
+                                  Func,
+                                  member_t<Sender, Func>>&&
+                                  is_nothrow_connectable_v<
+                                      member_t<Sender, Predecessor>,
                                       receiver_t<remove_cvref_t<Receiver>>>)
-      -> connect_result_t<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>> {
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
     return unifex::connect(
         static_cast<Sender&&>(s).pred_,
         receiver_t<remove_cvref_t<Receiver>>{
@@ -195,28 +202,28 @@ private:
       meta_quote2<_upon_done::sender>>::template apply<Sender, Func>;
 
 public:
-  template(typename Sender, typename Func)
-    (requires invocable<Func> AND tag_invocable<_fn, Sender, Func>) 
-  auto operator()(Sender&& predecessor, Func&& func) const
+  template(typename Sender, typename Func)(
+      requires invocable<Func> AND tag_invocable<_fn, Sender, Func>) auto
+  operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
-      -> _result_t<Sender, Func> {
+          -> _result_t<Sender, Func> {
     return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
   }
 
-  template(typename Sender, typename Func)
-    (requires(!tag_invocable<_fn, Sender, Func>) AND invocable<Func>)
-  auto operator()(Sender&& predecessor, Func&& func) const
+  template(typename Sender, typename Func)(
+      requires(!tag_invocable<_fn, Sender, Func>) AND invocable<Func>) auto
+  operator()(Sender&& predecessor, Func&& func) const
       noexcept(std::is_nothrow_constructible_v<
-               _upon_done::sender<Sender, Func>, Sender, Func>) 
-      -> _result_t<Sender, Func> {
+               _upon_done::sender<Sender, Func>,
+               Sender,
+               Func>) -> _result_t<Sender, Func> {
     return _upon_done::sender<Sender, Func>{
         (Sender &&)(predecessor), (Func &&)(func)};
   }
-  template(typename Func)
-    (requires invocable<Func>) 
-  constexpr auto operator()(Func&& func) const
+  template(typename Func)(requires invocable<Func>) constexpr auto
+  operator()(Func&& func) const
       noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
-      -> bind_back_result_t<_fn, Func> {
+          -> bind_back_result_t<_fn, Func> {
     return bind_back(*this, (Func &&)(func));
   }
 };

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -21,7 +21,7 @@ template <typename Result, typename = void>
 struct result_overload {
   using type = type_list<Result>;
 };
-template<>
+template <>
 struct result_overload<void> {
   using type = type_list<>;
 };
@@ -43,15 +43,15 @@ struct _receiver<Receiver, Func>::type {
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-  template (typename... Values)
-    (requires receiver_of<Receiver, Values...>)
-  void set_value(Values&&... values) && {
+  template(typename... Values)(
+      requires receiver_of<
+          Receiver,
+          Values...>) void set_value(Values&&... values) && {
     unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
   }
 
-  template (typename Error)
-    (requires receiver<Receiver, Error>)
-  void set_error(Error&& error) && noexcept{
+  template(typename Error)(requires receiver<Receiver, Error>) void set_error(
+      Error&& error) && noexcept {
     using result_t = std::invoke_result_t<Func, Error>;
     if constexpr (std::is_void_v<result_t>) {
       if constexpr (noexcept(std::invoke((Func &&) func_, (Error &&) error))) {
@@ -84,20 +84,18 @@ struct _receiver<Receiver, Func>::type {
     }
   }
 
-  void set_done() && noexcept { 
-    unifex::set_done((Receiver &&)(receiver_)); 
-  }
+  void set_done() && noexcept { unifex::set_done((Receiver &&)(receiver_)); }
 
-  template(typename CPO)
-    (requires is_receiver_query_cpo_v<CPO>)
-    friend auto tag_invoke( CPO cpo, const type& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const type& r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return (CPO &&)(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Visit>
-  friend void tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& self, Visit&& visit) {
     std::invoke(visit, self.receiver_);
   }
 };
@@ -149,16 +147,23 @@ public:
     return blocking(sender.pred_);
   }
 
-  template(typename Sender, typename Receiver)
-    (requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND
-     sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) 
-    friend auto tag_invoke( tag_t<unifex::connect>, Sender&& s, Receiver&& r) 
-    noexcept(
-        std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>&&
-        std::is_nothrow_constructible_v<Func, member_t<Sender, Func>>&&
-        is_nothrow_connectable_v<member_t<Sender, Predecessor>,
+  template(typename Sender, typename Receiver)(requires same_as<remove_cvref_t<Sender>, type> AND receiver<Receiver> AND sender_to<member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      Sender&& s,
+      Receiver&&
+          r) noexcept(std::
+                          is_nothrow_constructible_v<
+                              remove_cvref_t<Receiver>,
+                              Receiver>&&
+                              std::is_nothrow_constructible_v<
+                                  Func,
+                                  member_t<Sender, Func>>&&
+                                  is_nothrow_connectable_v<
+                                      member_t<Sender, Predecessor>,
                                       receiver_t<remove_cvref_t<Receiver>>>)
-      -> connect_result_t< member_t<Sender, Predecessor>, receiver_t<remove_cvref_t<Receiver>>> {
+      -> connect_result_t<
+          member_t<Sender, Predecessor>,
+          receiver_t<remove_cvref_t<Receiver>>> {
     return unifex::connect(
         static_cast<Sender&&>(s).pred_,
         receiver_t<remove_cvref_t<Receiver>>{
@@ -176,19 +181,21 @@ private:
       meta_quote2<_upon_error::sender>>::template apply<Sender, Func>;
 
 public:
-  template(typename Sender, typename Func)
-    (requires tag_invocable<_fn, Sender, Func>)
-  auto operator()(Sender&& predecessor, Func&& func) const
+  template(typename Sender, typename Func)(
+      requires tag_invocable<_fn, Sender, Func>) auto
+  operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
-      -> _result_t<Sender, Func> {
+          -> _result_t<Sender, Func> {
     return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
   }
 
-  template(typename Sender, typename Func)
-    (requires(!tag_invocable<_fn, Sender, Func>))
-  auto operator()(Sender&& predecessor, Func&& func) const
-      noexcept(std::is_nothrow_constructible_v<_upon_error::sender<Sender, Func>,
-               Sender, Func>) -> _result_t<Sender, Func> {
+  template(typename Sender, typename Func)(
+      requires(!tag_invocable<_fn, Sender, Func>)) auto
+  operator()(Sender&& predecessor, Func&& func) const
+      noexcept(std::is_nothrow_constructible_v<
+               _upon_error::sender<Sender, Func>,
+               Sender,
+               Func>) -> _result_t<Sender, Func> {
     return _upon_error::sender<Sender, Func>{
         (Sender &&)(predecessor), (Func &&)(func)};
   }
@@ -196,7 +203,7 @@ public:
   template <typename Func>
   constexpr auto operator()(Func&& func) const
       noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Func>)
-      -> bind_back_result_t<_fn, Func> {
+          -> bind_back_result_t<_fn, Func> {
     return bind_back(*this, (Func &&)(func));
   }
 };

--- a/include/unifex/utility.hpp
+++ b/include/unifex/utility.hpp
@@ -18,31 +18,30 @@
 #include <unifex/config.hpp>
 
 #if defined(UNIFEX_USE_ABSEIL)
-#include <absl/utility/utility.h>
+#  include <absl/utility/utility.h>
 #else
-#include <utility>
+#  include <utility>
 #endif
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
+namespace unifex {
 #if defined(UNIFEX_USE_ABSEIL)
-using absl::in_place_t;
-using absl::in_place_index_t;
-using absl::in_place_type_t;
 using absl::in_place;
+using absl::in_place_index_t;
+using absl::in_place_t;
+using absl::in_place_type_t;
 // using absl::in_place_index;
 // using absl::in_place_type;
 #else
-using std::in_place_t;
-using std::in_place_index_t;
-using std::in_place_type_t;
 using std::in_place;
+using std::in_place_index_t;
+using std::in_place_t;
+using std::in_place_type_t;
 // using std::in_place_index;
 // using std::in_place_type;
 #endif
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/variant.hpp
+++ b/include/unifex/variant.hpp
@@ -18,44 +18,43 @@
 #include <unifex/config.hpp>
 
 #if defined(UNIFEX_USE_ABSEIL)
-#include <absl/types/variant.h>
+#  include <absl/types/variant.h>
 #else
-#include <variant>
+#  include <variant>
 #endif
 
 #include <unifex/utility.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex
-{
+namespace unifex {
 #if defined(UNIFEX_USE_ABSEIL)
+using absl::bad_variant_access;
+using absl::holds_alternative;
+using absl::monostate;
 using absl::variant;
-using absl::variant_size;
 using absl::variant_alternative;
 using absl::variant_npos;
-using absl::holds_alternative;
+using absl::variant_size;
 using absl::visit;
-using absl::monostate;
-using absl::bad_variant_access;
 namespace var {
 using absl::get;
 using absl::get_if;
-}
+}  // namespace var
 #else
+using std::bad_variant_access;
+using std::holds_alternative;
+using std::monostate;
 using std::variant;
-using std::variant_size;
 using std::variant_alternative;
 using std::variant_npos;
-using std::holds_alternative;
+using std::variant_size;
 using std::visit;
-using std::monostate;
-using std::bad_variant_access;
 namespace var {
 using std::get;
 using std::get_if;
-}
+}  // namespace var
 #endif
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
-#include <unifex/type_traits.hpp>
-#include <unifex/type_list.hpp>
 #include <unifex/submit.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/get_stop_token.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
 #include <unifex/utility.hpp>
 
 #include <exception>
@@ -34,7 +34,8 @@
 namespace unifex {
 namespace _via {
 
-constexpr blocking_kind _blocking_kind(blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
+constexpr blocking_kind _blocking_kind(
+    blocking_kind predBlocking, blocking_kind succBlocking) noexcept {
   if (predBlocking == blocking_kind::never &&
       succBlocking == blocking_kind::never) {
     return blocking_kind::never;
@@ -44,9 +45,9 @@ constexpr blocking_kind _blocking_kind(blocking_kind predBlocking, blocking_kind
     return blocking_kind::always_inline;
   } else if (
       (predBlocking == blocking_kind::always_inline ||
-        predBlocking == blocking_kind::always) &&
+       predBlocking == blocking_kind::always) &&
       (succBlocking == blocking_kind::always_inline ||
-        succBlocking == blocking_kind::always)) {
+       succBlocking == blocking_kind::always)) {
     return blocking_kind::always;
   } else {
     return blocking_kind::maybe;
@@ -58,9 +59,8 @@ struct _value_receiver {
   struct type;
 };
 template <typename Receiver, typename... Values>
-using value_receiver = typename _value_receiver<
-    Receiver,
-    std::decay_t<Values>...>::type;
+using value_receiver =
+    typename _value_receiver<Receiver, std::decay_t<Values>...>::type;
 
 template <typename Receiver, typename... Values>
 struct _value_receiver<Receiver, Values...>::type {
@@ -70,7 +70,7 @@ struct _value_receiver<Receiver, Values...>::type {
 
   void set_value() noexcept {
     std::apply(
-        [&](Values && ... values) noexcept {
+        [&](Values&&... values) noexcept {
           unifex::set_value(
               std::forward<Receiver>(receiver_), (Values &&) values...);
         },
@@ -86,19 +86,17 @@ struct _value_receiver<Receiver, Values...>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const value_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const value_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
-  friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const value_receiver& r,
-      Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const value_receiver& r, Func&& func) {
     std::invoke(func, r.receiver_);
   }
 };
@@ -108,7 +106,8 @@ struct _error_receiver {
   struct type;
 };
 template <typename Receiver, typename Error>
-using error_receiver = typename _error_receiver<Receiver, std::decay_t<Error>>::type;
+using error_receiver =
+    typename _error_receiver<Receiver, std::decay_t<Error>>::type;
 
 template <typename Receiver, typename Error>
 struct _error_receiver<Receiver, Error>::type {
@@ -130,19 +129,17 @@ struct _error_receiver<Receiver, Error>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const error_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const error_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
-  friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const error_receiver& r,
-      Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const error_receiver& r, Func&& func) {
     std::invoke(func, r.receiver_);
   }
 };
@@ -173,19 +170,17 @@ struct _done_receiver<Receiver>::type {
     unifex::set_done(std::forward<Receiver>(receiver_));
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const done_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const done_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
-  friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const done_receiver& r,
-      Func&& func) {
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const done_receiver& r, Func&& func) {
     std::invoke(func, r.receiver_);
   }
 };
@@ -211,7 +206,8 @@ struct _predecessor_receiver<Successor, Receiver>::type {
           (Successor &&) successor_,
           value_receiver<Receiver, Values...>{
               std::tuple{(Values &&) values...}, (Receiver &&) receiver_});
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
@@ -224,7 +220,8 @@ struct _predecessor_receiver<Successor, Receiver>::type {
           (Successor &&) successor_,
           error_receiver<Receiver, Error>{
               (Error &&) error, (Receiver &&) receiver_});
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
@@ -235,25 +232,24 @@ struct _predecessor_receiver<Successor, Receiver>::type {
       submit(
           (Successor &&) successor_,
           done_receiver<Receiver>{(Receiver &&) receiver_});
-    } UNIFEX_CATCH (...) {
+    }
+    UNIFEX_CATCH(...) {
       unifex::set_error(
           static_cast<Receiver&&>(receiver_), std::current_exception());
     }
   }
 
-  template(typename CPO)
-      (requires is_receiver_query_cpo_v<CPO>)
-  friend auto tag_invoke(CPO cpo, const predecessor_receiver& r) noexcept(
-      is_nothrow_callable_v<CPO, const Receiver&>)
+  template(typename CPO)(requires is_receiver_query_cpo_v<CPO>) friend auto tag_invoke(
+      CPO cpo,
+      const predecessor_receiver&
+          r) noexcept(is_nothrow_callable_v<CPO, const Receiver&>)
       -> callable_result_t<CPO, const Receiver&> {
     return std::move(cpo)(std::as_const(r.receiver_));
   }
 
   template <typename Func>
   friend void tag_invoke(
-      tag_t<visit_continuations>,
-      const predecessor_receiver& r,
-      Func&& func) {
+      tag_t<visit_continuations>, const predecessor_receiver& r, Func&& func) {
     std::invoke(func, r.receiver_);
   }
 };
@@ -263,9 +259,9 @@ struct _sender {
   struct type;
 };
 template <typename Predecessor, typename Successor>
-using sender = typename _sender<
-    remove_cvref_t<Predecessor>,
-    remove_cvref_t<Successor>>::type;
+using sender =
+    typename _sender<remove_cvref_t<Predecessor>, remove_cvref_t<Successor>>::
+        type;
 
 template <typename Predecessor, typename Successor>
 struct _sender<Predecessor, Successor>::type {
@@ -277,30 +273,34 @@ struct _sender<Predecessor, Successor>::type {
   using overload_list = type_list<type_list<std::decay_t<Ts>...>>;
 
   template <
-      template <typename...> class Variant,
-      template <typename...> class Tuple>
-  using value_types =
-      type_list_nested_apply_t<
-          sender_value_types_t<Predecessor, concat_type_lists_unique_t, overload_list>,
-          Variant, Tuple>;
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = type_list_nested_apply_t<
+      sender_value_types_t<
+          Predecessor,
+          concat_type_lists_unique_t,
+          overload_list>,
+      Variant,
+      Tuple>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      typename concat_type_lists_unique_t<
-          sender_error_types_t<Predecessor, type_list>,
-          sender_error_types_t<Successor, type_list>,
-          type_list<std::exception_ptr>>::template apply<Variant>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Predecessor, type_list>,
+      sender_error_types_t<Successor, type_list>,
+      type_list<std::exception_ptr>>::template apply<Variant>;
 
-  static constexpr bool sends_done =
-    sender_traits<Predecessor>::sends_done ||
-    sender_traits<Successor>::sends_done;
+  static constexpr bool sends_done = sender_traits<Predecessor>::sends_done ||
+      sender_traits<Successor>::sends_done;
 
-  friend constexpr auto tag_invoke(tag_t<blocking>, const sender& self) noexcept {
+  friend constexpr auto
+  tag_invoke(tag_t<blocking>, const sender& self) noexcept {
     if constexpr (
         blocking_kind::maybe != cblocking<Predecessor>() &&
         blocking_kind::maybe != cblocking<Successor>()) {
-      return blocking_kind::constant<
-          _via::_blocking_kind(cblocking<Predecessor>(), cblocking<Successor>())>();
+      return blocking_kind::constant<_via::_blocking_kind(
+          cblocking<Predecessor>(), cblocking<Successor>())>();
     } else {
       return _via::_blocking_kind(blocking(self.pred_), blocking(self.succ_));
     }
@@ -315,26 +315,24 @@ struct _sender<Predecessor, Successor>::type {
             static_cast<Receiver&&>(receiver)});
   }
 };
-} // namespace _via
+}  // namespace _via
 
 namespace _via_cpo {
-  inline const struct _fn {
-    template (typename Scheduler, typename Sender)
-      (requires scheduler<Scheduler> AND sender<Sender>)
-    auto operator()(Scheduler&& sched, Sender&& send) const
-        noexcept(noexcept(
-            _via::sender<Sender, schedule_result_t<Scheduler>>{
-                (Sender&&) send, schedule(sched)}))
-        -> _via::sender<Sender, schedule_result_t<Scheduler>> {
-      return _via::sender<Sender, schedule_result_t<Scheduler>>{
-          (Sender&&) send,
-          schedule(sched)};
-    }
-  } via{};
-} // namespace _via_cpo
+inline const struct _fn {
+  template(typename Scheduler, typename Sender)(
+      requires scheduler<Scheduler> AND sender<Sender>) auto
+  operator()(Scheduler&& sched, Sender&& send) const
+      noexcept(noexcept(_via::sender<Sender, schedule_result_t<Scheduler>>{
+          (Sender &&) send, schedule(sched)}))
+          -> _via::sender<Sender, schedule_result_t<Scheduler>> {
+    return _via::sender<Sender, schedule_result_t<Scheduler>>{
+        (Sender &&) send, schedule(sched)};
+  }
+} via{};
+}  // namespace _via_cpo
 
 using _via_cpo::via;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via_stream.hpp
+++ b/include/unifex/via_stream.hpp
@@ -24,43 +24,41 @@
 
 namespace unifex {
 namespace _via_stream_cpo {
-  struct _fn {
-    template (typename StreamSender, typename Scheduler)
-      (requires scheduler<Scheduler>)
-    auto operator()(Scheduler&& scheduler, StreamSender&& stream) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return via(s, (decltype(sender))sender);
-          },
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
-          });
-    }
-    template (typename StreamSender, typename Scheduler)
-      (requires scheduler<Scheduler>)
-    auto operator()(StreamSender&& stream, Scheduler&& scheduler) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return via(s, (decltype(sender))sender);
-          },
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
-          });
-    }
-    template(typename Scheduler)
-      (requires scheduler<Scheduler>)
-    constexpr auto operator()(Scheduler&& scheduler) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Scheduler>)
-        -> bind_back_result_t<_fn, Scheduler> {
-      return bind_back(*this, (Scheduler&&)scheduler);
-    }
-  };
-} // namespace _via_stream_cpo
+struct _fn {
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(Scheduler&& scheduler, StreamSender&& stream) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return via(s, (decltype(sender))sender);
+        },
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return typed_via((decltype(sender))sender, s);
+        });
+  }
+  template(typename StreamSender, typename Scheduler)(
+      requires scheduler<Scheduler>) auto
+  operator()(StreamSender&& stream, Scheduler&& scheduler) const {
+    return adapt_stream(
+        (StreamSender &&) stream,
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return via(s, (decltype(sender))sender);
+        },
+        [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+          return typed_via((decltype(sender))sender, s);
+        });
+  }
+  template(typename Scheduler)(requires scheduler<Scheduler>) constexpr auto
+  operator()(Scheduler&& scheduler) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Scheduler>)
+          -> bind_back_result_t<_fn, Scheduler> {
+    return bind_back(*this, (Scheduler &&) scheduler);
+  }
+};
+}  // namespace _via_stream_cpo
 
-inline constexpr _via_stream_cpo::_fn via_stream {};
-} // namespace unifex
+inline constexpr _via_stream_cpo::_fn via_stream{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -35,163 +35,164 @@
 #  define _Out_writes_to_(A, B)
 #endif
 
-namespace unifex::win32::ntapi
-{
-  using HANDLE = void*;
-  using PHANDLE = HANDLE*;
-  using LONG = long;
-  using NTSTATUS = LONG;
-  using ULONG_PTR = std::uintptr_t;
-  using LONG_PTR = std::intptr_t;
-  using PVOID = void*;
-  using USHORT = unsigned short;
-  using LONG = long;
-  using LONGLONG = long long;
-  using ULONG = unsigned long;
-  using PULONG = ULONG*;
-  using DWORD = unsigned long;
-  using WCHAR = wchar_t;
-  using PWSTR = WCHAR*;
-  using BYTE = unsigned char;
-  using BOOLEAN = BYTE;
+namespace unifex::win32::ntapi {
+using HANDLE = void*;
+using PHANDLE = HANDLE*;
+using LONG = long;
+using NTSTATUS = LONG;
+using ULONG_PTR = std::uintptr_t;
+using LONG_PTR = std::intptr_t;
+using PVOID = void*;
+using USHORT = unsigned short;
+using LONG = long;
+using LONGLONG = long long;
+using ULONG = unsigned long;
+using PULONG = ULONG*;
+using DWORD = unsigned long;
+using WCHAR = wchar_t;
+using PWSTR = WCHAR*;
+using BYTE = unsigned char;
+using BOOLEAN = BYTE;
 
-  union LARGE_INTEGER {
-    struct {
-      DWORD LowPart;
-      LONG HighPart;
-    } u;
-    LONGLONG QuadPart;
+union LARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    LONG HighPart;
+  } u;
+  LONGLONG QuadPart;
+};
+using PLARGE_INTEGER = LARGE_INTEGER*;
+
+struct UNICODE_STRING {
+  USHORT Length;
+  USHORT MaximumLength;
+  PWSTR Buffer;
+};
+using PUNICODE_STRING = UNICODE_STRING*;
+
+struct IO_STATUS_BLOCK {
+  // Corresponds to OVERLAPPED::Internal
+  union {
+    NTSTATUS Status;
+    void* Pointer;
   };
-  using PLARGE_INTEGER = LARGE_INTEGER*;
 
-  struct UNICODE_STRING {
-    USHORT Length;
-    USHORT MaximumLength;
-    PWSTR Buffer;
-  };
-  using PUNICODE_STRING = UNICODE_STRING*;
+  // Corresponds to OVERLAPPED::InternalHigh
+  ULONG_PTR Information;
+};
+using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
 
-  struct IO_STATUS_BLOCK {
-    // Corresponds to OVERLAPPED::Internal
-    union {
-      NTSTATUS Status;
-      void* Pointer;
-    };
+using ACCESS_MASK = DWORD;
+using PACCESS_MASK = ACCESS_MASK*;
 
-    // Corresponds to OVERLAPPED::InternalHigh
-    ULONG_PTR Information;
-  };
-  using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
+struct OBJECT_ATTRIBUTES {
+  ULONG Length;
+  HANDLE RootDirectory;
+  PUNICODE_STRING ObjectName;
+  ULONG Attributes;
+  PVOID SecurityDescriptor;
+  PVOID SecurityQualityOfService;
+};
+using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
 
-  using ACCESS_MASK = DWORD;
-  using PACCESS_MASK = ACCESS_MASK*;
+struct FILE_COMPLETION_INFORMATION {
+  HANDLE Port;
+  PVOID Key;
+};
+using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
 
-  struct OBJECT_ATTRIBUTES {
-    ULONG Length;
-    HANDLE RootDirectory;
-    PUNICODE_STRING ObjectName;
-    ULONG Attributes;
-    PVOID SecurityDescriptor;
-    PVOID SecurityQualityOfService;
-  };
-  using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
+struct FILE_IO_COMPLETION_INFORMATION {
+  PVOID KeyContext;
+  PVOID ApcContext;
+  IO_STATUS_BLOCK IoStatusBlock;
+};
+using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
 
-  struct FILE_COMPLETION_INFORMATION {
-    HANDLE Port;
-    PVOID Key;
-  };
-  using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
+using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
+    _In_ PVOID ApcContext,
+    _In_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_ ULONG Reserved);
 
-  struct FILE_IO_COMPLETION_INFORMATION {
-    PVOID KeyContext;
-    PVOID ApcContext;
-    IO_STATUS_BLOCK IoStatusBlock;
-  };
-  using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
+// From
+// http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
+using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _Out_ PHANDLE FileHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_ATTRIBUTES ObjectAttributes,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_opt_ PLARGE_INTEGER AllocationSize,
+    _In_ ULONG FileAttributes,
+    _In_ ULONG ShareAccess,
+    _In_ ULONG CreateDisposition,
+    _In_ ULONG CreateOptions,
+    _In_opt_ PVOID EaBuffer,
+    _In_ ULONG EaLength);
+extern NtCreateFile_t NtCreateFile;
 
-  using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
-      _In_ PVOID ApcContext,
-      _In_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_ ULONG Reserved);
+using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE hFile,
+    _Out_ PIO_STATUS_BLOCK iosb,
+    _Out_ PIO_STATUS_BLOCK io_status);
+extern NtCancelIoFileEx_t NtCancelIoFileEx;
 
-  // From
-  // http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
-  using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _Out_ PHANDLE FileHandle,
-      _In_ ACCESS_MASK DesiredAccess,
-      _In_ POBJECT_ATTRIBUTES ObjectAttributes,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_opt_ PLARGE_INTEGER AllocationSize,
-      _In_ ULONG FileAttributes,
-      _In_ ULONG ShareAccess,
-      _In_ ULONG CreateDisposition,
-      _In_ ULONG CreateOptions,
-      _In_opt_ PVOID EaBuffer,
-      _In_ ULONG EaLength);
-  extern NtCreateFile_t NtCreateFile;
+using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE FileHandle,
+    _In_opt_ HANDLE Event,
+    _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+    _In_opt_ PVOID ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _Out_ PVOID Buffer,
+    _In_ ULONG Length,
+    _In_opt_ PLARGE_INTEGER ByteOffset,
+    _In_opt_ PULONG Key);
+extern NtReadFile_t NtReadFile;
 
-  using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE hFile,
-      _Out_ PIO_STATUS_BLOCK iosb,
-      _Out_ PIO_STATUS_BLOCK io_status);
-  extern NtCancelIoFileEx_t NtCancelIoFileEx;
+using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE FileHandle,
+    _In_opt_ HANDLE Event,
+    _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+    _In_opt_ PVOID ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_ PVOID Buffer,
+    _In_ ULONG Length,
+    _In_opt_ PLARGE_INTEGER ByteOffset,
+    _In_opt_ PULONG Key);
+extern NtWriteFile_t NtWriteFile;
 
-  using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE FileHandle,
-      _In_opt_ HANDLE Event,
-      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-      _In_opt_ PVOID ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _Out_ PVOID Buffer,
-      _In_ ULONG Length,
-      _In_opt_ PLARGE_INTEGER ByteOffset,
-      _In_opt_ PULONG Key);
-  extern NtReadFile_t NtReadFile;
+using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _In_ ULONG KeyContext,
+    _In_ PVOID ApcContext,
+    _In_ NTSTATUS IoStatus,
+    _In_ ULONG IoStatusInformation);
+extern NtSetIoCompletion_t NtSetIoCompletion;
 
-  using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE FileHandle,
-      _In_opt_ HANDLE Event,
-      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-      _In_opt_ PVOID ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_ PVOID Buffer,
-      _In_ ULONG Length,
-      _In_opt_ PLARGE_INTEGER ByteOffset,
-      _In_opt_ PULONG Key);
-  extern NtWriteFile_t NtWriteFile;
+using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _Out_ PVOID* CompletionKey,
+    _Out_ PVOID* ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_opt_ PLARGE_INTEGER Timeout);
+extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
 
-  using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _In_ ULONG KeyContext,
-      _In_ PVOID ApcContext,
-      _In_ NTSTATUS IoStatus,
-      _In_ ULONG IoStatusInformation);
-  extern NtSetIoCompletion_t NtSetIoCompletion;
+using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _Out_writes_to_(Count, *NumEntriesRemoved)
+        PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
+    _In_ ULONG Count,
+    _Out_ PULONG NumEntriesRemoved,
+    _In_opt_ PLARGE_INTEGER Timeout,
+    _In_ BOOLEAN Alertable);
+extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
 
-  using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _Out_ PVOID* CompletionKey,
-      _Out_ PVOID* ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_opt_ PLARGE_INTEGER Timeout);
-  extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
+using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(_In_ NTSTATUS Status);
+extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
 
-  using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _Out_writes_to_(Count, *NumEntriesRemoved)
-          PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
-      _In_ ULONG Count,
-      _Out_ PULONG NumEntriesRemoved,
-      _In_opt_ PLARGE_INTEGER Timeout,
-      _In_ BOOLEAN Alertable);
-  extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
+void ensure_initialised() noexcept;
 
-  using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(_In_ NTSTATUS Status);
-  extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
-
-  void ensure_initialised() noexcept;
-
-  constexpr bool ntstatus_success(NTSTATUS status) { return status >= 0; }
+constexpr bool ntstatus_success(NTSTATUS status) {
+  return status >= 0;
+}
 
 }  // namespace unifex::win32::ntapi
 

--- a/include/unifex/win32/detail/safe_handle.hpp
+++ b/include/unifex/win32/detail/safe_handle.hpp
@@ -23,53 +23,52 @@ namespace unifex::win32 {
 
 class safe_handle {
 public:
-    safe_handle() noexcept : handle_(nullptr) {}
+  safe_handle() noexcept : handle_(nullptr) {}
 
-    explicit safe_handle(handle_t h) noexcept : handle_(h) {}
+  explicit safe_handle(handle_t h) noexcept : handle_(h) {}
 
-    safe_handle(safe_handle&& h) noexcept : handle_(std::exchange(h.handle_, nullptr)) {}
+  safe_handle(safe_handle&& h) noexcept
+    : handle_(std::exchange(h.handle_, nullptr)) {}
 
-    ~safe_handle() { reset(); }
+  ~safe_handle() { reset(); }
 
-    safe_handle(const safe_handle&) = delete;
+  safe_handle(const safe_handle&) = delete;
 
-    safe_handle& operator=(safe_handle h) noexcept {
-        swap(h);
-        return *this;
-    }
+  safe_handle& operator=(safe_handle h) noexcept {
+    swap(h);
+    return *this;
+  }
 
-    handle_t get() const noexcept { return handle_; }
+  handle_t get() const noexcept { return handle_; }
 
-    handle_t release() noexcept { return std::exchange(handle_, nullptr); }
+  handle_t release() noexcept { return std::exchange(handle_, nullptr); }
 
-    void reset() noexcept;
+  void reset() noexcept;
 
-    void swap(safe_handle& other) noexcept {
-        std::swap(handle_, other.handle_);
-    }
+  void swap(safe_handle& other) noexcept { std::swap(handle_, other.handle_); }
 
-    friend bool operator==(const safe_handle& a, const safe_handle& b) noexcept {
-        return a.handle_ == b.handle_;
-    }
-    friend bool operator==(const safe_handle& a, handle_t b) noexcept {
-        return a.handle_ == b;
-    }
-    friend bool operator==(handle_t a, const safe_handle& b) noexcept {
-        return a == b.handle_;
-    }
+  friend bool operator==(const safe_handle& a, const safe_handle& b) noexcept {
+    return a.handle_ == b.handle_;
+  }
+  friend bool operator==(const safe_handle& a, handle_t b) noexcept {
+    return a.handle_ == b;
+  }
+  friend bool operator==(handle_t a, const safe_handle& b) noexcept {
+    return a == b.handle_;
+  }
 
-    friend bool operator!=(const safe_handle& a, const safe_handle& b) noexcept {
-        return !(a == b);
-    }
-    friend bool operator!=(const safe_handle& a, handle_t b) noexcept {
-        return !(a == b);
-    }
-    friend bool operator!=(handle_t a, const safe_handle& b) noexcept {
-        return !(a == b);
-    }
+  friend bool operator!=(const safe_handle& a, const safe_handle& b) noexcept {
+    return !(a == b);
+  }
+  friend bool operator!=(const safe_handle& a, handle_t b) noexcept {
+    return !(a == b);
+  }
+  friend bool operator!=(handle_t a, const safe_handle& b) noexcept {
+    return !(a == b);
+  }
 
 private:
-    handle_t handle_;
+  handle_t handle_;
 };
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -17,15 +17,14 @@
 
 #include <cstdint>
 
-namespace unifex::win32
-{
-  using handle_t = void*;              // HANDLE
-  using ulong_ptr_t = std::uintptr_t;  // ULONG_PTR
-  using long_ptr_t = std::intptr_t;    // LONG_PTR
-  using dword_t = unsigned long;       // DWORD
-  using socket_t = std::uintptr_t;     // SOCKET
-  using ulong_t = unsigned long;       // ULONG
-  using long_t = long;                 // LONG
+namespace unifex::win32 {
+using handle_t = void*;              // HANDLE
+using ulong_ptr_t = std::uintptr_t;  // ULONG_PTR
+using long_ptr_t = std::intptr_t;    // LONG_PTR
+using dword_t = unsigned long;       // DWORD
+using socket_t = std::uintptr_t;     // SOCKET
+using ulong_t = unsigned long;       // ULONG
+using long_t = long;                 // LONG
 
 #if defined(_MSC_VER)
 #  pragma warning(push)
@@ -36,32 +35,32 @@ namespace unifex::win32
 #else
 #  define UNIFEX_NAMELESS_UNION
 #endif
-  struct overlapped {
-    ulong_ptr_t Internal;
-    ulong_ptr_t InternalHigh;
-    UNIFEX_NAMELESS_UNION union {
-      struct {
-        dword_t Offset;
-        dword_t OffsetHigh;
-      };
-      void* Pointer;
+struct overlapped {
+  ulong_ptr_t Internal;
+  ulong_ptr_t InternalHigh;
+  UNIFEX_NAMELESS_UNION union {
+    struct {
+      dword_t Offset;
+      dword_t OffsetHigh;
     };
-    handle_t hEvent;
+    void* Pointer;
   };
+  handle_t hEvent;
+};
 #undef UNIFEX_NAMELESS_UNION
 #if defined(_MSC_VER)
 #  pragma warning(pop)
 #endif
 
-  struct wsabuf {
-    constexpr wsabuf() noexcept : len(0), buf(nullptr) {}
+struct wsabuf {
+  constexpr wsabuf() noexcept : len(0), buf(nullptr) {}
 
-    wsabuf(void* p, ulong_t sz) noexcept
-      : len(sz)
-      , buf(reinterpret_cast<char*>(p)) {}
+  wsabuf(void* p, ulong_t sz) noexcept
+    : len(sz)
+    , buf(reinterpret_cast<char*>(p)) {}
 
-    ulong_t len;
-    char* buf;
-  };
+  ulong_t len;
+  char* buf;
+};
 
 }  // namespace unifex::win32

--- a/include/unifex/win32/filetime_clock.hpp
+++ b/include/unifex/win32/filetime_clock.hpp
@@ -24,99 +24,96 @@ namespace unifex::win32 {
 
 class filetime_clock {
 public:
-    using rep = std::int64_t;
-    using ratio = std::ratio<1, 10'000'000>; // 100ns
-    using duration = std::chrono::duration<rep, ratio>;
+  using rep = std::int64_t;
+  using ratio = std::ratio<1, 10'000'000>;  // 100ns
+  using duration = std::chrono::duration<rep, ratio>;
 
-    static constexpr bool is_steady = false;
+  static constexpr bool is_steady = false;
 
-    class time_point {
-    public:
-        using duration = filetime_clock::duration;
+  class time_point {
+  public:
+    using duration = filetime_clock::duration;
 
-        constexpr time_point() noexcept : ticks_(0) {}
+    constexpr time_point() noexcept : ticks_(0) {}
 
-        constexpr time_point(const time_point&) noexcept = default;
+    constexpr time_point(const time_point&) noexcept = default;
 
-        time_point& operator=(const time_point&) noexcept = default;
+    time_point& operator=(const time_point&) noexcept = default;
 
-        std::uint64_t get_ticks() const noexcept {
-            return ticks_;
-        }
+    std::uint64_t get_ticks() const noexcept { return ticks_; }
 
-        static constexpr time_point max() noexcept {
-            time_point tp;
-            tp.ticks_ = std::numeric_limits<std::int64_t>::max();
-            return tp;
-        }
+    static constexpr time_point max() noexcept {
+      time_point tp;
+      tp.ticks_ = std::numeric_limits<std::int64_t>::max();
+      return tp;
+    }
 
-        static constexpr time_point min() noexcept {
-            return time_point{};
-        }
+    static constexpr time_point min() noexcept { return time_point{}; }
 
-        static time_point from_ticks(std::uint64_t ticks) noexcept {
-            time_point tp;
-            tp.ticks_ = ticks;
-            return tp;
-        }
+    static time_point from_ticks(std::uint64_t ticks) noexcept {
+      time_point tp;
+      tp.ticks_ = ticks;
+      return tp;
+    }
 
-        template <typename Rep, typename Ratio>
-        time_point& operator+=(
-            const std::chrono::duration<Rep, Ratio>& d) noexcept {
-            ticks_ += std::chrono::duration_cast<duration>(d).count();
-            return *this;
-        }
+    template <typename Rep, typename Ratio>
+    time_point&
+    operator+=(const std::chrono::duration<Rep, Ratio>& d) noexcept {
+      ticks_ += std::chrono::duration_cast<duration>(d).count();
+      return *this;
+    }
 
-        template <typename Rep, typename Ratio>
-        time_point& operator-=(
-            const std::chrono::duration<Rep, Ratio>& d) noexcept {
-            ticks_ -= std::chrono::duration_cast<duration>(d).count();
-            return *this;
-        }
+    template <typename Rep, typename Ratio>
+    time_point&
+    operator-=(const std::chrono::duration<Rep, Ratio>& d) noexcept {
+      ticks_ -= std::chrono::duration_cast<duration>(d).count();
+      return *this;
+    }
 
-        friend duration operator-(time_point a, time_point b) noexcept {
-            return duration{a.ticks_} - duration{b.ticks_};
-        }
+    friend duration operator-(time_point a, time_point b) noexcept {
+      return duration{a.ticks_} - duration{b.ticks_};
+    }
 
-        template <typename Rep, typename Ratio>
-        friend time_point operator+(time_point t, std::chrono::duration<Rep, Ratio> d) noexcept {
-            time_point tp = t;
-            tp += d;
-            return tp;
-        }
+    template <typename Rep, typename Ratio>
+    friend time_point
+    operator+(time_point t, std::chrono::duration<Rep, Ratio> d) noexcept {
+      time_point tp = t;
+      tp += d;
+      return tp;
+    }
 
-        friend bool operator==(time_point a, time_point b) noexcept {
-            return a.ticks_ == b.ticks_;
-        }
+    friend bool operator==(time_point a, time_point b) noexcept {
+      return a.ticks_ == b.ticks_;
+    }
 
-        friend bool operator!=(time_point a, time_point b) noexcept {
-            return a.ticks_ != b.ticks_;
-        }
+    friend bool operator!=(time_point a, time_point b) noexcept {
+      return a.ticks_ != b.ticks_;
+    }
 
-        friend bool operator<(time_point a, time_point b) noexcept {
-            return a.ticks_ < b.ticks_;
-        }
+    friend bool operator<(time_point a, time_point b) noexcept {
+      return a.ticks_ < b.ticks_;
+    }
 
-        friend bool operator>(time_point a, time_point b) noexcept {
-            return a.ticks_ > b.ticks_;
-        }
+    friend bool operator>(time_point a, time_point b) noexcept {
+      return a.ticks_ > b.ticks_;
+    }
 
-        friend bool operator<=(time_point a, time_point b) noexcept {
-            return a.ticks_ <= b.ticks_;
-        }
+    friend bool operator<=(time_point a, time_point b) noexcept {
+      return a.ticks_ <= b.ticks_;
+    }
 
-        friend bool operator>=(time_point a, time_point b) noexcept {
-            return a.ticks_ >= b.ticks_;
-        }
+    friend bool operator>=(time_point a, time_point b) noexcept {
+      return a.ticks_ >= b.ticks_;
+    }
 
-    private:
-        // Ticks since Jan 1, 1601 (UTC)
-        std::uint64_t ticks_;
-    };
+  private:
+    // Ticks since Jan 1, 1601 (UTC)
+    std::uint64_t ticks_;
+  };
 
-    static time_point now() noexcept;
+  static time_point now() noexcept;
 };
 
-} // namespace unifex::win32
+}  // namespace unifex::win32
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <unifex/get_stop_token.hpp>
 #include <unifex/io_concepts.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/pipe_concepts.hpp>
@@ -23,7 +24,6 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/span.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
 
 #include <unifex/detail/atomic_intrusive_queue.hpp>
 #include <unifex/detail/intrusive_list.hpp>
@@ -42,804 +42,804 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex::win32
-{
-  class low_latency_iocp_context {
-    class scheduler;
+namespace unifex::win32 {
+class low_latency_iocp_context {
+  class scheduler;
 
-    class readable_byte_stream;
-    class writable_byte_stream;
+  class readable_byte_stream;
+  class writable_byte_stream;
 
-    class schedule_sender;
-
-    template <typename Receiver>
-    struct _schedule_op {
-      class type;
-    };
-    template <typename Receiver>
-    using schedule_op = typename _schedule_op<Receiver>::type;
-
-    template <typename Buffer>
-    struct _read_file_sender {
-      class type;
-    };
-    template <typename Buffer>
-    using read_file_sender = typename _read_file_sender<Buffer>::type;
-
-    template <typename Buffer>
-    struct _write_file_sender {
-      class type;
-    };
-    template <typename Buffer>
-    using write_file_sender = typename _write_file_sender<Buffer>::type;
-
-    template <typename Buffer, typename Receiver>
-    struct _read_file_op {
-      class type;
-    };
-    template <typename Buffer, typename Receiver>
-    using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
-
-    template <typename Buffer, typename Receiver>
-    struct _write_file_op {
-      class type;
-    };
-    template <typename Buffer, typename Receiver>
-    using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
-
-  public:
-    // Initialise the IOCP context and pre-allocate storage for I/O
-    // state needed to support at most 'maxIoOperations' concurrent I/O
-    // operations.
-    explicit low_latency_iocp_context(std::size_t maxIoOperations);
-
-    low_latency_iocp_context(low_latency_iocp_context&&) = delete;
-    low_latency_iocp_context(const low_latency_iocp_context&) = delete;
-    low_latency_iocp_context&
-    operator=(const low_latency_iocp_context&) = delete;
-    low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
-
-    ~low_latency_iocp_context();
-
-    // Drive the event loop until a request to stop is communicated via
-    // the passed StopToken.
-    template <typename StopToken>
-    void run(StopToken st);
-
-    // Obtain a handle to this execution context that can be used to
-    // schedule work and open I/O resources.
-    scheduler get_scheduler() noexcept;
-
-  private:
-    struct vectored_io_state;
-
-    // This value chosen so that vectored_io_state is 512 bytes on 64-bit
-    // architectures and 256 bytes on 32-bit architectures.
-    static constexpr std::size_t max_vectored_io_size = 30;
-
-    struct operation_base {
-      explicit operation_base(low_latency_iocp_context& ctx) noexcept
-        : context(ctx) {}
-
-      using callback_t = void(operation_base*) noexcept;
-      low_latency_iocp_context& context;
-      callback_t* callback = nullptr;
-      operation_base* next = nullptr;
-      operation_base* prev = nullptr;
-    };
-
-    using operation_queue = intrusive_list<
-        operation_base,
-        &operation_base::next,
-        &operation_base::prev>;
-
-    struct io_operation : operation_base {
-      explicit io_operation(
-          low_latency_iocp_context& context,
-          handle_t fileHandle,
-          bool skipNotificationOnSuccess) noexcept
-        : operation_base(context)
-        , fileHandle(fileHandle)
-        , skipNotificationOnSuccess(skipNotificationOnSuccess)
-        , ioState(nullptr) {}
-
-      const handle_t fileHandle;
-      const bool skipNotificationOnSuccess;
-      vectored_io_state* ioState;
-
-      // Cancel outstanding I/O operations (if any)
-      void cancel_io() noexcept;
-
-      // Poll for whether or not the operation has completed.
-      // Returns 'true' if the operation is completed (in which case the
-      // operation has 'acquire' semantics), 'false' otherwise.
-      bool is_complete() noexcept;
-
-      // Start reading the next 'buffer.size()' bytes into 'buffer'.
-      //
-      // Returns 'true' if a additional read-operations can be submitted.
-      // This will only be the case if all of the following are true:
-      // - a read of the entirety of 'buffer' was successfully started
-      // - we haven't reached the maximum number of I/O operations in
-      //   this batch.
-      //
-      // Once all I/O operations have been started, the caller should
-      // schedule a 'poll' of this operation by setting this->callback
-      // and calling context.schedule_poll(this). This will schedule the
-      // callback to be run immediately (if it completed synchronously).
-      bool start_read(span<std::byte> buffer) noexcept;
-
-      // Start writing the context of 'buffer' to fileHandle.
-      bool start_write(span<const std::byte> buffer) noexcept;
-
-      std::size_t get_result(std::error_code& ec) noexcept;
-    };
-
-    struct vectored_io_state {
-      // Parent operation.
-      //
-      // May be nullptr if this operation already completed due to a poll.
-      // If this is the case then when all pending completion notifications
-      // are received then this will just go straight back on the free-list.
-      io_operation* parent = nullptr;
-
-      // Intrusive list ptr.
-      vectored_io_state* next = nullptr;
-      vectored_io_state* prev = nullptr;
-
-      // Total number of operations started
-      std::uint8_t operationCount = 0;
-
-      // Number of operations not yet received completion-notification
-      // via the IOCP. The vectored_io_state structure is not free to
-      // be reused until this number reaches zero.
-      std::uint8_t pendingCompletionNotifications = 0;
-
-      // Whether or not the 'parent' has already been notified of completion.
-      bool completed = false;
-
-      ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
-    };
-
-    struct stop_operation : operation_base {
-      explicit stop_operation(low_latency_iocp_context& ctx) noexcept
-        : operation_base(ctx) {
-        this->callback = &request_stop_callback;
-      }
-
-      ~stop_operation() {
-        if (isEnqueued) {
-          // Flush any items in the remote-queue into the ready queue
-          // just in case this operation is still in the remote queue.
-          (void)context.try_dequeue_remote_work();
-
-          // This operation should now be in the ready queue, remove it.
-          context.readyQueue_.remove(this);
-        }
-      }
-
-      void start() noexcept {
-        if (context.is_running_on_io_thread()) {
-          stopRequestedFlag = true;
-        } else {
-          isEnqueued = true;
-          context.schedule_remote(this);
-        }
-      }
-
-      static void request_stop_callback(operation_base* op) noexcept {
-        auto& self = *static_cast<stop_operation*>(op);
-        self.stopRequestedFlag = true;
-        self.isEnqueued = false;
-      }
-
-      bool stopRequestedFlag = false;
-
-    private:
-      bool isEnqueued = false;
-    };
-
-    struct stop_callback {
-      stop_operation& op;
-
-      void operator()() noexcept { op.start(); }
-    };
-
-    void run_impl(bool& stopFlag);
-
-    // Dequeue items from remote queue and move them to the
-    // ready-to-run queue.
-    // Returns true if any items were dequeued.
-    bool try_dequeue_remote_work() noexcept;
-
-    bool poll_is_complete(vectored_io_state& state) noexcept;
-
-    // Obtain the I/O state that contains a given io_status_block structure.
-    vectored_io_state* to_io_state(ntapi::IO_STATUS_BLOCK* io) noexcept;
-
-    bool is_running_on_io_thread() const noexcept {
-      return activeThreadId_.load(std::memory_order_relaxed) ==
-          std::this_thread::get_id();
-    }
-
-    void schedule(operation_base* op) noexcept;
-    void schedule_local(operation_base* op) noexcept;
-    void schedule_remote(operation_base* op) noexcept;
-
-    // If an I/O state is available, attaches an unused I/O state to
-    // op->ioState and returns true, otherwise returns false if no
-    // I/O state is currently available.
-    //
-    // If 'true' is returned then the caller can populate op->ioState
-    // and initiate the I/O using its IO_STATUS_BLOCK structures.
-    [[nodiscard]] bool try_allocate_io_state_for(io_operation* op) noexcept;
-
-    // Schedule the specified 'op' to be called back (calling op->callback)
-    // when an I/O state becomes available and has been allocated to 'op'.
-    //
-    // Do this only after an unsuccessful call to try_allocate_io_state_for()
-    // asynchronously wait until some other I/O operation completes and frees
-    // up an other I/O state.
-    void schedule_when_io_state_available(io_operation* op) noexcept;
-
-    // Mark the io state as released and let it return to the pool.
-    void release_io_state(vectored_io_state* state) noexcept;
-
-    // Schedule this operation to be polled next time we run out of work
-    // in the ready-queue before going back to the OS for completion-events.
-    void schedule_poll_io(io_operation* op) noexcept;
-
-    // Attempt to associate the specified file-handle with this I/O context
-    // so that its I/O completion events are posted to this context's IOCP.
-    void associate_file_handle(handle_t fileHandle);
-
-  private:
-    ////
-    // State that won't change after initialisation or that change rarely
-    // e.g. only on each call to run().
-
-    std::atomic<std::thread::id> activeThreadId_;
-    safe_handle iocp_;
-    std::size_t ioPoolSize_;
-    std::unique_ptr<vectored_io_state[]> ioPool_;
-
-    /////
-    // State that is accessed/modified by the I/O thread only.
-
-    alignas(64) intrusive_stack<
-        vectored_io_state,
-        &vectored_io_state::next> ioFreeList_;
-
-    // Newly launched operations that we want to poll for completion as soon as
-    // we run out of 'ready-to-run' work to do.
-    operation_queue pollQueue_;
-
-    // Operations waiting to acquire a vectored_io_operation.
-    // These will be resumed in-order as vectored_io_operations are returned to
-    // the pool.
-    operation_queue pendingIoQueue_;
-
-    // Operations that are ready to run.
-    operation_queue readyQueue_;
-
-    /////
-    // State that may be accessed/modified by other threads.
-
-    alignas(64) atomic_intrusive_queue<
-        operation_base,
-        &operation_base::next> remoteQueue_;
-  };
-
-  template <typename StopToken>
-  void low_latency_iocp_context::run(StopToken stopToken) {
-    stop_operation op{*this};
-    typename StopToken::template callback_type<stop_callback> cb{
-        std::move(stopToken), stop_callback{op}};
-    run_impl(op.stopRequestedFlag);
-  }
-
-  ///////////////////////////
-  // schedule
+  class schedule_sender;
 
   template <typename Receiver>
-  class low_latency_iocp_context::_schedule_op<Receiver>::type
-    : private low_latency_iocp_context::operation_base {
-  public:
-    template <typename Receiver2>
-    explicit type(low_latency_iocp_context& context, Receiver2&& r)
+  struct _schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_op = typename _schedule_op<Receiver>::type;
+
+  template <typename Buffer>
+  struct _read_file_sender {
+    class type;
+  };
+  template <typename Buffer>
+  using read_file_sender = typename _read_file_sender<Buffer>::type;
+
+  template <typename Buffer>
+  struct _write_file_sender {
+    class type;
+  };
+  template <typename Buffer>
+  using write_file_sender = typename _write_file_sender<Buffer>::type;
+
+  template <typename Buffer, typename Receiver>
+  struct _read_file_op {
+    class type;
+  };
+  template <typename Buffer, typename Receiver>
+  using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
+
+  template <typename Buffer, typename Receiver>
+  struct _write_file_op {
+    class type;
+  };
+  template <typename Buffer, typename Receiver>
+  using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
+
+public:
+  // Initialise the IOCP context and pre-allocate storage for I/O
+  // state needed to support at most 'maxIoOperations' concurrent I/O
+  // operations.
+  explicit low_latency_iocp_context(std::size_t maxIoOperations);
+
+  low_latency_iocp_context(low_latency_iocp_context&&) = delete;
+  low_latency_iocp_context(const low_latency_iocp_context&) = delete;
+  low_latency_iocp_context& operator=(const low_latency_iocp_context&) = delete;
+  low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
+
+  ~low_latency_iocp_context();
+
+  // Drive the event loop until a request to stop is communicated via
+  // the passed StopToken.
+  template <typename StopToken>
+  void run(StopToken st);
+
+  // Obtain a handle to this execution context that can be used to
+  // schedule work and open I/O resources.
+  scheduler get_scheduler() noexcept;
+
+private:
+  struct vectored_io_state;
+
+  // This value chosen so that vectored_io_state is 512 bytes on 64-bit
+  // architectures and 256 bytes on 32-bit architectures.
+  static constexpr std::size_t max_vectored_io_size = 30;
+
+  struct operation_base {
+    explicit operation_base(low_latency_iocp_context& ctx) noexcept
+      : context(ctx) {}
+
+    using callback_t = void(operation_base*) noexcept;
+    low_latency_iocp_context& context;
+    callback_t* callback = nullptr;
+    operation_base* next = nullptr;
+    operation_base* prev = nullptr;
+  };
+
+  using operation_queue = intrusive_list<
+      operation_base,
+      &operation_base::next,
+      &operation_base::prev>;
+
+  struct io_operation : operation_base {
+    explicit io_operation(
+        low_latency_iocp_context& context,
+        handle_t fileHandle,
+        bool skipNotificationOnSuccess) noexcept
       : operation_base(context)
-      , receiver_((Receiver2 &&) r) {
-      this->callback = &execute_callback;
+      , fileHandle(fileHandle)
+      , skipNotificationOnSuccess(skipNotificationOnSuccess)
+      , ioState(nullptr) {}
+
+    const handle_t fileHandle;
+    const bool skipNotificationOnSuccess;
+    vectored_io_state* ioState;
+
+    // Cancel outstanding I/O operations (if any)
+    void cancel_io() noexcept;
+
+    // Poll for whether or not the operation has completed.
+    // Returns 'true' if the operation is completed (in which case the
+    // operation has 'acquire' semantics), 'false' otherwise.
+    bool is_complete() noexcept;
+
+    // Start reading the next 'buffer.size()' bytes into 'buffer'.
+    //
+    // Returns 'true' if a additional read-operations can be submitted.
+    // This will only be the case if all of the following are true:
+    // - a read of the entirety of 'buffer' was successfully started
+    // - we haven't reached the maximum number of I/O operations in
+    //   this batch.
+    //
+    // Once all I/O operations have been started, the caller should
+    // schedule a 'poll' of this operation by setting this->callback
+    // and calling context.schedule_poll(this). This will schedule the
+    // callback to be run immediately (if it completed synchronously).
+    bool start_read(span<std::byte> buffer) noexcept;
+
+    // Start writing the context of 'buffer' to fileHandle.
+    bool start_write(span<const std::byte> buffer) noexcept;
+
+    std::size_t get_result(std::error_code& ec) noexcept;
+  };
+
+  struct vectored_io_state {
+    // Parent operation.
+    //
+    // May be nullptr if this operation already completed due to a poll.
+    // If this is the case then when all pending completion notifications
+    // are received then this will just go straight back on the free-list.
+    io_operation* parent = nullptr;
+
+    // Intrusive list ptr.
+    vectored_io_state* next = nullptr;
+    vectored_io_state* prev = nullptr;
+
+    // Total number of operations started
+    std::uint8_t operationCount = 0;
+
+    // Number of operations not yet received completion-notification
+    // via the IOCP. The vectored_io_state structure is not free to
+    // be reused until this number reaches zero.
+    std::uint8_t pendingCompletionNotifications = 0;
+
+    // Whether or not the 'parent' has already been notified of completion.
+    bool completed = false;
+
+    ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
+  };
+
+  struct stop_operation : operation_base {
+    explicit stop_operation(low_latency_iocp_context& ctx) noexcept
+      : operation_base(ctx) {
+      this->callback = &request_stop_callback;
     }
 
-    void start() & noexcept { this->context.schedule(this); }
+    ~stop_operation() {
+      if (isEnqueued) {
+        // Flush any items in the remote-queue into the ready queue
+        // just in case this operation is still in the remote queue.
+        (void)context.try_dequeue_remote_work();
+
+        // This operation should now be in the ready queue, remove it.
+        context.readyQueue_.remove(this);
+      }
+    }
+
+    void start() noexcept {
+      if (context.is_running_on_io_thread()) {
+        stopRequestedFlag = true;
+      } else {
+        isEnqueued = true;
+        context.schedule_remote(this);
+      }
+    }
+
+    static void request_stop_callback(operation_base* op) noexcept {
+      auto& self = *static_cast<stop_operation*>(op);
+      self.stopRequestedFlag = true;
+      self.isEnqueued = false;
+    }
+
+    bool stopRequestedFlag = false;
 
   private:
-    static void execute_callback(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
+    bool isEnqueued = false;
+  };
 
+  struct stop_callback {
+    stop_operation& op;
+
+    void operator()() noexcept { op.start(); }
+  };
+
+  void run_impl(bool& stopFlag);
+
+  // Dequeue items from remote queue and move them to the
+  // ready-to-run queue.
+  // Returns true if any items were dequeued.
+  bool try_dequeue_remote_work() noexcept;
+
+  bool poll_is_complete(vectored_io_state& state) noexcept;
+
+  // Obtain the I/O state that contains a given io_status_block structure.
+  vectored_io_state* to_io_state(ntapi::IO_STATUS_BLOCK* io) noexcept;
+
+  bool is_running_on_io_thread() const noexcept {
+    return activeThreadId_.load(std::memory_order_relaxed) ==
+        std::this_thread::get_id();
+  }
+
+  void schedule(operation_base* op) noexcept;
+  void schedule_local(operation_base* op) noexcept;
+  void schedule_remote(operation_base* op) noexcept;
+
+  // If an I/O state is available, attaches an unused I/O state to
+  // op->ioState and returns true, otherwise returns false if no
+  // I/O state is currently available.
+  //
+  // If 'true' is returned then the caller can populate op->ioState
+  // and initiate the I/O using its IO_STATUS_BLOCK structures.
+  [[nodiscard]] bool try_allocate_io_state_for(io_operation* op) noexcept;
+
+  // Schedule the specified 'op' to be called back (calling op->callback)
+  // when an I/O state becomes available and has been allocated to 'op'.
+  //
+  // Do this only after an unsuccessful call to try_allocate_io_state_for()
+  // asynchronously wait until some other I/O operation completes and frees
+  // up an other I/O state.
+  void schedule_when_io_state_available(io_operation* op) noexcept;
+
+  // Mark the io state as released and let it return to the pool.
+  void release_io_state(vectored_io_state* state) noexcept;
+
+  // Schedule this operation to be polled next time we run out of work
+  // in the ready-queue before going back to the OS for completion-events.
+  void schedule_poll_io(io_operation* op) noexcept;
+
+  // Attempt to associate the specified file-handle with this I/O context
+  // so that its I/O completion events are posted to this context's IOCP.
+  void associate_file_handle(handle_t fileHandle);
+
+private:
+  ////
+  // State that won't change after initialisation or that change rarely
+  // e.g. only on each call to run().
+
+  std::atomic<std::thread::id> activeThreadId_;
+  safe_handle iocp_;
+  std::size_t ioPoolSize_;
+  std::unique_ptr<vectored_io_state[]> ioPool_;
+
+  /////
+  // State that is accessed/modified by the I/O thread only.
+
+  alignas(64)
+      intrusive_stack<vectored_io_state, &vectored_io_state::next> ioFreeList_;
+
+  // Newly launched operations that we want to poll for completion as soon as
+  // we run out of 'ready-to-run' work to do.
+  operation_queue pollQueue_;
+
+  // Operations waiting to acquire a vectored_io_operation.
+  // These will be resumed in-order as vectored_io_operations are returned to
+  // the pool.
+  operation_queue pendingIoQueue_;
+
+  // Operations that are ready to run.
+  operation_queue readyQueue_;
+
+  /////
+  // State that may be accessed/modified by other threads.
+
+  alignas(64) atomic_intrusive_queue<
+      operation_base,
+      &operation_base::next> remoteQueue_;
+};
+
+template <typename StopToken>
+void low_latency_iocp_context::run(StopToken stopToken) {
+  stop_operation op{*this};
+  typename StopToken::template callback_type<stop_callback> cb{
+      std::move(stopToken), stop_callback{op}};
+  run_impl(op.stopRequestedFlag);
+}
+
+///////////////////////////
+// schedule
+
+template <typename Receiver>
+class low_latency_iocp_context::_schedule_op<Receiver>::type
+  : private low_latency_iocp_context::operation_base {
+public:
+  template <typename Receiver2>
+  explicit type(low_latency_iocp_context& context, Receiver2&& r)
+    : operation_base(context)
+    , receiver_((Receiver2 &&) r) {
+    this->callback = &execute_callback;
+  }
+
+  void start() & noexcept { this->context.schedule(this); }
+
+private:
+  static void execute_callback(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+
+    if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(std::move(self.receiver_));
+        return;
+      }
+    }
+
+    if constexpr (is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(self.receiver_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(std::move(self.receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(self.receiver_), std::current_exception());
+      }
+    }
+  }
+
+  Receiver receiver_;
+};
+
+class low_latency_iocp_context::schedule_sender {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
+
+  explicit schedule_sender(low_latency_iocp_context& context) noexcept
+    : context_(context) {}
+
+  template(typename Receiver)(requires receiver_of<Receiver>) friend auto tag_invoke(
+      tag_t<connect>,
+      const schedule_sender& s,
+      Receiver&& r) noexcept(std::
+                                 is_nothrow_constructible_v<
+                                     remove_cvref_t<Receiver>,
+                                     Receiver>)
+      -> schedule_op<remove_cvref_t<Receiver>> {
+    return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver &&) r};
+  }
+
+private:
+  template <typename Receiver>
+  using schedule_op = schedule_op<Receiver>;
+  low_latency_iocp_context& context_;
+};
+
+///////////////////////////
+// read_file
+
+template <typename Buffer, typename Receiver>
+class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
+  : private low_latency_iocp_context::io_operation {
+public:
+  template <typename Receiver2, typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& ctx,
+      handle_t fileHandle,
+      bool skipNotificationOnSuccess,
+      Buffer2&& buffer,
+      Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2 &&) r)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  void start() & noexcept {
+    if (this->context.is_running_on_io_thread()) {
+      acquire_io_state(this);
+    } else {
+      this->callback = &acquire_io_state;
+      this->context.schedule_remote(this);
+    }
+  }
+
+private:
+  struct cancel_callback {
+    type& op;
+    void operator()() noexcept { op.cancel_io(); }
+  };
+
+  static void acquire_io_state(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    if (self.context.try_allocate_io_state_for(&self)) {
+      start_io(op);
+    } else {
+      // TODO: Add support for cancellation while waiting in the
+      // pendingIoQueue_.
+
+      self.callback = &start_io;
+      self.context.schedule_when_io_state_available(&self);
+    }
+  }
+
+  static void start_io(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    // TODO: Add support for a BufferSequence concept to allow
+    // vectorised I/O here.
+    // For now, just assume that 'Buffer' is convertible to a
+    // 'span<std::byte>'.
+
+    self.start_read(self.buffer_);
+
+    if (self.ioState->pendingCompletionNotifications == 0) {
+      self.ioState->completed = true;
+      self.callback = &on_complete;
+      self.context.readyQueue_.push_front(op);
+    } else {
       if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(std::move(self.receiver_));
-          return;
-        }
+        self.stopCallback_.construct(
+            get_stop_token(self.receiver_), cancel_callback{self});
+        self.callback = &on_cancellable_complete;
+      } else {
+        self.callback = &on_complete;
       }
 
+      self.context.schedule_poll_io(&self);
+    }
+  }
+
+  static void on_cancellable_complete(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    self.stopCallback_.destruct();
+
+    on_complete(op);
+  }
+
+  static void on_complete(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+
+    std::error_code ec;
+    std::size_t totalBytesTransferred = self.get_result(ec);
+
+    self.context.release_io_state(self.ioState);
+
+    // Treat partial failure as a success case.
+    // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+    // instead?
+    if (!ec || totalBytesTransferred > 0) {
       if constexpr (is_nothrow_callable_v<
-                        decltype(unifex::set_value),
-                        Receiver>) {
-        unifex::set_value(std::move(self.receiver_));
+                        decltype(set_value),
+                        Receiver,
+                        std::size_t>) {
+        unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
       } else {
         UNIFEX_TRY {
-          unifex::set_value(std::move(self.receiver_));
-        } UNIFEX_CATCH (...) {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+        }
+        UNIFEX_CATCH(...) {
           unifex::set_error(
               std::move(self.receiver_), std::current_exception());
         }
       }
+    } else if (ec == std::errc::operation_canceled) {
+      unifex::set_done(std::move(self.receiver_));
+    } else {
+      unifex::set_error(std::move(self.receiver_), std::move(ec));
     }
-
-    Receiver receiver_;
-  };
-
-  class low_latency_iocp_context::schedule_sender {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = true;
-
-    explicit schedule_sender(low_latency_iocp_context& context) noexcept
-      : context_(context) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver>) friend auto tag_invoke(
-        tag_t<connect>,
-        const schedule_sender& s,
-        Receiver&& r) noexcept(std::is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> schedule_op<remove_cvref_t<Receiver>> {
-      return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver &&) r};
-    }
-
-  private:
-    template <typename Receiver>
-    using schedule_op = schedule_op<Receiver>;
-    low_latency_iocp_context& context_;
-  };
-
-  ///////////////////////////
-  // read_file
-
-  template <typename Buffer, typename Receiver>
-  class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
-    : private low_latency_iocp_context::io_operation {
-  public:
-    template <typename Receiver2, typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& ctx,
-        handle_t fileHandle,
-        bool skipNotificationOnSuccess,
-        Buffer2&& buffer,
-        Receiver2&& r)
-      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-      , receiver_((Receiver2 &&) r)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    void start() & noexcept {
-      if (this->context.is_running_on_io_thread()) {
-        acquire_io_state(this);
-      } else {
-        this->callback = &acquire_io_state;
-        this->context.schedule_remote(this);
-      }
-    }
-
-  private:
-    struct cancel_callback {
-      type& op;
-      void operator()() noexcept { op.cancel_io(); }
-    };
-
-    static void acquire_io_state(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      if (self.context.try_allocate_io_state_for(&self)) {
-        start_io(op);
-      } else {
-        // TODO: Add support for cancellation while waiting in the
-        // pendingIoQueue_.
-
-        self.callback = &start_io;
-        self.context.schedule_when_io_state_available(&self);
-      }
-    }
-
-    static void start_io(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      // TODO: Add support for a BufferSequence concept to allow
-      // vectorised I/O here.
-      // For now, just assume that 'Buffer' is convertible to a
-      // 'span<std::byte>'.
-
-      self.start_read(self.buffer_);
-
-      if (self.ioState->pendingCompletionNotifications == 0) {
-        self.ioState->completed = true;
-        self.callback = &on_complete;
-        self.context.readyQueue_.push_front(op);
-      } else {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-          self.stopCallback_.construct(
-              get_stop_token(self.receiver_), cancel_callback{self});
-          self.callback = &on_cancellable_complete;
-        } else {
-          self.callback = &on_complete;
-        }
-
-        self.context.schedule_poll_io(&self);
-      }
-    }
-
-    static void on_cancellable_complete(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      self.stopCallback_.destruct();
-
-      on_complete(op);
-    }
-
-    static void on_complete(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-
-      std::error_code ec;
-      std::size_t totalBytesTransferred = self.get_result(ec);
-
-      self.context.release_io_state(self.ioState);
-
-      // Treat partial failure as a success case.
-      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
-      // instead?
-      if (!ec || totalBytesTransferred > 0) {
-        if constexpr (is_nothrow_callable_v<
-                          decltype(set_value),
-                          Receiver,
-                          std::size_t>) {
-          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                std::move(self.receiver_), std::current_exception());
-          }
-        }
-      } else if (ec == std::errc::operation_canceled) {
-        unifex::set_done(std::move(self.receiver_));
-      } else {
-        unifex::set_error(std::move(self.receiver_), std::move(ec));
-      }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver>::template callback_type<cancel_callback>>
-        stopCallback_;
-  };
-
-  template <typename Buffer>
-  class low_latency_iocp_context::_read_file_sender<Buffer>::type {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<std::size_t>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr, std::error_code>;
-
-    static constexpr bool sends_done = true;
-
-    template <typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& context,
-        handle_t fileHandle,
-        bool skipNotificationsOnSuccess,
-        Buffer2&& buffer)
-      : context_(context)
-      , fileHandle_(fileHandle)
-      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
-        tag_t<unifex::connect>,
-        type&& self,
-        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
-                                   std::is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
-      return read_file_op<Buffer, remove_cvref_t<Receiver>>{
-          self.context_,
-          self.fileHandle_,
-          self.skipNotificationsOnSuccess_,
-          std::move(self.buffer_),
-          (Receiver &&) r};
-    }
-
-  private:
-    template <typename Buf, typename Receiver>
-    using read_file_op = read_file_op<Buf, Receiver>;
-    low_latency_iocp_context& context_;
-    handle_t fileHandle_;
-    bool skipNotificationsOnSuccess_;
-    Buffer buffer_;
-  };
-
-  //////////////////////////
-  // write_file
-
-  template <typename Buffer, typename Receiver>
-  class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
-    : private low_latency_iocp_context::io_operation {
-  public:
-    template <typename Receiver2, typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& ctx,
-        handle_t fileHandle,
-        bool skipNotificationOnSuccess,
-        Buffer2&& buffer,
-        Receiver2&& r)
-      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-      , receiver_((Receiver2 &&) r)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    void start() & noexcept {
-      if (this->context.is_running_on_io_thread()) {
-        acquire_io_state(this);
-      } else {
-        this->callback = &acquire_io_state;
-        this->context.schedule_remote(this);
-      }
-    }
-
-  private:
-    struct cancel_callback {
-      type& op;
-      void operator()() noexcept { op.cancel_io(); }
-    };
-
-    static void acquire_io_state(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      if (self.context.try_allocate_io_state_for(&self)) {
-        start_io(op);
-      } else {
-        // TODO: Add support for cancellation while waiting in the
-        // pendingIoQueue_.
-
-        self.callback = &start_io;
-        self.context.schedule_when_io_state_available(&self);
-      }
-    }
-
-    static void start_io(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      // TODO: Add support for a BufferSequence concept to allow
-      // vectorised I/O here.
-      // For now, just assume that 'Buffer' is convertible to a
-      // 'span<std::byte>'.
-
-      self.start_write(self.buffer_);
-
-      if (self.ioState->pendingCompletionNotifications == 0) {
-        self.ioState->completed = true;
-        self.callback = &on_complete;
-        self.context.readyQueue_.push_front(op);
-      } else {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-          self.stopCallback_.construct(
-              get_stop_token(self.receiver_), cancel_callback{self});
-          self.callback = &on_cancellable_complete;
-        } else {
-          self.callback = &on_complete;
-        }
-
-        self.context.schedule_poll_io(&self);
-      }
-    }
-
-    static void on_cancellable_complete(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      self.stopCallback_.destruct();
-
-      on_complete(op);
-    }
-
-    static void on_complete(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-
-      std::error_code ec;
-      std::size_t totalBytesTransferred = self.get_result(ec);
-
-      self.context.release_io_state(self.ioState);
-
-      // Treat partial failure as a success case.
-      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
-      // instead?
-      if (!ec || totalBytesTransferred > 0) {
-        if constexpr (is_nothrow_callable_v<
-                          decltype(set_value),
-                          Receiver,
-                          std::size_t>) {
-          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                std::move(self.receiver_), std::current_exception());
-          }
-        }
-      } else if (ec == std::errc::operation_canceled) {
-        unifex::set_done(std::move(self.receiver_));
-      } else {
-        unifex::set_error(std::move(self.receiver_), std::move(ec));
-      }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver>::template callback_type<cancel_callback>>
-        stopCallback_;
-  };
-
-  template <typename Buffer>
-  class low_latency_iocp_context::_write_file_sender<Buffer>::type {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<std::size_t>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr, std::error_code>;
-
-    static constexpr bool sends_done = true;
-
-    template <typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& context,
-        handle_t fileHandle,
-        bool skipNotificationsOnSuccess,
-        Buffer2&& buffer)
-      : context_(context)
-      , fileHandle_(fileHandle)
-      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
-        tag_t<unifex::connect>,
-        type&& self,
-        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
-                                   std::is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
-      return write_file_op<Buffer, remove_cvref_t<Receiver>>{
-          self.context_,
-          self.fileHandle_,
-          self.skipNotificationsOnSuccess_,
-          std::move(self.buffer_),
-          (Receiver &&) r};
-    }
-
-  private:
-    template <typename Buf, typename Receiver>
-    using write_file_op = write_file_op<Buf, Receiver>;
-    low_latency_iocp_context& context_;
-    handle_t fileHandle_;
-    bool skipNotificationsOnSuccess_;
-    Buffer buffer_;
-  };
-
-  class low_latency_iocp_context::readable_byte_stream {
-  public:
-    explicit readable_byte_stream(
-        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
-      : context_(context)
-      , fileHandle_(std::move(fileHandle)) {}
-
-    template(typename Buffer)(requires convertible_to<Buffer, span<std::byte>>) friend read_file_sender<
-        remove_cvref_t<
-            Buffer>> tag_invoke(tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
-      return read_file_sender<remove_cvref_t<Buffer>>{
-          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
-    }
-
-  private:
-    template <typename Buffer>
-    using read_file_sender = read_file_sender<Buffer>;
-
-    low_latency_iocp_context& context_;
-    safe_handle fileHandle_;
-  };
-
-  class low_latency_iocp_context::writable_byte_stream {
-  public:
-    explicit writable_byte_stream(
-        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
-      : context_(context)
-      , fileHandle_(std::move(fileHandle)) {}
-
-    template(typename Buffer)(requires convertible_to<Buffer, span<const std::byte>>) friend write_file_sender<
-        remove_cvref_t<
-            Buffer>> tag_invoke(tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
-      return write_file_sender<remove_cvref_t<Buffer>>{
-          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
-    }
-
-  private:
-    template <typename Buffer>
-    using write_file_sender = write_file_sender<Buffer>;
-
-    low_latency_iocp_context& context_;
-    safe_handle fileHandle_;
-  };
-
-  class low_latency_iocp_context::scheduler {
-  public:
-    explicit scheduler(low_latency_iocp_context& context) noexcept
-      : context_(&context) {}
-
-    schedule_sender schedule() const noexcept {
-      return schedule_sender{*context_};
-    }
-
-    friend std::tuple<readable_byte_stream, writable_byte_stream>
-    tag_invoke(tag_t<unifex::open_pipe>, scheduler s) {
-      return open_pipe_impl(*s.context_);
-    }
-
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-      return a.context_ == b.context_;
-    }
-
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-      return !(a == b);
-    }
-
-  private:
-    static std::tuple<readable_byte_stream, writable_byte_stream>
-    open_pipe_impl(low_latency_iocp_context& ctx);
-
-    low_latency_iocp_context* context_;
-  };
-
-  inline low_latency_iocp_context::scheduler
-  low_latency_iocp_context::get_scheduler() noexcept {
-    return scheduler{*this};
   }
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver>::template callback_type<cancel_callback>>
+      stopCallback_;
+};
+
+template <typename Buffer>
+class low_latency_iocp_context::_read_file_sender<Buffer>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<std::size_t>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr, std::error_code>;
+
+  static constexpr bool sends_done = true;
+
+  template <typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& context,
+      handle_t fileHandle,
+      bool skipNotificationsOnSuccess,
+      Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      type&& self,
+      Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                 std::is_nothrow_constructible_v<
+                                     remove_cvref_t<Receiver>,
+                                     Receiver>)
+      -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
+    return read_file_op<Buffer, remove_cvref_t<Receiver>>{
+        self.context_,
+        self.fileHandle_,
+        self.skipNotificationsOnSuccess_,
+        std::move(self.buffer_),
+        (Receiver &&) r};
+  }
+
+private:
+  template <typename Buf, typename Receiver>
+  using read_file_op = read_file_op<Buf, Receiver>;
+  low_latency_iocp_context& context_;
+  handle_t fileHandle_;
+  bool skipNotificationsOnSuccess_;
+  Buffer buffer_;
+};
+
+//////////////////////////
+// write_file
+
+template <typename Buffer, typename Receiver>
+class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
+  : private low_latency_iocp_context::io_operation {
+public:
+  template <typename Receiver2, typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& ctx,
+      handle_t fileHandle,
+      bool skipNotificationOnSuccess,
+      Buffer2&& buffer,
+      Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2 &&) r)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  void start() & noexcept {
+    if (this->context.is_running_on_io_thread()) {
+      acquire_io_state(this);
+    } else {
+      this->callback = &acquire_io_state;
+      this->context.schedule_remote(this);
+    }
+  }
+
+private:
+  struct cancel_callback {
+    type& op;
+    void operator()() noexcept { op.cancel_io(); }
+  };
+
+  static void acquire_io_state(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    if (self.context.try_allocate_io_state_for(&self)) {
+      start_io(op);
+    } else {
+      // TODO: Add support for cancellation while waiting in the
+      // pendingIoQueue_.
+
+      self.callback = &start_io;
+      self.context.schedule_when_io_state_available(&self);
+    }
+  }
+
+  static void start_io(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    // TODO: Add support for a BufferSequence concept to allow
+    // vectorised I/O here.
+    // For now, just assume that 'Buffer' is convertible to a
+    // 'span<std::byte>'.
+
+    self.start_write(self.buffer_);
+
+    if (self.ioState->pendingCompletionNotifications == 0) {
+      self.ioState->completed = true;
+      self.callback = &on_complete;
+      self.context.readyQueue_.push_front(op);
+    } else {
+      if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+        self.stopCallback_.construct(
+            get_stop_token(self.receiver_), cancel_callback{self});
+        self.callback = &on_cancellable_complete;
+      } else {
+        self.callback = &on_complete;
+      }
+
+      self.context.schedule_poll_io(&self);
+    }
+  }
+
+  static void on_cancellable_complete(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    self.stopCallback_.destruct();
+
+    on_complete(op);
+  }
+
+  static void on_complete(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+
+    std::error_code ec;
+    std::size_t totalBytesTransferred = self.get_result(ec);
+
+    self.context.release_io_state(self.ioState);
+
+    // Treat partial failure as a success case.
+    // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+    // instead?
+    if (!ec || totalBytesTransferred > 0) {
+      if constexpr (is_nothrow_callable_v<
+                        decltype(set_value),
+                        Receiver,
+                        std::size_t>) {
+        unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+      } else {
+        UNIFEX_TRY {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+        }
+        UNIFEX_CATCH(...) {
+          unifex::set_error(
+              std::move(self.receiver_), std::current_exception());
+        }
+      }
+    } else if (ec == std::errc::operation_canceled) {
+      unifex::set_done(std::move(self.receiver_));
+    } else {
+      unifex::set_error(std::move(self.receiver_), std::move(ec));
+    }
+  }
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver>::template callback_type<cancel_callback>>
+      stopCallback_;
+};
+
+template <typename Buffer>
+class low_latency_iocp_context::_write_file_sender<Buffer>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<std::size_t>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr, std::error_code>;
+
+  static constexpr bool sends_done = true;
+
+  template <typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& context,
+      handle_t fileHandle,
+      bool skipNotificationsOnSuccess,
+      Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
+      tag_t<unifex::connect>,
+      type&& self,
+      Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                 std::is_nothrow_constructible_v<
+                                     remove_cvref_t<Receiver>,
+                                     Receiver>)
+      -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
+    return write_file_op<Buffer, remove_cvref_t<Receiver>>{
+        self.context_,
+        self.fileHandle_,
+        self.skipNotificationsOnSuccess_,
+        std::move(self.buffer_),
+        (Receiver &&) r};
+  }
+
+private:
+  template <typename Buf, typename Receiver>
+  using write_file_op = write_file_op<Buf, Receiver>;
+  low_latency_iocp_context& context_;
+  handle_t fileHandle_;
+  bool skipNotificationsOnSuccess_;
+  Buffer buffer_;
+};
+
+class low_latency_iocp_context::readable_byte_stream {
+public:
+  explicit readable_byte_stream(
+      low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle)) {}
+
+  template(typename Buffer)(requires convertible_to<Buffer, span<std::byte>>) friend read_file_sender<
+      remove_cvref_t<
+          Buffer>> tag_invoke(tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
+    return read_file_sender<remove_cvref_t<Buffer>>{
+        stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
+  }
+
+private:
+  template <typename Buffer>
+  using read_file_sender = read_file_sender<Buffer>;
+
+  low_latency_iocp_context& context_;
+  safe_handle fileHandle_;
+};
+
+class low_latency_iocp_context::writable_byte_stream {
+public:
+  explicit writable_byte_stream(
+      low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle)) {}
+
+  template(typename Buffer)(requires convertible_to<Buffer, span<const std::byte>>) friend write_file_sender<
+      remove_cvref_t<
+          Buffer>> tag_invoke(tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
+    return write_file_sender<remove_cvref_t<Buffer>>{
+        stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
+  }
+
+private:
+  template <typename Buffer>
+  using write_file_sender = write_file_sender<Buffer>;
+
+  low_latency_iocp_context& context_;
+  safe_handle fileHandle_;
+};
+
+class low_latency_iocp_context::scheduler {
+public:
+  explicit scheduler(low_latency_iocp_context& context) noexcept
+    : context_(&context) {}
+
+  schedule_sender schedule() const noexcept {
+    return schedule_sender{*context_};
+  }
+
+  friend std::tuple<readable_byte_stream, writable_byte_stream>
+  tag_invoke(tag_t<unifex::open_pipe>, scheduler s) {
+    return open_pipe_impl(*s.context_);
+  }
+
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.context_ == b.context_;
+  }
+
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return !(a == b);
+  }
+
+private:
+  static std::tuple<readable_byte_stream, writable_byte_stream>
+  open_pipe_impl(low_latency_iocp_context& ctx);
+
+  low_latency_iocp_context* context_;
+};
+
+inline low_latency_iocp_context::scheduler
+low_latency_iocp_context::get_scheduler() noexcept {
+  return scheduler{*this};
+}
 
 }  // namespace unifex::win32
 

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -15,25 +15,25 @@
  */
 #pragma once
 
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/stop_token_concepts.hpp>
-#include <unifex/manual_lifetime.hpp>
 #include <unifex/exception.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/stop_token_concepts.hpp>
 
 #include <unifex/win32/filetime_clock.hpp>
 
-#include <windows.h>
 #include <threadpoolapiset.h>
+#include <windows.h>
 
-#include <utility>
+#include <atomic>
+#include <cstdio>
 #include <exception>
 #include <new>
 #include <system_error>
-#include <atomic>
-#include <cstdio>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -41,84 +41,88 @@ namespace unifex {
 namespace win32 {
 
 class windows_thread_pool {
-    class scheduler;
-    class schedule_sender;
-    class schedule_op_base;
-    template<typename Receiver>
-    struct _schedule_op {
-        class type;
-    };
-    template<typename Receiver>
-    using schedule_op = typename _schedule_op<Receiver>::type;
+  class scheduler;
+  class schedule_sender;
+  class schedule_op_base;
+  template <typename Receiver>
+  struct _schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_op = typename _schedule_op<Receiver>::type;
 
-    template<typename StopToken>
-    struct _cancellable_schedule_op_base {
-        class type;
-    };
-    template<typename StopToken>
-    using cancellable_schedule_op_base = typename _cancellable_schedule_op_base<StopToken>::type;
+  template <typename StopToken>
+  struct _cancellable_schedule_op_base {
+    class type;
+  };
+  template <typename StopToken>
+  using cancellable_schedule_op_base =
+      typename _cancellable_schedule_op_base<StopToken>::type;
 
-    template<typename Receiver>
-    struct _cancellable_schedule_op {
-        class type;
-    };
-    template <typename Receiver>
-    using cancellable_schedule_op = typename _cancellable_schedule_op<Receiver>::type;
+  template <typename Receiver>
+  struct _cancellable_schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using cancellable_schedule_op =
+      typename _cancellable_schedule_op<Receiver>::type;
 
-    template<typename StopToken>
-    struct _time_schedule_op_base {
-        class type;
-    };
-    template<typename StopToken>
-    using time_schedule_op_base = typename _time_schedule_op_base<StopToken>::type;
+  template <typename StopToken>
+  struct _time_schedule_op_base {
+    class type;
+  };
+  template <typename StopToken>
+  using time_schedule_op_base =
+      typename _time_schedule_op_base<StopToken>::type;
 
-    template<typename Receiver>
-    struct _time_schedule_op {
-        class type;
-    };
-    template<typename Receiver>
-    using time_schedule_op = typename _time_schedule_op<Receiver>::type;
+  template <typename Receiver>
+  struct _time_schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using time_schedule_op = typename _time_schedule_op<Receiver>::type;
 
-    template<typename Receiver>
-    struct _schedule_at_op {
-        class type;
-    };
-    template<typename Receiver>
-    using schedule_at_op = typename _schedule_at_op<Receiver>::type;
+  template <typename Receiver>
+  struct _schedule_at_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_at_op = typename _schedule_at_op<Receiver>::type;
 
-    template<typename Duration, typename Receiver>
-    struct _schedule_after_op {
-        class type;
-    };
-    template<typename Duration, typename Receiver>
-    using schedule_after_op = typename _schedule_after_op<Duration, Receiver>::type;
+  template <typename Duration, typename Receiver>
+  struct _schedule_after_op {
+    class type;
+  };
+  template <typename Duration, typename Receiver>
+  using schedule_after_op =
+      typename _schedule_after_op<Duration, Receiver>::type;
 
-    class schedule_at_sender;
+  class schedule_at_sender;
 
-    template<typename Duration>
-    struct _schedule_after_sender {
-        class type;
-    };
-    template<typename Duration>
-    using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
+  template <typename Duration>
+  struct _schedule_after_sender {
+    class type;
+  };
+  template <typename Duration>
+  using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
 
-    using clock_type = filetime_clock;
+  using clock_type = filetime_clock;
 
 public:
+  // Initialise to use the process' default thread-pool.
+  windows_thread_pool() noexcept;
 
-    // Initialise to use the process' default thread-pool.
-    windows_thread_pool() noexcept;
+  // Construct to an independend thread-pool with a dynamic number of
+  // threads that varies between a min and a max number of threads.
+  explicit windows_thread_pool(
+      std::uint32_t minThreadCount, std::uint32_t maxThreadCount);
 
-    // Construct to an independend thread-pool with a dynamic number of
-    // threads that varies between a min and a max number of threads.
-    explicit windows_thread_pool(std::uint32_t minThreadCount, std::uint32_t maxThreadCount);
+  ~windows_thread_pool();
 
-    ~windows_thread_pool();
-
-    scheduler get_scheduler() noexcept;
+  scheduler get_scheduler() noexcept;
 
 private:
-    PTP_POOL threadPool_;
+  PTP_POOL threadPool_;
 };
 
 /////////////////////////
@@ -126,302 +130,315 @@ private:
 
 class windows_thread_pool::schedule_op_base {
 public:
-    schedule_op_base(schedule_op_base&&) = delete;
-    schedule_op_base& operator=(schedule_op_base&&) = delete;
+  schedule_op_base(schedule_op_base&&) = delete;
+  schedule_op_base& operator=(schedule_op_base&&) = delete;
 
-    ~schedule_op_base();
+  ~schedule_op_base();
 
-    void start() & noexcept;
+  void start() & noexcept;
 
 protected:
-    schedule_op_base(windows_thread_pool& pool, PTP_WORK_CALLBACK workCallback);
+  schedule_op_base(windows_thread_pool& pool, PTP_WORK_CALLBACK workCallback);
 
 private:
-    TP_CALLBACK_ENVIRON environ_;
-    PTP_WORK work_;
+  TP_CALLBACK_ENVIRON environ_;
+  PTP_WORK work_;
 };
 
-template<typename Receiver>
-class windows_thread_pool::_schedule_op<Receiver>::type final : public windows_thread_pool::schedule_op_base {
+template <typename Receiver>
+class windows_thread_pool::_schedule_op<Receiver>::type final
+  : public windows_thread_pool::schedule_op_base {
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Receiver2&& r)
     : schedule_op_base(pool, &work_callback)
-    , receiver_((Receiver2&&)r)
-    {}
+    , receiver_((Receiver2 &&) r) {}
 
 private:
-    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
-        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(op.receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(op.receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(op.receiver_), std::current_exception());
-            }
-        }
+  static void CALLBACK
+  work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+    if constexpr (is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(op.receiver_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(std::move(op.receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(op.receiver_), std::current_exception());
+      }
     }
+  }
 
-    Receiver receiver_;
+  Receiver receiver_;
 };
 
 ///////////////////////////
 // Cancellable schedule() operation
 
-template<typename StopToken>
+template <typename StopToken>
 class windows_thread_pool::_cancellable_schedule_op_base<StopToken>::type {
 public:
-    type(type&&) = delete;
-    type& operator=(type&&) = delete;
+  type(type&&) = delete;
+  type& operator=(type&&) = delete;
 
-    ~type() {
-        ::CloseThreadpoolWork(work_);
-        ::DestroyThreadpoolEnvironment(&environ_);
-        delete state_;
-    }
+  ~type() {
+    ::CloseThreadpoolWork(work_);
+    ::DestroyThreadpoolEnvironment(&environ_);
+    delete state_;
+  }
 
 protected:
-    explicit type(windows_thread_pool& pool, bool isStopPossible) {
-        ::InitializeThreadpoolEnvironment(&environ_);
-        ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
+  explicit type(windows_thread_pool& pool, bool isStopPossible) {
+    ::InitializeThreadpoolEnvironment(&environ_);
+    ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
 
-        work_ = ::CreateThreadpoolWork(
-            isStopPossible ? &stoppable_work_callback : &unstoppable_work_callback,
-            static_cast<void*>(this),
-            &environ_);
-        if (work_ == nullptr) {
-            DWORD errorCode = ::GetLastError();
-            ::DestroyThreadpoolEnvironment(&environ_);
-            throw_(
-                std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateThreadpoolWork()"});
-        }
-
-        if (isStopPossible) {
-            state_ = new (std::nothrow) std::atomic<std::uint32_t>(not_started);
-            if (state_ == nullptr) {
-                ::CloseThreadpoolWork(work_);
-                ::DestroyThreadpoolEnvironment(&environ_);
-                throw_(std::bad_alloc{});
-            }
-        } else {
-            state_ = nullptr;
-        }
+    work_ = ::CreateThreadpoolWork(
+        isStopPossible ? &stoppable_work_callback : &unstoppable_work_callback,
+        static_cast<void*>(this),
+        &environ_);
+    if (work_ == nullptr) {
+      DWORD errorCode = ::GetLastError();
+      ::DestroyThreadpoolEnvironment(&environ_);
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "CreateThreadpoolWork()"});
     }
 
-    void start_impl(const StopToken& stopToken) & noexcept {
-        if (state_ != nullptr) {
-            // Short-circuit all of this if stopToken.stop_requested() is already true.
-            if (stopToken.stop_requested()) {
-                set_done_impl();
-                return;
-            }
-
-            stopCallback_.construct(stopToken, stop_requested_callback{*this});
-
-            // Take a copy of the 'state' pointer prior to submitting the
-            // work as the operation-state may have already been destroyed
-            // on another thread by the time SubmitThreadpoolWork() returns.
-            auto* state = state_;
-
-            ::SubmitThreadpoolWork(work_);
-
-            // Signal that SubmitThreadpoolWork() has returned and that it is
-            // now safe for the stop-request to request cancellation of the
-            // work items.
-            const auto prevState = state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
-            if ((prevState & stop_requested_flag) != 0) {
-                // stop was requested before the call to SubmitThreadpoolWork()
-                // returned and before the work started executing. It was not
-                // safe for the request_stop() method to cancel the work before
-                // it had finished being submitted so it has delegated responsibility
-                // for cancelling the just-submitted work to us to do once we
-                // finished submitting the work.
-                complete_with_done();
-            } else if ((prevState & running_flag) != 0) {
-                // Otherwise, it's possible that the work item may have started
-                // running on another thread already, prior to us returning.
-                // If this is the case then, to avoid leaving us with a
-                // dangling reference to the 'state' when the operation-state
-                // is destroyed, it will detach the 'state' from the operation-state
-                // and delegate the delete of the 'state' to us.
-                delete state;
-            }
-        } else {
-            // A stop-request is not possible so skip the extra
-            // synchronisation needed to support it.
-            ::SubmitThreadpoolWork(work_);
-        }
+    if (isStopPossible) {
+      state_ = new (std::nothrow) std::atomic<std::uint32_t>(not_started);
+      if (state_ == nullptr) {
+        ::CloseThreadpoolWork(work_);
+        ::DestroyThreadpoolEnvironment(&environ_);
+        throw_(std::bad_alloc{});
+      }
+    } else {
+      state_ = nullptr;
     }
+  }
+
+  void start_impl(const StopToken& stopToken) & noexcept {
+    if (state_ != nullptr) {
+      // Short-circuit all of this if stopToken.stop_requested() is already
+      // true.
+      if (stopToken.stop_requested()) {
+        set_done_impl();
+        return;
+      }
+
+      stopCallback_.construct(stopToken, stop_requested_callback{*this});
+
+      // Take a copy of the 'state' pointer prior to submitting the
+      // work as the operation-state may have already been destroyed
+      // on another thread by the time SubmitThreadpoolWork() returns.
+      auto* state = state_;
+
+      ::SubmitThreadpoolWork(work_);
+
+      // Signal that SubmitThreadpoolWork() has returned and that it is
+      // now safe for the stop-request to request cancellation of the
+      // work items.
+      const auto prevState =
+          state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
+      if ((prevState & stop_requested_flag) != 0) {
+        // stop was requested before the call to SubmitThreadpoolWork()
+        // returned and before the work started executing. It was not
+        // safe for the request_stop() method to cancel the work before
+        // it had finished being submitted so it has delegated responsibility
+        // for cancelling the just-submitted work to us to do once we
+        // finished submitting the work.
+        complete_with_done();
+      } else if ((prevState & running_flag) != 0) {
+        // Otherwise, it's possible that the work item may have started
+        // running on another thread already, prior to us returning.
+        // If this is the case then, to avoid leaving us with a
+        // dangling reference to the 'state' when the operation-state
+        // is destroyed, it will detach the 'state' from the operation-state
+        // and delegate the delete of the 'state' to us.
+        delete state;
+      }
+    } else {
+      // A stop-request is not possible so skip the extra
+      // synchronisation needed to support it.
+      ::SubmitThreadpoolWork(work_);
+    }
+  }
 
 private:
-    static void CALLBACK unstoppable_work_callback(
-            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
-        op.set_value_impl();
+  static void CALLBACK unstoppable_work_callback(
+      PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+    op.set_value_impl();
+  }
+
+  static void CALLBACK stoppable_work_callback(
+      PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+
+    // Signal that the work callback has started executing.
+    auto prevState =
+        op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
+    if ((prevState & stop_requested_flag) != 0) {
+      // request_stop() is already running and is waiting for this callback
+      // to finish executing. So we return immediately here without doing
+      // anything further so that we don't introduce a deadlock.
+      // In particular, we don't want to try to deregister the stop-callback
+      // which will block waiting for the request_stop() method to return.
+      return;
     }
 
-    static void CALLBACK stoppable_work_callback(
-            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
+    // Note that it's possible that stop might be requested after setting
+    // the 'starting' flag but before we deregister the stop callback.
+    // We're going to ignore these stop-requests as we already won the race
+    // in the fetch_add() above and ignoring them simplifies some of the
+    // cancellation logic.
 
-        // Signal that the work callback has started executing.
-        auto prevState = op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
-        if ((prevState & stop_requested_flag) != 0) {
-            // request_stop() is already running and is waiting for this callback
-            // to finish executing. So we return immediately here without doing
-            // anything further so that we don't introduce a deadlock.
-            // In particular, we don't want to try to deregister the stop-callback
-            // which will block waiting for the request_stop() method to return.
-            return;
-        }
+    op.stopCallback_.destruct();
 
-        // Note that it's possible that stop might be requested after setting
-        // the 'starting' flag but before we deregister the stop callback.
-        // We're going to ignore these stop-requests as we already won the race
-        // in the fetch_add() above and ignoring them simplifies some of the
-        // cancellation logic.
-
-        op.stopCallback_.destruct();
-
-        prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
-        if (prevState == starting_flag) {
-            // start() method has not yet finished submitting the work
-            // on another thread and so is still accessing the 'state'.
-            // This means we don't want to let the operation-state destructor
-            // free the state memory. Instead, we have just delegated
-            // responsibility for freeing this memory to the start() method
-            // and we clear the start_ member here to prevent the destructor
-            // from freeing it.
-            op.state_ = nullptr;
-        }
-
-        op.set_value_impl();
+    prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
+    if (prevState == starting_flag) {
+      // start() method has not yet finished submitting the work
+      // on another thread and so is still accessing the 'state'.
+      // This means we don't want to let the operation-state destructor
+      // free the state memory. Instead, we have just delegated
+      // responsibility for freeing this memory to the start() method
+      // and we clear the start_ member here to prevent the destructor
+      // from freeing it.
+      op.state_ = nullptr;
     }
 
-    void request_stop() noexcept {
-        auto prevState = state_->load(std::memory_order_relaxed);
-        do {
-            UNIFEX_ASSERT((prevState & running_flag) == 0);
-            if ((prevState & starting_flag) != 0) {
-                // Work callback won the race and will be waiting for
-                // us to return so it can deregister the stop-callback.
-                // Return immediately so we don't deadlock.
-                return;
-            }
-        } while (!state_->compare_exchange_weak(
-            prevState,
-            prevState | stop_requested_flag,
-            std::memory_order_acq_rel,
-            std::memory_order_relaxed));
+    op.set_value_impl();
+  }
 
-        UNIFEX_ASSERT((prevState & starting_flag) == 0);
+  void request_stop() noexcept {
+    auto prevState = state_->load(std::memory_order_relaxed);
+    do {
+      UNIFEX_ASSERT((prevState & running_flag) == 0);
+      if ((prevState & starting_flag) != 0) {
+        // Work callback won the race and will be waiting for
+        // us to return so it can deregister the stop-callback.
+        // Return immediately so we don't deadlock.
+        return;
+      }
+    } while (!state_->compare_exchange_weak(
+        prevState,
+        prevState | stop_requested_flag,
+        std::memory_order_acq_rel,
+        std::memory_order_relaxed));
 
-        if ((prevState & submit_complete_flag) != 0) {
-            // start() has finished calling SubmitThreadpoolWork() and the work has not
-            // yet started executing the work so it's safe for this method to now try
-            // and cancel the work. While it's possible that the work callback will start
-            // executing concurrently on a thread-pool thread, we are guaranteed that
-            // it will see our write of the stop_requested_flag and will promptly
-            // return without blocking.
-            complete_with_done();
-        } else {
-            // Otherwise, as the start() method has not yet finished calling
-            // SubmitThreadpoolWork() we can't safely call WaitForThreadpoolWorkCallbacks().
-            // In this case we are delegating responsibility for calling complete_with_done()
-            // to start() method when it eventually returns from SubmitThreadpoolWork().
-        }
+    UNIFEX_ASSERT((prevState & starting_flag) == 0);
+
+    if ((prevState & submit_complete_flag) != 0) {
+      // start() has finished calling SubmitThreadpoolWork() and the work has
+      // not yet started executing the work so it's safe for this method to now
+      // try and cancel the work. While it's possible that the work callback
+      // will start executing concurrently on a thread-pool thread, we are
+      // guaranteed that it will see our write of the stop_requested_flag and
+      // will promptly return without blocking.
+      complete_with_done();
+    } else {
+      // Otherwise, as the start() method has not yet finished calling
+      // SubmitThreadpoolWork() we can't safely call
+      // WaitForThreadpoolWorkCallbacks(). In this case we are delegating
+      // responsibility for calling complete_with_done() to start() method when
+      // it eventually returns from SubmitThreadpoolWork().
     }
+  }
 
-    void complete_with_done() noexcept {
-        const BOOL cancelPending = TRUE;
-        ::WaitForThreadpoolWorkCallbacks(work_, cancelPending);
+  void complete_with_done() noexcept {
+    const BOOL cancelPending = TRUE;
+    ::WaitForThreadpoolWorkCallbacks(work_, cancelPending);
 
-        // Destruct the stop-callback before calling set_done() as the call
-        // to set_done() will invalidate the stop-token and we need to
-        // make sure that
-        stopCallback_.destruct();
+    // Destruct the stop-callback before calling set_done() as the call
+    // to set_done() will invalidate the stop-token and we need to
+    // make sure that
+    stopCallback_.destruct();
 
-        // Now that the work has been successfully cancelled we can
-        // call the receiver's set_done().
-        set_done_impl();
-    }
+    // Now that the work has been successfully cancelled we can
+    // call the receiver's set_done().
+    set_done_impl();
+  }
 
-    virtual void set_done_impl() noexcept = 0;
-    virtual void set_value_impl() noexcept = 0;
+  virtual void set_done_impl() noexcept = 0;
+  virtual void set_value_impl() noexcept = 0;
 
-    struct stop_requested_callback {
-        type& op_;
+  struct stop_requested_callback {
+    type& op_;
 
-        void operator()() noexcept {
-            op_.request_stop();
-        }
-    };
+    void operator()() noexcept { op_.request_stop(); }
+  };
 
-    /////////////////
-    // Flags to use for state_ member
+  /////////////////
+  // Flags to use for state_ member
 
-    // Initial state. start() not yet called.
-    static constexpr std::uint32_t not_started = 0;
+  // Initial state. start() not yet called.
+  static constexpr std::uint32_t not_started = 0;
 
-    // Flag set once start() has finished calling ThreadpoolSubmitWork()
-    static constexpr std::uint32_t submit_complete_flag = 1;
+  // Flag set once start() has finished calling ThreadpoolSubmitWork()
+  static constexpr std::uint32_t submit_complete_flag = 1;
 
-    // Flag set by request_stop()
-    static constexpr std::uint32_t stop_requested_flag = 2;
+  // Flag set by request_stop()
+  static constexpr std::uint32_t stop_requested_flag = 2;
 
-    // Flag set by cancellable_work_callback() when it starts executing.
-    // This is before deregistering the stop-callback.
-    static constexpr std::uint32_t starting_flag = 4;
+  // Flag set by cancellable_work_callback() when it starts executing.
+  // This is before deregistering the stop-callback.
+  static constexpr std::uint32_t starting_flag = 4;
 
-    // Flag set by cancellable_work_callback() after having deregistered
-    // the stop-callback, just before it calls the receiver.
-    static constexpr std::uint32_t running_flag = 8;
+  // Flag set by cancellable_work_callback() after having deregistered
+  // the stop-callback, just before it calls the receiver.
+  static constexpr std::uint32_t running_flag = 8;
 
-    PTP_WORK work_;
-    TP_CALLBACK_ENVIRON environ_;
-    std::atomic<std::uint32_t>* state_;
-    manual_lifetime<typename StopToken::template callback_type<stop_requested_callback>> stopCallback_;
+  PTP_WORK work_;
+  TP_CALLBACK_ENVIRON environ_;
+  std::atomic<std::uint32_t>* state_;
+  manual_lifetime<
+      typename StopToken::template callback_type<stop_requested_callback>>
+      stopCallback_;
 };
 
-template<typename Receiver>
+template <typename Receiver>
 class windows_thread_pool::_cancellable_schedule_op<Receiver>::type final
-    : public windows_thread_pool::cancellable_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::cancellable_schedule_op_base<stop_token_type_t<Receiver>>;
-public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Receiver2&& r)
-    : base(pool, unifex::get_stop_token(r).stop_possible())
-    , receiver_((Receiver2&&)r)
-    {}
+  : public windows_thread_pool::cancellable_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base = windows_thread_pool::cancellable_schedule_op_base<
+      stop_token_type_t<Receiver>>;
 
-    void start() & noexcept {
-        this->start_impl(get_stop_token(receiver_));
-    }
+public:
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Receiver2&& r)
+    : base(pool, unifex::get_stop_token(r).stop_possible())
+    , receiver_((Receiver2 &&) r) {}
+
+  void start() & noexcept { this->start_impl(get_stop_token(receiver_)); }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(std::move(receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-            unifex::set_done(std::move(receiver_));
-        } else {
-            UNIFEX_ASSERT(false);
-        }
+  void set_done_impl() noexcept override {
+    if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      unifex::set_done(std::move(receiver_));
+    } else {
+      UNIFEX_ASSERT(false);
     }
+  }
 
-    Receiver receiver_;
+  Receiver receiver_;
 };
 
 ////////////////////////////////////////////////////
@@ -429,367 +446,391 @@ private:
 
 class windows_thread_pool::schedule_sender {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver> AND
-            is_stop_never_possible_v<stop_token_type_t<Receiver>>)
-    schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_, (Receiver&&)r};
-    }
+  template(typename Receiver)(
+      requires receiver_of<Receiver> AND
+          is_stop_never_possible_v<stop_token_type_t<Receiver>>)
+      schedule_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, (Receiver &&) r};
+  }
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver> AND
-            (!is_stop_never_possible_v<stop_token_type_t<Receiver>>))
-    cancellable_schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return cancellable_schedule_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_, (Receiver&&)r};
-    }
+  template(typename Receiver)(requires receiver_of<Receiver> AND(
+      !is_stop_never_possible_v<stop_token_type_t<Receiver>>))
+      cancellable_schedule_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return cancellable_schedule_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, (Receiver &&) r};
+  }
 
 private:
-    friend scheduler;
+  friend scheduler;
 
-    explicit schedule_sender(windows_thread_pool& pool) noexcept
-    : pool_(&pool)
-    {}
+  explicit schedule_sender(windows_thread_pool& pool) noexcept : pool_(&pool) {}
 
-    windows_thread_pool* pool_;
+  windows_thread_pool* pool_;
 };
 
 /////////////////////////////////
 // time_schedule_op
 
-template<typename StopToken>
+template <typename StopToken>
 class windows_thread_pool::_time_schedule_op_base<StopToken>::type {
 protected:
-    explicit type(windows_thread_pool& pool, bool isStopPossible) {
-        ::InitializeThreadpoolEnvironment(&environ_);
-        ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
+  explicit type(windows_thread_pool& pool, bool isStopPossible) {
+    ::InitializeThreadpoolEnvironment(&environ_);
+    ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
 
-        // Give the optimiser a hand for cases where the parameter
-        // can never be true.
-        if constexpr (is_stop_never_possible_v<StopToken>) {
-            isStopPossible = false;
-        }
-
-        timer_ = ::CreateThreadpoolTimer(
-            isStopPossible ? &stoppable_timer_callback : &timer_callback, static_cast<void*>(this), &environ_);
-        if (timer_ == nullptr) {
-            DWORD errorCode = ::GetLastError();
-            ::DestroyThreadpoolEnvironment(&environ_);
-            throw_(
-                std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateThreadpoolTimer()"});
-        }
-
-        if (isStopPossible) {
-            state_ = new (std::nothrow) std::atomic<std::uint32_t>{not_started};
-            if (state_ == nullptr) {
-                ::CloseThreadpoolTimer(timer_);
-                ::DestroyThreadpoolEnvironment(&environ_);
-                throw_(std::bad_alloc{});
-            }
-        }
+    // Give the optimiser a hand for cases where the parameter
+    // can never be true.
+    if constexpr (is_stop_never_possible_v<StopToken>) {
+      isStopPossible = false;
     }
 
-public:
-    ~type() {
+    timer_ = ::CreateThreadpoolTimer(
+        isStopPossible ? &stoppable_timer_callback : &timer_callback,
+        static_cast<void*>(this),
+        &environ_);
+    if (timer_ == nullptr) {
+      DWORD errorCode = ::GetLastError();
+      ::DestroyThreadpoolEnvironment(&environ_);
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "CreateThreadpoolTimer()"});
+    }
+
+    if (isStopPossible) {
+      state_ = new (std::nothrow) std::atomic<std::uint32_t>{not_started};
+      if (state_ == nullptr) {
         ::CloseThreadpoolTimer(timer_);
         ::DestroyThreadpoolEnvironment(&environ_);
-        delete state_;
+        throw_(std::bad_alloc{});
+      }
     }
+  }
+
+public:
+  ~type() {
+    ::CloseThreadpoolTimer(timer_);
+    ::DestroyThreadpoolEnvironment(&environ_);
+    delete state_;
+  }
 
 protected:
-    void start_impl(const StopToken& stopToken, FILETIME dueTime) noexcept {
-        auto startTimer = [&]() noexcept {
-            const DWORD periodInMs = 0;   // Single-shot
-            const DWORD maxDelayInMs = 0; // Max delay to allow timer coalescing
-            ::SetThreadpoolTimer(timer_, &dueTime, periodInMs, maxDelayInMs);
-        };
-
-        if constexpr (!is_stop_never_possible_v<StopToken>) {
-            auto* const state = state_;
-            if (state != nullptr) {
-                // Short-circuit extra work submitting the
-                // timer if stop has already been requested.
-                if (stopToken.stop_requested()) {
-                    set_done_impl();
-                    return;
-                }
-
-                stopCallback_.construct(stopToken, stop_requested_callback{*this});
-
-                startTimer();
-
-                const auto prevState = state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
-                if ((prevState & stop_requested_flag) != 0) {
-                    complete_with_done();
-                } else if ((prevState & running_flag) != 0) {
-                    delete state;
-                }
-
-                return;
-            }
-        }
-
-        startTimer();
-    }
-
- private:
-    virtual void set_value_impl() noexcept = 0;
-    virtual void set_done_impl() noexcept = 0;
-
-    static void CALLBACK timer_callback(
-            [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
-            void* timerContext,
-            [[maybe_unused]] PTP_TIMER timer) noexcept {
-        type& op = *static_cast<type*>(timerContext);
-        op.set_value_impl();
-    }
-
-    static void CALLBACK stoppable_timer_callback(
-            [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
-            void* timerContext,
-            [[maybe_unused]] PTP_TIMER timer) noexcept {
-        type& op = *static_cast<type*>(timerContext);
-
-        auto prevState = op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
-        if ((prevState & stop_requested_flag) != 0) {
-            return;
-        }
-
-        op.stopCallback_.destruct();
-
-        prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
-        if (prevState == starting_flag) {
-            op.state_ = nullptr;
-        }
-
-        op.set_value_impl();
-    }
-
-    void request_stop() noexcept {
-        auto prevState = state_->load(std::memory_order_relaxed);
-        do {
-            UNIFEX_ASSERT((prevState & running_flag) == 0);
-            if ((prevState & starting_flag) != 0) {
-                return;
-            }
-        } while (!state_->compare_exchange_weak(
-            prevState,
-            prevState | stop_requested_flag,
-            std::memory_order_acq_rel,
-            std::memory_order_relaxed));
-
-        UNIFEX_ASSERT((prevState & starting_flag) == 0);
-
-        if ((prevState & submit_complete_flag) != 0) {
-            complete_with_done();
-        }
-    }
-
-    void complete_with_done() noexcept {
-        const BOOL cancelPending = TRUE;
-        ::WaitForThreadpoolTimerCallbacks(timer_, cancelPending);
-
-        stopCallback_.destruct();
-
-        set_done_impl();
-    }
-
-    struct stop_requested_callback {
-        type& op_;
-        void operator()() noexcept {
-            op_.request_stop();
-        }
+  void start_impl(const StopToken& stopToken, FILETIME dueTime) noexcept {
+    auto startTimer = [&]() noexcept {
+      const DWORD periodInMs = 0;    // Single-shot
+      const DWORD maxDelayInMs = 0;  // Max delay to allow timer coalescing
+      ::SetThreadpoolTimer(timer_, &dueTime, periodInMs, maxDelayInMs);
     };
 
-    /////////////////
-    // Flags to use for state_ member
+    if constexpr (!is_stop_never_possible_v<StopToken>) {
+      auto* const state = state_;
+      if (state != nullptr) {
+        // Short-circuit extra work submitting the
+        // timer if stop has already been requested.
+        if (stopToken.stop_requested()) {
+          set_done_impl();
+          return;
+        }
 
-    // Initial state. start() not yet called.
-    static constexpr std::uint32_t not_started = 0;
+        stopCallback_.construct(stopToken, stop_requested_callback{*this});
 
-    // Flag set once start() has finished calling ThreadpoolSubmitWork()
-    static constexpr std::uint32_t submit_complete_flag = 1;
+        startTimer();
 
-    // Flag set by request_stop()
-    static constexpr std::uint32_t stop_requested_flag = 2;
+        const auto prevState =
+            state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
+        if ((prevState & stop_requested_flag) != 0) {
+          complete_with_done();
+        } else if ((prevState & running_flag) != 0) {
+          delete state;
+        }
 
-    // Flag set by cancellable_work_callback() when it starts executing.
-    // This is before deregistering the stop-callback.
-    static constexpr std::uint32_t starting_flag = 4;
+        return;
+      }
+    }
 
-    // Flag set by cancellable_work_callback() after having deregistered
-    // the stop-callback, just before it calls the receiver.
-    static constexpr std::uint32_t running_flag = 8;
+    startTimer();
+  }
 
-    PTP_TIMER timer_;
-    TP_CALLBACK_ENVIRON environ_;
-    std::atomic<std::uint32_t>* state_{nullptr};
-    manual_lifetime<typename StopToken::template callback_type<stop_requested_callback>> stopCallback_;
+private:
+  virtual void set_value_impl() noexcept = 0;
+  virtual void set_done_impl() noexcept = 0;
+
+  static void CALLBACK timer_callback(
+      [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
+      void* timerContext,
+      [[maybe_unused]] PTP_TIMER timer) noexcept {
+    type& op = *static_cast<type*>(timerContext);
+    op.set_value_impl();
+  }
+
+  static void CALLBACK stoppable_timer_callback(
+      [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
+      void* timerContext,
+      [[maybe_unused]] PTP_TIMER timer) noexcept {
+    type& op = *static_cast<type*>(timerContext);
+
+    auto prevState =
+        op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
+    if ((prevState & stop_requested_flag) != 0) {
+      return;
+    }
+
+    op.stopCallback_.destruct();
+
+    prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
+    if (prevState == starting_flag) {
+      op.state_ = nullptr;
+    }
+
+    op.set_value_impl();
+  }
+
+  void request_stop() noexcept {
+    auto prevState = state_->load(std::memory_order_relaxed);
+    do {
+      UNIFEX_ASSERT((prevState & running_flag) == 0);
+      if ((prevState & starting_flag) != 0) {
+        return;
+      }
+    } while (!state_->compare_exchange_weak(
+        prevState,
+        prevState | stop_requested_flag,
+        std::memory_order_acq_rel,
+        std::memory_order_relaxed));
+
+    UNIFEX_ASSERT((prevState & starting_flag) == 0);
+
+    if ((prevState & submit_complete_flag) != 0) {
+      complete_with_done();
+    }
+  }
+
+  void complete_with_done() noexcept {
+    const BOOL cancelPending = TRUE;
+    ::WaitForThreadpoolTimerCallbacks(timer_, cancelPending);
+
+    stopCallback_.destruct();
+
+    set_done_impl();
+  }
+
+  struct stop_requested_callback {
+    type& op_;
+    void operator()() noexcept { op_.request_stop(); }
+  };
+
+  /////////////////
+  // Flags to use for state_ member
+
+  // Initial state. start() not yet called.
+  static constexpr std::uint32_t not_started = 0;
+
+  // Flag set once start() has finished calling ThreadpoolSubmitWork()
+  static constexpr std::uint32_t submit_complete_flag = 1;
+
+  // Flag set by request_stop()
+  static constexpr std::uint32_t stop_requested_flag = 2;
+
+  // Flag set by cancellable_work_callback() when it starts executing.
+  // This is before deregistering the stop-callback.
+  static constexpr std::uint32_t starting_flag = 4;
+
+  // Flag set by cancellable_work_callback() after having deregistered
+  // the stop-callback, just before it calls the receiver.
+  static constexpr std::uint32_t running_flag = 8;
+
+  PTP_TIMER timer_;
+  TP_CALLBACK_ENVIRON environ_;
+  std::atomic<std::uint32_t>* state_{nullptr};
+  manual_lifetime<
+      typename StopToken::template callback_type<stop_requested_callback>>
+      stopCallback_;
 };
 
 /////////////////////////////////
 // schedule_at() operation
 
-template<typename Receiver>
+template <typename Receiver>
 class windows_thread_pool::_schedule_at_op<Receiver>::type final
-    : public windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+  : public windows_thread_pool::time_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base =
+      windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, windows_thread_pool::clock_type::time_point dueTime, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(
+      windows_thread_pool& pool,
+      windows_thread_pool::clock_type::time_point dueTime,
+      Receiver2&& r)
     : base(pool, get_stop_token(r).stop_possible())
     , dueTime_(dueTime)
-    , receiver_((Receiver2&&)r) {}
+    , receiver_((Receiver2 &&) r) {}
 
-    void start() & noexcept {
-        ULARGE_INTEGER ticks;
-        ticks.QuadPart = dueTime_.get_ticks();
+  void start() & noexcept {
+    ULARGE_INTEGER ticks;
+    ticks.QuadPart = dueTime_.get_ticks();
 
-        FILETIME ft;
-        ft.dwLowDateTime = ticks.LowPart;
-        ft.dwHighDateTime = ticks.HighPart;
+    FILETIME ft;
+    ft.dwLowDateTime = ticks.LowPart;
+    ft.dwHighDateTime = ticks.HighPart;
 
-        this->start_impl(get_stop_token(receiver_), ft);
-    }
+    this->start_impl(get_stop_token(receiver_), ft);
+  }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (unifex::is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(std::move(receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        unifex::set_done(std::move(receiver_));
-    }
+  void set_done_impl() noexcept override {
+    unifex::set_done(std::move(receiver_));
+  }
 
-    windows_thread_pool::clock_type::time_point dueTime_;
-    Receiver receiver_;
+  windows_thread_pool::clock_type::time_point dueTime_;
+  Receiver receiver_;
 };
 
 class windows_thread_pool::schedule_at_sender {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    explicit schedule_at_sender(windows_thread_pool& pool, filetime_clock::time_point dueTime)
+  explicit schedule_at_sender(
+      windows_thread_pool& pool, filetime_clock::time_point dueTime)
     : pool_(&pool)
-    , dueTime_(dueTime)
-    {}
+    , dueTime_(dueTime) {}
 
-    template(typename Receiver)
-        (requires unifex::receiver_of<Receiver>)
-    schedule_at_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_at_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_,
-            dueTime_,
-            (Receiver&&)r
-        };
-    }
+  template(typename Receiver)(requires unifex::receiver_of<Receiver>)
+      schedule_at_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_at_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, dueTime_, (Receiver &&) r};
+  }
 
 private:
-    windows_thread_pool* pool_;
-    filetime_clock::time_point dueTime_;
+  windows_thread_pool* pool_;
+  filetime_clock::time_point dueTime_;
 };
 
 //////////////////////////////////
 // schedule_after()
 
-template<typename Duration, typename Receiver>
+template <typename Duration, typename Receiver>
 class windows_thread_pool::_schedule_after_op<Duration, Receiver>::type final
-    : public windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+  : public windows_thread_pool::time_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base =
+      windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Duration duration, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Duration duration, Receiver2&& r)
     : base(pool, get_stop_token(r).stop_possible())
     , duration_(duration)
-    , receiver_((Receiver2&&)r) {}
+    , receiver_((Receiver2 &&) r) {}
 
-    void start() & noexcept {
-        auto dueTime = filetime_clock::now() + duration_;
+  void start() & noexcept {
+    auto dueTime = filetime_clock::now() + duration_;
 
-        ULARGE_INTEGER ticks;
-        ticks.QuadPart = dueTime.get_ticks();
+    ULARGE_INTEGER ticks;
+    ticks.QuadPart = dueTime.get_ticks();
 
-        FILETIME ft;
-        ft.dwLowDateTime = ticks.LowPart;
-        ft.dwHighDateTime = ticks.HighPart;
+    FILETIME ft;
+    ft.dwLowDateTime = ticks.LowPart;
+    ft.dwHighDateTime = ticks.HighPart;
 
-        this->start_impl(get_stop_token(receiver_), ft);
-    }
+    this->start_impl(get_stop_token(receiver_), ft);
+  }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (unifex::is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY {
+        unifex::set_value(std::move(receiver_));
+      }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        unifex::set_done(std::move(receiver_));
-    }
+  void set_done_impl() noexcept override {
+    unifex::set_done(std::move(receiver_));
+  }
 
-    Duration duration_;
-    Receiver receiver_;
+  Duration duration_;
+  Receiver receiver_;
 };
 
-
-template<typename Duration>
+template <typename Duration>
 class windows_thread_pool::_schedule_after_sender<Duration>::type {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    explicit type(windows_thread_pool& pool, Duration duration)
+  explicit type(windows_thread_pool& pool, Duration duration)
     : pool_(&pool)
-    , duration_(duration)
-    {}
+    , duration_(duration) {}
 
-    template(typename Receiver)
-        (requires unifex::receiver_of<Receiver>)
-    schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>>{
-            *pool_,
-            duration_,
-            (Receiver&&)r
-        };
-    }
+  template(typename Receiver)(requires unifex::receiver_of<Receiver>)
+      schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>>{
+        *pool_, duration_, (Receiver &&) r};
+  }
 
 private:
-    windows_thread_pool* pool_;
-    Duration duration_;
+  windows_thread_pool* pool_;
+  Duration duration_;
 };
 
 /////////////////////////////////
@@ -797,52 +838,47 @@ private:
 
 class windows_thread_pool::scheduler {
 public:
-    using time_point = filetime_clock::time_point;
+  using time_point = filetime_clock::time_point;
 
-    schedule_sender schedule() const noexcept {
-        return schedule_sender{*pool_};
-    }
+  schedule_sender schedule() const noexcept { return schedule_sender{*pool_}; }
 
-    time_point now() const noexcept {
-        return filetime_clock::now();
-    }
+  time_point now() const noexcept { return filetime_clock::now(); }
 
-    schedule_at_sender schedule_at(time_point tp) const noexcept {
-        return schedule_at_sender{*pool_, tp};
-    }
+  schedule_at_sender schedule_at(time_point tp) const noexcept {
+    return schedule_at_sender{*pool_, tp};
+  }
 
-    template<typename Duration>
-    schedule_after_sender<Duration> schedule_after(Duration d) const
-            noexcept(std::is_nothrow_move_constructible_v<Duration>) {
-        return schedule_after_sender<Duration>{*pool_, std::move(d)};
-    }
+  template <typename Duration>
+  schedule_after_sender<Duration> schedule_after(Duration d) const
+      noexcept(std::is_nothrow_move_constructible_v<Duration>) {
+    return schedule_after_sender<Duration>{*pool_, std::move(d)};
+  }
 
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-        return a.pool_ == b.pool_;
-    }
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.pool_ == b.pool_;
+  }
 
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-        return a.pool_ != b.pool_;
-    }
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return a.pool_ != b.pool_;
+  }
 
 private:
-    friend windows_thread_pool;
+  friend windows_thread_pool;
 
-    explicit scheduler(windows_thread_pool& pool) noexcept
-    : pool_(&pool)
-    {}
+  explicit scheduler(windows_thread_pool& pool) noexcept : pool_(&pool) {}
 
-    windows_thread_pool* pool_;
+  windows_thread_pool* pool_;
 };
 
 /////////////////////////
 // scheduler methods
 
-inline windows_thread_pool::scheduler windows_thread_pool::get_scheduler() noexcept {
-    return scheduler{*this};
+inline windows_thread_pool::scheduler
+windows_thread_pool::get_scheduler() noexcept {
+  return scheduler{*this};
 }
 
-} // namespace win32
-} // namespace unifex
+}  // namespace win32
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/with_allocator.hpp
+++ b/include/unifex/with_allocator.hpp
@@ -22,23 +22,22 @@
 
 namespace unifex {
 namespace _with_alloc_cpo {
-  struct _fn {
-    template <typename Sender, typename Allocator>
-    auto operator()(Sender &&sender, Allocator &&allocator) const {
-      return with_query_value((Sender &&) sender, get_allocator,
-                              (Allocator &&) allocator);
-    }
-    template <typename Allocator>
-    constexpr auto operator()(Allocator&& allocator) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Allocator>)
-        -> bind_back_result_t<_fn, Allocator> {
-      return bind_back(*this, (Allocator&&)allocator);
-    }
-  };
-} // namespace _with_alloc_cpo
+struct _fn {
+  template <typename Sender, typename Allocator>
+  auto operator()(Sender&& sender, Allocator&& allocator) const {
+    return with_query_value(
+        (Sender &&) sender, get_allocator, (Allocator &&) allocator);
+  }
+  template <typename Allocator>
+  constexpr auto operator()(Allocator&& allocator) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, Allocator>)
+          -> bind_back_result_t<_fn, Allocator> {
+    return bind_back(*this, (Allocator &&) allocator);
+  }
+};
+}  // namespace _with_alloc_cpo
 
-inline constexpr _with_alloc_cpo::_fn with_allocator {};
-} // namespace unifex
+inline constexpr _with_alloc_cpo::_fn with_allocator{};
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -15,11 +15,11 @@
  */
 #pragma once
 
+#include <unifex/bind_back.hpp>
 #include <unifex/get_allocator.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
-#include <unifex/bind_back.hpp>
 #include <unifex/type_traits.hpp>
 
 #include <unifex/detail/prologue.hpp>
@@ -36,24 +36,25 @@ using receiver_wrapper = typename _receiver_wrapper<CPO, Value, Receiver>::type;
 
 template <typename CPO, typename Value, typename Receiver>
 class _receiver_wrapper<CPO, Value, Receiver>::type {
- public:
+public:
   template <typename Receiver2>
-  explicit type(Receiver2 &&receiver, const Value& val)
+  explicit type(Receiver2&& receiver, const Value& val)
     : receiver_((Receiver2 &&) receiver)
     , val_(&val) {}
 
- private:
-  friend const Value &tag_invoke(CPO, const type &r) noexcept {
+private:
+  friend const Value& tag_invoke(CPO, const type& r) noexcept {
     return *r.val_;
   }
 
-  template(typename OtherCPO, typename Self, typename... Args)
-    (requires same_as<remove_cvref_t<Self>, type> AND
-              callable<OtherCPO, member_t<Self, Receiver>, Args...>)
-  friend auto tag_invoke(OtherCPO cpo, Self&& self, Args&&... args)
-      noexcept(is_nothrow_callable_v<OtherCPO, member_t<Self, Receiver>, Args...>)
+  template(typename OtherCPO, typename Self, typename... Args)(
+      requires same_as<remove_cvref_t<Self>, type> AND callable<
+          OtherCPO,
+          member_t<Self, Receiver>,
+          Args...>) friend auto tag_invoke(OtherCPO cpo, Self&& self, Args&&... args) noexcept(is_nothrow_callable_v<OtherCPO, member_t<Self, Receiver>, Args...>)
       -> callable_result_t<OtherCPO, member_t<Self, Receiver>, Args...> {
-    return static_cast<OtherCPO&&>(cpo)(static_cast<Self&&>(self).receiver_, static_cast<Args&&>(args)...);
+    return static_cast<OtherCPO&&>(cpo)(
+        static_cast<Self&&>(self).receiver_, static_cast<Args&&>(args)...);
   }
 
   Receiver receiver_;
@@ -65,24 +66,23 @@ struct _op {
   class type;
 };
 template <typename CPO, typename Value, typename Sender, typename Receiver>
-using operation = typename _op<CPO, Value, Sender, remove_cvref_t<Receiver>>::type;
+using operation =
+    typename _op<CPO, Value, Sender, remove_cvref_t<Receiver>>::type;
 
 template <typename CPO, typename Value, typename Sender, typename Receiver>
 class _op<CPO, Value, Sender, Receiver>::type {
- public:
+public:
   template <typename Receiver2, typename Value2>
-  explicit type(Sender &&sender, Receiver2 &&receiver, Value2 &&value)
+  explicit type(Sender&& sender, Receiver2&& receiver, Value2&& value)
     : value_((Value2 &&) value)
-    , innerOp_(
-          connect((Sender &&) sender,
-                  receiver_wrapper<CPO, Value, Receiver>{
-                      (Receiver2 &&) receiver, value_})) {}
+    , innerOp_(connect(
+          (Sender &&) sender,
+          receiver_wrapper<CPO, Value, Receiver>{
+              (Receiver2 &&) receiver, value_})) {}
 
-  void start() & noexcept {
-    unifex::start(innerOp_);
-  }
+  void start() & noexcept { unifex::start(innerOp_); }
 
- private:
+private:
   UNIFEX_NO_UNIQUE_ADDRESS Value value_;
   /*UNIFEX_NO_UNIQUE_ADDRESS*/
   connect_result_t<Sender, receiver_wrapper<CPO, Value, Receiver>> innerOp_;
@@ -99,8 +99,11 @@ using sender =
 template <typename CPO, typename Value, typename Sender>
 class _sender<CPO, Value, Sender>::type {
 public:
-  template <template <typename...> class Variant,
-            template <typename...> class Tuple>
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
   using value_types = sender_value_types_t<Sender, Variant, Tuple>;
 
   template <template <typename...> class Variant>
@@ -109,24 +112,37 @@ public:
   static constexpr bool sends_done = sender_traits<Sender>::sends_done;
 
   template <typename Sender2, typename Value2>
-  explicit type(Sender2 &&sender, Value2 &&value)
-    : sender_((Sender2 &&) sender), value_((Value &&) value) {}
+  explicit type(Sender2&& sender, Value2&& value)
+    : sender_((Sender2 &&) sender)
+    , value_((Value &&) value) {}
 
-  template(typename Self, typename Receiver)
-    (requires same_as<remove_cvref_t<Self>, type> AND
-      constructible_from<Value, member_t<Self, Value>> AND
-      sender_to<
-        member_t<Self, Sender>,
-        receiver_wrapper<CPO, Value, remove_cvref_t<Receiver>>>)
-  friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, Receiver &&receiver)
-      noexcept(std::is_nothrow_constructible_v<Value, member_t<Self, Value>> &&
-               is_nothrow_connectable_v<
-                  member_t<Self, Sender>,
-                  receiver_wrapper<CPO, Value, remove_cvref_t<Receiver>>>)
+  template(typename Self, typename Receiver)(
+      requires same_as<remove_cvref_t<Self>, type> AND
+          constructible_from<Value, member_t<Self, Value>> AND sender_to<
+              member_t<Self, Sender>,
+              receiver_wrapper<
+                  CPO,
+                  Value,
+                  remove_cvref_t<
+                      Receiver>>>) friend auto tag_invoke(tag_t<unifex::connect>, Self&& s, Receiver&& receiver) noexcept(std::
+                                                                                                                              is_nothrow_constructible_v<
+                                                                                                                                  Value,
+                                                                                                                                  member_t<
+                                                                                                                                      Self,
+                                                                                                                                      Value>>&&
+                                                                                                                                  is_nothrow_connectable_v<
+                                                                                                                                      member_t<
+                                                                                                                                          Self,
+                                                                                                                                          Sender>,
+                                                                                                                                      receiver_wrapper<
+                                                                                                                                          CPO,
+                                                                                                                                          Value,
+                                                                                                                                          remove_cvref_t<
+                                                                                                                                              Receiver>>>)
       -> operation<CPO, Value, member_t<Self, Sender>, Receiver> {
     return operation<CPO, Value, member_t<Self, Sender>, Receiver>{
         static_cast<Self&&>(s).sender_,
-        static_cast<Receiver &&>(receiver),
+        static_cast<Receiver&&>(receiver),
         static_cast<Self&&>(s).value_};
   }
 
@@ -134,31 +150,29 @@ private:
   Sender sender_;
   Value value_;
 };
-} // namespace _with_query_value
+}  // namespace _with_query_value
 
 namespace _with_query_value_cpo {
-  inline const struct _fn {
-    template <typename Sender, typename CPO, typename Value>
-    _with_query_value::sender<CPO, Value, Sender>
-    operator()(Sender &&sender, CPO, Value &&value) const {
-      static_assert(
-          std::is_empty_v<CPO>,
-          "with_query_value() does not support stateful CPOs");
-      return _with_query_value::sender<CPO, Value, Sender>{
-          (Sender &&) sender,
-          (Value &&) value};
-    }
-    template <typename CPO, typename Value>
-    constexpr auto operator()(const CPO&, Value&& value) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, CPO, Value>)
-        -> bind_back_result_t<_fn, CPO, Value> {
-      return bind_back(*this, CPO{}, (Value&&)value);
-    }
-  } with_query_value {};
-} // namespace _with_query_value_cpo
+inline const struct _fn {
+  template <typename Sender, typename CPO, typename Value>
+  _with_query_value::sender<CPO, Value, Sender>
+  operator()(Sender&& sender, CPO, Value&& value) const {
+    static_assert(
+        std::is_empty_v<CPO>,
+        "with_query_value() does not support stateful CPOs");
+    return _with_query_value::sender<CPO, Value, Sender>{
+        (Sender &&) sender, (Value &&) value};
+  }
+  template <typename CPO, typename Value>
+  constexpr auto operator()(const CPO&, Value&& value) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, CPO, Value>)
+          -> bind_back_result_t<_fn, CPO, Value> {
+    return bind_back(*this, CPO{}, (Value &&) value);
+  }
+} with_query_value{};
+}  // namespace _with_query_value_cpo
 using _with_query_value_cpo::with_query_value;
 
-} // namespace unifex
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,77 +1,84 @@
-# Copyright (c) 2019-present, Facebook, Inc.
+#Copyright(c) 2019 - present, Facebook, Inc.
 #
-# This source code is licensed under the license found in the
-# LICENSE.txt file in the root directory of this source tree.
+#This source code is licensed under the license found in the
+#LICENSE.txt file in the root directory of this source tree.
 
 add_library(unifex "")
 
-target_sources(unifex
-  PRIVATE
-    async_manual_reset_event.cpp
-    async_mutex.cpp
-    exception.cpp
-    inplace_stop_token.cpp
-    manual_event_loop.cpp
-    static_thread_pool.cpp
-    task.cpp
-    thread_unsafe_event_loop.cpp
-    timed_single_thread_context.cpp
-    trampoline_scheduler.cpp)
+    target_sources(
+        unifex PRIVATE async_manual_reset_event.cpp async_mutex.cpp exception
+            .cpp inplace_stop_token.cpp manual_event_loop.cpp static_thread_pool
+            .cpp task.cpp thread_unsafe_event_loop
+            .cpp timed_single_thread_context.cpp trampoline_scheduler.cpp)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_sources(unifex
-    PRIVATE
-      linux/mmap_region.cpp
-      linux/monotonic_clock.cpp
-      linux/safe_file_descriptor.cpp
-      linux/io_epoll_context.cpp)
+        if (CMAKE_SYSTEM_NAME STREQUAL "Linux") target_sources(
+            unifex PRIVATE linux / mmap_region.cpp linux /
+            monotonic_clock.cpp linux / safe_file_descriptor.cpp linux /
+            io_epoll_context.cpp)
 
-  target_link_libraries(unifex
-    PUBLIC
-      pthread)
+            target_link_libraries(unifex PUBLIC pthread)
 
-if (NOT UNIFEX_NO_LIBURING)
+                if (NOT UNIFEX_NO_LIBURING)
 
-  target_sources(unifex
-    PRIVATE
-      linux/io_uring_context.cpp
-      linux/io_uring_syscall.cpp)
+                    target_sources(
+                        unifex PRIVATE linux / io_uring_context.cpp linux /
+                        io_uring_syscall.cpp)
 
-  target_include_directories(unifex
-    PUBLIC
-      ${UNIFEX_URING_INCLUDE_DIRS})
+                        target_include_directories(unifex PUBLIC ${
+                            UNIFEX_URING_INCLUDE_DIRS})
 
-  target_link_libraries(unifex
-    PRIVATE
-      ${UNIFEX_URING_LIBRARY})
+                            target_link_libraries(unifex PRIVATE ${
+                                UNIFEX_URING_LIBRARY})
 
-endif()
+                                endif()
 
-endif()
+                                    endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+                                        if (CMAKE_SYSTEM_NAME STREQUAL
+                                            "Windows")
 
-  target_sources(unifex
-    PRIVATE
-      win32/filetime_clock.cpp
-      win32/safe_handle.cpp
-      win32/windows_thread_pool.cpp
-      win32/low_latency_iocp_context.cpp
-      win32/ntapi.cpp)
+                                            target_sources(
+                                                unifex PRIVATE win32 /
+                                                filetime_clock.cpp win32 /
+                                                safe_handle.cpp win32 /
+                                                windows_thread_pool.cpp win32 /
+                                                low_latency_iocp_context
+                                                    .cpp win32 /
+                                                ntapi.cpp)
 
-endif()
+                                                endif()
 
-configure_file(
-  ../include/unifex/config.hpp.in
-  "${PROJECT_BINARY_DIR}/include/unifex/config.hpp")
+                                                    configure_file(
+                                                            ../ include /
+                                                        unifex /
+                                                        config.hpp.in
+                                                        "${PROJECT_BINARY_DIR}/"
+                                                        "include/unifex/"
+                                                        "config.hpp")
 
-target_include_directories(unifex
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
-    "${PROJECT_BINARY_DIR}/include")
+                                                        target_include_directories(
+                                                            unifex PUBLIC $<
+                                                                BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} /
+                                                                    ../
+                                                                include /> "${"
+                                                                           "PRO"
+                                                                           "JEC"
+                                                                           "T_"
+                                                                           "BIN"
+                                                                           "ARY"
+                                                                           "_DI"
+                                                                           "R}/"
+                                                                           "inc"
+                                                                           "lud"
+                                                                           "e")
 
-target_compile_features(unifex PUBLIC cxx_std_17)
+                                                            target_compile_features(
+                                                                unifex PUBLIC
+                                                                    cxx_std_17)
 
-if(CXX_COROUTINES_HAVE_COROUTINES)
-  target_link_libraries(unifex PUBLIC std::coroutines)
-endif()
+                                                                if (CXX_COROUTINES_HAVE_COROUTINES)
+                                                                    target_link_libraries(
+                                                                        unifex PUBLIC
+                                                                            std::
+                                                                                coroutines)
+                                                                        endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,84 +1,77 @@
-#Copyright(c) 2019 - present, Facebook, Inc.
+# Copyright (c) 2019-present, Facebook, Inc.
 #
-#This source code is licensed under the license found in the
-#LICENSE.txt file in the root directory of this source tree.
+# This source code is licensed under the license found in the
+# LICENSE.txt file in the root directory of this source tree.
 
 add_library(unifex "")
 
-    target_sources(
-        unifex PRIVATE async_manual_reset_event.cpp async_mutex.cpp exception
-            .cpp inplace_stop_token.cpp manual_event_loop.cpp static_thread_pool
-            .cpp task.cpp thread_unsafe_event_loop
-            .cpp timed_single_thread_context.cpp trampoline_scheduler.cpp)
+target_sources(unifex
+  PRIVATE
+    async_manual_reset_event.cpp
+    async_mutex.cpp
+    exception.cpp
+    inplace_stop_token.cpp
+    manual_event_loop.cpp
+    static_thread_pool.cpp
+    task.cpp
+    thread_unsafe_event_loop.cpp
+    timed_single_thread_context.cpp
+    trampoline_scheduler.cpp)
 
-        if (CMAKE_SYSTEM_NAME STREQUAL "Linux") target_sources(
-            unifex PRIVATE linux / mmap_region.cpp linux /
-            monotonic_clock.cpp linux / safe_file_descriptor.cpp linux /
-            io_epoll_context.cpp)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_sources(unifex
+    PRIVATE
+      linux/mmap_region.cpp
+      linux/monotonic_clock.cpp
+      linux/safe_file_descriptor.cpp
+      linux/io_epoll_context.cpp)
 
-            target_link_libraries(unifex PUBLIC pthread)
+  target_link_libraries(unifex
+    PUBLIC
+      pthread)
 
-                if (NOT UNIFEX_NO_LIBURING)
+if (NOT UNIFEX_NO_LIBURING)
 
-                    target_sources(
-                        unifex PRIVATE linux / io_uring_context.cpp linux /
-                        io_uring_syscall.cpp)
+  target_sources(unifex
+    PRIVATE
+      linux/io_uring_context.cpp
+      linux/io_uring_syscall.cpp)
 
-                        target_include_directories(unifex PUBLIC ${
-                            UNIFEX_URING_INCLUDE_DIRS})
+  target_include_directories(unifex
+    PUBLIC
+      ${UNIFEX_URING_INCLUDE_DIRS})
 
-                            target_link_libraries(unifex PRIVATE ${
-                                UNIFEX_URING_LIBRARY})
+  target_link_libraries(unifex
+    PRIVATE
+      ${UNIFEX_URING_LIBRARY})
 
-                                endif()
+endif()
 
-                                    endif()
+endif()
 
-                                        if (CMAKE_SYSTEM_NAME STREQUAL
-                                            "Windows")
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
-                                            target_sources(
-                                                unifex PRIVATE win32 /
-                                                filetime_clock.cpp win32 /
-                                                safe_handle.cpp win32 /
-                                                windows_thread_pool.cpp win32 /
-                                                low_latency_iocp_context
-                                                    .cpp win32 /
-                                                ntapi.cpp)
+  target_sources(unifex
+    PRIVATE
+      win32/filetime_clock.cpp
+      win32/safe_handle.cpp
+      win32/windows_thread_pool.cpp
+      win32/low_latency_iocp_context.cpp
+      win32/ntapi.cpp)
 
-                                                endif()
+endif()
 
-                                                    configure_file(
-                                                            ../ include /
-                                                        unifex /
-                                                        config.hpp.in
-                                                        "${PROJECT_BINARY_DIR}/"
-                                                        "include/unifex/"
-                                                        "config.hpp")
+configure_file(
+  ../include/unifex/config.hpp.in
+  "${PROJECT_BINARY_DIR}/include/unifex/config.hpp")
 
-                                                        target_include_directories(
-                                                            unifex PUBLIC $<
-                                                                BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} /
-                                                                    ../
-                                                                include /> "${"
-                                                                           "PRO"
-                                                                           "JEC"
-                                                                           "T_"
-                                                                           "BIN"
-                                                                           "ARY"
-                                                                           "_DI"
-                                                                           "R}/"
-                                                                           "inc"
-                                                                           "lud"
-                                                                           "e")
+target_include_directories(unifex
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
+    "${PROJECT_BINARY_DIR}/include")
 
-                                                            target_compile_features(
-                                                                unifex PUBLIC
-                                                                    cxx_std_17)
+target_compile_features(unifex PUBLIC cxx_std_17)
 
-                                                                if (CXX_COROUTINES_HAVE_COROUTINES)
-                                                                    target_link_libraries(
-                                                                        unifex PUBLIC
-                                                                            std::
-                                                                                coroutines)
-                                                                        endif()
+if(CXX_COROUTINES_HAVE_COROUTINES)
+  target_link_libraries(unifex PUBLIC std::coroutines)
+endif()

--- a/source/async_manual_reset_event.cpp
+++ b/source/async_manual_reset_event.cpp
@@ -38,7 +38,8 @@ void async_manual_reset_event::set() noexcept {
   }
 }
 
-void async_manual_reset_event::start_or_wait(_op_base& op, async_manual_reset_event& evt) noexcept {
+void async_manual_reset_event::start_or_wait(
+    _op_base& op, async_manual_reset_event& evt) noexcept {
   // Try to push op onto the stack of waiting ops.
   void* const signalledState = &evt;
 
@@ -61,4 +62,4 @@ void async_manual_reset_event::start_or_wait(_op_base& op, async_manual_reset_ev
       std::memory_order_acquire));
 }
 
-} // namespace unfiex::_amre
+}  // namespace unifex::_amre

--- a/source/async_mutex.cpp
+++ b/source/async_mutex.cpp
@@ -16,14 +16,15 @@
 
 #include <unifex/async_mutex.hpp>
 
-
 namespace unifex {
 
-async_mutex::async_mutex() noexcept : atomicQueue_(false) {}
+async_mutex::async_mutex() noexcept : atomicQueue_(false) {
+}
 
-async_mutex::~async_mutex() {}
+async_mutex::~async_mutex() {
+}
 
-bool async_mutex::try_enqueue(waiter_base *base) noexcept {
+bool async_mutex::try_enqueue(waiter_base* base) noexcept {
   return atomicQueue_.enqueue_or_mark_active(base);
 }
 
@@ -36,8 +37,8 @@ void async_mutex::unlock() noexcept {
     pendingQueue_ = std::move(newWaiters);
   }
 
-  waiter_base *item = pendingQueue_.pop_front();
+  waiter_base* item = pendingQueue_.pop_front();
   item->resume_(item);
 }
 
-} // namespace unifex
+}  // namespace unifex

--- a/source/exception.cpp
+++ b/source/exception.cpp
@@ -28,10 +28,11 @@ inline void _ref::rethrow() const {
 std::exception_ptr _fn::operator()(_ref const e) const noexcept {
   UNIFEX_TRY {
     e.rethrow();
-  } UNIFEX_CATCH(...) {
+  }
+  UNIFEX_CATCH(...) {
     return std::current_exception();
   }
 }
 #endif
-} // namespace _except_ptr
-} // namespace unifex
+}  // namespace _except_ptr
+}  // namespace unifex

--- a/source/inplace_stop_token.cpp
+++ b/source/inplace_stop_token.cpp
@@ -18,7 +18,7 @@
 #include <unifex/spin_wait.hpp>
 
 #ifndef NDEBUG
-#include <stdio.h>
+#  include <stdio.h>
 #endif
 
 namespace unifex {
@@ -170,4 +170,4 @@ void inplace_stop_source::remove_callback(
   }
 }
 
-} // namespace unifex
+}  // namespace unifex

--- a/source/linux/io_uring_syscall.cpp
+++ b/source/linux/io_uring_syscall.cpp
@@ -18,59 +18,59 @@
 
 #if !UNIFEX_NO_LIBURING
 
-#include "io_uring_syscall.hpp"
+#  include "io_uring_syscall.hpp"
 
 // Based on liburing's syscall.c by Jens Axboe
 
-#include <unistd.h>
-#include <sys/syscall.h>
-#include <sys/uio.h>
+#  include <sys/syscall.h>
+#  include <sys/uio.h>
+#  include <unistd.h>
 
-#ifdef __alpha__
+#  ifdef __alpha__
 /*
  * alpha is the only exception, all other architectures
  * have common numbers for new system calls.
  */
-# ifndef __NR_io_uring_setup
-#  define __NR_io_uring_setup		535
-# endif
-# ifndef __NR_io_uring_enter
-#  define __NR_io_uring_enter		536
-# endif
-# ifndef __NR_io_uring_register
-#  define __NR_io_uring_register	537
-# endif
-#else /* !__alpha__ */
-# ifndef __NR_io_uring_setup
-#  define __NR_io_uring_setup		425
-# endif
-# ifndef __NR_io_uring_enter
-#  define __NR_io_uring_enter		426
-# endif
-# ifndef __NR_io_uring_register
-#  define __NR_io_uring_register	427
-# endif
-#endif
+#    ifndef __NR_io_uring_setup
+#      define __NR_io_uring_setup 535
+#    endif
+#    ifndef __NR_io_uring_enter
+#      define __NR_io_uring_enter 536
+#    endif
+#    ifndef __NR_io_uring_register
+#      define __NR_io_uring_register 537
+#    endif
+#  else /* !__alpha__ */
+#    ifndef __NR_io_uring_setup
+#      define __NR_io_uring_setup 425
+#    endif
+#    ifndef __NR_io_uring_enter
+#      define __NR_io_uring_enter 426
+#    endif
+#    ifndef __NR_io_uring_register
+#      define __NR_io_uring_register 427
+#    endif
+#  endif
 
-namespace unifex::linuxos
-{
-    int io_uring_register(int fd, unsigned opcode, const void *arg,
-			    unsigned nr_args)
-    {
-        return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
-    }
-
-    int io_uring_setup(unsigned entries, struct io_uring_params *p)
-    {
-        return syscall(__NR_io_uring_setup, entries, p);
-    }
-
-    int io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
-                       unsigned flags, sigset_t *sig)
-    {
-        return syscall(__NR_io_uring_enter, fd, to_submit, min_complete,
-                       flags, sig, _NSIG / 8);
-    }
+namespace unifex::linuxos {
+int io_uring_register(
+    int fd, unsigned opcode, const void* arg, unsigned nr_args) {
+  return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
 }
 
-#endif // UNIFEX_NO_LIBURING
+int io_uring_setup(unsigned entries, struct io_uring_params* p) {
+  return syscall(__NR_io_uring_setup, entries, p);
+}
+
+int io_uring_enter(
+    int fd,
+    unsigned to_submit,
+    unsigned min_complete,
+    unsigned flags,
+    sigset_t* sig) {
+  return syscall(
+      __NR_io_uring_enter, fd, to_submit, min_complete, flags, sig, _NSIG / 8);
+}
+}  // namespace unifex::linuxos
+
+#endif  // UNIFEX_NO_LIBURING

--- a/source/linux/io_uring_syscall.hpp
+++ b/source/linux/io_uring_syscall.hpp
@@ -15,12 +15,17 @@
  */
 #pragma once
 
-#include <signal.h>
 #include <linux/io_uring.h>
+#include <signal.h>
 
-namespace unifex::linuxos
-{
-    int io_uring_register(int fd, unsigned opcode, const void *arg, unsigned nr_args);
-    int io_uring_setup(unsigned entries, struct io_uring_params *p);
-    int io_uring_enter(int fd, unsigned to_submit, unsigned min_complete, unsigned flags, sigset_t *sig);
-}
+namespace unifex::linuxos {
+int io_uring_register(
+    int fd, unsigned opcode, const void* arg, unsigned nr_args);
+int io_uring_setup(unsigned entries, struct io_uring_params* p);
+int io_uring_enter(
+    int fd,
+    unsigned to_submit,
+    unsigned min_complete,
+    unsigned flags,
+    sigset_t* sig);
+}  // namespace unifex::linuxos

--- a/source/linux/mmap_region.cpp
+++ b/source/linux/mmap_region.cpp
@@ -25,4 +25,4 @@ mmap_region::~mmap_region() {
   }
 }
 
-} // namespace unifex::linuxos
+}  // namespace unifex::linuxos

--- a/source/linux/monotonic_clock.cpp
+++ b/source/linux/monotonic_clock.cpp
@@ -25,4 +25,4 @@ monotonic_clock::time_point monotonic_clock::now() noexcept {
   return time_point::from_seconds_and_nanoseconds(ts.tv_sec, ts.tv_nsec);
 }
 
-} // namespace unifex::linuxos
+}  // namespace unifex::linuxos

--- a/source/linux/safe_file_descriptor.cpp
+++ b/source/linux/safe_file_descriptor.cpp
@@ -15,7 +15,6 @@
  */
 #include <unifex/linux/safe_file_descriptor.hpp>
 
-
 #include <unistd.h>
 
 namespace unifex::linuxos {
@@ -26,4 +25,4 @@ void safe_file_descriptor::close() noexcept {
   UNIFEX_ASSERT(result == 0);
 }
 
-} // namespace unifex::linuxos
+}  // namespace unifex::linuxos

--- a/source/manual_event_loop.cpp
+++ b/source/manual_event_loop.cpp
@@ -22,7 +22,8 @@ void context::run() {
   std::unique_lock lock{mutex_};
   while (true) {
     while (head_ == nullptr) {
-      if (stop_) return;
+      if (stop_)
+        return;
       cv_.wait(lock);
     }
     auto* task = head_;
@@ -54,5 +55,5 @@ void context::enqueue(task_base* task) {
   cv_.notify_one();
 }
 
-} // _manual_event_loop
-} // unifex
+}  // namespace _manual_event_loop
+}  // namespace unifex

--- a/source/static_thread_pool.cpp
+++ b/source/static_thread_pool.cpp
@@ -17,137 +17,137 @@
 
 namespace unifex {
 namespace _static_thread_pool {
-  context::context()
-    : context(std::thread::hardware_concurrency()) {}
+context::context() : context(std::thread::hardware_concurrency()) {
+}
 
-  context::context(std::uint32_t threadCount)
-    : threadCount_(threadCount)
-    , threadStates_(threadCount)
-    , nextThread_(0) {
-    UNIFEX_ASSERT(threadCount > 0);
+context::context(std::uint32_t threadCount)
+  : threadCount_(threadCount)
+  , threadStates_(threadCount)
+  , nextThread_(0) {
+  UNIFEX_ASSERT(threadCount > 0);
 
-    threads_.reserve(threadCount);
+  threads_.reserve(threadCount);
 
-    UNIFEX_TRY {
-      for (std::uint32_t i = 0; i < threadCount; ++i) {
-        threads_.emplace_back([this, i] { run(i); });
-      }
-    } UNIFEX_CATCH (...) {
-      request_stop();
-      join();
-      UNIFEX_RETHROW();
+  UNIFEX_TRY {
+    for (std::uint32_t i = 0; i < threadCount; ++i) {
+      threads_.emplace_back([this, i] { run(i); });
     }
   }
-
-  context::~context() {
+  UNIFEX_CATCH(...) {
     request_stop();
     join();
+    UNIFEX_RETHROW();
   }
+}
 
-  void context::request_stop() noexcept {
-    for (auto& state : threadStates_) {
-      state.request_stop();
-    }
+context::~context() {
+  request_stop();
+  join();
+}
+
+void context::request_stop() noexcept {
+  for (auto& state : threadStates_) {
+    state.request_stop();
   }
+}
 
-  void context::run(std::uint32_t index) noexcept {
-    while (true) {
-      task_base* task = nullptr;
-      for (std::uint32_t i = 0; i < threadCount_; ++i) {
-        auto queueIndex = (index + i) < threadCount_
-            ? (index + i)
-            : (index + i - threadCount_);
-        auto& state = threadStates_[queueIndex];
-        task = state.try_pop();
-        if (task != nullptr) {
-          break;
-        }
+void context::run(std::uint32_t index) noexcept {
+  while (true) {
+    task_base* task = nullptr;
+    for (std::uint32_t i = 0; i < threadCount_; ++i) {
+      auto queueIndex =
+          (index + i) < threadCount_ ? (index + i) : (index + i - threadCount_);
+      auto& state = threadStates_[queueIndex];
+      task = state.try_pop();
+      if (task != nullptr) {
+        break;
       }
+    }
 
+    if (task == nullptr) {
+      task = threadStates_[index].pop();
       if (task == nullptr) {
-        task = threadStates_[index].pop();
-        if (task == nullptr) {
-          // request_stop() was called.
-          return;
-        }
-      }
-
-      task->execute(task);
-    }
-  }
-
-  void context::join() noexcept {
-    for (auto& t : threads_) {
-      t.join();
-    }
-    threads_.clear();
-  }
-
-  void context::enqueue(task_base* task) noexcept {
-    const std::uint32_t threadCount = static_cast<std::uint32_t>(threads_.size());
-    const std::uint32_t startIndex =
-        nextThread_.fetch_add(1, std::memory_order_relaxed) % threadCount;
-
-    // First try to enqueue to one of the threads without blocking.
-    for (std::uint32_t i = 0; i < threadCount; ++i) {
-      const auto index = (startIndex + i) < threadCount
-          ? (startIndex + i)
-          : (startIndex + i - threadCount);
-      if (threadStates_[index].try_push(task)) {
+        // request_stop() was called.
         return;
       }
     }
 
-    // Otherwise, do a blocking enqueue on the selected thread.
-    threadStates_[startIndex].push(task);
+    task->execute(task);
+  }
+}
+
+void context::join() noexcept {
+  for (auto& t : threads_) {
+    t.join();
+  }
+  threads_.clear();
+}
+
+void context::enqueue(task_base* task) noexcept {
+  const std::uint32_t threadCount = static_cast<std::uint32_t>(threads_.size());
+  const std::uint32_t startIndex =
+      nextThread_.fetch_add(1, std::memory_order_relaxed) % threadCount;
+
+  // First try to enqueue to one of the threads without blocking.
+  for (std::uint32_t i = 0; i < threadCount; ++i) {
+    const auto index = (startIndex + i) < threadCount
+        ? (startIndex + i)
+        : (startIndex + i - threadCount);
+    if (threadStates_[index].try_push(task)) {
+      return;
+    }
   }
 
-  task_base* context::thread_state::try_pop() {
-    std::unique_lock lk{mut_, std::try_to_lock};
-    if (!lk || queue_.empty()) {
+  // Otherwise, do a blocking enqueue on the selected thread.
+  threadStates_[startIndex].push(task);
+}
+
+task_base* context::thread_state::try_pop() {
+  std::unique_lock lk{mut_, std::try_to_lock};
+  if (!lk || queue_.empty()) {
+    return nullptr;
+  }
+  return queue_.pop_front();
+}
+
+task_base* context::thread_state::pop() {
+  std::unique_lock lk{mut_};
+  while (queue_.empty()) {
+    if (stopRequested_) {
       return nullptr;
     }
-    return queue_.pop_front();
+    cv_.wait(lk);
   }
+  return queue_.pop_front();
+}
 
-  task_base* context::thread_state::pop() {
-    std::unique_lock lk{mut_};
-    while (queue_.empty()) {
-      if (stopRequested_) {
-        return nullptr;
-      }
-      cv_.wait(lk);
-    }
-    return queue_.pop_front();
+bool context::thread_state::try_push(task_base* task) {
+  std::unique_lock lk{mut_, std::try_to_lock};
+  if (!lk) {
+    return false;
   }
-
-  bool context::thread_state::try_push(task_base* task) {
-    std::unique_lock lk{mut_, std::try_to_lock};
-    if (!lk) {
-      return false;
-    }
-    const bool wasEmpty = queue_.empty();
-    queue_.push_back(task);
-    if (wasEmpty) {
-      cv_.notify_one();
-    }
-    return true;
-  }
-
-  void context::thread_state::push(task_base* task) {
-    std::lock_guard lk{mut_};
-    const bool wasEmpty = queue_.empty();
-    queue_.push_back(task);
-    if (wasEmpty) {
-      cv_.notify_one();
-    }
-  }
-
-  void context::thread_state::request_stop() {
-    std::lock_guard lk{mut_};
-    stopRequested_ = true;
+  const bool wasEmpty = queue_.empty();
+  queue_.push_back(task);
+  if (wasEmpty) {
     cv_.notify_one();
   }
+  return true;
+}
 
-} // namespace _static_thread_pool
-} // namespace unifex
+void context::thread_state::push(task_base* task) {
+  std::lock_guard lk{mut_};
+  const bool wasEmpty = queue_.empty();
+  queue_.push_back(task);
+  if (wasEmpty) {
+    cv_.notify_one();
+  }
+}
+
+void context::thread_state::request_stop() {
+  std::lock_guard lk{mut_};
+  stopRequested_ = true;
+  cv_.notify_one();
+}
+
+}  // namespace _static_thread_pool
+}  // namespace unifex

--- a/source/task.cpp
+++ b/source/task.cpp
@@ -17,28 +17,28 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <unifex/task.hpp>
-#include <unifex/at_coroutine_exit.hpp>
+#  include <unifex/at_coroutine_exit.hpp>
+#  include <unifex/task.hpp>
 
 namespace unifex::_task {
 void _promise_base::transform_schedule_sender_impl_(any_scheduler newSched) {
-  // If we haven't already inserted a cleanup action to take us back to the correct
-  // scheduler, do so now:
+  // If we haven't already inserted a cleanup action to take us back to the
+  // correct scheduler, do so now:
   if (!std::exchange(this->rescheduled_, true)) {
     // Create a cleanup action that transitions back onto the current scheduler:
     auto cleanupTask = at_coroutine_exit(schedule, this->sched_);
-    // Insert the cleanup action into the head of the continuation chain by making
-    // direct calls to the cleanup task's awaiter member functions. See type
-    // _cleanup_task in at_coroutine_exit.hpp:
+    // Insert the cleanup action into the head of the continuation chain by
+    // making direct calls to the cleanup task's awaiter member functions. See
+    // type _cleanup_task in at_coroutine_exit.hpp:
     cleanupTask.await_suspend_impl_(*this);
-    (void) cleanupTask.await_resume();
+    (void)cleanupTask.await_resume();
   }
 
   // Update the current scheduler. (Don't do this before we have inserted the
-  // cleanup action because the insertion of the cleanup action reads this task's
-  // current scheduler.)
+  // cleanup action because the insertion of the cleanup action reads this
+  // task's current scheduler.)
   this->sched_ = std::move(newSched);
 }
-} // unifex::_task
+}  // namespace unifex::_task
 
 #endif

--- a/source/thread_unsafe_event_loop.cpp
+++ b/source/thread_unsafe_event_loop.cpp
@@ -88,4 +88,4 @@ void thread_unsafe_event_loop::run_until_empty() noexcept {
   }
 }
 
-} // namespace unifex
+}  // namespace unifex

--- a/source/timed_single_thread_context.cpp
+++ b/source/timed_single_thread_context.cpp
@@ -18,8 +18,8 @@
 namespace unifex {
 
 timed_single_thread_context::timed_single_thread_context()
-: thread_([this] { this->run(); })
-{}
+  : thread_([this] { this->run(); }) {
+}
 
 timed_single_thread_context::~timed_single_thread_context() {
   {
@@ -122,4 +122,4 @@ void _timed_single_thread_context::cancel_callback::operator()() noexcept {
   }
 }
 
-} // namespace unifex
+}  // namespace unifex

--- a/source/trampoline_scheduler.cpp
+++ b/source/trampoline_scheduler.cpp
@@ -29,4 +29,4 @@ void trampoline_scheduler::trampoline_state::drain() noexcept {
   }
 }
 
-} // namespace unifex
+}  // namespace unifex

--- a/source/win32/filetime_clock.cpp
+++ b/source/win32/filetime_clock.cpp
@@ -22,14 +22,14 @@
 namespace unifex::win32 {
 
 filetime_clock::time_point filetime_clock::now() noexcept {
-    FILETIME filetime;
-    ::GetSystemTimeAsFileTime(&filetime);
+  FILETIME filetime;
+  ::GetSystemTimeAsFileTime(&filetime);
 
-    ULARGE_INTEGER ticks;
-    ticks.HighPart = filetime.dwHighDateTime;
-    ticks.LowPart = filetime.dwLowDateTime;
+  ULARGE_INTEGER ticks;
+  ticks.HighPart = filetime.dwHighDateTime;
+  ticks.LowPart = filetime.dwLowDateTime;
 
-    return time_point::from_ticks(ticks.QuadPart);
+  return time_point::from_ticks(ticks.QuadPart);
 }
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -16,8 +16,8 @@
 
 #include <unifex/win32/low_latency_iocp_context.hpp>
 
-#include <unifex/scope_guard.hpp>
 #include <unifex/exception.hpp>
+#include <unifex/scope_guard.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -26,701 +26,693 @@
 #include <system_error>
 
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
+#  define WIN32_LEAN_AND_MEAN 1
 #endif
 
 #include <Windows.h>
 
-namespace unifex::win32
-{
-  namespace
-  {
-    static safe_handle create_iocp() {
-      HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
-      if (h == NULL) {
-        DWORD errorCode = ::GetLastError();
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "CreateIoCompletionPort()"});
-      }
-
-      return safe_handle{h};
-    }
-
-  }  // namespace
-
-  low_latency_iocp_context::low_latency_iocp_context(
-      std::size_t maxIoOperations)
-    : activeThreadId_(std::thread::id())
-    , iocp_(create_iocp())
-    , ioPoolSize_(maxIoOperations)
-    , ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
-    // Make sure the WinNT APIs are initialised and available.
-    // Only need to do this on construction as this will be guaranteed
-    // to run before anything else needs to call them.
-    ntapi::ensure_initialised();
-
-    // Build the I/O free-list in reverse so front of free-list
-    // is first element in array.
-    for (std::size_t i = 0; i < maxIoOperations; ++i) {
-      ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
-    }
+namespace unifex::win32 {
+namespace {
+static safe_handle create_iocp() {
+  HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+  if (h == NULL) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "CreateIoCompletionPort()"});
   }
 
-  low_latency_iocp_context::~low_latency_iocp_context() {
-    // Wait until the completion-event for every io-state has been
-    // received before we free the memory for the io-states.
-    std::size_t remaining = ioPoolSize_;
-    while (!ioFreeList_.empty()) {
-      (void)ioFreeList_.pop_front();
-      --remaining;
-    }
+  return safe_handle{h};
+}
 
-    if (remaining > 0) {
-      constexpr std::uint32_t completionBufferSize = 128;
-      ntapi::FILE_IO_COMPLETION_INFORMATION
-          completionBuffer[completionBufferSize];
-      std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+}  // namespace
 
-      do {
-        ntapi::ULONG numEntriesRemoved = 0;
-        ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
-            iocp_.get(),
-            completionBuffer,
-            completionBufferSize,
-            &numEntriesRemoved,
-            NULL,    // no timeout
-            FALSE);  // not alertable
-        if (!ntapi::ntstatus_success(ntstat)) {
-          std::terminate();
-        }
+low_latency_iocp_context::low_latency_iocp_context(std::size_t maxIoOperations)
+  : activeThreadId_(std::thread::id())
+  , iocp_(create_iocp())
+  , ioPoolSize_(maxIoOperations)
+  , ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
+  // Make sure the WinNT APIs are initialised and available.
+  // Only need to do this on construction as this will be guaranteed
+  // to run before anything else needs to call them.
+  ntapi::ensure_initialised();
 
-        for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
-          auto& entry = completionBuffer[i];
-          if (entry.ApcContext != nullptr) {
-            ntapi::IO_STATUS_BLOCK* iosb =
-                reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-            auto* state = to_io_state(iosb);
-            UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-            --state->pendingCompletionNotifications;
-            if (state->pendingCompletionNotifications == 0) {
-              --remaining;
-            }
-          }
-        }
-      } while (remaining > 0);
-    }
+  // Build the I/O free-list in reverse so front of free-list
+  // is first element in array.
+  for (std::size_t i = 0; i < maxIoOperations; ++i) {
+    ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
+  }
+}
+
+low_latency_iocp_context::~low_latency_iocp_context() {
+  // Wait until the completion-event for every io-state has been
+  // received before we free the memory for the io-states.
+  std::size_t remaining = ioPoolSize_;
+  while (!ioFreeList_.empty()) {
+    (void)ioFreeList_.pop_front();
+    --remaining;
   }
 
-  void low_latency_iocp_context::run_impl(bool& stopFlag) {
-    ntapi::LARGE_INTEGER zero;
-    zero.QuadPart = 0;
-
-    const ntapi::PLARGE_INTEGER zeroTimeout = &zero;
-    const ntapi::PLARGE_INTEGER infiniteTimeout = nullptr;
-
-    [[maybe_unused]] auto prevId = activeThreadId_.exchange(
-        std::this_thread::get_id(), std::memory_order_relaxed);
-    UNIFEX_ASSERT(prevId == std::thread::id());
-
-    scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
-      activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
-    };
-
+  if (remaining > 0) {
     constexpr std::uint32_t completionBufferSize = 128;
     ntapi::FILE_IO_COMPLETION_INFORMATION
         completionBuffer[completionBufferSize];
     std::memset(&completionBuffer, 0, sizeof(completionBuffer));
 
-    bool shouldCheckRemoteQueue = true;
-
-    // Make sure that we leave the remote queue in a
-    // state such that the  'shouldCheckRemoteQueue = true'
-    // is a valid initial state for the next caller to run().
-    scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
-      if (!shouldCheckRemoteQueue) {
-        (void)remoteQueue_.try_mark_active();
-      }
-    };
-
-    while (!stopFlag) {
-process_ready_queue:
-      // Process/drain all ready-to-run work.
-      while (!readyQueue_.empty()) {
-        operation_base* task = readyQueue_.pop_front();
-        task->callback(task);
-      }
-
-      // Check whether the stop request was processed
-      // when draining the ready queue.
-      if (stopFlag) {
-        break;
-      }
-
-      // Check the poll-queue for I/O operations that might have completed
-      // already but where we have not yet seen the IOCP event.
-
-      while (!pollQueue_.empty()) {
-        io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
-        auto* state = op->ioState;
-        UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-        UNIFEX_ASSERT(!state->completed);
-
-        if (poll_is_complete(*state)) {
-          // Completed before we received any notifications via IOCP.
-          // Schedule it to resume now, before polling any other I/Os
-          // to give those other I/Os time to complete.
-          state->completed = true;
-          schedule_local(state->parent);
-          goto process_ready_queue;
-        }
-      }
-
-process_remote_queue:
-      if (shouldCheckRemoteQueue) {
-        if (try_dequeue_remote_work()) {
-          goto process_ready_queue;
-        }
-      }
-
-      // Now check if there are any IOCP events.
-get_iocp_entries:
-      const ntapi::BOOLEAN alertable = FALSE;
-      ntapi::ULONG completionEntriesRetrieved = 0;
+    do {
+      ntapi::ULONG numEntriesRemoved = 0;
       ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
           iocp_.get(),
           completionBuffer,
           completionBufferSize,
-          &completionEntriesRetrieved,
-          shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
-          alertable);
-      if (ntstat == STATUS_TIMEOUT) {
-        UNIFEX_ASSERT(shouldCheckRemoteQueue);
-
-        // Previous call was non-blocking.
-        // About to transition to blocking-call, but first need to
-        // mark remote queue inactive so that remote threads know
-        // they need to post an event to wake this thread up.
-        if (remoteQueue_.try_mark_inactive()) {
-          shouldCheckRemoteQueue = false;
-          goto get_iocp_entries;
-        } else {
-          goto process_remote_queue;
-        }
-      } else if (!ntapi::ntstatus_success(ntstat)) {
-        DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "NtRemoveIoCompletionEx()"});
+          &numEntriesRemoved,
+          NULL,    // no timeout
+          FALSE);  // not alertable
+      if (!ntapi::ntstatus_success(ntstat)) {
+        std::terminate();
       }
 
-      // Process completion-entries we received from the OS.
-      for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
-        ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
+      for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
+        auto& entry = completionBuffer[i];
         if (entry.ApcContext != nullptr) {
           ntapi::IO_STATUS_BLOCK* iosb =
               reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-          // TODO: Do we need to store the error-code/bytes-transferred here?
-          // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
-          // Should we be copying entry.IoStatusBlock to '*iosb'?
-
-          UNIFEX_ASSERT(iosb->Status != STATUS_PENDING);
-
-          vectored_io_state* state = to_io_state(iosb);
-
+          auto* state = to_io_state(iosb);
           UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-          if (--state->pendingCompletionNotifications == 0) {
-            // This was the last pending notification for this state.
-            if (state->parent != nullptr) {
-              // An operation is still attached to this state.
-              // Notify it if we hadn't already done so.
-              if (!state->completed) {
-                state->completed = true;
-                schedule_local(state->parent);
-              }
-            } else {
-              // Otherwise the operation has already detached
-              // from this I/O state and so we can immediately
-              // return it to the pool.
-              release_io_state(state);
-            }
+          --state->pendingCompletionNotifications;
+          if (state->pendingCompletionNotifications == 0) {
+            --remaining;
           }
-        } else {
-          // A remote-thread wake-up notification.
-          shouldCheckRemoteQueue = true;
         }
       }
+    } while (remaining > 0);
+  }
+}
+
+void low_latency_iocp_context::run_impl(bool& stopFlag) {
+  ntapi::LARGE_INTEGER zero;
+  zero.QuadPart = 0;
+
+  const ntapi::PLARGE_INTEGER zeroTimeout = &zero;
+  const ntapi::PLARGE_INTEGER infiniteTimeout = nullptr;
+
+  [[maybe_unused]] auto prevId = activeThreadId_.exchange(
+      std::this_thread::get_id(), std::memory_order_relaxed);
+  UNIFEX_ASSERT(prevId == std::thread::id());
+
+  scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
+    activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
+  };
+
+  constexpr std::uint32_t completionBufferSize = 128;
+  ntapi::FILE_IO_COMPLETION_INFORMATION completionBuffer[completionBufferSize];
+  std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+
+  bool shouldCheckRemoteQueue = true;
+
+  // Make sure that we leave the remote queue in a
+  // state such that the  'shouldCheckRemoteQueue = true'
+  // is a valid initial state for the next caller to run().
+  scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
+    if (!shouldCheckRemoteQueue) {
+      (void)remoteQueue_.try_mark_active();
     }
-  }
+  };
 
-  bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
-    auto items = remoteQueue_.dequeue_all_reversed();
-    if (items.empty()) {
-      return false;
-    }
-
-    // Note that this ends up enqueueing entries in reverse.
-    // TODO: Modify this so it enqueues items in a way that
-    // preserves order.
-    do {
-      schedule_local(items.pop_front());
-    } while (!items.empty());
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::poll_is_complete(
-      vectored_io_state& state) noexcept {
-    // TODO: Double check the memory barriers/atomics we need to use
-    // here to ensure we perform this read, that it doesn't tear and
-    // that it has the appropriate memory semantics.
-
-    for (std::size_t i = 0; i < state.operationCount; ++i) {
-      // Mark volatile to indicate to the compiler that it might change in the
-      // background. The kernel might update it as the I/O completes.
-      volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
-      if (iosb->Status == STATUS_PENDING) {
-        return false;
-      }
-    }
-
-    // Make sure that we have visibility of the results of the I/O operations
-    // (assuming that the OS used a "release" memory semantic when writing
-    // to the 'Status' field).
-    std::atomic_thread_fence(std::memory_order_acquire);
-
-    return true;
-  }
-
-  low_latency_iocp_context::vectored_io_state*
-  low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
-    vectored_io_state* const pool = ioPool_.get();
-
-    std::ptrdiff_t offset =
-        reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
-    UNIFEX_ASSERT(offset >= 0);
-
-    std::ptrdiff_t index = offset / sizeof(vectored_io_state);
-    UNIFEX_ASSERT(index < static_cast<std::ptrdiff_t>(ioPoolSize_));
-
-    return &pool[index];
-  }
-
-  void low_latency_iocp_context::schedule(operation_base* op) noexcept {
-    if (is_running_on_io_thread()) {
-      schedule_local(op);
-    } else {
-      schedule_remote(op);
-    }
-  }
-
-  void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    readyQueue_.push_back(op);
-  }
-
-  void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
-    UNIFEX_ASSERT(!is_running_on_io_thread());
-    if (remoteQueue_.enqueue(op)) {
-      // I/O thread is potentially sleeping.
-      // Post a wake-up NOP event to the queue.
-
-      // BUGBUG: This could potentially fail and if it does then
-      // the I/O thread might never respond to remote enqueues.
-      // For now we just treat this as a (hopefully rare) unrecoverable error.
-      ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
-          iocp_.get(),
-          0,        // KeyContext
-          nullptr,  // ApcContext
-          0,        // NTSTATUS (0 = success)
-          0);       // IoStatusInformation
-      if (!ntapi::ntstatus_success(ntstat)) {
-        // Failed to post an event to the I/O completion port.
-        std::terminate();
-      }
-    }
-  }
-
-  bool low_latency_iocp_context::try_allocate_io_state_for(
-      io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-
-    if (ioFreeList_.empty()) {
-      return false;
+  while (!stopFlag) {
+process_ready_queue:
+    // Process/drain all ready-to-run work.
+    while (!readyQueue_.empty()) {
+      operation_base* task = readyQueue_.pop_front();
+      task->callback(task);
     }
 
-    UNIFEX_ASSERT(pendingIoQueue_.empty());
-
-    // An operation is already available
-    auto* state = ioFreeList_.pop_front();
-    state->parent = op;
-    state->completed = false;
-    state->operationCount = 0;
-    state->pendingCompletionNotifications = 0;
-    op->ioState = state;
-
-    return true;
-  }
-
-  void low_latency_iocp_context::schedule_when_io_state_available(
-      io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    UNIFEX_ASSERT(ioFreeList_.empty());
-    pendingIoQueue_.push_back(op);
-  }
-
-  void low_latency_iocp_context::release_io_state(
-      vectored_io_state* state) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-
-    if (state->pendingCompletionNotifications == 0) {
-      // Can be freed immediately.
-
-      if (pendingIoQueue_.empty()) {
-        ioFreeList_.push_front(state);
-      } else {
-        UNIFEX_ASSERT(ioFreeList_.empty());
-
-        // Another operation was waiting for an I/O state.
-        // Give the I/O state directly to the operation instead
-        // of adding it to the free-list. This prevents some other
-        // operation from skipping the queue and acquiring it
-        // before this I/O operation can run.
-        auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
-
-        state->parent = op;
-        state->completed = false;
-        state->operationCount = 0;
-        state->pendingCompletionNotifications = 0;
-        op->ioState = state;
-
-        schedule_local(op);
-      }
-    } else {
-      // Mark it to be freed once all of its I/O completion
-      // notifications have been received.
-      state->parent = nullptr;
-    }
-  }
-
-  void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    UNIFEX_ASSERT(op != nullptr);
-    UNIFEX_ASSERT(op->ioState != nullptr);
-
-    if (op->ioState->pendingCompletionNotifications > 0) {
-      pollQueue_.push_back(op);
-    } else {
-      // No need to poll, schedule straight to the front of the ready-to-run
-      // queue.
-      readyQueue_.push_front(op);
-    }
-  }
-
-  void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
-    const HANDLE result =
-        ::CreateIoCompletionPort(fileHandle, iocp_.get(), 0, 0);
-    if (result == nullptr) {
-      DWORD errorCode = ::GetLastError();
-      throw_(std::system_error{
-          static_cast<int>(errorCode),
-          std::system_category(),
-          "CreateIoCompletionPort"});
-    }
-
-    const BOOL ok = ::SetFileCompletionNotificationModes(
-        fileHandle,
-        FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE);
-    if (!ok) {
-      DWORD errorCode = ::GetLastError();
-      throw_(std::system_error{
-          static_cast<int>(errorCode),
-          std::system_category(),
-          "SetFileCompletionNotificationModes"});
-    }
-  }
-
-  void low_latency_iocp_context::io_operation::cancel_io() noexcept {
-    UNIFEX_ASSERT(ioState != nullptr);
-
-    // Cancel operations in reverse order so that later operations
-    // are cancelled first and don't accidentally end up with earlier
-    // operations being cancelled and later ones completing due to
-    // a race.
-    for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
-      ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
-      ntapi::IO_STATUS_BLOCK ioStatus;
-      [[maybe_unused]] ntapi::NTSTATUS ntstat =
-          ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
-      // TODO: Check ntstat for failure.
-      // Can't really do much here even if there is failure, anyway.
-    }
-  }
-
-  bool low_latency_iocp_context::io_operation::is_complete() noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-
-    if (ioState->pendingCompletionNotifications == 0) {
-      return true;
-    }
-
-    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-      volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
-
-      // Mark volatile to indicate to the compiler that it might change in the
-      // background. The kernel might update it as the I/O completes.
-      if (iosb->Status == STATUS_PENDING) {
-        return false;
-      }
-    }
-
-    // Make sure that we have visibility of the results of all of the I/O
-    // operations.
-    // Assuming that the OS used a "release" memory semantic when writing
-    // to the 'Status' field here.
-    std::atomic_thread_fence(std::memory_order_acquire);
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::io_operation::start_read(
-      span<std::byte> buffer) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
-
-    std::size_t offset = 0;
-    while (offset < buffer.size()) {
-      ntapi::IO_STATUS_BLOCK& iosb =
-          ioState->operations[ioState->operationCount];
-      ++ioState->operationCount;
-
-      iosb.Status = STATUS_PENDING;
-      iosb.Information = 0;
-
-      // Truncate over-large chunks to a number of bytes that will still
-      // preserve alignment requirements of the underlying device if this
-      // happens to be an unbuffered storage device.
-      // In this case we truncate to the largest multiple of 64k less than
-      // 2^32 to allow for up to 64k alignment.
-      // TODO: Ideally we'd just use the underlying alignment of the
-      // file-handle.
-      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
-
-      std::size_t chunkSize = buffer.size() - offset;
-      if (chunkSize > maxChunkSize) {
-        chunkSize = truncatedChunkSize;
-      }
-
-      ntapi::NTSTATUS status = ntapi::NtReadFile(
-          fileHandle,
-          NULL,                                  // Event
-          NULL,                                  // ApcRoutine
-          &iosb,                                 // ApcContext
-          &iosb,                                 // IoStatusBlock
-          buffer.data() + offset,                // Buffer
-          static_cast<ntapi::ULONG>(chunkSize),  // Length
-          nullptr,                               // ByteOffset
-          nullptr);                              // Key
-      if (status == STATUS_PENDING) {
-        ++ioState->pendingCompletionNotifications;
-      } else if (ntapi::ntstatus_success(status)) {
-        // Succeeded synchronously.
-        if (!skipNotificationOnSuccess) {
-          ++ioState->pendingCompletionNotifications;
-        }
-      } else {
-        // Immediate failure.
-        // Don't launch any more operations.
-        // TODO: Should we cancel any prior launched operations?
-        return false;
-      }
-
-      if (ioState->operationCount == max_vectored_io_size) {
-        // We've launched as many operations as we can.
-        return false;
-      }
-
-      offset += chunkSize;
-    }
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::io_operation::start_write(
-      span<const std::byte> buffer) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
-
-    std::size_t offset = 0;
-    while (offset < buffer.size()) {
-      ntapi::IO_STATUS_BLOCK& iosb =
-          ioState->operations[ioState->operationCount];
-      ++ioState->operationCount;
-
-      iosb.Status = STATUS_PENDING;
-      iosb.Information = 0;
-
-      // Truncate over-large chunks to a number of bytes that will still
-      // preserve alignment requirements of the underlying device if this
-      // happens to be an unbuffered storage device.
-      // In this case we truncate to the largest multiple of 64k less than
-      // 2^32 to allow for up to 64k alignment.
-      // TODO: Ideally we'd just use the underlying alignment of the
-      // file-handle.
-      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
-
-      std::size_t chunkSize = buffer.size() - offset;
-      if (chunkSize > maxChunkSize) {
-        chunkSize = truncatedChunkSize;
-      }
-
-      ntapi::NTSTATUS status = ntapi::NtWriteFile(
-          fileHandle,
-          NULL,                                            // Event
-          NULL,                                            // ApcRoutine
-          &iosb,                                           // ApcContext
-          &iosb,                                           // IoStatusBlock
-          const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
-          static_cast<ntapi::ULONG>(chunkSize),            // Length
-          nullptr,                                         // ByteOffset
-          nullptr);                                        // Key
-      if (status == STATUS_PENDING) {
-        ++ioState->pendingCompletionNotifications;
-      } else if (ntapi::ntstatus_success(status)) {
-        // Succeeded synchronously.
-        if (!skipNotificationOnSuccess) {
-          ++ioState->pendingCompletionNotifications;
-        }
-      } else {
-        // Immediate failure.
-        // Don't launch any more operations.
-        // TODO: Should we cancel any prior launched operations?
-        return false;
-      }
-
-      if (ioState->operationCount == max_vectored_io_size) {
-        return false;
-      }
-
-      offset += chunkSize;
-    }
-
-    return true;
-  }
-
-  std::size_t low_latency_iocp_context::io_operation::get_result(
-      std::error_code& ec) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->completed);
-
-    ec = std::error_code{};
-
-    std::size_t totalBytesTransferred = 0;
-    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-      const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
-
-      UNIFEX_ASSERT(iosb.Status != STATUS_PENDING);
-
-      totalBytesTransferred += iosb.Information;
-
-      if (!ntapi::ntstatus_success(iosb.Status)) {
-        ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
-        ec = std::error_code(
-            static_cast<int>(errorCode), std::system_category());
-        break;
-      }
-    }
-
-    return totalBytesTransferred;
-  }
-
-  std::tuple<
-      low_latency_iocp_context::readable_byte_stream,
-      low_latency_iocp_context::writable_byte_stream>
-  low_latency_iocp_context::scheduler::open_pipe_impl(
-      low_latency_iocp_context& context) {
-    std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
-
-    safe_handle serverHandle;
-
-    auto toHex = [](std::uint8_t value) noexcept -> char {
-      return value < 10 ? char('0' + value) : char('a' - 10 + value);
-    };
-
-    char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
-
-    // Try to create the server side of a new named pipe
-    // Use a randomly generated name to ensure uniqueness.
-
-    const DWORD pipeBufferSize = 16 * 1024;
-    const int maxAttempts = 100;
-
-    for (int attempt = 1;; ++attempt) {
-      const std::uint64_t randomNumber = rand();
-      for (int i = 0; i < 16; ++i) {
-        pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
-      }
-      pipeName[25] = '\0';
-
-      HANDLE pipe = ::CreateNamedPipeA(
-          pipeName,
-          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED |
-              FILE_FLAG_FIRST_PIPE_INSTANCE,
-          PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS |
-              PIPE_WAIT,
-          1,               // nMaxInstances
-          0,               // nOutBufferSize
-          pipeBufferSize,  // nInBufferSize
-          0,               // nDefaultTimeout
-          nullptr);        // lpSecurityAttributes
-      if (pipe == INVALID_HANDLE_VALUE) {
-        DWORD errorCode = ::GetLastError();
-        if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
-          // Try again with a different random name
-          continue;
-        }
-
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "open_pipe: CreateNamedPipe"});
-      }
-
-      serverHandle = safe_handle{pipe};
+    // Check whether the stop request was processed
+    // when draining the ready queue.
+    if (stopFlag) {
       break;
     }
 
-    // Open the client-side of this named-pipe
-    safe_handle clientHandle{::CreateFileA(
-        pipeName,
-        GENERIC_WRITE,
-        0,              // dwShareMode
-        nullptr,        // lpSecurityAttributes
-        OPEN_EXISTING,  // dwCreationDisposition
-        FILE_FLAG_OVERLAPPED,
-        nullptr)};
-    if (clientHandle == INVALID_HANDLE_VALUE) {
-      DWORD errorCode = ::GetLastError();
+    // Check the poll-queue for I/O operations that might have completed
+    // already but where we have not yet seen the IOCP event.
+
+    while (!pollQueue_.empty()) {
+      io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
+      auto* state = op->ioState;
+      UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
+      UNIFEX_ASSERT(!state->completed);
+
+      if (poll_is_complete(*state)) {
+        // Completed before we received any notifications via IOCP.
+        // Schedule it to resume now, before polling any other I/Os
+        // to give those other I/Os time to complete.
+        state->completed = true;
+        schedule_local(state->parent);
+        goto process_ready_queue;
+      }
+    }
+
+process_remote_queue:
+    if (shouldCheckRemoteQueue) {
+      if (try_dequeue_remote_work()) {
+        goto process_ready_queue;
+      }
+    }
+
+    // Now check if there are any IOCP events.
+get_iocp_entries:
+    const ntapi::BOOLEAN alertable = FALSE;
+    ntapi::ULONG completionEntriesRetrieved = 0;
+    ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
+        iocp_.get(),
+        completionBuffer,
+        completionBufferSize,
+        &completionEntriesRetrieved,
+        shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
+        alertable);
+    if (ntstat == STATUS_TIMEOUT) {
+      UNIFEX_ASSERT(shouldCheckRemoteQueue);
+
+      // Previous call was non-blocking.
+      // About to transition to blocking-call, but first need to
+      // mark remote queue inactive so that remote threads know
+      // they need to post an event to wake this thread up.
+      if (remoteQueue_.try_mark_inactive()) {
+        shouldCheckRemoteQueue = false;
+        goto get_iocp_entries;
+      } else {
+        goto process_remote_queue;
+      }
+    } else if (!ntapi::ntstatus_success(ntstat)) {
+      DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
       throw_(std::system_error{
           static_cast<int>(errorCode),
           std::system_category(),
-          "open_pipe: CreateFile"});
+          "NtRemoveIoCompletionEx()"});
     }
 
-    context.associate_file_handle(serverHandle.get());
-    context.associate_file_handle(clientHandle.get());
+    // Process completion-entries we received from the OS.
+    for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
+      ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
+      if (entry.ApcContext != nullptr) {
+        ntapi::IO_STATUS_BLOCK* iosb =
+            reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
+        // TODO: Do we need to store the error-code/bytes-transferred here?
+        // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
+        // Should we be copying entry.IoStatusBlock to '*iosb'?
 
-    return {
-        readable_byte_stream{context, std::move(serverHandle)},
-        writable_byte_stream{context, std::move(clientHandle)}};
+        UNIFEX_ASSERT(iosb->Status != STATUS_PENDING);
+
+        vectored_io_state* state = to_io_state(iosb);
+
+        UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
+        if (--state->pendingCompletionNotifications == 0) {
+          // This was the last pending notification for this state.
+          if (state->parent != nullptr) {
+            // An operation is still attached to this state.
+            // Notify it if we hadn't already done so.
+            if (!state->completed) {
+              state->completed = true;
+              schedule_local(state->parent);
+            }
+          } else {
+            // Otherwise the operation has already detached
+            // from this I/O state and so we can immediately
+            // return it to the pool.
+            release_io_state(state);
+          }
+        }
+      } else {
+        // A remote-thread wake-up notification.
+        shouldCheckRemoteQueue = true;
+      }
+    }
   }
+}
+
+bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
+  auto items = remoteQueue_.dequeue_all_reversed();
+  if (items.empty()) {
+    return false;
+  }
+
+  // Note that this ends up enqueueing entries in reverse.
+  // TODO: Modify this so it enqueues items in a way that
+  // preserves order.
+  do {
+    schedule_local(items.pop_front());
+  } while (!items.empty());
+
+  return true;
+}
+
+bool low_latency_iocp_context::poll_is_complete(
+    vectored_io_state& state) noexcept {
+  // TODO: Double check the memory barriers/atomics we need to use
+  // here to ensure we perform this read, that it doesn't tear and
+  // that it has the appropriate memory semantics.
+
+  for (std::size_t i = 0; i < state.operationCount; ++i) {
+    // Mark volatile to indicate to the compiler that it might change in the
+    // background. The kernel might update it as the I/O completes.
+    volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
+    if (iosb->Status == STATUS_PENDING) {
+      return false;
+    }
+  }
+
+  // Make sure that we have visibility of the results of the I/O operations
+  // (assuming that the OS used a "release" memory semantic when writing
+  // to the 'Status' field).
+  std::atomic_thread_fence(std::memory_order_acquire);
+
+  return true;
+}
+
+low_latency_iocp_context::vectored_io_state*
+low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
+  vectored_io_state* const pool = ioPool_.get();
+
+  std::ptrdiff_t offset =
+      reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
+  UNIFEX_ASSERT(offset >= 0);
+
+  std::ptrdiff_t index = offset / sizeof(vectored_io_state);
+  UNIFEX_ASSERT(index < static_cast<std::ptrdiff_t>(ioPoolSize_));
+
+  return &pool[index];
+}
+
+void low_latency_iocp_context::schedule(operation_base* op) noexcept {
+  if (is_running_on_io_thread()) {
+    schedule_local(op);
+  } else {
+    schedule_remote(op);
+  }
+}
+
+void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  readyQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
+  UNIFEX_ASSERT(!is_running_on_io_thread());
+  if (remoteQueue_.enqueue(op)) {
+    // I/O thread is potentially sleeping.
+    // Post a wake-up NOP event to the queue.
+
+    // BUGBUG: This could potentially fail and if it does then
+    // the I/O thread might never respond to remote enqueues.
+    // For now we just treat this as a (hopefully rare) unrecoverable error.
+    ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
+        iocp_.get(),
+        0,        // KeyContext
+        nullptr,  // ApcContext
+        0,        // NTSTATUS (0 = success)
+        0);       // IoStatusInformation
+    if (!ntapi::ntstatus_success(ntstat)) {
+      // Failed to post an event to the I/O completion port.
+      std::terminate();
+    }
+  }
+}
+
+bool low_latency_iocp_context::try_allocate_io_state_for(
+    io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+
+  if (ioFreeList_.empty()) {
+    return false;
+  }
+
+  UNIFEX_ASSERT(pendingIoQueue_.empty());
+
+  // An operation is already available
+  auto* state = ioFreeList_.pop_front();
+  state->parent = op;
+  state->completed = false;
+  state->operationCount = 0;
+  state->pendingCompletionNotifications = 0;
+  op->ioState = state;
+
+  return true;
+}
+
+void low_latency_iocp_context::schedule_when_io_state_available(
+    io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  UNIFEX_ASSERT(ioFreeList_.empty());
+  pendingIoQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::release_io_state(
+    vectored_io_state* state) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+
+  if (state->pendingCompletionNotifications == 0) {
+    // Can be freed immediately.
+
+    if (pendingIoQueue_.empty()) {
+      ioFreeList_.push_front(state);
+    } else {
+      UNIFEX_ASSERT(ioFreeList_.empty());
+
+      // Another operation was waiting for an I/O state.
+      // Give the I/O state directly to the operation instead
+      // of adding it to the free-list. This prevents some other
+      // operation from skipping the queue and acquiring it
+      // before this I/O operation can run.
+      auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
+
+      state->parent = op;
+      state->completed = false;
+      state->operationCount = 0;
+      state->pendingCompletionNotifications = 0;
+      op->ioState = state;
+
+      schedule_local(op);
+    }
+  } else {
+    // Mark it to be freed once all of its I/O completion
+    // notifications have been received.
+    state->parent = nullptr;
+  }
+}
+
+void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  UNIFEX_ASSERT(op != nullptr);
+  UNIFEX_ASSERT(op->ioState != nullptr);
+
+  if (op->ioState->pendingCompletionNotifications > 0) {
+    pollQueue_.push_back(op);
+  } else {
+    // No need to poll, schedule straight to the front of the ready-to-run
+    // queue.
+    readyQueue_.push_front(op);
+  }
+}
+
+void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
+  const HANDLE result = ::CreateIoCompletionPort(fileHandle, iocp_.get(), 0, 0);
+  if (result == nullptr) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "CreateIoCompletionPort"});
+  }
+
+  const BOOL ok = ::SetFileCompletionNotificationModes(
+      fileHandle,
+      FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE);
+  if (!ok) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "SetFileCompletionNotificationModes"});
+  }
+}
+
+void low_latency_iocp_context::io_operation::cancel_io() noexcept {
+  UNIFEX_ASSERT(ioState != nullptr);
+
+  // Cancel operations in reverse order so that later operations
+  // are cancelled first and don't accidentally end up with earlier
+  // operations being cancelled and later ones completing due to
+  // a race.
+  for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
+    ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
+    ntapi::IO_STATUS_BLOCK ioStatus;
+    [[maybe_unused]] ntapi::NTSTATUS ntstat =
+        ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
+    // TODO: Check ntstat for failure.
+    // Can't really do much here even if there is failure, anyway.
+  }
+}
+
+bool low_latency_iocp_context::io_operation::is_complete() noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+
+  if (ioState->pendingCompletionNotifications == 0) {
+    return true;
+  }
+
+  for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+    volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
+
+    // Mark volatile to indicate to the compiler that it might change in the
+    // background. The kernel might update it as the I/O completes.
+    if (iosb->Status == STATUS_PENDING) {
+      return false;
+    }
+  }
+
+  // Make sure that we have visibility of the results of all of the I/O
+  // operations.
+  // Assuming that the OS used a "release" memory semantic when writing
+  // to the 'Status' field here.
+  std::atomic_thread_fence(std::memory_order_acquire);
+
+  return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_read(
+    span<std::byte> buffer) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
+
+  std::size_t offset = 0;
+  while (offset < buffer.size()) {
+    ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[ioState->operationCount];
+    ++ioState->operationCount;
+
+    iosb.Status = STATUS_PENDING;
+    iosb.Information = 0;
+
+    // Truncate over-large chunks to a number of bytes that will still
+    // preserve alignment requirements of the underlying device if this
+    // happens to be an unbuffered storage device.
+    // In this case we truncate to the largest multiple of 64k less than
+    // 2^32 to allow for up to 64k alignment.
+    // TODO: Ideally we'd just use the underlying alignment of the
+    // file-handle.
+    static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+    static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+    std::size_t chunkSize = buffer.size() - offset;
+    if (chunkSize > maxChunkSize) {
+      chunkSize = truncatedChunkSize;
+    }
+
+    ntapi::NTSTATUS status = ntapi::NtReadFile(
+        fileHandle,
+        NULL,                                  // Event
+        NULL,                                  // ApcRoutine
+        &iosb,                                 // ApcContext
+        &iosb,                                 // IoStatusBlock
+        buffer.data() + offset,                // Buffer
+        static_cast<ntapi::ULONG>(chunkSize),  // Length
+        nullptr,                               // ByteOffset
+        nullptr);                              // Key
+    if (status == STATUS_PENDING) {
+      ++ioState->pendingCompletionNotifications;
+    } else if (ntapi::ntstatus_success(status)) {
+      // Succeeded synchronously.
+      if (!skipNotificationOnSuccess) {
+        ++ioState->pendingCompletionNotifications;
+      }
+    } else {
+      // Immediate failure.
+      // Don't launch any more operations.
+      // TODO: Should we cancel any prior launched operations?
+      return false;
+    }
+
+    if (ioState->operationCount == max_vectored_io_size) {
+      // We've launched as many operations as we can.
+      return false;
+    }
+
+    offset += chunkSize;
+  }
+
+  return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_write(
+    span<const std::byte> buffer) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
+
+  std::size_t offset = 0;
+  while (offset < buffer.size()) {
+    ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[ioState->operationCount];
+    ++ioState->operationCount;
+
+    iosb.Status = STATUS_PENDING;
+    iosb.Information = 0;
+
+    // Truncate over-large chunks to a number of bytes that will still
+    // preserve alignment requirements of the underlying device if this
+    // happens to be an unbuffered storage device.
+    // In this case we truncate to the largest multiple of 64k less than
+    // 2^32 to allow for up to 64k alignment.
+    // TODO: Ideally we'd just use the underlying alignment of the
+    // file-handle.
+    static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+    static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+    std::size_t chunkSize = buffer.size() - offset;
+    if (chunkSize > maxChunkSize) {
+      chunkSize = truncatedChunkSize;
+    }
+
+    ntapi::NTSTATUS status = ntapi::NtWriteFile(
+        fileHandle,
+        NULL,                                            // Event
+        NULL,                                            // ApcRoutine
+        &iosb,                                           // ApcContext
+        &iosb,                                           // IoStatusBlock
+        const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
+        static_cast<ntapi::ULONG>(chunkSize),            // Length
+        nullptr,                                         // ByteOffset
+        nullptr);                                        // Key
+    if (status == STATUS_PENDING) {
+      ++ioState->pendingCompletionNotifications;
+    } else if (ntapi::ntstatus_success(status)) {
+      // Succeeded synchronously.
+      if (!skipNotificationOnSuccess) {
+        ++ioState->pendingCompletionNotifications;
+      }
+    } else {
+      // Immediate failure.
+      // Don't launch any more operations.
+      // TODO: Should we cancel any prior launched operations?
+      return false;
+    }
+
+    if (ioState->operationCount == max_vectored_io_size) {
+      return false;
+    }
+
+    offset += chunkSize;
+  }
+
+  return true;
+}
+
+std::size_t low_latency_iocp_context::io_operation::get_result(
+    std::error_code& ec) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->completed);
+
+  ec = std::error_code{};
+
+  std::size_t totalBytesTransferred = 0;
+  for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+    const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
+
+    UNIFEX_ASSERT(iosb.Status != STATUS_PENDING);
+
+    totalBytesTransferred += iosb.Information;
+
+    if (!ntapi::ntstatus_success(iosb.Status)) {
+      ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
+      ec = std::error_code(static_cast<int>(errorCode), std::system_category());
+      break;
+    }
+  }
+
+  return totalBytesTransferred;
+}
+
+std::tuple<
+    low_latency_iocp_context::readable_byte_stream,
+    low_latency_iocp_context::writable_byte_stream>
+low_latency_iocp_context::scheduler::open_pipe_impl(
+    low_latency_iocp_context& context) {
+  std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
+
+  safe_handle serverHandle;
+
+  auto toHex = [](std::uint8_t value) noexcept -> char {
+    return value < 10 ? char('0' + value) : char('a' - 10 + value);
+  };
+
+  char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
+
+  // Try to create the server side of a new named pipe
+  // Use a randomly generated name to ensure uniqueness.
+
+  const DWORD pipeBufferSize = 16 * 1024;
+  const int maxAttempts = 100;
+
+  for (int attempt = 1;; ++attempt) {
+    const std::uint64_t randomNumber = rand();
+    for (int i = 0; i < 16; ++i) {
+      pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
+    }
+    pipeName[25] = '\0';
+
+    HANDLE pipe = ::CreateNamedPipeA(
+        pipeName,
+        PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED |
+            FILE_FLAG_FIRST_PIPE_INSTANCE,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS |
+            PIPE_WAIT,
+        1,               // nMaxInstances
+        0,               // nOutBufferSize
+        pipeBufferSize,  // nInBufferSize
+        0,               // nDefaultTimeout
+        nullptr);        // lpSecurityAttributes
+    if (pipe == INVALID_HANDLE_VALUE) {
+      DWORD errorCode = ::GetLastError();
+      if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
+        // Try again with a different random name
+        continue;
+      }
+
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "open_pipe: CreateNamedPipe"});
+    }
+
+    serverHandle = safe_handle{pipe};
+    break;
+  }
+
+  // Open the client-side of this named-pipe
+  safe_handle clientHandle{::CreateFileA(
+      pipeName,
+      GENERIC_WRITE,
+      0,              // dwShareMode
+      nullptr,        // lpSecurityAttributes
+      OPEN_EXISTING,  // dwCreationDisposition
+      FILE_FLAG_OVERLAPPED,
+      nullptr)};
+  if (clientHandle == INVALID_HANDLE_VALUE) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "open_pipe: CreateFile"});
+  }
+
+  context.associate_file_handle(serverHandle.get());
+  context.associate_file_handle(clientHandle.get());
+
+  return {
+      readable_byte_stream{context, std::move(serverHandle)},
+      writable_byte_stream{context, std::move(clientHandle)}};
+}
 
 }  // namespace unifex::win32

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -21,45 +21,44 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-namespace unifex::win32::ntapi
-{
-  NtCreateFile_t NtCreateFile = nullptr;
-  NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
-  NtReadFile_t NtReadFile = nullptr;
-  NtWriteFile_t NtWriteFile = nullptr;
-  NtSetIoCompletion_t NtSetIoCompletion = nullptr;
-  NtRemoveIoCompletion_t NtRemoveIoCompletion = nullptr;
-  NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx = nullptr;
-  RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
+namespace unifex::win32::ntapi {
+NtCreateFile_t NtCreateFile = nullptr;
+NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
+NtReadFile_t NtReadFile = nullptr;
+NtWriteFile_t NtWriteFile = nullptr;
+NtSetIoCompletion_t NtSetIoCompletion = nullptr;
+NtRemoveIoCompletion_t NtRemoveIoCompletion = nullptr;
+NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx = nullptr;
+RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
 
-  static void do_initialisation() noexcept {
-    HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
-    if (ntdll == NULL) {
+static void do_initialisation() noexcept {
+  HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) {
+    std::terminate();
+  }
+
+  auto init = [&](auto& fnPtr, const char* name) noexcept {
+    FARPROC p = ::GetProcAddress(ntdll, name);
+    if (p == NULL) {
       std::terminate();
     }
+    fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
+        reinterpret_cast<void (*)()>(p));
+  };
 
-    auto init = [&](auto& fnPtr, const char* name) noexcept {
-      FARPROC p = ::GetProcAddress(ntdll, name);
-      if (p == NULL) {
-        std::terminate();
-      }
-      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
-        reinterpret_cast<void(*)()>(p));
-    };
+  init(NtCreateFile, "NtCreateFile");
+  init(NtCancelIoFileEx, "NtCancelIoFileEx");
+  init(NtReadFile, "NtReadFile");
+  init(NtWriteFile, "NtWriteFile");
+  init(NtSetIoCompletion, "NtSetIoCompletion");
+  init(NtRemoveIoCompletion, "NtRemoveIoCompletion");
+  init(NtRemoveIoCompletionEx, "NtRemoveIoCompletionEx");
+  init(RtlNtStatusToDosError, "RtlNtStatusToDosError");
+}
 
-    init(NtCreateFile, "NtCreateFile");
-    init(NtCancelIoFileEx, "NtCancelIoFileEx");
-    init(NtReadFile, "NtReadFile");
-    init(NtWriteFile, "NtWriteFile");
-    init(NtSetIoCompletion, "NtSetIoCompletion");
-    init(NtRemoveIoCompletion, "NtRemoveIoCompletion");
-    init(NtRemoveIoCompletionEx, "NtRemoveIoCompletionEx");
-    init(RtlNtStatusToDosError, "RtlNtStatusToDosError");
-  }
-
-  void ensure_initialised() noexcept {
-    static struct initialiser {
-      initialiser() noexcept { do_initialisation(); }
-    } dummy;
-  }
+void ensure_initialised() noexcept {
+  static struct initialiser {
+    initialiser() noexcept { do_initialisation(); }
+  } dummy;
+}
 }  // namespace unifex::win32::ntapi

--- a/source/win32/safe_handle.cpp
+++ b/source/win32/safe_handle.cpp
@@ -22,10 +22,10 @@
 namespace unifex::win32 {
 
 void safe_handle::reset() noexcept {
-    handle_t h = std::exchange(handle_, nullptr);
-    if (h != nullptr && h != INVALID_HANDLE_VALUE) {
-        ::CloseHandle(h);
-    }
+  handle_t h = std::exchange(handle_, nullptr);
+  if (h != nullptr && h != INVALID_HANDLE_VALUE) {
+    ::CloseHandle(h);
+  }
 }
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,27 @@
-# Copyright (c) 2019-present, Facebook, Inc.
+#Copyright(c) 2019 - present, Facebook, Inc.
 #
-# This source code is licensed under the license found in the
-# LICENSE.txt file in the root directory of this source tree.
+#This source code is licensed under the license found in the
+#LICENSE.txt file in the root directory of this source tree.
 
-file(GLOB test-sources "*_test.cpp")
-foreach(file-path ${test-sources})
-    string( REPLACE ".cpp" "" file-path-without-ext ${file-path} )
-    get_filename_component(file-name ${file-path-without-ext} NAME)
-    add_executable( ${file-name} ${file-path})
-    target_link_libraries(${file-name} PUBLIC unifex gtest_main)
-    add_test(NAME "test-${file-name}" COMMAND ${file-name})
-endforeach()
+file(GLOB test - sources "*_test.cpp") foreach (file - path ${test - sources})
+    string(
+        REPLACE ".cpp"
+                "" file -
+        path - without - ext ${file - path})
+        get_filename_component(file - name ${file - path - without - ext} NAME)
+            add_executable(${file - name} ${file - path}) target_link_libraries(
+                ${file - name} PUBLIC unifex
+                    gtest_main) add_test(NAME "test-${file-name}" COMMAND ${
+                file - name}) endforeach()
 
-if(CXX_MEMORY_RESOURCE_HAVE_PMR)
-  target_link_libraries(any_unique_test PUBLIC std::memory_resource)
-  target_link_libraries(submit_allocator_customisation_test PUBLIC std::memory_resource)
-endif()
+                if (CXX_MEMORY_RESOURCE_HAVE_PMR) target_link_libraries(
+                    any_unique_test PUBLIC std::memory_resource)
+                    target_link_libraries(
+                        submit_allocator_customisation_test PUBLIC
+                            std::memory_resource) endif()
 
-target_link_libraries(any_sender_of_test PUBLIC gmock)
-target_link_libraries(async_manual_reset_event_test PUBLIC gmock)
-target_link_libraries(async_scope_test PUBLIC gmock)
+                        target_link_libraries(any_sender_of_test PUBLIC gmock)
+                            target_link_libraries(
+                                async_manual_reset_event_test PUBLIC gmock)
+                                target_link_libraries(
+                                    async_scope_test PUBLIC gmock)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,27 +1,22 @@
-#Copyright(c) 2019 - present, Facebook, Inc.
+# Copyright (c) 2019-present, Facebook, Inc.
 #
-#This source code is licensed under the license found in the
-#LICENSE.txt file in the root directory of this source tree.
+# This source code is licensed under the license found in the
+# LICENSE.txt file in the root directory of this source tree.
 
-file(GLOB test - sources "*_test.cpp") foreach (file - path ${test - sources})
-    string(
-        REPLACE ".cpp"
-                "" file -
-        path - without - ext ${file - path})
-        get_filename_component(file - name ${file - path - without - ext} NAME)
-            add_executable(${file - name} ${file - path}) target_link_libraries(
-                ${file - name} PUBLIC unifex
-                    gtest_main) add_test(NAME "test-${file-name}" COMMAND ${
-                file - name}) endforeach()
+file(GLOB test-sources "*_test.cpp")
+foreach(file-path ${test-sources})
+    string( REPLACE ".cpp" "" file-path-without-ext ${file-path} )
+    get_filename_component(file-name ${file-path-without-ext} NAME)
+    add_executable( ${file-name} ${file-path})
+    target_link_libraries(${file-name} PUBLIC unifex gtest_main)
+    add_test(NAME "test-${file-name}" COMMAND ${file-name})
+endforeach()
 
-                if (CXX_MEMORY_RESOURCE_HAVE_PMR) target_link_libraries(
-                    any_unique_test PUBLIC std::memory_resource)
-                    target_link_libraries(
-                        submit_allocator_customisation_test PUBLIC
-                            std::memory_resource) endif()
+if(CXX_MEMORY_RESOURCE_HAVE_PMR)
+  target_link_libraries(any_unique_test PUBLIC std::memory_resource)
+  target_link_libraries(submit_allocator_customisation_test PUBLIC std::memory_resource)
+endif()
 
-                        target_link_libraries(any_sender_of_test PUBLIC gmock)
-                            target_link_libraries(
-                                async_manual_reset_event_test PUBLIC gmock)
-                                target_link_libraries(
-                                    async_scope_test PUBLIC gmock)
+target_link_libraries(any_sender_of_test PUBLIC gmock)
+target_link_libraries(async_manual_reset_event_test PUBLIC gmock)
+target_link_libraries(async_scope_test PUBLIC gmock)

--- a/test/allocate_test.cpp
+++ b/test/allocate_test.cpp
@@ -15,10 +15,10 @@
  */
 
 #include <unifex/allocate.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/single_thread_context.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
-#include <unifex/scheduler_concepts.hpp>
 
 #include <array>
 #include <cstdio>
@@ -33,8 +33,7 @@ TEST(Allocate, Smoke) {
   auto thread = threadContext.get_scheduler();
   int count = 0;
 
-  sync_wait(allocate(then(
-      schedule(thread), [&] { ++count; })));
+  sync_wait(allocate(then(schedule(thread), [&] { ++count; })));
 
   EXPECT_EQ(count, 1);
 }
@@ -45,10 +44,7 @@ TEST(Allocate, Pipeable) {
   auto thread = threadContext.get_scheduler();
   int count = 0;
 
-  schedule(thread)
-    | then([&] { ++count; })
-    | allocate()
-    | sync_wait();
+  schedule(thread) | then([&] { ++count; }) | allocate() | sync_wait();
 
   EXPECT_EQ(count, 1);
 }

--- a/test/any_scheduler_test.cpp
+++ b/test/any_scheduler_test.cpp
@@ -18,8 +18,8 @@
 
 #include <unifex/inline_scheduler.hpp>
 #include <unifex/single_thread_context.hpp>
-#include <unifex/then.hpp>
 #include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
 
 #include <gtest/gtest.h>
 
@@ -49,7 +49,7 @@ TEST(AnySchedulerTest, EqualityComparable) {
 TEST(AnySchedulerTest, Schedule) {
   any_scheduler sched = inline_scheduler{};
   int i = 0;
-  sync_wait(then(schedule(sched), [&]{ ++i; }));
+  sync_wait(then(schedule(sched), [&] { ++i; }));
   EXPECT_EQ(i, 1);
 }
 
@@ -58,6 +58,6 @@ TEST(AnySchedulerRefTest, Schedule) {
   inline_scheduler sched{};
   any_scheduler_ref schedRef = sched;
   int i = 0;
-  sync_wait(then(schedule(schedRef), [&]{ ++i; }));
+  sync_wait(then(schedule(schedRef), [&] { ++i; }));
   EXPECT_EQ(i, 1);
 }

--- a/test/any_sender_of_test.cpp
+++ b/test/any_sender_of_test.cpp
@@ -15,21 +15,21 @@
  */
 #include <unifex/any_sender_of.hpp>
 
+#include <unifex/any_scheduler.hpp>
 #include <unifex/finally.hpp>
+#include <unifex/inline_scheduler.hpp>
 #include <unifex/just.hpp>
 #include <unifex/ready_done_sender.hpp>
 #include <unifex/then.hpp>
-#include <unifex/inline_scheduler.hpp>
-#include <unifex/any_scheduler.hpp>
 
 #include "mock_receiver.hpp"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
+#include <unifex/variant.hpp>
 #include <string>
 #include <tuple>
-#include <unifex/variant.hpp>
 
 using namespace unifex;
 using namespace unifex_test;
@@ -63,19 +63,19 @@ struct AnySenderOfTestImpl : Test {
 
   static_assert(typed_sender<any_sender>);
   static_assert(sender_to<any_sender, mock_receiver<void(T...)>>);
-  static_assert(std::is_same_v<variant<std::tuple<T...>>,
-                               sender_value_types_t<any_sender, variant, std::tuple>>);
-  static_assert(std::is_same_v<variant<std::exception_ptr>,
-                               sender_error_types_t<any_sender, variant>>);
+  static_assert(std::is_same_v<
+                variant<std::tuple<T...>>,
+                sender_value_types_t<any_sender, variant, std::tuple>>);
+  static_assert(std::is_same_v<
+                variant<std::exception_ptr>,
+                sender_error_types_t<any_sender, variant>>);
 
   static auto default_just() {
     if constexpr (value_count == 0) {
       return just();
-    }
-    else if constexpr (value_count == 1) {
+    } else if constexpr (value_count == 1) {
       return just(42);
-    }
-    else if constexpr (value_count == 2) {
+    } else if constexpr (value_count == 2) {
       return just(42, std::string{"hello"});
     }
   }
@@ -84,11 +84,9 @@ struct AnySenderOfTestImpl : Test {
   static auto& expect_set_value_call(U& receiver) noexcept {
     if constexpr (value_count == 0) {
       return EXPECT_CALL(receiver, set_value());
-    }
-    else if constexpr (value_count == 1) {
+    } else if constexpr (value_count == 1) {
       return EXPECT_CALL(receiver, set_value(_));
-    }
-    else if constexpr (value_count == 2) {
+    } else if constexpr (value_count == 2) {
       return EXPECT_CALL(receiver, set_value(_, _));
     }
   }
@@ -98,14 +96,11 @@ template <typename Sig>
 struct AnySenderOfTest;
 
 template <typename... Ts>
-struct AnySenderOfTest<void(Ts...)>
-  : AnySenderOfTestImpl<false, Ts...>
-{};
+struct AnySenderOfTest<void(Ts...)> : AnySenderOfTestImpl<false, Ts...> {};
 
 template <typename... Ts>
 struct AnySenderOfTest<void(Ts...) noexcept>
-  : AnySenderOfTestImpl<true, Ts...>
-{};
+  : AnySenderOfTestImpl<true, Ts...> {};
 
 using AnySenderOfTestTypes = Types<
     void(),
@@ -117,7 +112,10 @@ using AnySenderOfTestTypes = Types<
 
 TYPED_TEST_SUITE(AnySenderOfTest, AnySenderOfTestTypes, );
 
-template <typename SenderSig, typename ReceiverSig = SenderSig, typename... ExtraReceiverSigs>
+template <
+    typename SenderSig,
+    typename ReceiverSig = SenderSig,
+    typename... ExtraReceiverSigs>
 void testWrappingAJust() noexcept {
   using test_t = AnySenderOfTest<SenderSig>;
   using any_sender = typename test_t::any_sender;
@@ -128,29 +126,35 @@ void testWrappingAJust() noexcept {
 
   auto op = connect(std::move(sender), receiver);
 
-  test_t::expect_set_value_call(*receiver)
-      .WillOnce(Invoke([](auto... values) noexcept {
+  test_t::expect_set_value_call(*receiver).WillOnce(
+      Invoke([](auto... values) noexcept {
         if constexpr (test_t::value_count == 0) {
           EXPECT_EQ(std::tuple{}, std::tie(values...));
         } else if constexpr (test_t::value_count == 1) {
           EXPECT_EQ(std::tuple{42}, std::tie(values...));
         } else {
           static_assert(test_t::value_count == 2, "Unimplemented");
-          EXPECT_EQ((std::tuple{42, std::string{"hello"}}), std::tie(values...));
+          EXPECT_EQ(
+              (std::tuple{42, std::string{"hello"}}), std::tie(values...));
         }
       }));
 
   start(op);
 }
 
-} // <anonymous namespace>
+}  // namespace
 
 TYPED_TEST(AnySenderOfTest, AnySenderOfCanWrapAJust) {
   testWrappingAJust<TypeParam>();
 }
 
 TYPED_TEST(AnySenderOfTest, AnySenderOfCanConnectToAMultiReceiver) {
-  testWrappingAJust<TypeParam, void(), void(int), void(int, std::string), void(int, int, int)>();
+  testWrappingAJust<
+      TypeParam,
+      void(),
+      void(int),
+      void(int, std::string),
+      void(int, int, int)>();
 }
 
 #if !defined(_MSC_VER)
@@ -170,15 +174,14 @@ TYPED_TEST(AnySenderOfTest, AnySenderOfCanBeCancelled) {
   start(op);
 }
 
-#if !UNIFEX_NO_EXCEPTIONS
+#  if !UNIFEX_NO_EXCEPTIONS
 TYPED_TEST(AnySenderOfTest, AnySenderOfCanError) {
   using test_t = AnySenderOfTest<TypeParam>;
   using any_sender = typename test_t::any_sender;
 
-  any_sender sender = finally(test_t::default_just(),
-      then(just(), [] {
-        throw std::runtime_error("uh oh");
-      }));
+  any_sender sender = finally(test_t::default_just(), then(just(), [] {
+                                throw std::runtime_error("uh oh");
+                              }));
 
   mock_receiver<TypeParam> receiver;
 
@@ -199,17 +202,17 @@ TYPED_TEST(AnySenderOfTest, AnySenderOfCanError) {
 
   start(op);
 }
-#endif // !UNIFEX_NO_EXCEPTIONS
-#endif // !defined(_MSC_VER)
+#  endif  // !UNIFEX_NO_EXCEPTIONS
+#endif    // !defined(_MSC_VER)
 
 TEST(AnySenderOfTest, SchedulerProvider) {
-  // Build a list of required receiver queries; in this case, just get_scheduler:
-  using Queries =
-      with_receiver_queries<overload<any_scheduler(const this_&)>(get_scheduler)>;
+  // Build a list of required receiver queries; in this case, just
+  // get_scheduler:
+  using Queries = with_receiver_queries<overload<any_scheduler(const this_&)>(
+      get_scheduler)>;
 
   // From that list of receiver queries, generate a type-erased sender:
-  using Sender =
-      Queries::any_sender_of<int, std::string>;
+  using Sender = Queries::any_sender_of<int, std::string>;
 
   // Type-erase a sender. This sender only connects to receivers that have
   // implemented the required receiver queries.
@@ -218,7 +221,8 @@ TEST(AnySenderOfTest, SchedulerProvider) {
   // Wrap the sender such that all passed-in receivers are wrapped in a
   // wrapper that implements the get_scheduler query to return an
   // inline_scheduler
-  auto sender = with_query_value(std::move(j), get_scheduler, inline_scheduler{});
+  auto sender =
+      with_query_value(std::move(j), get_scheduler, inline_scheduler{});
 
   mock_receiver<void(int, std::string)> receiver;
 

--- a/test/async_mutex_test.cpp
+++ b/test/async_mutex_test.cpp
@@ -30,11 +30,11 @@
 using namespace unifex;
 
 TEST(async_mutex, multiple_threads) {
-#if !defined(UNIFEX_TEST_LIMIT_ASYNC_MUTEX_ITERATIONS)
+#  if !defined(UNIFEX_TEST_LIMIT_ASYNC_MUTEX_ITERATIONS)
   constexpr int iterations = 100'000;
-#else
+#  else
   constexpr int iterations = UNIFEX_TEST_LIMIT_ASYNC_MUTEX_ITERATIONS;
-#endif
+#  endif
 
   async_mutex mutex;
 
@@ -53,9 +53,8 @@ TEST(async_mutex, multiple_threads) {
   single_thread_context ctx1;
   single_thread_context ctx2;
 
-  sync_wait(when_all(
-      makeTask(ctx1.get_scheduler()),
-      makeTask(ctx2.get_scheduler())));
+  sync_wait(
+      when_all(makeTask(ctx1.get_scheduler()), makeTask(ctx2.get_scheduler())));
 
   EXPECT_EQ(2 * iterations, sharedState);
 }

--- a/test/awaitable_senders_test.cpp
+++ b/test/awaitable_senders_test.cpp
@@ -18,17 +18,17 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <unifex/just.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/task.hpp>
-#include <unifex/stop_when.hpp>
-#include <unifex/timed_single_thread_context.hpp>
-#include <unifex/when_all.hpp>
-#include <unifex/scheduler_concepts.hpp>
+#  include <unifex/just.hpp>
+#  include <unifex/scheduler_concepts.hpp>
+#  include <unifex/stop_when.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/task.hpp>
+#  include <unifex/timed_single_thread_context.hpp>
+#  include <unifex/when_all.hpp>
 
-#include <chrono>
+#  include <chrono>
 
-#include <gtest/gtest.h>
+#  include <gtest/gtest.h>
 
 using namespace unifex;
 using namespace std::chrono_literals;
@@ -38,8 +38,7 @@ TEST(awaitable_senders, non_void) {
     co_return co_await just(42);
   };
 
-  optional<int> answer =
-      sync_wait(makeTask());
+  optional<int> answer = sync_wait(makeTask());
 
   EXPECT_TRUE(answer.has_value());
   EXPECT_EQ(42, *answer);
@@ -52,8 +51,7 @@ TEST(awaitable_senders, void) {
     co_return unifex::unit{};
   };
 
-  optional<unifex::unit> answer =
-      sync_wait(makeTask());
+  optional<unifex::unit> answer = sync_wait(makeTask());
 
   EXPECT_TRUE(answer.has_value());
 }
@@ -61,8 +59,7 @@ TEST(awaitable_senders, void) {
 TEST(awaitable_senders, task_cancellation) {
   timed_single_thread_context ctx;
   auto sched = ctx.get_scheduler();
-  sync_wait(
-    stop_when(
+  sync_wait(stop_when(
       [&]() -> task<int> {
         co_await schedule_after(sched, 500ms);
         ADD_FAILURE();

--- a/test/delay_test.cpp
+++ b/test/delay_test.cpp
@@ -17,12 +17,12 @@
 #include <unifex/for_each.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/range_stream.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/stop_when.hpp>
 #include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
 #include <unifex/timed_single_thread_context.hpp>
 #include <unifex/typed_via_stream.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/then.hpp>
-#include <unifex/stop_when.hpp>
 
 #include <chrono>
 #include <cstdio>
@@ -39,17 +39,17 @@ TEST(Delay, Smoke) {
 
   auto startTime = steady_clock::now();
 
-  sync_wait(
-      stop_when(
-          for_each(
-              delay(range_stream{0, 100}, context.get_scheduler(), 100ms),
-              [startTime](int value) {
-                auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);
-                std::printf("[%i ms] %i\n", (int)ms.count(), value);
-              }),
-          then(
-            schedule_at(context.get_scheduler(), startTime + 500ms),
-            [] { std::printf("cancelling\n"); })));
+  sync_wait(stop_when(
+      for_each(
+          delay(range_stream{0, 100}, context.get_scheduler(), 100ms),
+          [startTime](int value) {
+            auto ms =
+                duration_cast<milliseconds>(steady_clock::now() - startTime);
+            std::printf("[%i ms] %i\n", (int)ms.count(), value);
+          }),
+      then(schedule_at(context.get_scheduler(), startTime + 500ms), [] {
+        std::printf("cancelling\n");
+      })));
 }
 
 TEST(Delay, Pipeable) {
@@ -57,15 +57,13 @@ TEST(Delay, Pipeable) {
 
   auto startTime = steady_clock::now();
 
-  range_stream{0, 100}
-    | delay(context.get_scheduler(), 100ms)
-    | for_each(
-        [startTime](int value) {
+  range_stream{0, 100} | delay(context.get_scheduler(), 100ms) |
+      for_each([startTime](int value) {
         auto ms = duration_cast<milliseconds>(steady_clock::now() - startTime);
         std::printf("[%i ms] %i\n", (int)ms.count(), value);
-        })
-    | stop_when(
-        schedule_at(context.get_scheduler(), startTime + 500ms)
-          | then([] { std::printf("cancelling\n"); }))
-    | sync_wait();
+      }) |
+      stop_when(
+          schedule_at(context.get_scheduler(), startTime + 500ms) |
+          then([] { std::printf("cancelling\n"); })) |
+      sync_wait();
 }

--- a/test/detach_on_cancel_test.cpp
+++ b/test/detach_on_cancel_test.cpp
@@ -167,7 +167,7 @@ TEST_F(detach_on_cancel_test, cancellation_and_completion_race) {
 TEST_F(detach_on_cancel_test, error_types_propagate) {
   using namespace unifex;
   using error_types =
-    sender_error_types_t<decltype(detach_on_cancel(just())), type_list>;
+      sender_error_types_t<decltype(detach_on_cancel(just())), type_list>;
   using v = typename error_types::template apply<unifex::variant>;
 
   EXPECT_GE(unifex::variant_size<v>::value, 1);

--- a/test/execute_test.cpp
+++ b/test/execute_test.cpp
@@ -30,18 +30,11 @@ TEST(Execute, execute_with_scheduler) {
 TEST(Execute, Pipeable) {
   int i = 0;
   struct _receiver {
-    int *p;
-    void set_value() && noexcept {
-      *p += 1;
-    }
-    void set_error(std::exception_ptr) && noexcept {
-      *p += 2;
-    }
-    void set_done() && noexcept {
-      *p += 4;
-    }
+    int* p;
+    void set_value() && noexcept { *p += 1; }
+    void set_error(std::exception_ptr) && noexcept { *p += 2; }
+    void set_done() && noexcept { *p += 4; }
   };
-  schedule(inline_scheduler{})
-    | submit(_receiver{&i});
+  schedule(inline_scheduler{}) | submit(_receiver{&i});
   EXPECT_EQ(1, i);
 }

--- a/test/finally_test.cpp
+++ b/test/finally_test.cpp
@@ -15,15 +15,15 @@
  */
 #include <unifex/finally.hpp>
 #include <unifex/inplace_stop_token.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/then.hpp>
 #include <unifex/just.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/just_error.hpp>
 #include <unifex/let_done.hpp>
 #include <unifex/let_error.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <cstdio>
 #include <thread>
@@ -35,10 +35,11 @@ using namespace unifex;
 TEST(Finally, Value) {
   timed_single_thread_context context;
 
-  auto res = just(42)
-    | finally(schedule(context.get_scheduler()))
-    | then([](int i){ return std::make_pair(i, std::this_thread::get_id() ); })
-    | sync_wait();
+  auto res = just(42) | finally(schedule(context.get_scheduler())) |
+      then([](int i) {
+               return std::make_pair(i, std::this_thread::get_id());
+             }) |
+      sync_wait();
 
   ASSERT_FALSE(!res);
   EXPECT_EQ(res->first, 42);
@@ -48,10 +49,8 @@ TEST(Finally, Value) {
 TEST(Finally, Done) {
   timed_single_thread_context context;
 
-  auto res = just_done()
-    | finally(schedule(context.get_scheduler()))
-    | let_done([](){ return just(std::this_thread::get_id()); })
-    | sync_wait();
+  auto res = just_done() | finally(schedule(context.get_scheduler())) |
+      let_done([]() { return just(std::this_thread::get_id()); }) | sync_wait();
 
   ASSERT_FALSE(!res);
   EXPECT_EQ(*res, context.get_thread_id());
@@ -60,10 +59,8 @@ TEST(Finally, Done) {
 TEST(Finally, Error) {
   timed_single_thread_context context;
 
-  auto res = just_error(-1)
-    | finally(schedule(context.get_scheduler()))
-    | let_error([]{ return just(std::this_thread::get_id()); })
-    | sync_wait();
+  auto res = just_error(-1) | finally(schedule(context.get_scheduler())) |
+      let_error([] { return just(std::this_thread::get_id()); }) | sync_wait();
 
   ASSERT_TRUE(res.has_value());
   EXPECT_EQ(*res, context.get_thread_id());
@@ -75,7 +72,7 @@ TEST(Finally, BlockingKind) {
   static_assert(blocking_kind::always_inline == cblocking<Snd1>());
 
   timed_single_thread_context context;
-  
+
   auto snd2 = finally(just(), schedule(context.get_scheduler()));
   using Snd2 = decltype(snd2);
   static_assert(blocking_kind::maybe == cblocking<Snd2>());

--- a/test/find_if_test.cpp
+++ b/test/find_if_test.cpp
@@ -13,62 +13,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <unifex/find_if.hpp>
 #include <unifex/just.hpp>
 #include <unifex/let_value.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/static_thread_pool.hpp>
-#include <unifex/find_if.hpp>
-#include <unifex/then.hpp>
-#include <unifex/when_all.hpp>
 #include <unifex/on.hpp>
 #include <unifex/optional.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/static_thread_pool.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/when_all.hpp>
 
 #include <gtest/gtest.h>
 
 TEST(find_if, find_if_sequential) {
-    using namespace unifex;
+  using namespace unifex;
 
-    std::vector<int> input{1, 2, 3, 4};
-    // Apply linear find_if.
-    // As for std::find_if it returns the first instance that matches the
-    // predicate where the algorithm takes an iterator pair as the first
-    // two arguments, and forwards all other arguments to the predicate and
-    // onwards to the result.
-    // Precise API shape for the data being passed through is TBD, this is
-    // one option only.
-    optional<std::vector<int>::iterator> result = sync_wait(then(
-        find_if(
-            just(begin(input), end(input), 3),
-            [&](const int& v, int another_parameter) noexcept {
-              return v == another_parameter;
-            },
-            unifex::seq),
-        [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
-          UNIFEX_ASSERT(another_parameter == 3);
-          return v;
-        }));
+  std::vector<int> input{1, 2, 3, 4};
+  // Apply linear find_if.
+  // As for std::find_if it returns the first instance that matches the
+  // predicate where the algorithm takes an iterator pair as the first
+  // two arguments, and forwards all other arguments to the predicate and
+  // onwards to the result.
+  // Precise API shape for the data being passed through is TBD, this is
+  // one option only.
+  optional<std::vector<int>::iterator> result = sync_wait(then(
+      find_if(
+          just(begin(input), end(input), 3),
+          [&](const int& v, int another_parameter) noexcept {
+            return v == another_parameter;
+          },
+          unifex::seq),
+      [](std::vector<int>::iterator v,
+         [[maybe_unused]] int another_parameter) noexcept {
+        UNIFEX_ASSERT(another_parameter == 3);
+        return v;
+      }));
 
-    EXPECT_EQ(**result, 3);
+  EXPECT_EQ(**result, 3);
 }
 
 // This test causes the MSVC compiler to ICE. Not yet reported.
 #ifndef _MSC_VER
 TEST(find_if, find_if_parallel) {
-    using namespace unifex;
+  using namespace unifex;
 
-    std::vector<int> input;
-    std::atomic<int> countOfTasksRun = 0;
-    constexpr int checkValue = 7;
+  std::vector<int> input;
+  std::atomic<int> countOfTasksRun = 0;
+  constexpr int checkValue = 7;
 
-    for(int i = 2; i < 128; ++i) {
-      input.push_back(i);
-    }
-    static_thread_pool ctx;
-    optional<std::vector<int>::iterator> result = sync_wait(
-      unifex::on(
-        ctx.get_scheduler(),
-        then(
+  for (int i = 2; i < 128; ++i) {
+    input.push_back(i);
+  }
+  static_thread_pool ctx;
+  optional<std::vector<int>::iterator> result = sync_wait(unifex::on(
+      ctx.get_scheduler(),
+      then(
           find_if(
               just(begin(input), end(input), checkValue),
               [&](const int& v, int another_parameter) noexcept {
@@ -77,56 +77,57 @@ TEST(find_if, find_if_parallel) {
                 return v == another_parameter;
               },
               unifex::par),
-          [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
+          [](std::vector<int>::iterator v,
+             [[maybe_unused]] int another_parameter) noexcept {
             UNIFEX_ASSERT(another_parameter == checkValue);
             return v;
           })));
 
-    EXPECT_EQ(**result, checkValue);
-    // Expect 62 iterations to run to validate cancellation
-    // This is based on some implementation details:
-    //  * bulk_schedule's bulk_cancellation_chunk_size
-    //  * find_if's max_num_chunks and min_chunk_size
-    // find_if tries to launch 32 chunks of 4 elements each.
-    // bulk_schedule then chunks those into 16 element cancellation chunks.
-    // bulk_schedule launches a whole 16 element chunk.
-    // Most of them run to completion without finding the element.
-    // The second finds element 7 half way through and terminates early in
-    // the find_if algorithm.
-    // It ends up running the comparison operator 62 times.
-    // In general cancellation is best effort.
-    // Note though that the current implementation launches tasks in-order, so it
-    // cannot cancel earlier tasks, which makes find_if's find-fist rule safe.
-    EXPECT_EQ(countOfTasksRun, 62);
+  EXPECT_EQ(**result, checkValue);
+  // Expect 62 iterations to run to validate cancellation
+  // This is based on some implementation details:
+  //  * bulk_schedule's bulk_cancellation_chunk_size
+  //  * find_if's max_num_chunks and min_chunk_size
+  // find_if tries to launch 32 chunks of 4 elements each.
+  // bulk_schedule then chunks those into 16 element cancellation chunks.
+  // bulk_schedule launches a whole 16 element chunk.
+  // Most of them run to completion without finding the element.
+  // The second finds element 7 half way through and terminates early in
+  // the find_if algorithm.
+  // It ends up running the comparison operator 62 times.
+  // In general cancellation is best effort.
+  // Note though that the current implementation launches tasks in-order, so it
+  // cannot cancel earlier tasks, which makes find_if's find-fist rule safe.
+  EXPECT_EQ(countOfTasksRun, 62);
 }
 #endif
 
 TEST(find_if, Pipeable) {
-    using namespace unifex;
+  using namespace unifex;
 
-    static_thread_pool ctx;
+  static_thread_pool ctx;
 
-    std::vector<int> input{1, 2, 3, 4};
-    // Apply linear find_if.
-    // As for std::find_if it returns the first instance that matches the
-    // predicate where the algorithm takes an iterator pair as the first
-    // two arguments, and forwards all other arguments to the predicate and
-    // onwards to the result.
-    // Precise API shape for the data being passed through is TBD, this is
-    // one option only.
-    auto op = just(begin(input), end(input), 3)
-      | find_if(
-          [&](const int& v, int another_parameter) noexcept {
-            return v == another_parameter;
-          },
-          unifex::seq)
-      | then(
-          [](std::vector<int>::iterator v, [[maybe_unused]] int another_parameter) noexcept {
-            UNIFEX_ASSERT(another_parameter == 3);
-            return v;
-          });
-    optional<std::vector<int>::iterator> result =
-        sync_wait(on(ctx.get_scheduler(), std::move(op)));
+  std::vector<int> input{1, 2, 3, 4};
+  // Apply linear find_if.
+  // As for std::find_if it returns the first instance that matches the
+  // predicate where the algorithm takes an iterator pair as the first
+  // two arguments, and forwards all other arguments to the predicate and
+  // onwards to the result.
+  // Precise API shape for the data being passed through is TBD, this is
+  // one option only.
+  auto op = just(begin(input), end(input), 3) |
+      find_if(
+                [&](const int& v, int another_parameter) noexcept {
+                  return v == another_parameter;
+                },
+                unifex::seq) |
+      then([](std::vector<int>::iterator v,
+              [[maybe_unused]] int another_parameter) noexcept {
+              UNIFEX_ASSERT(another_parameter == 3);
+              return v;
+            });
+  optional<std::vector<int>::iterator> result =
+      sync_wait(on(ctx.get_scheduler(), std::move(op)));
 
-    EXPECT_EQ(**result, 3);
+  EXPECT_EQ(**result, 3);
 }

--- a/test/for_each_test.cpp
+++ b/test/for_each_test.cpp
@@ -16,8 +16,8 @@
 #include <unifex/for_each.hpp>
 #include <unifex/range_stream.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/trampoline_scheduler.hpp>
 #include <unifex/then.hpp>
+#include <unifex/trampoline_scheduler.hpp>
 #include <unifex/transform_stream.hpp>
 #include <unifex/typed_via_stream.hpp>
 
@@ -29,20 +29,16 @@ using namespace unifex;
 
 TEST(ForEach, Smoke) {
   sync_wait(then(
-    for_each(
-      transform_stream(
-        range_stream{0, 10}, [](int value) { return value * value; }),
-      [](int value) { std::printf("got %i\n", value); }),
-    []() { std::printf("done\n"); }));
+      for_each(
+          transform_stream(
+              range_stream{0, 10}, [](int value) { return value * value; }),
+          [](int value) { std::printf("got %i\n", value); }),
+      []() { std::printf("done\n"); }));
 }
 
 TEST(ForEach, Pipeable) {
-  range_stream{0, 10}
-    | transform_stream(
-        [](int value) { return value * value; })
-    | for_each(
-      [](int value) { std::printf("got %i\n", value); })
-    | then(
-      []() { std::printf("done\n"); })
-    | sync_wait();
+  range_stream{0, 10} |
+      transform_stream([](int value) { return value * value; }) |
+      for_each([](int value) { std::printf("got %i\n", value); }) |
+      then([]() { std::printf("done\n"); }) | sync_wait();
 }

--- a/test/get_scheduler_test.cpp
+++ b/test/get_scheduler_test.cpp
@@ -35,8 +35,7 @@ TEST(get_scheduler, schedule) {
 
   // Check that the schedule() operation can pick up the current
   // scheduler from the receiver which we inject by using 'with_query_value()'.
-  sync_wait(with_query_value(schedule(), get_scheduler,
-                             ctx.get_scheduler()));
+  sync_wait(with_query_value(schedule(), get_scheduler, ctx.get_scheduler()));
 }
 
 TEST(get_scheduler, schedule_after) {
@@ -55,14 +54,16 @@ TEST(get_scheduler, current_scheduler) {
   // composed operations.
   sync_wait(with_query_value(
       then(
-          for_each(via_stream(current_scheduler,
-                              transform_stream(range_stream{0, 10},
-                                               [](int value) {
-                                                 return value * value;
-                                               })),
-                   [](int value) { std::printf("got %i\n", value); }),
+          for_each(
+              via_stream(
+                  current_scheduler,
+                  transform_stream(
+                      range_stream{0, 10},
+                      [](int value) { return value * value; })),
+              [](int value) { std::printf("got %i\n", value); }),
           []() { std::printf("done\n"); }),
-      get_scheduler, ctx.get_scheduler()));
+      get_scheduler,
+      ctx.get_scheduler()));
 }
 
 TEST(get_scheduler, Pipeable) {
@@ -70,13 +71,10 @@ TEST(get_scheduler, Pipeable) {
 
   // Check that this can propagate through multiple levels of
   // composed operations.
-  range_stream{0, 10}
-    | transform_stream([](int value) {
-        return value * value;
-    })
-    | via_stream(current_scheduler)
-    | for_each([](int value) { std::printf("got %i\n", value); })
-    | then([]() { std::printf("done\n"); })
-    | with_query_value(get_scheduler, ctx.get_scheduler())
-    | sync_wait();
+  range_stream{0, 10} |
+      transform_stream([](int value) { return value * value; }) |
+      via_stream(current_scheduler) |
+      for_each([](int value) { std::printf("got %i\n", value); }) |
+      then([]() { std::printf("done\n"); }) |
+      with_query_value(get_scheduler, ctx.get_scheduler()) | sync_wait();
 }

--- a/test/indexed_for_test.cpp
+++ b/test/indexed_for_test.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <unifex/indexed_for.hpp>
 #include <unifex/just.hpp>
 #include <unifex/let_value.hpp>
-#include <unifex/then.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/indexed_for.hpp>
+#include <unifex/then.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -29,10 +29,10 @@ using namespace unifex;
 
 namespace execution {
 class sequenced_policy {};
-class parallel_policy{};
+class parallel_policy {};
 inline constexpr sequenced_policy seq{};
 inline constexpr parallel_policy par{};
-}
+}  // namespace execution
 
 namespace {
 namespace ranges {
@@ -47,9 +47,7 @@ struct int_iterator {
     return base_ + static_cast<int>(offset);
   }
 
-  int operator*() const {
-    return base_;
-  }
+  int operator*() const { return base_; }
 
   int_iterator operator++() {
     ++base_;
@@ -62,9 +60,7 @@ struct int_iterator {
     return cur;
   }
 
-  bool operator!=(const int_iterator& rhs) const {
-    return base_ != rhs.base_;
-  }
+  bool operator!=(const int_iterator& rhs) const { return base_ != rhs.base_; }
 
   int base_;
 };
@@ -73,31 +69,22 @@ struct iota_view {
   int size_;
   using iterator = int_iterator;
 
-  int_iterator begin() {
-    return int_iterator{0};
-  }
+  int_iterator begin() { return int_iterator{0}; }
 
-  int_iterator end() {
-    return int_iterator{size_};
-  }
+  int_iterator end() { return int_iterator{size_}; }
 
-  size_t size() const {
-    return size_;
-  }
+  size_t size() const { return size_; }
 };
-} // namespace ranges
-} // anonymous namespace
+}  // namespace ranges
+}  // anonymous namespace
 
 TEST(indexed_for, Pipeable) {
   // use seq, which supports a forward range
-  auto result = just(42)
-    | indexed_for(
-        execution::seq,
-        ranges::iota_view{10},
-        [](int idx, int& x) {
-          x = x + idx;
-        })
-    | sync_wait();
+  auto result = just(42) |
+      indexed_for(execution::seq,
+                  ranges::iota_view{10},
+                  [](int idx, int& x) { x = x + idx; }) |
+      sync_wait();
 
   // ranges::iota_view{10} produces [0, 9] so our accumulator is summing
   // 42 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 +  9, which is 42 + 45 = 87.

--- a/test/into_variant_test.cpp
+++ b/test/into_variant_test.cpp
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/let_done.hpp>
-#include <unifex/then.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/when_all.hpp>
-#include <unifex/just_error.hpp>
-#include <unifex/just.hpp>
 #include <unifex/into_variant.hpp>
+#include <unifex/just.hpp>
 #include <unifex/just_done.hpp>
-#include <exception>
+#include <unifex/just_error.hpp>
+#include <unifex/let_done.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
 #include <unifex/variant.hpp>
+#include <unifex/when_all.hpp>
+#include <exception>
 #include <gtest/gtest.h>
 
 using namespace unifex;
@@ -30,59 +30,57 @@ using namespace unifex;
 template <typename... T>
 using vt_t = variant<std::tuple<T...>>;
 
-using std::tuple;
 using std::is_same_v;
+using std::tuple;
 
-
-TEST(IntoVariant, StaticTypeCheck){
-  auto snd1 = just(42)
-            | into_variant();
-  static_assert(is_same_v<decltype(snd1)::value_types<variant, tuple>,
-      vt_t<vt_t<int>>>);
-  static_assert(is_same_v<decltype(snd1)::error_types<variant>,
-      variant<std::exception_ptr>>);
+TEST(IntoVariant, StaticTypeCheck) {
+  auto snd1 = just(42) | into_variant();
+  static_assert(
+      is_same_v<decltype(snd1)::value_types<variant, tuple>, vt_t<vt_t<int>>>);
+  static_assert(is_same_v<
+                decltype(snd1)::error_types<variant>,
+                variant<std::exception_ptr>>);
   static_assert(decltype(snd1)::sends_done == false);
 
-  auto snd2 = just_error(42)
-            | into_variant();
-  static_assert(is_same_v<decltype(snd2)::value_types<variant, tuple>,
-      vt_t<variant<>>>);
-  static_assert(is_same_v<decltype(snd2)::error_types<variant>,
-      variant<int>>);
+  auto snd2 = just_error(42) | into_variant();
+  static_assert(
+      is_same_v<decltype(snd2)::value_types<variant, tuple>, vt_t<variant<>>>);
+  static_assert(is_same_v<decltype(snd2)::error_types<variant>, variant<int>>);
   static_assert(decltype(snd2)::sends_done == false);
 
-  auto snd3 = just_done()
-            | into_variant();
-  static_assert(is_same_v<decltype(snd3)::value_types<variant, tuple>,
-      vt_t<variant<>>>);
-  static_assert(is_same_v<decltype(snd3)::error_types<variant>,
-      variant<>>);
+  auto snd3 = just_done() | into_variant();
+  static_assert(
+      is_same_v<decltype(snd3)::value_types<variant, tuple>, vt_t<variant<>>>);
+  static_assert(is_same_v<decltype(snd3)::error_types<variant>, variant<>>);
   static_assert(decltype(snd3)::sends_done == true);
 
-  auto snd4 = when_all( just(42), just(42.0), just_error(42) )
-            | into_variant();
-  static_assert(is_same_v<decltype(snd4)::value_types<variant, tuple>,
-      vt_t<vt_t<vt_t<int>, vt_t<double>, variant<>>>>);
-  static_assert(is_same_v<decltype(snd4)::error_types<variant>,
-      variant<std::exception_ptr, int>>);
+  auto snd4 = when_all(just(42), just(42.0), just_error(42)) | into_variant();
+  static_assert(is_same_v<
+                decltype(snd4)::value_types<variant, tuple>,
+                vt_t<vt_t<vt_t<int>, vt_t<double>, variant<>>>>);
+  static_assert(is_same_v<
+                decltype(snd4)::error_types<variant>,
+                variant<std::exception_ptr, int>>);
   static_assert(decltype(snd4)::sends_done == true);
 
-  auto snd5 = just(42) | let_done([]{return just("hello");}) | into_variant();
-  static_assert(is_same_v<decltype(snd5)::value_types<variant, tuple>,
-      vt_t<variant<tuple<int>, tuple<const char*>>>>);
-  static_assert(is_same_v<decltype(snd5)::error_types<variant>,
-      variant<std::exception_ptr>>);
+  auto snd5 =
+      just(42) | let_done([] { return just("hello"); }) | into_variant();
+  static_assert(is_same_v<
+                decltype(snd5)::value_types<variant, tuple>,
+                vt_t<variant<tuple<int>, tuple<const char*>>>>);
+  static_assert(is_same_v<
+                decltype(snd5)::error_types<variant>,
+                variant<std::exception_ptr>>);
   static_assert(decltype(snd5)::sends_done == false);
 }
 
-TEST(IntoVariant, Working){
+TEST(IntoVariant, Working) {
   bool called = false;
-  auto x = sync_wait(into_variant(when_all(
-          just(42),
-          just(42.0) | then([&](double d){
-            called = true;
-            return d + 1;
-          }))));
+  auto x = sync_wait(
+      into_variant(when_all(just(42), just(42.0) | then([&](double d) {
+                                        called = true;
+                                        return d + 1;
+                                      }))));
   EXPECT_TRUE(called);
   EXPECT_TRUE(x.has_value());
   const auto& [vt_first_val, vt_second_val] = var::get<0>(x.value());
@@ -92,17 +90,13 @@ TEST(IntoVariant, Working){
   EXPECT_EQ(second_val, 43.0);
 }
 
-TEST(IntoVariant, Pipeable){
+TEST(IntoVariant, Pipeable) {
   bool called = false;
-  auto x = when_all(
-      just(42),
-      just(42.5)
-      | then([&](double d){
-          called = true;
-          return d + 1;
-        }))
-      | into_variant()
-      | sync_wait();
+  auto x = when_all(just(42), just(42.5) | then([&](double d) {
+                                called = true;
+                                return d + 1;
+                              })) |
+      into_variant() | sync_wait();
   EXPECT_TRUE(called);
   EXPECT_TRUE(x.has_value());
   const auto& [vt_first_val, vt_second_val] = var::get<0>(x.value());
@@ -112,12 +106,13 @@ TEST(IntoVariant, Pipeable){
   EXPECT_EQ(second_val, 43.5);
 }
 
-TEST(IntoVariant, OneOfPossibleValues){
+TEST(IntoVariant, OneOfPossibleValues) {
   bool called = false;
-  auto x = just(42)
-    | let_done([&]{ called = true; return just(42.5); })
-    | into_variant()
-    | sync_wait();
+  auto x = just(42) | let_done([&] {
+             called = true;
+             return just(42.5);
+           }) |
+      into_variant() | sync_wait();
   EXPECT_FALSE(called);
   EXPECT_TRUE(x.has_value());
   const auto& [val] = var::get<0>(x.value());

--- a/test/invoke_test.cpp
+++ b/test/invoke_test.cpp
@@ -18,12 +18,12 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <unifex/invoke.hpp>
-#include <unifex/task.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/optional.hpp>
+#  include <unifex/invoke.hpp>
+#  include <unifex/optional.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/task.hpp>
 
-#include <gtest/gtest.h>
+#  include <gtest/gtest.h>
 
 using namespace unifex;
 
@@ -89,11 +89,13 @@ TEST(CoInvoke, WithLvalueArgumentsWithByRefCaptures) {
 }
 
 TEST(CoInvoke, WithLvalueFunctionObject) {
-  auto fn = []() -> task<int> { co_return 42; };
+  auto fn = []() -> task<int> {
+    co_return 42;
+  };
   task<int> t = co_invoke(fn);
   optional<int> result = sync_wait(std::move(t));
   ASSERT_TRUE(!!result);
   EXPECT_EQ(*result, 42);
 }
 
-#endif // !UNIFEX_NO_COROUTINES
+#endif  // !UNIFEX_NO_COROUTINES

--- a/test/just_void_or_done_test.cpp
+++ b/test/just_void_or_done_test.cpp
@@ -26,8 +26,7 @@ namespace unifex {
 namespace {
 
 TEST(just_void_or_done, just_void) {
-  optional<int> i =
-      sync_wait(then(just_void_or_done(true), [] { return 42; }));
+  optional<int> i = sync_wait(then(just_void_or_done(true), [] { return 42; }));
   ASSERT_TRUE(i.has_value());
   EXPECT_EQ(*i, 42);
 }

--- a/test/let_done_test.cpp
+++ b/test/let_done_test.cpp
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/just.hpp>
 #include <unifex/just_done.hpp>
-#include <unifex/on.hpp>
-#include <unifex/then.hpp>
+#include <unifex/just_from.hpp>
 #include <unifex/let_done.hpp>
+#include <unifex/on.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/sequence.hpp>
 #include <unifex/stop_when.hpp>
-#include <unifex/just_from.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -41,13 +41,10 @@ TEST(TransformDone, Smoke) {
 
   int count = 0;
 
-  sync_wait(
-    stop_when(
+  sync_wait(stop_when(
       sequence(
-        let_done(
-          schedule_after(scheduler, 200ms), 
-          []{ return just(); }), 
-        just_from([&]{ ++count; })),
+          let_done(schedule_after(scheduler, 200ms), [] { return just(); }),
+          just_from([&] { ++count; })),
       schedule_after(scheduler, 100ms)));
 
   EXPECT_EQ(count, 1);
@@ -61,8 +58,8 @@ TEST(TransformDone, StayDone) {
   int count = 0;
 
   auto op = sequence(
-    on(scheduler, just_done() | let_done([]{ return just(); })),
-    just_from([&]{ ++count; }));
+      on(scheduler, just_done() | let_done([] { return just(); })),
+      just_from([&] { ++count; }));
   sync_wait(std::move(op));
 
   EXPECT_EQ(count, 1);
@@ -76,29 +73,21 @@ TEST(TransformDone, Pipeable) {
   int count = 0;
 
   sequence(
-    schedule_after(scheduler, 200ms)
-      | let_done(
-          []{ return just(); }), 
-    just_from([&]{ ++count; }))
-    | stop_when(schedule_after(scheduler, 100ms))
-    | sync_wait();
+      schedule_after(scheduler, 200ms) | let_done([] { return just(); }),
+      just_from([&] { ++count; })) |
+      stop_when(schedule_after(scheduler, 100ms)) | sync_wait();
 
   EXPECT_EQ(count, 1);
 }
 
 TEST(TransformDone, WithValue) {
-  auto one = 
-    just_done()
-    | let_done([] { return just(42); })
-    | sync_wait();
+  auto one = just_done() | let_done([] { return just(42); }) | sync_wait();
 
   EXPECT_TRUE(one.has_value());
   EXPECT_EQ(*one, 42);
 
-  auto multiple = 
-    just_done()
-    | let_done([] { return just(42, 1, 2); })
-    | sync_wait();
+  auto multiple =
+      just_done() | let_done([] { return just(42, 1, 2); }) | sync_wait();
 
   EXPECT_TRUE(multiple.has_value());
   EXPECT_EQ(*multiple, std::tuple(42, 1, 2));

--- a/test/let_error_test.cpp
+++ b/test/let_error_test.cpp
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/just.hpp>
 #include <unifex/just_error.hpp>
-#include <unifex/on.hpp>
-#include <unifex/then.hpp>
+#include <unifex/just_from.hpp>
 #include <unifex/let_done.hpp>
 #include <unifex/let_error.hpp>
+#include <unifex/on.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/sequence.hpp>
 #include <unifex/stop_when.hpp>
-#include <unifex/just_from.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -42,15 +42,14 @@ TEST(TransformError, Smoke) {
 
   int count = 0;
 
-  sync_wait(
-    stop_when(
+  sync_wait(stop_when(
       sequence(
-        let_error(
-          let_done(
-            schedule_after(scheduler, 200ms), 
-            []{ return just_error(-1); }),
-          []{ return just(); }),
-        just_from([&]{ ++count; })),
+          let_error(
+              let_done(
+                  schedule_after(scheduler, 200ms),
+                  [] { return just_error(-1); }),
+              [] { return just(); }),
+          just_from([&] { ++count; })),
       schedule_after(scheduler, 100ms)));
 
   EXPECT_EQ(count, 1);
@@ -64,8 +63,8 @@ TEST(TransformError, StayError) {
   int count = 0;
 
   auto op = sequence(
-    on(scheduler, just_error(42) | let_error([]{ return just(); })),
-    just_from([&]{ ++count; }));
+      on(scheduler, just_error(42) | let_error([] { return just(); })),
+      just_from([&] { ++count; }));
   sync_wait(std::move(op));
 
   EXPECT_EQ(count, 1);
@@ -79,29 +78,23 @@ TEST(TransformError, Pipeable) {
   int count = 0;
 
   sequence(
-    schedule_after(scheduler, 200ms)
-      | let_done([]{ return just_error(-1); })
-      | let_error([]{ return just(); }), 
-    just_from([&]{ ++count; }))
-    | stop_when(schedule_after(scheduler, 100ms))
-    | sync_wait();
+      schedule_after(scheduler, 200ms) | let_done([] {
+        return just_error(-1);
+      }) | let_error([] { return just(); }),
+      just_from([&] { ++count; })) |
+      stop_when(schedule_after(scheduler, 100ms)) | sync_wait();
 
   EXPECT_EQ(count, 1);
 }
 
 TEST(TransformError, WithValue) {
-  auto one = 
-    just_error(-1)
-    | let_error([]{ return just(42); })
-    | sync_wait();
+  auto one = just_error(-1) | let_error([] { return just(42); }) | sync_wait();
 
   EXPECT_TRUE(one.has_value());
   EXPECT_EQ(*one, 42);
 
-  auto multiple = 
-    just_error(-1)
-    | let_error([]{ return just(42, 1, 2); })
-    | sync_wait();
+  auto multiple =
+      just_error(-1) | let_error([] { return just(42, 1, 2); }) | sync_wait();
 
   EXPECT_TRUE(multiple.has_value());
   EXPECT_EQ(*multiple, std::tuple(42, 1, 2));

--- a/test/mock_receiver.hpp
+++ b/test/mock_receiver.hpp
@@ -73,32 +73,26 @@ struct mock_receiver_body : mock_receiver_body_base<Sigs>... {
 
 template <typename... Sigs>
 struct mock_receiver {
- private:
-  std::shared_ptr<mock_receiver_body<Sigs...>> body_
-      = std::make_shared<mock_receiver_body<Sigs...>>();
+private:
+  std::shared_ptr<mock_receiver_body<Sigs...>> body_ =
+      std::make_shared<mock_receiver_body<Sigs...>>();
 
- public:
+public:
   template <typename... T>
-  auto set_value(T&&... ts) noexcept(noexcept(body_->set_value((T&&)ts...)))
-      -> decltype(body_->set_value((T&&)ts...)) {
-    body_->set_value((T&&)ts...);
+  auto set_value(T&&... ts) noexcept(noexcept(body_->set_value((T &&) ts...)))
+      -> decltype(body_->set_value((T &&) ts...)) {
+    body_->set_value((T &&) ts...);
   }
 
   void set_error(std::exception_ptr eptr) noexcept {
     body_->set_error(std::move(eptr));
   }
 
-  void set_done() noexcept {
-    body_->set_done();
-  }
+  void set_done() noexcept { body_->set_done(); }
 
-  auto& operator*() noexcept {
-    return *body_;
-  }
+  auto& operator*() noexcept { return *body_; }
 
-  const auto& operator*() const noexcept {
-    return *body_;
-  }
+  const auto& operator*() const noexcept { return *body_; }
 };
 
-} // namespace unifex_test
+}  // namespace unifex_test

--- a/test/on_stream_test.cpp
+++ b/test/on_stream_test.cpp
@@ -49,12 +49,10 @@ TEST(on_stream, Pipeable) {
   single_thread_context context1;
   single_thread_context context2;
 
-  range_stream{0, 10}
-    | transform_stream(
-        [](int value) { return value * value; })
-    | on_stream(context2.get_scheduler())
-    | typed_via_stream(context1.get_scheduler())
-    | for_each([](int value) { std::printf("got %i\n", value); })
-    | then([]() { std::printf("done\n"); })
-    | sync_wait();
+  range_stream{0, 10} |
+      transform_stream([](int value) { return value * value; }) |
+      on_stream(context2.get_scheduler()) |
+      typed_via_stream(context1.get_scheduler()) |
+      for_each([](int value) { std::printf("got %i\n", value); }) |
+      then([]() { std::printf("done\n"); }) | sync_wait();
 }

--- a/test/reduce_stream_test.cpp
+++ b/test/reduce_stream_test.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/sync_wait.hpp>
-#include <unifex/transform_stream.hpp>
-#include <unifex/reduce_stream.hpp>
-#include <unifex/then.hpp>
 #include <unifex/range_stream.hpp>
+#include <unifex/reduce_stream.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/transform_stream.hpp>
 
 #include <cstdio>
 
@@ -31,8 +31,7 @@ TEST(reduce_stream, Smoke) {
   sync_wait(then(
       reduce_stream(
           transform_stream(
-              range_stream{0, 10},
-              [](int value) { return value * value; }),
+              range_stream{0, 10}, [](int value) { return value * value; }),
           0,
           [](int state, int value) { return state + value; }),
       [&](int result) { finalResult = result; }));
@@ -44,14 +43,10 @@ TEST(reduce_stream, Smoke) {
 TEST(reduce_stream, Pipeable) {
   int finalResult;
 
-  range_stream{0, 10}
-    | transform_stream(
-        [](int value) { return value * value; })
-    | reduce_stream(
-        0,
-        [](int state, int value) { return state + value; })
-    | then([&](int result) { finalResult = result; })
-    | sync_wait();
+  range_stream{0, 10} |
+      transform_stream([](int value) { return value * value; }) |
+      reduce_stream(0, [](int state, int value) { return state + value; }) |
+      then([&](int result) { finalResult = result; }) | sync_wait();
 
   EXPECT_EQ(finalResult, 285);
   std::printf("result = %i\n", finalResult);

--- a/test/repeat_effect_test.cpp
+++ b/test/repeat_effect_test.cpp
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/just.hpp>
-#include <unifex/then.hpp>
+#include <unifex/just_from.hpp>
 #include <unifex/repeat_effect_until.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/sequence.hpp>
 #include <unifex/stop_when.hpp>
-#include <unifex/just_from.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -39,12 +39,9 @@ TEST(RepeatEffect, Smoke) {
 
   std::atomic<int> count{0};
 
-  sync_wait(
-    stop_when(
-      repeat_effect(
-        sequence(
-          schedule_after(scheduler, 50ms), 
-          just_from([&]{ ++count; }))),
+  sync_wait(stop_when(
+      repeat_effect(sequence(
+          schedule_after(scheduler, 50ms), just_from([&] { ++count; }))),
       schedule_after(scheduler, 500ms)));
 
   EXPECT_GT(count.load(), 1);
@@ -57,12 +54,9 @@ TEST(RepeatEffect, Pipeable) {
 
   std::atomic<int> count{0};
 
-  sequence(
-    schedule_after(scheduler, 50ms), 
-    just_from([&]{ ++count; }))
-    | repeat_effect()
-    | stop_when(schedule_after(scheduler, 500ms))
-    | sync_wait();
+  sequence(schedule_after(scheduler, 50ms), just_from([&] { ++count; })) |
+      repeat_effect() | stop_when(schedule_after(scheduler, 500ms)) |
+      sync_wait();
 
   EXPECT_GT(count.load(), 1);
 }

--- a/test/schedule_with_subsceduler_test.cpp
+++ b/test/schedule_with_subsceduler_test.cpp
@@ -15,8 +15,8 @@
  */
 #include <unifex/schedule_with_subscheduler.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <gtest/gtest.h>
 
@@ -38,12 +38,11 @@ TEST(schedule_with_subscheduler, Pipeable) {
   timed_single_thread_context context;
   auto scheduler = context.get_scheduler();
 
-  optional<bool> result = scheduler
-    | schedule_with_subscheduler()
-    | then([&](auto subScheduler) noexcept {
-        return subScheduler == scheduler;
-      })
-    | sync_wait();
+  optional<bool> result = scheduler | schedule_with_subscheduler() |
+      then([&](auto subScheduler) noexcept {
+                            return subScheduler == scheduler;
+                          }) |
+      sync_wait();
 
   EXPECT_TRUE(result.has_value());
   EXPECT_TRUE(result.value());

--- a/test/static_thread_pool_test.cpp
+++ b/test/static_thread_pool_test.cpp
@@ -33,7 +33,7 @@ template <typename Scheduler, typename F>
 auto run_on(Scheduler&& s, F&& func) {
   return then(schedule((Scheduler &&) s), (F &&) func);
 }
-} // anonymous namespace
+}  // anonymous namespace
 
 TEST(StaticThreadPool, Smoke) {
   static_thread_pool tpContext;

--- a/test/stop_when_test.cpp
+++ b/test/stop_when_test.cpp
@@ -14,127 +14,116 @@
  * limitations under the License.
  */
 
-#include <unifex/stop_when.hpp>
+#include <unifex/on.hpp>
+#include <unifex/optional.hpp>
 #include <unifex/scheduler_concepts.hpp>
+#include <unifex/stop_when.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/timed_single_thread_context.hpp>
-#include <unifex/on.hpp>
-#include <unifex/optional.hpp>
 
 #include <chrono>
 
 #include <gtest/gtest.h>
 
 TEST(StopWhen, SourceCompletesFirst) {
-    using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
-    unifex::timed_single_thread_context ctx;
+  unifex::timed_single_thread_context ctx;
 
-    bool sourceExecuted = false;
-    bool triggerExecuted = false;
-    
-    unifex::optional<int> result = unifex::sync_wait(
-        unifex::on(
-            ctx.get_scheduler(),
-            unifex::stop_when(
-                unifex::then(
-                    unifex::schedule_after(10ms),
-                    [&] {
-                        sourceExecuted = true;
-                        return 42;
-                    }),
-                unifex::then(
-                    unifex::schedule_after(1s),
-                    [&] { triggerExecuted = true; }))));
+  bool sourceExecuted = false;
+  bool triggerExecuted = false;
 
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(42, result.value());
+  unifex::optional<int> result = unifex::sync_wait(unifex::on(
+      ctx.get_scheduler(),
+      unifex::stop_when(
+          unifex::then(
+              unifex::schedule_after(10ms),
+              [&] {
+                sourceExecuted = true;
+                return 42;
+              }),
+          unifex::then(
+              unifex::schedule_after(1s), [&] { triggerExecuted = true; }))));
 
-    EXPECT_TRUE(sourceExecuted);
-    EXPECT_FALSE(triggerExecuted);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(42, result.value());
+
+  EXPECT_TRUE(sourceExecuted);
+  EXPECT_FALSE(triggerExecuted);
 }
 
 TEST(StopWhen, TriggerCompletesFirst) {
-    using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
-    unifex::timed_single_thread_context ctx;
+  unifex::timed_single_thread_context ctx;
 
-    bool sourceExecuted = false;
-    bool triggerExecuted = false;
-    
-    unifex::optional<int> result = unifex::sync_wait(
-        unifex::on(
-            ctx.get_scheduler(),
-            unifex::stop_when(
-                unifex::then(
-                    unifex::schedule_after(1s),
-                    [&] {
-                        sourceExecuted = true;
-                        return 42;
-                    }),
-                unifex::then(
-                    unifex::schedule_after(10ms),
-                    [&] { triggerExecuted = true; }))));
+  bool sourceExecuted = false;
+  bool triggerExecuted = false;
 
-    EXPECT_FALSE(result.has_value());
-    EXPECT_FALSE(sourceExecuted);
-    EXPECT_TRUE(triggerExecuted);
+  unifex::optional<int> result = unifex::sync_wait(unifex::on(
+      ctx.get_scheduler(),
+      unifex::stop_when(
+          unifex::then(
+              unifex::schedule_after(1s),
+              [&] {
+                sourceExecuted = true;
+                return 42;
+              }),
+          unifex::then(
+              unifex::schedule_after(10ms), [&] { triggerExecuted = true; }))));
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_FALSE(sourceExecuted);
+  EXPECT_TRUE(triggerExecuted);
 }
 
 TEST(StopWhen, CancelledFromParent) {
-    using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
-    unifex::timed_single_thread_context ctx;
+  unifex::timed_single_thread_context ctx;
 
-    bool sourceExecuted = false;
-    bool triggerExecuted = false;
-    
-    unifex::optional<int> result = unifex::sync_wait(
-        unifex::on(
-            ctx.get_scheduler(),
-            unifex::stop_when(
-                unifex::stop_when(
-                    unifex::then(
-                        unifex::schedule_after(1s),
-                        [&] {
-                            sourceExecuted = true;
-                            return 42;
-                        }),
-                    unifex::then(
-                        unifex::schedule_after(2s),
-                        [&] {
-                            triggerExecuted = true;
-                        })),
-                unifex::schedule_after(10ms))));
+  bool sourceExecuted = false;
+  bool triggerExecuted = false;
 
-    EXPECT_FALSE(result.has_value());
-    EXPECT_FALSE(sourceExecuted);
-    EXPECT_FALSE(triggerExecuted);
+  unifex::optional<int> result = unifex::sync_wait(unifex::on(
+      ctx.get_scheduler(),
+      unifex::stop_when(
+          unifex::stop_when(
+              unifex::then(
+                  unifex::schedule_after(1s),
+                  [&] {
+                    sourceExecuted = true;
+                    return 42;
+                  }),
+              unifex::then(
+                  unifex::schedule_after(2s), [&] { triggerExecuted = true; })),
+          unifex::schedule_after(10ms))));
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_FALSE(sourceExecuted);
+  EXPECT_FALSE(triggerExecuted);
 }
 
 TEST(StopWhen, Pipeable) {
-    using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
-    unifex::timed_single_thread_context ctx;
+  unifex::timed_single_thread_context ctx;
 
-    bool sourceExecuted = false;
-    bool triggerExecuted = false;
+  bool sourceExecuted = false;
+  bool triggerExecuted = false;
 
-    auto op = unifex::schedule_after(1s)
-      | unifex::then(
-        [&] {
-            sourceExecuted = true;
-            return 42;
-        })
-      | unifex::stop_when(
-          unifex::schedule_after(10ms)
-            | unifex::then(
-              [&] { triggerExecuted = true; }));
-    unifex::optional<int> result =
-        unifex::sync_wait(unifex::on(ctx.get_scheduler(), std::move(op)));
+  auto op = unifex::schedule_after(1s) | unifex::then([&] {
+              sourceExecuted = true;
+              return 42;
+            }) |
+      unifex::stop_when(unifex::schedule_after(10ms) | unifex::then([&] {
+                          triggerExecuted = true;
+                        }));
+  unifex::optional<int> result =
+      unifex::sync_wait(unifex::on(ctx.get_scheduler(), std::move(op)));
 
-    EXPECT_FALSE(result.has_value());
-    EXPECT_FALSE(sourceExecuted);
-    EXPECT_TRUE(triggerExecuted);
+  EXPECT_FALSE(result.has_value());
+  EXPECT_FALSE(sourceExecuted);
+  EXPECT_TRUE(triggerExecuted);
 }

--- a/test/tag_invoke_test.cpp
+++ b/test/tag_invoke_test.cpp
@@ -20,19 +20,23 @@
 #include <gtest/gtest.h>
 
 namespace {
-inline constexpr struct test_cpo {} test;
+inline constexpr struct test_cpo {
+} test;
 
 struct X {
-    friend void tag_invoke(test_cpo, X) {}
-    friend constexpr bool tag_invoke(test_cpo, X, int a) noexcept { return a > 0; }
+  friend void tag_invoke(test_cpo, X) {}
+  friend constexpr bool tag_invoke(test_cpo, X, int a) noexcept {
+    return a > 0;
+  }
 };
 
 struct Y {};
-} // anonymous namespace
+}  // anonymous namespace
 
 // Tests of the tag_invoke metafunctions.
 static_assert(std::is_same_v<void, unifex::tag_invoke_result_t<test_cpo, X>>);
-static_assert(std::is_same_v<bool, unifex::tag_invoke_result_t<test_cpo, X, int>>);
+static_assert(
+    std::is_same_v<bool, unifex::tag_invoke_result_t<test_cpo, X, int>>);
 static_assert(unifex::is_tag_invocable_v<test_cpo, X>);
 static_assert(unifex::is_tag_invocable_v<test_cpo, X, int>);
 static_assert(!unifex::is_tag_invocable_v<test_cpo, Y>);
@@ -41,13 +45,13 @@ static_assert(unifex::is_nothrow_tag_invocable_v<test_cpo, X, int>);
 static_assert(!unifex::is_nothrow_tag_invocable_v<test_cpo, Y>);
 
 TEST(tag_invoke, tag_invoke_usage) {
-    unifex::tag_invoke(test, X{});
-    EXPECT_TRUE(unifex::tag_invoke(test_cpo{}, X{}, 42));
+  unifex::tag_invoke(test, X{});
+  EXPECT_TRUE(unifex::tag_invoke(test_cpo{}, X{}, 42));
 }
 
 TEST(tag_invoke, tag_invoke_constexpr) {
-    constexpr bool result1 = unifex::tag_invoke(test, X{}, 42);
-    constexpr bool result2 = unifex::tag_invoke(test, X{}, -3);
-    EXPECT_TRUE(result1);
-    EXPECT_FALSE(result2);
+  constexpr bool result1 = unifex::tag_invoke(test, X{}, 42);
+  constexpr bool result2 = unifex::tag_invoke(test, X{}, -3);
+  EXPECT_TRUE(result1);
+  EXPECT_FALSE(result2);
 }

--- a/test/task_void_test.cpp
+++ b/test/task_void_test.cpp
@@ -18,28 +18,28 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <atomic>
+#  include <atomic>
 
-#include <unifex/static_thread_pool.hpp>
-#include <unifex/when_all.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/let_value_with.hpp>
-#include <unifex/task.hpp>
+#  include <unifex/let_value_with.hpp>
+#  include <unifex/static_thread_pool.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/task.hpp>
+#  include <unifex/when_all.hpp>
 
-#include <gtest/gtest.h>
+#  include <gtest/gtest.h>
 
 using namespace unifex;
 
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<void> child(Scheduler s, std::atomic<int>& x) {
+(requires scheduler<Scheduler>)
+    task<void> child(Scheduler s, std::atomic<int>& x) {
   co_await schedule(s);
   ++x;
 }
 
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<void> example(Scheduler s, std::atomic<int>& x) {
+(requires scheduler<Scheduler>)
+    task<void> example(Scheduler s, std::atomic<int>& x) {
   ++x;
   co_await when_all(child(s, x), child(s, x));
 }
@@ -57,4 +57,4 @@ TEST(TaskVoid, WhenAll) {
   EXPECT_EQ(x.load(), 45);
 }
 
-#endif // !UNIFEX_NO_COROUTINES
+#endif  // !UNIFEX_NO_COROUTINES

--- a/test/then_test.cpp
+++ b/test/then_test.cpp
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/just.hpp>
-#include <unifex/then.hpp>
 #include <unifex/let_done.hpp>
+#include <unifex/scheduler_concepts.hpp>
 #include <unifex/sequence.hpp>
 #include <unifex/stop_when.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -38,10 +38,7 @@ TEST(Transform, Smoke) {
 
   int count = 0;
 
-  sync_wait(
-        then(
-          schedule_after(scheduler, 200ms), 
-          [&]{ ++count; }));
+  sync_wait(then(schedule_after(scheduler, 200ms), [&] { ++count; }));
 
   EXPECT_EQ(count, 1);
 }
@@ -49,16 +46,11 @@ TEST(Transform, Smoke) {
 TEST(Pipeable, Transform) {
   int count = 0;
 
-  just()
-    | then([&]{ ++count; })
-    | sync_wait();
+  just() | then([&] { ++count; }) | sync_wait();
 
-  auto twocount = then([&]{ ++count; }) | then([&]{ ++count; });
+  auto twocount = then([&] { ++count; }) | then([&] { ++count; });
 
-  just()
-    | then([&]{ ++count; })
-    | twocount
-    | sync_wait();
+  just() | then([&] { ++count; }) | twocount | sync_wait();
 
   EXPECT_EQ(count, 4);
 }

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,79 +1,70 @@
-#include <unifex/when_all.hpp>
-#include <unifex/then.hpp>
 #include <unifex/just.hpp>
-#include <unifex/sync_wait.hpp>
 #include <unifex/just_done.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/then.hpp>
 #include <unifex/upon_done.hpp>
+#include <unifex/when_all.hpp>
 #include "unifex/let_done.hpp"
 #include "unifex/timed_single_thread_context.hpp"
 
+#include <chrono>
 #include <gtest/gtest.h>
 #include <type_traits>
 #include <variant>
-#include <chrono>
 
 using namespace unifex;
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
 TEST(UponDone, StaticTypeCheck) {
-  auto res1 = just(42)
-    | upon_done([]{
-        return 2;
-      });
-  static_assert(std::is_same_v<decltype(res1)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto res1 = just(42) | upon_done([] { return 2; });
+  static_assert(std::is_same_v<
+                decltype(res1)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>>>);
 
-  auto res2 = just()
-    | upon_done([]{
-        return 2;
-      });
-  static_assert(std::is_same_v<decltype(res2)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<>>>);
+  auto res2 = just() | upon_done([] { return 2; });
+  static_assert(std::is_same_v<
+                decltype(res2)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<>>>);
 
-  auto res3 = just(42)
-    | upon_done([]{
-        return;
-      });
-  static_assert(std::is_same_v<decltype(res3)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto res3 = just(42) | upon_done([] { return; });
+  static_assert(std::is_same_v<
+                decltype(res3)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>>>);
 
-  auto res4 = just(42)
-    | upon_done([]{
-        return 2.0;
-      });
-  static_assert(std::is_same_v<decltype(res4)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto res4 = just(42) | upon_done([] { return 2.0; });
+  static_assert(std::is_same_v<
+                decltype(res4)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>>>);
 
-  auto res5 = just_done()
-    | upon_done([]{
-        return 2;
-      });
-  static_assert(std::is_same_v<decltype(res5)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto res5 = just_done() | upon_done([] { return 2; });
+  static_assert(std::is_same_v<
+                decltype(res5)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>>>);
 
-  auto res6 = just_done()
-    | upon_done([]{
-      });
-  static_assert(std::is_same_v<decltype(res6)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<>>>);
+  auto res6 = just_done() | upon_done([] {});
+  static_assert(std::is_same_v<
+                decltype(res6)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<>>>);
 
   timed_single_thread_context context;
   auto scheduler = context.get_scheduler();
-  auto sch_then_sender = schedule_after(scheduler, 200ms)
-    | then([]{return 2;});
-  static_assert(std::is_same_v<decltype(sch_then_sender)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto sch_then_sender =
+      schedule_after(scheduler, 200ms) | then([] { return 2; });
+  static_assert(
+      std::is_same_v<
+          decltype(sch_then_sender)::value_types<std::variant, std::tuple>,
+          std::variant<std::tuple<int>>>);
 
-  auto res7 = sch_then_sender
-    | upon_done([]{});
-  static_assert(std::is_same_v<decltype(res7)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>, std::tuple<>>>);
+  auto res7 = sch_then_sender | upon_done([] {});
+  static_assert(std::is_same_v<
+                decltype(res7)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>, std::tuple<>>>);
 
-  auto res8 = std::move(sch_then_sender)
-    | upon_done([]{ return 1.2; });
-  static_assert(std::is_same_v<decltype(res8)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>, std::tuple<double>>>);
+  auto res8 = std::move(sch_then_sender) | upon_done([] { return 1.2; });
+  static_assert(std::is_same_v<
+                decltype(res8)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>, std::tuple<double>>>);
 }
 
 TEST(UponDone, Working) {
@@ -82,26 +73,24 @@ TEST(UponDone, Working) {
   EXPECT_EQ(count, 1);
 }
 
-TEST(UponDone, Pipeable){
+TEST(UponDone, Pipeable) {
   int count = 0;
 
-  just_done()
-    | upon_done([&]{count++;})
-    | sync_wait();
+  just_done() | upon_done([&] { count++; }) | sync_wait();
 
-  just_done()
-    | upon_done([&]{count++;})
-    | sync_wait();
+  just_done() | upon_done([&] { count++; }) | sync_wait();
 
   EXPECT_EQ(count, 2);
 }
 
-TEST(UponDone, NotCalled){
+TEST(UponDone, NotCalled) {
   int count = 0;
 
-  auto x = just(42)
-    | upon_done([&]{count++; return 2;})
-    | sync_wait();
+  auto x = just(42) | upon_done([&] {
+             count++;
+             return 2;
+           }) |
+      sync_wait();
 
   EXPECT_EQ(count, 0);
   EXPECT_EQ(x.value(), 42);
@@ -109,24 +98,22 @@ TEST(UponDone, NotCalled){
 
 TEST(UponDone, ReturningValue) {
   int count = 0;
-  auto res = just_done()
-    | upon_done([&]{
-        count++;
-        return 42;
-      })
-    | sync_wait();
+  auto res = just_done() | upon_done([&] {
+               count++;
+               return 42;
+             }) |
+      sync_wait();
   EXPECT_EQ(count, 1);
   EXPECT_EQ(res.value(), 42);
 }
 
-TEST(UponDone, NotCalledWithDifferentReturnType){
+TEST(UponDone, NotCalledWithDifferentReturnType) {
   int count = 0;
-  auto res = just(42)
-    | upon_done([&]{
-        count++;
-        return 2.0;
-      })
-    | sync_wait();
+  auto res = just(42) | upon_done([&] {
+               count++;
+               return 2.0;
+             }) |
+      sync_wait();
   EXPECT_EQ(count, 0);
   EXPECT_EQ(res.value(), 42);
 }

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -10,31 +10,25 @@
 using namespace unifex;
 
 TEST(UponError, StaticTypeCheck) {
-  auto res1 = just(42)
-    | upon_error([](auto){return 42;});
-  static_assert(std::is_same_v<decltype(res1)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>>>);
+  auto res1 = just(42) | upon_error([](auto) { return 42; });
+  static_assert(std::is_same_v<
+                decltype(res1)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>>>);
 
-  auto res2 = just()
-    | upon_error([](auto){
-        return 2;
-      });
-  static_assert(std::is_same_v<decltype(res2)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<>, std::tuple<int>>>);
+  auto res2 = just() | upon_error([](auto) { return 2; });
+  static_assert(std::is_same_v<
+                decltype(res2)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<>, std::tuple<int>>>);
 
-  auto res3 = just(42)
-    | upon_error([](auto){
-        return;
-      });
-  static_assert(std::is_same_v<decltype(res3)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>, std::tuple<>>>);
+  auto res3 = just(42) | upon_error([](auto) { return; });
+  static_assert(std::is_same_v<
+                decltype(res3)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>, std::tuple<>>>);
 
-  auto res4 = just(42)
-    | upon_error([](auto){
-        return 2.0;
-      });
-  static_assert(std::is_same_v<decltype(res4)::value_types<std::variant, std::tuple>,
-      std::variant<std::tuple<int>, std::tuple<double>>>);
+  auto res4 = just(42) | upon_error([](auto) { return 2.0; });
+  static_assert(std::is_same_v<
+                decltype(res4)::value_types<std::variant, std::tuple>,
+                std::variant<std::tuple<int>, std::tuple<double>>>);
 }
 
 TEST(UponError, Working) {
@@ -49,39 +43,35 @@ TEST(UponError, Working) {
 
 TEST(UponError, Pipeable) {
   int val = 0;
-  auto res = just_error(42) 
-    | upon_error([&](auto err_val) {
-        val = err_val;
-        return 2;
-      })
-    | sync_wait();
+  auto res = just_error(42) | upon_error([&](auto err_val) {
+               val = err_val;
+               return 2;
+             }) |
+      sync_wait();
   EXPECT_EQ(val, 42);
   EXPECT_EQ(res.value(), 2);
 }
 
 TEST(UponError, NotCalled) {
   int val = 0;
-  auto res = just(42)
-    | upon_error([&](auto) {
-      val++;
-      return 2;
-    })
-    | sync_wait();
+  auto res = just(42) | upon_error([&](auto) {
+               val++;
+               return 2;
+             }) |
+      sync_wait();
   EXPECT_EQ(val, 0);
   EXPECT_EQ(res.value(), 42);
 }
 
 TEST(UponError, ExceptionHandling) {
   int val = 0;
-  try{
-    just(42)
-      | upon_error([&](auto) {
-        val = 1;
-        throw 2;
-        return 2;
-      })
-      | sync_wait();
-  } catch(int err){
+  try {
+    just(42) | upon_error([&](auto) {
+      val = 1;
+      throw 2;
+      return 2;
+    }) | sync_wait();
+  } catch (int err) {
     EXPECT_EQ(err, 2);
   }
   EXPECT_EQ(val, 0);

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -16,11 +16,11 @@
 #include <unifex/just.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/then.hpp>
-#include <unifex/when_all.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/utility.hpp>
 #include <unifex/variant.hpp>
+#include <unifex/when_all.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -34,7 +34,7 @@ using namespace std::chrono_literals;
 
 namespace {
 struct my_error {};
-}
+}  // namespace
 
 #if !UNIFEX_NO_EXCEPTIONS
 
@@ -93,7 +93,7 @@ TEST(WhenAll2, Smoke) {
   EXPECT_FALSE(ranFinalCallback);
 }
 
-#endif // !UNIFEX_NO_EXCEPTIONS
+#endif  // !UNIFEX_NO_EXCEPTIONS
 
 struct string_const_ref_sender {
   template <

--- a/test/windows_threadpool_test.cpp
+++ b/test/windows_threadpool_test.cpp
@@ -16,156 +16,149 @@
 
 #ifdef _WIN32
 
-#include <unifex/win32/windows_thread_pool.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/then.hpp>
-#include <unifex/when_all.hpp>
-#include <unifex/repeat_effect_until.hpp>
-#include <unifex/stop_when.hpp>
-#include <unifex/let_done.hpp>
-#include <unifex/just.hpp>
-#include <unifex/materialize.hpp>
+#  include <unifex/just.hpp>
+#  include <unifex/let_done.hpp>
+#  include <unifex/materialize.hpp>
+#  include <unifex/repeat_effect_until.hpp>
+#  include <unifex/stop_when.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/then.hpp>
+#  include <unifex/when_all.hpp>
+#  include <unifex/win32/windows_thread_pool.hpp>
 
-#include <chrono>
+#  include <chrono>
 
-#include <gtest/gtest.h>
+#  include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
 
 TEST(windows_thread_pool, construct_destruct) {
-    unifex::win32::windows_thread_pool tp;
+  unifex::win32::windows_thread_pool tp;
 }
 
 TEST(windows_thread_pool, custom_thread_pool) {
-    unifex::win32::windows_thread_pool tp{2, 4};
-    auto s = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp{2, 4};
+  auto s = tp.get_scheduler();
 
-    std::atomic<int> count = 0;
+  std::atomic<int> count = 0;
 
-    auto incrementCountOnTp = unifex::then(unifex::schedule(s), [&] { ++count; });
+  auto incrementCountOnTp = unifex::then(unifex::schedule(s), [&] { ++count; });
 
-    unifex::sync_wait(unifex::when_all(
-        incrementCountOnTp,
-        incrementCountOnTp,
-        incrementCountOnTp,
-        incrementCountOnTp));
+  unifex::sync_wait(unifex::when_all(
+      incrementCountOnTp,
+      incrementCountOnTp,
+      incrementCountOnTp,
+      incrementCountOnTp));
 
-    EXPECT_EQ(4, count.load());
+  EXPECT_EQ(4, count.load());
 }
 
 TEST(windows_thread_pool, schedule) {
-    unifex::win32::windows_thread_pool tp;
-    unifex::sync_wait(unifex::schedule(tp.get_scheduler()));
+  unifex::win32::windows_thread_pool tp;
+  unifex::sync_wait(unifex::schedule(tp.get_scheduler()));
 }
 
 TEST(windows_thread_pool, schedule_completes_on_a_different_thread) {
-    unifex::win32::windows_thread_pool tp;
-    const auto mainThreadId = std::this_thread::get_id();
-    auto workThreadId = unifex::sync_wait(
-        unifex::then(
-            unifex::schedule(tp.get_scheduler()),
-            [&]() noexcept { return std::this_thread::get_id(); }));
-    EXPECT_NE(workThreadId, mainThreadId);
+  unifex::win32::windows_thread_pool tp;
+  const auto mainThreadId = std::this_thread::get_id();
+  auto workThreadId = unifex::sync_wait(
+      unifex::then(unifex::schedule(tp.get_scheduler()), [&]() noexcept {
+        return std::this_thread::get_id();
+      }));
+  EXPECT_NE(workThreadId, mainThreadId);
 }
 
 TEST(windows_thread_pool, schedule_multiple_in_parallel) {
-    unifex::win32::windows_thread_pool tp;
-    auto sch = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto sch = tp.get_scheduler();
 
-    unifex::sync_wait(unifex::then(
-        unifex::when_all(
-            unifex::schedule(sch),
-            unifex::schedule(sch),
-            unifex::schedule(sch)),
-        [](auto&&...) noexcept { return 0; }));
+  unifex::sync_wait(unifex::then(
+      unifex::when_all(
+          unifex::schedule(sch), unifex::schedule(sch), unifex::schedule(sch)),
+      [](auto&&...) noexcept { return 0; }));
 }
 
 TEST(windows_thread_pool, schedule_cancellation_thread_safety) {
-    unifex::win32::windows_thread_pool tp;
-    auto sch = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto sch = tp.get_scheduler();
 
-    unifex::sync_wait(unifex::repeat_effect_until(
-        unifex::let_done(
-            unifex::stop_when(
-                unifex::repeat_effect(unifex::schedule(sch)),
-                unifex::schedule(sch)),
-            [] { return unifex::just(); }),
-        [n=0]() mutable noexcept { return n++ == 1000; }));
+  unifex::sync_wait(unifex::repeat_effect_until(
+      unifex::let_done(
+          unifex::stop_when(
+              unifex::repeat_effect(unifex::schedule(sch)),
+              unifex::schedule(sch)),
+          [] { return unifex::just(); }),
+      [n = 0]() mutable noexcept { return n++ == 1000; }));
 }
 
 TEST(windows_thread_pool, schedule_after) {
-    unifex::win32::windows_thread_pool tp;
-    auto s = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto s = tp.get_scheduler();
 
-    auto startTime = s.now();
+  auto startTime = s.now();
 
-    unifex::sync_wait(unifex::schedule_after(s, 50ms));
+  unifex::sync_wait(unifex::schedule_after(s, 50ms));
 
-    auto duration = s.now() - startTime;
+  auto duration = s.now() - startTime;
 
-    EXPECT_TRUE(duration > 40ms);
-    EXPECT_TRUE(duration < 100ms);
+  EXPECT_TRUE(duration > 40ms);
+  EXPECT_TRUE(duration < 100ms);
 }
 
 TEST(windows_thread_pool, schedule_after_cancellation) {
-    unifex::win32::windows_thread_pool tp;
-    auto s = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto s = tp.get_scheduler();
 
-    auto startTime = s.now();
+  auto startTime = s.now();
 
-    bool ranWork = false;
+  bool ranWork = false;
 
-    unifex::sync_wait(
-        unifex::let_done(
-            unifex::stop_when(
-                unifex::then(
-                    unifex::schedule_after(s, 5s),
-                    [&] { ranWork = true; }),
-                unifex::schedule_after(s, 5ms)),
-            [] { return unifex::just(); }));
+  unifex::sync_wait(unifex::let_done(
+      unifex::stop_when(
+          unifex::then(unifex::schedule_after(s, 5s), [&] { ranWork = true; }),
+          unifex::schedule_after(s, 5ms)),
+      [] { return unifex::just(); }));
 
-    auto duration = s.now() - startTime;
+  auto duration = s.now() - startTime;
 
-    // Work should have been cancelled.
-    EXPECT_FALSE(ranWork);
-    EXPECT_LT(duration, 1s);
+  // Work should have been cancelled.
+  EXPECT_FALSE(ranWork);
+  EXPECT_LT(duration, 1s);
 }
 
 TEST(windows_thread_pool, schedule_at) {
-    unifex::win32::windows_thread_pool tp;
-    auto s = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto s = tp.get_scheduler();
 
-    auto startTime = s.now();
+  auto startTime = s.now();
 
-    unifex::sync_wait(unifex::schedule_at(s, startTime + 100ms));
+  unifex::sync_wait(unifex::schedule_at(s, startTime + 100ms));
 
-    auto endTime = s.now();
-    EXPECT_TRUE(endTime >= (startTime + 100ms));
-    EXPECT_TRUE(endTime < (startTime + 150ms));
+  auto endTime = s.now();
+  EXPECT_TRUE(endTime >= (startTime + 100ms));
+  EXPECT_TRUE(endTime < (startTime + 150ms));
 }
 
 TEST(windows_thread_pool, schedule_at_cancellation) {
-    unifex::win32::windows_thread_pool tp;
-    auto s = tp.get_scheduler();
+  unifex::win32::windows_thread_pool tp;
+  auto s = tp.get_scheduler();
 
-    auto startTime = s.now();
+  auto startTime = s.now();
 
-    bool ranWork = false;
+  bool ranWork = false;
 
-    unifex::sync_wait(
-        unifex::let_done(
-            unifex::stop_when(
-                unifex::then(
-                    unifex::schedule_at(s, startTime + 5s),
-                    [&] { ranWork = true; }),
-                unifex::schedule_at(s, startTime + 5ms)),
-            [] { return unifex::just(); }));
+  unifex::sync_wait(unifex::let_done(
+      unifex::stop_when(
+          unifex::then(
+              unifex::schedule_at(s, startTime + 5s), [&] { ranWork = true; }),
+          unifex::schedule_at(s, startTime + 5ms)),
+      [] { return unifex::just(); }));
 
-    auto duration = s.now() - startTime;
+  auto duration = s.now() - startTime;
 
-    // Work should have been cancelled.
-    EXPECT_FALSE(ranWork);
-    EXPECT_LT(duration, 1s);
+  // Work should have been cancelled.
+  EXPECT_FALSE(ranWork);
+  EXPECT_LT(duration, 1s);
 }
 
-#endif // _WIN32
+#endif  // _WIN32


### PR DESCRIPTION
Ran `find include/ source/ test/ -type f -exec clang-format -i {} +` to clang-format all files under `include/`, `source/` and `test/`.