### PR TITLE
fix `async_scope_test::attach_record_done`

### DIFF
--- a/test/async_scope_test.cpp
+++ b/test/async_scope_test.cpp
@@ -668,7 +668,9 @@ TEST_F(async_scope_test, attach_record_done) {
 
     void set_done() noexcept {
       auto& localEvt = evt;
-      sync_wait(localEvt.async_wait());
+      sync_wait(when_all(localEvt.async_wait(), just_from([&]() noexcept {
+                           localEvt.set();
+                         })));
     }
   };
 


### PR DESCRIPTION
* inplace execution of `set_done()` causes the test to hang as `just_from()` arm of `when_all()` won't `start()`
* receiver may `set()` the event after `async_wait()` suspends