### PR TITLE
Fix race condition in `when_all`

### DIFF
--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <unifex/allocate.hpp>
+#include <unifex/finally.hpp>
+#include <unifex/get_stop_token.hpp>
 #include <unifex/just.hpp>
+#include <unifex/just_from.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/repeat_effect_until.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/then.hpp>
-#include <unifex/when_all.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/utility.hpp>
 #include <unifex/variant.hpp>
+#include <unifex/when_all.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -34,7 +40,65 @@ using namespace std::chrono_literals;
 
 namespace {
 struct my_error {};
+
+template <typename StopToken, typename Callback>
+auto make_stop_callback(StopToken stoken, Callback callback) {
+  using stop_callback_t = typename StopToken::template callback_type<Callback>;
+
+  return stop_callback_t{stoken, std::move(callback)};
 }
+
+struct _cancel_only_sender {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+  static constexpr bool sends_done = true;
+
+  template <typename Receiver>
+  struct operation;
+
+  template <typename Receiver>
+  struct cancel_operation {
+    operation<Receiver>& op_;
+
+    void operator()() noexcept { op_.set_done(); }
+  };
+
+  template <typename Receiver>
+  struct operation {
+    using receiver_t = unifex::remove_cvref_t<Receiver>;
+    using receiver_stop_token_t = stop_token_type_t<Receiver&>;
+
+    receiver_t receiver_;
+    receiver_stop_token_t stoken_ = get_stop_token(receiver_);
+    cancel_operation<receiver_t> cancel_{*this};
+    decltype(make_stop_callback(stoken_, cancel_)) callback_ =
+        make_stop_callback(stoken_, cancel_);
+
+    void start() noexcept {}
+
+    void set_done() noexcept { unifex::set_done(std::move(receiver_)); }
+  };
+
+  template <typename Receiver>
+  auto connect(Receiver&& receiver) const& noexcept {
+    return operation<Receiver>{static_cast<Receiver&&>(receiver)};
+  }
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&...) const noexcept {
+    return _cancel_only_sender{};
+  }
+} cancel_only_sender{};
+
+}  // namespace
 
 #if !UNIFEX_NO_EXCEPTIONS
 
@@ -93,7 +157,7 @@ TEST(WhenAll2, Smoke) {
   EXPECT_FALSE(ranFinalCallback);
 }
 
-#endif // !UNIFEX_NO_EXCEPTIONS
+#endif  // !UNIFEX_NO_EXCEPTIONS
 
 struct string_const_ref_sender {
   template <
@@ -141,4 +205,15 @@ TEST(WhenAll2, SenderIsLvalueConnectable) {
   auto test = unifex::when_all(unifex::just(), unifex::just());
 
   unifex::sync_wait(test);
+}
+
+TEST(WhenAll2, ErrorCancelsRest) {
+  try {
+    sync_wait(when_all(
+        // arm #1: use allocate() to trigger ASAN
+        finally(allocate(when_all(cancel_only_sender())), just()),
+        // arm #2: immediately throw to trigger cancellation of arm #1
+        just_from([]() { throw 1; })));
+  } catch (...) {
+  }
 }


### PR DESCRIPTION
* `request_stop()` from `set_error()` in one *arm* is *racing* with `set_done()` in another *arm*
* introduce ownership transfer of `deliver_result` to and from
  `cancel_operation`