### PR TITLE
Fix let_value to query sender properties through sender_traits

### DIFF
--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -250,12 +250,12 @@ private:
   using predecessor_type = remove_cvref_t<Predecessor>;
   UNIFEX_NO_UNIQUE_ADDRESS SuccessorFactory func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-  UNIFEX_NO_UNIQUE_ADDRESS typename predecessor_type::
+  UNIFEX_NO_UNIQUE_ADDRESS typename sender_traits<predecessor_type>::
       template value_types<manual_lifetime_union, decayed_tuple>
           values_;
   union {
     manual_lifetime<connect_result_t<Predecessor, predecessor_receiver<operation>>> predOp_;
-    typename predecessor_type::template
+    typename sender_traits<predecessor_type>::template
         value_types<manual_lifetime_union, successor_operation>
             succOp_;
   };


### PR DESCRIPTION
let_value queries its predecessor Sender's value_types incorrectly.
It assumes the Sender has a value_types member alias template, but it may not.  The "right" way is to use sender_traits<Predecessor>.