### PR TITLE
fix cancellation race in `detach_on_cancel()`

### DIFF
--- a/include/unifex/detach_on_cancel.hpp
+++ b/include/unifex/detach_on_cancel.hpp
@@ -37,23 +37,13 @@ struct operation_state {
   struct cancel_callback final {
     detached_state* state_;
 
-    void operator()() noexcept {
-      state_->stopSource_.request_stop();
-      auto* op = state_->parentOp_.exchange(nullptr, std::memory_order_acq_rel);
-      if (op != nullptr) {
-        // We won the race for cancellation
-        // ownership is transferred to the detached state
-        (void)op->state_.release();
-        op->callback_.destruct();
-        unifex::set_done(std::move(op->receiver_));
-      }
-    }
+    void operator()() noexcept { state_->request_stop(); }
   };
 
   struct type final {
     type(UpstreamSender&& s, DownstreamReceiver&& r)
       : receiver_(std::move(r))
-      , state_(std::make_unique<detached_state>(this, (UpstreamSender &&) s)) {}
+      , state_(std::make_unique<detached_state>(*this, (UpstreamSender &&) s)) {}
 
     friend void tag_invoke(tag_t<unifex::start>, type& op) noexcept {
       auto& childOp = op.state_->childOp_;
@@ -68,27 +58,15 @@ struct operation_state {
         callback_;
     std::unique_ptr<detached_state> state_;
   };
+  // use low 2 bits of type* as ref count
+  static_assert(alignof(type) > 2);
 };
 
 template <typename UpstreamSender, typename DownstreamReceiver>
 struct operation_state<UpstreamSender, DownstreamReceiver>::_receiver final {
-private:
-  auto tryGetOp() noexcept {
-    // if cancellation won, parentOp_ would be null at this point
-    // see operation_state::cancel_callback()
-    auto* op = state_->parentOp_.exchange(nullptr, std::memory_order_acq_rel);
-    if (op != nullptr) {
-      op->callback_.destruct();
-    } else {
-      delete state_;
-    }
-    return op;
-  }
-
-public:
   template <typename... Values>
   void set_value(Values&&... values) noexcept {
-    if (auto op = tryGetOp()) {
+    if (auto op = state_->try_get_op()) {
       UNIFEX_TRY {
         unifex::set_value(std::move(op->receiver_), (Values &&) values...);
       }
@@ -100,13 +78,13 @@ public:
 
   template <typename Error>
   void set_error(Error&& error) noexcept {
-    if (auto op = tryGetOp()) {
+    if (auto op = state_->try_get_op()) {
       unifex::set_error(std::move(op->receiver_), (Error &&) error);
     }
   }
 
   void set_done() noexcept {
-    if (auto op = tryGetOp()) {
+    if (auto op = state_->try_get_op()) {
       unifex::set_done(std::move(op->receiver_));
     }
   }
@@ -120,18 +98,84 @@ public:
 
 template <typename UpstreamSender, typename DownstreamReceiver>
 struct operation_state<UpstreamSender, DownstreamReceiver>::detached_state final {
+  using parent_op_t =
+      typename operation_state<UpstreamSender, DownstreamReceiver>::type;
+
   detached_state(
-      typename operation_state<UpstreamSender, DownstreamReceiver>::type* op,
-      UpstreamSender&& s) //
+      parent_op_t& op,
+      UpstreamSender&& s)  //
       noexcept(is_nothrow_connectable_v<UpstreamSender, _receiver>)
-    : parentOp_(op)
+    : parentOp_(init_refcount(op))
     , childOp_(connect(std::move(s), _receiver{this})) {}
 
-  std::atomic<
-      typename operation_state<UpstreamSender, DownstreamReceiver>::type*>
-      parentOp_;
+  static constexpr std::uintptr_t mask = ~std::uintptr_t{3u};
+  // operation_state::type* stored as integer: low 2 bits for ref count
+  std::atomic_uintptr_t parentOp_;
   inplace_stop_source stopSource_;
   connect_result_t<UpstreamSender, _receiver> childOp_;
+
+  void request_stop() noexcept {
+    auto expected = parentOp_.load(std::memory_order_relaxed);
+    if (ref_count(expected) == 0u) {
+      // try_get_op already executed
+      return;
+    }
+    UNIFEX_ASSERT(ref_count(expected) == 1u);
+    // 1. set ref count to 2
+    // 2. zero the pointer
+    // if successful, callback owns the op and ptr remains in `expected`
+    if (!parentOp_.compare_exchange_strong(
+            expected,
+            2u,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      UNIFEX_ASSERT(ref_count(expected) == 0u);
+      return;
+    }
+    stopSource_.request_stop();
+    auto refCount = parentOp_.fetch_sub(1u, std::memory_order_acq_rel);
+    UNIFEX_ASSERT(parent_op_ptr(refCount) == nullptr);
+    auto op = parent_op_ptr(expected);
+    op->callback_.destruct();
+    if (refCount == 1u) {
+      // callback owns the detached state
+      op->state_.reset();
+    } else {
+      (void)op->state_.release();
+    }
+    unifex::set_done(std::move(op->receiver_));
+  }
+
+  parent_op_t* try_get_op() noexcept {
+    auto op = parentOp_.fetch_sub(1u, std::memory_order_acq_rel);
+    if (ref_count(op) != 1u) {
+      // decrement from 2 means lost race with stop callback
+      UNIFEX_ASSERT(ref_count(op) == 2u);
+      UNIFEX_ASSERT(parent_op_ptr(op) == nullptr);
+      return nullptr;
+    }
+    if (auto ptr = parent_op_ptr(op)) {
+      ptr->callback_.destruct();
+      return ptr;
+    }
+    // stop owns callback destruction
+    delete this;
+    return nullptr;
+  }
+
+private:
+  // ref count in low 2 bits: start at 1
+  static std::uintptr_t init_refcount(parent_op_t& parentOp) noexcept {
+    return reinterpret_cast<std::uintptr_t>(&parentOp) | std::uintptr_t{1u};
+  }
+
+  static parent_op_t* parent_op_ptr(std::uintptr_t parentOp) noexcept {
+    return reinterpret_cast<parent_op_t*>(parentOp & mask);
+  }
+
+  static std::uintptr_t ref_count(std::uintptr_t parentOp) noexcept {
+    return parentOp & ~mask;
+  }
 };
 
 template <typename Sender>


### PR DESCRIPTION
* use ref counting to pass ownership of `detached_state`
* regression tests