### PR TITLE
make `async_scope::attached_sender` copyable

### DIFF
--- a/include/unifex/async_scope.hpp
+++ b/include/unifex/async_scope.hpp
@@ -784,11 +784,13 @@ public:
       std::is_nothrow_constructible_v<Sender, Sender2>)
     : scope_(scope)
     , sender_(static_cast<Sender2&&>(sender)) {
-    if (scope_) {
-      if (!try_record_start(scope_)) {
-        scope_ = nullptr;
-      }
-    }
+    try_attach();
+  }
+
+  type(const type& t) noexcept(std::is_nothrow_copy_constructible_v<Sender>)
+    : scope_(t.scope_)
+    , sender_(t.sender_) {
+    try_attach();
   }
 
   type(type&& t) noexcept(std::is_nothrow_move_constructible_v<Sender>)
@@ -822,6 +824,14 @@ public:
 private:
   async_scope* scope_;
   UNIFEX_NO_UNIQUE_ADDRESS Sender sender_;
+
+  void try_attach() noexcept {
+    if (scope_) {
+      if (!try_record_start(scope_)) {
+        scope_ = nullptr;
+      }
+    }
+  }
 };
 
 template <typename Sender>


### PR DESCRIPTION
* copy constructor calls `async_scope::try_record_start` internally
* copy of attached Sender will increment outstanding number of
  operations on async_scope