### PR TITLE
connect_awaitable gcc 10.2 promise fix

### DIFF
--- a/test/awaitable_senders_test.cpp
+++ b/test/awaitable_senders_test.cpp
@@ -23,8 +23,11 @@
 #include <unifex/task.hpp>
 #include <unifex/stop_when.hpp>
 #include <unifex/timed_single_thread_context.hpp>
+#include <unifex/let_value.hpp>
+#include <unifex/let_value_with.hpp>
 #include <unifex/when_all.hpp>
 #include <unifex/scheduler_concepts.hpp>
+#include <unifex/async_scope.hpp>
 
 #include <chrono>
 
@@ -80,6 +83,24 @@ TEST(awaitable_senders, await_multi_value_sender) {
   }());
 
   EXPECT_EQ(52, result);
+}
+
+TEST(awaitable_senders, spawn_awaitable_on_async_scope) {
+    auto sndr = let_value_with(
+        []() { return async_scope{};},
+        [](async_scope& scope) {
+            scope.spawn(
+                let_value(
+                    []() -> task<void> { co_return; }(),
+                    []() { return just(); }
+                )
+            );
+            return scope.complete();
+        }
+    );
+
+    auto results = sync_wait(std::move(sndr));
+    EXPECT_TRUE(results.has_value());
 }
 
 #endif  // UNIFEX_NO_COROUTINES


### PR DESCRIPTION
The test I added crashed when built with gcc 10.2 due to a bug in this compiler version that passes pre-copy references to the coroutine function arguments rather than post-copy into the coroutine frame. Printing the addresses in gdb show that the references refer to the pre-copy memory addresses of the awaitable and receiver, rather than post-copy (in the coroutine frame).

gcc 10.2's level of coroutine support is definitely not as great as 10.3 or newer major versions, although I thought it was worth it nonetheless to highlight this bug with a potential fix. The fix I have is not all that great since it requires a memory allocation, so I'll definitely take suggestions.