### PR TITLE
#445 Fix race condition in `when_all`

### DIFF
--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -92,20 +92,20 @@ struct _operation_tuple<Index, Receiver>::type {
   void start() noexcept {}
 };
 
-struct cancel_operation {
-  inplace_stop_source& stopSource_;
-
-  void operator()() noexcept {
-    stopSource_.request_stop();
-  }
-};
-
 template <typename Receiver, typename... Senders>
 struct _op {
   struct type;
 };
 template <typename Receiver, typename... Senders>
 using operation = typename _op<remove_cvref_t<Receiver>, Senders...>::type;
+
+template <typename Receiver, typename... Senders>
+struct cancel_operation {
+  operation<Receiver, Senders...>& op_;
+  void operator()() noexcept {
+    op_.request_stop();
+  }
+};
 
 template <typename... Errors>
 using unique_decayed_error_types = concat_type_lists_unique_t<
@@ -211,19 +211,39 @@ struct _op<Receiver, Senders...>::type {
 
   void start() noexcept {
     stopCallback_.construct(
-        get_stop_token(receiver_), cancel_operation{stopSource_});
+        get_stop_token(receiver_),
+        cancel_operation<Receiver, Senders...>{*this});
     ops_.start();
+  }
+
+  void request_stop() noexcept {
+    // mark callback as running (own deliver_result)
+    auto oldCount = refCount_.fetch_add(1, std::memory_order_relaxed);
+    UNIFEX_ASSERT(!(oldCount & callback_running_bit));
+    stopSource_.request_stop();
+    // unmark (deliver_result back to operation)
+    oldCount = refCount_.fetch_sub(1, std::memory_order_relaxed);
+    UNIFEX_ASSERT(oldCount & callback_running_bit);
+    // deliver_result as there are no more operations
+    if (oldCount == 1) {
+      unifex::set_done(std::move(receiver_));
+    }
   }
 
   private:
   void element_complete() noexcept {
-    if (refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // +2 for last operation, +1 for callback running
+    if (refCount_.fetch_sub(2, std::memory_order_release) < 4) {
       deliver_result();
     }
   }
 
   void deliver_result() noexcept {
     stopCallback_.destruct();
+    if (refCount_.load(std::memory_order_acquire) == 1) {
+      // request_stop owns deliver_result (callback running)
+      return;
+    }
 
     if (get_stop_token(receiver_).stop_requested()) {
       unifex::set_done(std::move(receiver_));
@@ -253,13 +273,16 @@ struct _op<Receiver, Senders...>::type {
     }
   }
 
+  static constexpr std::size_t callback_running_bit{1};
   std::tuple<std::optional<value_variant_for_sender<remove_cvref_t<Senders>>>...> values_;
   std::optional<error_types<std::variant, remove_cvref_t<Senders>...>> error_;
-  std::atomic<std::size_t> refCount_{sizeof...(Senders)};
+  // count left-shifted by 1 to allow add 1 when stop is requested
+  std::atomic<std::size_t> refCount_{sizeof...(Senders) << 1};
   std::atomic<bool> doneOrError_{false};
   inplace_stop_source stopSource_;
-  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-      Receiver&>::template callback_type<cancel_operation>>
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<
+      typename stop_token_type_t<Receiver&>::template callback_type<
+          cancel_operation<Receiver, Senders...>>>
       stopCallback_;
   Receiver receiver_;
   template <std::size_t Index>

--- a/test/when_all_2_test.cpp
+++ b/test/when_all_2_test.cpp
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <unifex/allocate.hpp>
+#include <unifex/finally.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/just.hpp>
+#include <unifex/just_from.hpp>
+#include <unifex/receiver_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/when_all.hpp>
 
 #include <chrono>
@@ -31,7 +37,65 @@ using namespace std::chrono_literals;
 
 namespace {
 struct my_error {};
+
+template <typename StopToken, typename Callback>
+auto make_stop_callback(StopToken stoken, Callback callback) {
+  using stop_callback_t = typename StopToken::template callback_type<Callback>;
+
+  return stop_callback_t{stoken, std::move(callback)};
 }
+
+struct _cancel_only_sender {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+  static constexpr bool sends_done = true;
+
+  template <typename Receiver>
+  struct operation;
+
+  template <typename Receiver>
+  struct cancel_operation {
+    operation<Receiver>& op_;
+
+    void operator()() noexcept { op_.set_done(); }
+  };
+
+  template <typename Receiver>
+  struct operation {
+    using receiver_t = unifex::remove_cvref_t<Receiver>;
+    using receiver_stop_token_t = stop_token_type_t<Receiver&>;
+
+    receiver_t receiver_;
+    receiver_stop_token_t stoken_ = get_stop_token(receiver_);
+    cancel_operation<receiver_t> cancel_{*this};
+    decltype(make_stop_callback(stoken_, cancel_)) callback_ =
+        make_stop_callback(stoken_, cancel_);
+
+    void start() noexcept {}
+
+    void set_done() noexcept { unifex::set_done(std::move(receiver_)); }
+  };
+
+  template <typename Receiver>
+  auto connect(Receiver&& receiver) const& noexcept {
+    return operation<Receiver>{static_cast<Receiver&&>(receiver)};
+  }
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&...) const noexcept {
+    return _cancel_only_sender{};
+  }
+} cancel_only_sender{};
+
+}  // namespace
 
 #if !UNIFEX_NO_EXCEPTIONS
 
@@ -90,7 +154,7 @@ TEST(WhenAll2, Smoke) {
   EXPECT_FALSE(ranFinalCallback);
 }
 
-#endif // !UNIFEX_NO_EXCEPTIONS
+#endif  // !UNIFEX_NO_EXCEPTIONS
 
 struct string_const_ref_sender {
   template <
@@ -132,4 +196,15 @@ TEST(WhenAll2, ResultsAreDecayCopied) {
       "hello world", std::get<0>(std::get<0>(std::get<0>(result.value()))));
   EXPECT_EQ(
       "hello world", std::get<0>(std::get<0>(std::get<1>(result.value()))));
+}
+
+TEST(WhenAll2, ErrorCancelsRest) {
+  try {
+    sync_wait(when_all(
+        // arm #1: use allocate() to trigger ASAN
+        finally(allocate(when_all(cancel_only_sender())), just()),
+        // arm #2: immediately throw to trigger cancellation of arm #1
+        just_from([]() { throw 1; })));
+  } catch (...) {
+  }
 }


### PR DESCRIPTION
    * `request_stop()` from `set_error()` in one *arm* is *racing* with `set_done()` in another *arm*
    * `cancel_operation` increments `refCount_` to keep operation state alive while it's executing