### PR TITLE
make io_uring syscalls retrying on interruptions

### DIFF
--- a/source/linux/io_uring_syscall.cpp
+++ b/source/linux/io_uring_syscall.cpp
@@ -18,59 +18,83 @@
 
 #if !UNIFEX_NO_LIBURING
 
-#include "io_uring_syscall.hpp"
+#  include "io_uring_syscall.hpp"
 
 // Based on liburing's syscall.c by Jens Axboe
 
-#include <unistd.h>
-#include <sys/syscall.h>
-#include <sys/uio.h>
+#  include <errno.h>
+#  include <sys/syscall.h>
+#  include <sys/uio.h>
+#  include <unistd.h>
 
-#ifdef __alpha__
+#  ifdef __alpha__
 /*
  * alpha is the only exception, all other architectures
  * have common numbers for new system calls.
  */
-# ifndef __NR_io_uring_setup
-#  define __NR_io_uring_setup		535
-# endif
-# ifndef __NR_io_uring_enter
-#  define __NR_io_uring_enter		536
-# endif
-# ifndef __NR_io_uring_register
-#  define __NR_io_uring_register	537
-# endif
-#else /* !__alpha__ */
-# ifndef __NR_io_uring_setup
-#  define __NR_io_uring_setup		425
-# endif
-# ifndef __NR_io_uring_enter
-#  define __NR_io_uring_enter		426
-# endif
-# ifndef __NR_io_uring_register
-#  define __NR_io_uring_register	427
-# endif
-#endif
+#    ifndef __NR_io_uring_setup
+#      define __NR_io_uring_setup 535
+#    endif
+#    ifndef __NR_io_uring_enter
+#      define __NR_io_uring_enter 536
+#    endif
+#    ifndef __NR_io_uring_register
+#      define __NR_io_uring_register 537
+#    endif
+#  else /* !__alpha__ */
+#    ifndef __NR_io_uring_setup
+#      define __NR_io_uring_setup 425
+#    endif
+#    ifndef __NR_io_uring_enter
+#      define __NR_io_uring_enter 426
+#    endif
+#    ifndef __NR_io_uring_register
+#      define __NR_io_uring_register 427
+#    endif
+#  endif
 
-namespace unifex::linuxos
-{
-    int io_uring_register(int fd, unsigned opcode, const void *arg,
-			    unsigned nr_args)
-    {
-        return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+namespace unifex::linuxos {
+template <typename F>
+int retryInterruptableSyscall(F&& func) {
+  while (true) {
+    auto ret = func();
+    if (ret == EINTR) {
+      continue;
     }
 
-    int io_uring_setup(unsigned entries, struct io_uring_params *p)
-    {
-        return syscall(__NR_io_uring_setup, entries, p);
-    }
-
-    int io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
-                       unsigned flags, sigset_t *sig)
-    {
-        return syscall(__NR_io_uring_enter, fd, to_submit, min_complete,
-                       flags, sig, _NSIG / 8);
-    }
+    return ret;
+  }
 }
 
-#endif // UNIFEX_NO_LIBURING
+int io_uring_register(
+    int fd, unsigned opcode, const void* arg, unsigned nr_args) {
+  return retryInterruptableSyscall([=]() {
+    return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+  });
+}
+
+int io_uring_setup(unsigned entries, struct io_uring_params* p) {
+  return retryInterruptableSyscall(
+      [=]() { return syscall(__NR_io_uring_setup, entries, p); });
+}
+
+int io_uring_enter(
+    int fd,
+    unsigned to_submit,
+    unsigned min_complete,
+    unsigned flags,
+    sigset_t* sig) {
+  return retryInterruptableSyscall([=]() {
+    return syscall(
+        __NR_io_uring_enter,
+        fd,
+        to_submit,
+        min_complete,
+        flags,
+        sig,
+        _NSIG / 8);
+  });
+}
+}  // namespace unifex::linuxos
+
+#endif  // UNIFEX_NO_LIBURING


### PR DESCRIPTION
io_uring context has to retry on interruptions as this is what may happen in the middle of the syscall 