### PR TITLE
Allow linking to liburing fetched from CMake

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -41,7 +41,7 @@ if (NOT UNIFEX_NO_LIBURING)
 
   target_include_directories(unifex
     PUBLIC
-      ${UNIFEX_URING_INCLUDE_DIRS})
+      $<BUILD_INTERFACE:${UNIFEX_URING_INCLUDE_DIRS}>)
 
   target_link_libraries(unifex
     PRIVATE


### PR DESCRIPTION
👋 I have a project pulling in libunifex, where rather than a user having to install liburing manually with apt. I've fetched it through CMake for them, and build it all for them. This way the only thing the user really needs is a C++-Compiler, and well CMake. Unfortunately by default this doesn't work by default because CMake will complain about the build directories being used:

```text
CMake Error in build/debug/_deps/unifex-src/source/CMakeLists.txt:
  Target "unifex" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/home/cynthia/projects/personal/<project-name>/build/debug/_deps/liburing-src/src/include"

  which is prefixed in the build directory.
```

As far as I understand, this should be safe to change for everyone and won't break any existing users. However, will allow me to pull in liburing for the user on my project.