### PR TITLE
add `unifex::v2::async_scope`

### DIFF
--- a/include/unifex/v2/async_scope.hpp
+++ b/include/unifex/v2/async_scope.hpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/async_manual_reset_event.hpp>
+#include <unifex/just_from.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/sequence.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex::v2 {
+
+namespace _async_scope {
+
+template <typename Sender>
+struct _nest_sender final {
+  struct type;
+};
+
+template <typename Sender>
+using nest_sender = typename _nest_sender<Sender>::type;
+
+struct async_scope;
+
+struct scope_reference final {
+  scope_reference() noexcept = default;
+
+  explicit scope_reference(async_scope* scope) noexcept
+    : scope_(scope_or_nullptr(scope)) {}
+
+  scope_reference(scope_reference&& other) noexcept
+    : scope_(std::exchange(other.scope_, nullptr)) {}
+
+  scope_reference(const scope_reference& other) noexcept
+    : scope_reference(other.scope_) {}
+
+  ~scope_reference();
+
+  scope_reference& operator=(scope_reference rhs) noexcept {
+    std::swap(scope_, rhs.scope_);
+    return *this;
+  }
+
+  explicit operator bool() const noexcept { return scope_ != nullptr; }
+
+private:
+  async_scope* scope_ = nullptr;
+
+  static async_scope* scope_or_nullptr(async_scope* scope) noexcept;
+};
+
+struct async_scope final {
+  async_scope() noexcept = default;
+
+  async_scope(async_scope&&) = delete;
+
+  ~async_scope() {
+    UNIFEX_ASSERT(join_started());
+    UNIFEX_ASSERT(use_count() == 0);
+  }
+
+  [[nodiscard]] auto join() noexcept {
+    return sequence(
+        just_from([this]() noexcept { end_scope(); }), evt_.async_wait());
+  }
+
+  // Equivalent to, but more efficient than, join_started() && use_count() == 0
+  bool joined() const noexcept {
+    auto state = opState_.load(std::memory_order_relaxed);
+    return state == 0u;
+  }
+
+  template(typename Sender)      //
+      (requires sender<Sender>)  //
+      [[nodiscard]] auto nest(Sender&& sender) noexcept(
+          std::is_nothrow_constructible_v<
+              nest_sender<remove_cvref_t<Sender>>,
+              Sender,
+              scope_reference>) {
+    if (scope_reference scope{this}) {
+      return nest_sender<remove_cvref_t<Sender>>{
+          static_cast<Sender&&>(sender), std::move(scope)};
+    } else {
+      return nest_sender<remove_cvref_t<Sender>>{};
+    }
+  }
+
+  bool join_started() const noexcept {
+    auto state = opState_.load(std::memory_order_relaxed);
+    return scope_ended(state);
+  }
+
+  std::size_t use_count() const noexcept {
+    auto state = opState_.load(std::memory_order_relaxed);
+    return use_count(state);
+  }
+
+private:
+  static constexpr std::size_t scopeEndedBit{1u};
+
+  /**
+   * Returns true if the given state is marked with "stopping", indicating that
+   * no more work may be spawned within the scope.
+   */
+  static bool scope_ended(std::size_t state) noexcept {
+    return (state & scopeEndedBit) == 0u;
+  }
+
+  /**
+   * Returns the number of outstanding operations in the scope.
+   */
+  static std::size_t use_count(std::size_t state) noexcept {
+    return state >> 1;
+  }
+
+  // (opState_ & 1) is 1 until this scope has been ended
+  // (opState_ >> 1) is the number of outstanding operations
+  std::atomic<std::size_t> opState_{1u};
+  async_manual_reset_event evt_;
+
+  /**
+   * Marks the scope to prevent nest from starting any new work.
+   */
+  void end_scope() noexcept {
+    // prevent new work from being nested within this scope; by clearing the
+    // scopeEndedBit, we cause try_record_start() to fail because the scope has
+    // ended
+    auto oldState =
+        opState_.fetch_and(~scopeEndedBit, std::memory_order_acq_rel);
+
+    if (use_count(oldState) == 0) {
+      // there are no outstanding operations to wait for
+      evt_.set();
+    }
+  }
+
+  friend void record_completion(async_scope* scope) noexcept {
+    auto oldState = scope->opState_.fetch_sub(2u, std::memory_order_acq_rel);
+
+    if (scope_ended(oldState) && use_count(oldState) == 1u) {
+      // the scope is stopping and we're the last op to finish
+      scope->evt_.set();
+    }
+  }
+
+  [[nodiscard]] friend bool try_record_start(async_scope* scope) noexcept {
+    auto opState = scope->opState_.load(std::memory_order_relaxed);
+
+    do {
+      if (scope_ended(opState)) {
+        return false;
+      }
+
+      UNIFEX_ASSERT(opState + 2u > opState);
+    } while (!scope->opState_.compare_exchange_weak(
+        opState, opState + 2u, std::memory_order_relaxed));
+
+    return true;
+  }
+
+  friend void end_scope(async_scope& scope) noexcept { scope.end_scope(); }
+};
+
+template <typename Sender, typename Receiver>
+struct _nest_op final {
+  struct type;
+};
+
+template <typename Sender, typename Receiver>
+using nest_op = typename _nest_op<Sender, Receiver>::type;
+
+template <typename Sender, typename Receiver>
+struct _nest_op<Sender, Receiver>::type final {
+  template <typename Sender2, typename Receiver2>
+  explicit type(Sender2&& s, Receiver2&& r, scope_reference&& scope) noexcept(
+      is_nothrow_connectable_v<Sender2, Receiver2>)
+    : scope_(std::move(scope)) {
+    UNIFEX_ASSERT(scope_);
+    activate_union_member_with(op_, [&]() {
+      return unifex::connect(
+          static_cast<Sender2&&>(s), static_cast<Receiver2&&>(r));
+    });
+  }
+
+  explicit type(Receiver&& r) noexcept(
+      std::is_nothrow_move_constructible_v<Receiver>) {
+    activate_union_member(receiver_, std::move(r));
+  }
+
+  explicit type(const Receiver& r) noexcept(
+      std::is_nothrow_copy_constructible_v<Receiver>) {
+    activate_union_member(receiver_, r);
+  }
+
+  type(type&& op) = delete;
+
+  ~type() {
+    if (scope_) {
+      deactivate_union_member(op_);
+    } else {
+      deactivate_union_member(receiver_);
+    }
+  }
+
+  friend void tag_invoke(tag_t<start>, type& op) noexcept {
+    if (op.scope_) {
+      unifex::start(op.op_.get());
+    } else {
+      unifex::set_done(std::move(op).receiver_.get());
+    }
+  }
+
+private:
+  using op_t = connect_result_t<Sender, Receiver>;
+
+  scope_reference scope_;
+  union {
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<Receiver> receiver_;
+    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<op_t> op_;
+  };
+};
+
+template <typename Sender>
+struct _nest_sender<Sender>::type final {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = sender_value_types_t<Sender, Variant, Tuple>;
+
+  template <template <typename...> class Variant>
+  using error_types = sender_error_types_t<Sender, Variant>;
+
+  static constexpr bool sends_done = true;
+
+  type() noexcept = default;
+
+  template <typename Sender2>
+  explicit type(Sender2&& sender, scope_reference&& scope) noexcept(
+      std::is_nothrow_constructible_v<Sender, Sender2>)
+    : scope_(std::move(scope)) {
+    UNIFEX_ASSERT(scope_);
+    sender_.construct(static_cast<Sender2&&>(sender));
+  }
+
+  type(const type& t) noexcept(std::is_nothrow_copy_constructible_v<Sender>)
+    : scope_(t.scope_) {
+    if (scope_) {
+      sender_.construct(t.sender_.get());
+    }
+  }
+
+  type(type&& t) noexcept(std::is_nothrow_move_constructible_v<Sender>)
+    : scope_(std::move(t).scope_) {
+    if (scope_) {
+      sender_.construct(std::move(t).sender_.get());
+      t.sender_.destruct();
+    }
+  }
+
+  ~type() {
+    if (scope_) {
+      sender_.destruct();
+    }
+  }
+
+  // helper to compute the noexcept clause for connect
+  template <typename S, typename Receiver>
+  static constexpr bool nothrow_connect =
+      // we either construct a next_op from our wrapped sender, the receiver,
+      // and a scope reference
+      std::is_nothrow_constructible_v<
+          nest_op<Sender, remove_cvref_t<Receiver>>,
+          // this applies the cvref-ness of *this to the Sender type
+          decltype(std::declval<S>().sender_.get()),
+          Receiver,
+          scope_reference>
+          // or we construct a next_op from the receiver
+          && std::is_nothrow_constructible_v<
+              nest_op<Sender, remove_cvref_t<Receiver>>,
+              Receiver>;
+
+  template(typename Receiver)                                 //
+      (requires sender_to<Sender, remove_cvref_t<Receiver>>)  //
+      friend auto tag_invoke(tag_t<connect>, type&& s, Receiver&& r) noexcept(
+          nothrow_connect<type, Receiver>)
+          -> nest_op<Sender, remove_cvref_t<Receiver>> {
+    auto scope = std::move(s).scope_;
+
+    if (scope) {
+      // since we've nulled out the sender's scope, its destructor won't clean
+      // up the sender_ member, which means we have to do it here, but not until
+      // after we construct our return value
+      scope_guard destroySender = [&s]() noexcept {
+        s.sender_.destruct();
+      };
+
+      return nest_op<Sender, remove_cvref_t<Receiver>>{
+          std::move(s).sender_.get(),
+          static_cast<Receiver&&>(r),
+          std::move(scope)};
+    } else {
+      return nest_op<Sender, remove_cvref_t<Receiver>>{
+          static_cast<Receiver&&>(r)};
+    }
+  }
+
+  template(typename Receiver)                                        //
+      (requires sender_to<const Sender&, remove_cvref_t<Receiver>>)  //
+      friend auto tag_invoke(
+          tag_t<connect>,
+          const type& s,
+          Receiver&& r) noexcept(nothrow_connect<const type&, Receiver>)
+          -> nest_op<Sender, remove_cvref_t<Receiver>> {
+    // make a copy of the scope_reference, which will try to record the start of
+    // a new nested operation
+    auto scope = s.scope_;
+
+    if (scope) {
+      return nest_op<Sender, remove_cvref_t<Receiver>>{
+          s.sender_.get(), static_cast<Receiver&&>(r), std::move(scope)};
+    } else {
+      return nest_op<Sender, remove_cvref_t<Receiver>>{
+          static_cast<Receiver&&>(r)};
+    }
+  }
+
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type&) noexcept {
+    if constexpr (
+        cblocking<Sender>() == blocking_kind::always_inline ||
+        cblocking<Sender>() == blocking_kind::always) {
+      return cblocking<Sender>();
+    } else {
+      return blocking_kind::maybe;
+    }
+  }
+
+private:
+  scope_reference scope_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<Sender> sender_;
+};
+
+inline scope_reference::~scope_reference() {
+  if (scope_ != nullptr) {
+    record_completion(scope_);
+  }
+}
+
+inline async_scope*
+scope_reference::scope_or_nullptr(async_scope* scope) noexcept {
+  if (scope != nullptr && try_record_start(scope)) {
+    return scope;
+  }
+
+  return nullptr;
+}
+
+}  // namespace _async_scope
+
+using _async_scope::async_scope;
+
+}  // namespace unifex::v2
+
+#include <unifex/detail/epilogue.hpp>

--- a/test/async_scope_v2_test.cpp
+++ b/test/async_scope_v2_test.cpp
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/v2/async_scope.hpp>
+
+#include <unifex/just.hpp>
+#include <unifex/just_done.hpp>
+#include <unifex/just_error.hpp>
+#include <unifex/just_from.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/when_all.hpp>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+struct async_scope_v2_test : testing::Test {
+  unifex::v2::async_scope scope;
+
+  async_scope_v2_test() = default;
+
+  ~async_scope_v2_test() { unifex::sync_wait(scope.join()); }
+};
+
+template <typename...>
+struct variant final {};
+
+template <typename...>
+struct tuple final {};
+
+template <bool ThrowOnCopy, bool ThrowOnMove>
+struct custom_receiver final {
+  custom_receiver() noexcept = default;
+
+  custom_receiver(const custom_receiver&) noexcept(!ThrowOnCopy) = default;
+
+  custom_receiver(custom_receiver&&) noexcept(!ThrowOnMove) = default;
+
+  ~custom_receiver() = default;
+
+  custom_receiver&
+  operator=(const custom_receiver&) noexcept(!ThrowOnCopy) = default;
+
+  custom_receiver&
+  operator=(custom_receiver&&) noexcept(!ThrowOnMove) = default;
+
+  template <typename... T>
+  void set_value(T&&...) noexcept {}
+
+  template <typename E>
+  void set_error(E&&) noexcept {}
+
+  void set_done() noexcept {}
+};
+
+using nothrow_receiver = custom_receiver<false, false>;
+using allthrow_receiver = custom_receiver<true, true>;
+
+struct throwing_sender final {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = false;
+
+  UNIFEX_TEMPLATE(typename Receiver)                                //
+  (requires unifex::sender_to<decltype(unifex::just()), Receiver>)  //
+      friend auto tag_invoke(
+          unifex::tag_t<unifex::connect>,
+          throwing_sender&&,
+          Receiver&& receiver) noexcept(false) {
+    return unifex::connect(unifex::just(), std::forward<Receiver>(receiver));
+  }
+};
+
+TEST_F(async_scope_v2_test, unused_scoped_is_safe_to_join) {
+  // this test does nothing beyond construct and destruct the fixture, which has
+  // the side effect of constructing a scope and then joining it.
+
+  EXPECT_EQ(0, scope.use_count());
+  EXPECT_FALSE(scope.join_started());
+
+  static_assert(
+      std::is_nothrow_default_constructible_v<unifex::v2::async_scope>);
+  static_assert(std::is_nothrow_destructible_v<unifex::v2::async_scope>);
+  static_assert(!std::is_move_constructible_v<unifex::v2::async_scope>);
+  static_assert(!std::is_copy_constructible_v<unifex::v2::async_scope>);
+  static_assert(!std::is_move_assignable_v<unifex::v2::async_scope>);
+  static_assert(!std::is_copy_assignable_v<unifex::v2::async_scope>);
+}
+
+TEST_F(
+    async_scope_v2_test, nest_of_nullary_just_has_expected_static_properties) {
+  using just_sender_t = decltype(unifex::just());
+
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t>())));
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t&>())));
+
+  auto sender = scope.nest(unifex::just());
+
+  using sender_t = decltype(sender);
+  using value_types = unifex::sender_value_types_t<sender_t, variant, tuple>;
+  using error_types = unifex::sender_error_types_t<sender_t, variant>;
+
+  // values_types is just the nested sender's value_types
+  static_assert(std::is_same_v<value_types, variant<tuple<>>>);
+  // error_types is the nested sender's error_types
+  static_assert(std::is_same_v<error_types, variant<std::exception_ptr>>);
+  // sends_done is always true because the sender completes with done if nesting
+  // fails
+  static_assert(sender_t::sends_done);
+
+  static_assert(std::is_nothrow_move_constructible_v<sender_t>);
+  static_assert(std::is_nothrow_copy_constructible_v<sender_t>);
+}
+
+TEST_F(
+    async_scope_v2_test,
+    nest_of_just_of_string_has_expected_static_properties) {
+  using namespace std::literals::string_literals;
+
+  using just_sender_t = decltype(unifex::just("hello, world!"s));
+
+  // just_sender_t has a noexcept move constructor...
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t>())));
+
+  // ...but its copy constructor may throw when copying the string
+  static_assert(!noexcept(scope.nest(std::declval<just_sender_t&>())));
+
+  auto sender = scope.nest(unifex::just("hello, world!"s));
+
+  using sender_t = decltype(sender);
+  using value_types = unifex::sender_value_types_t<sender_t, variant, tuple>;
+  using error_types = unifex::sender_error_types_t<sender_t, variant>;
+
+  // values_types is just the nested sender's value_types
+  static_assert(std::is_same_v<value_types, variant<tuple<std::string>>>);
+  // error_types is the nested sender's error_types
+  static_assert(std::is_same_v<error_types, variant<std::exception_ptr>>);
+  // sends_done is always true because the sender completes with done if nesting
+  // fails
+  static_assert(sender_t::sends_done);
+
+  static_assert(std::is_nothrow_move_constructible_v<sender_t>);
+  static_assert(!std::is_nothrow_copy_constructible_v<sender_t>);
+}
+
+TEST_F(
+    async_scope_v2_test,
+    nest_of_just_error_of_int_has_expected_static_properties) {
+  using just_sender_t = decltype(unifex::just_error(42));
+
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t>())));
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t&>())));
+
+  auto sender = scope.nest(unifex::just_error(42));
+
+  using sender_t = decltype(sender);
+  using value_types = unifex::sender_value_types_t<sender_t, variant, tuple>;
+  using error_types = unifex::sender_error_types_t<sender_t, variant>;
+
+  // values_types is just the nested sender's value_types
+  static_assert(std::is_same_v<value_types, variant<>>);
+  // error_types is the nested sender's error_types
+  static_assert(std::is_same_v<error_types, variant<int>>);
+  // sends_done is always true because the sender completes with done if nesting
+  // fails
+  static_assert(sender_t::sends_done);
+
+  static_assert(std::is_nothrow_move_constructible_v<sender_t>);
+  static_assert(std::is_nothrow_copy_constructible_v<sender_t>);
+}
+
+TEST_F(async_scope_v2_test, nest_of_just_done_has_expected_static_properties) {
+  using just_sender_t = decltype(unifex::just_done());
+
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t>())));
+  static_assert(noexcept(scope.nest(std::declval<just_sender_t&>())));
+
+  auto sender = scope.nest(unifex::just_done());
+
+  using sender_t = decltype(sender);
+  using value_types = unifex::sender_value_types_t<sender_t, variant, tuple>;
+  using error_types = unifex::sender_error_types_t<sender_t, variant>;
+
+  // values_types is just the nested sender's value_types
+  static_assert(std::is_same_v<value_types, variant<>>);
+  // error_types is the nested sender's error_types
+  static_assert(std::is_same_v<error_types, variant<>>);
+  // sends_done is always true because the sender completes with done if nesting
+  // fails
+  static_assert(sender_t::sends_done);
+
+  static_assert(std::is_nothrow_move_constructible_v<sender_t>);
+  static_assert(std::is_nothrow_copy_constructible_v<sender_t>);
+}
+
+#if !defined(__GNUC__) || __GNUC__ > 9
+// GCC9's std::tuple<> fails to find a copy constructor for just(newtype{})
+TEST_F(
+    async_scope_v2_test,
+    nest_of_just_of_newtype_has_expected_static_properties) {
+  struct newtype {
+    newtype() = default;
+    newtype(const newtype&) noexcept(false) = default;
+    newtype(newtype&&) noexcept(false) = default;
+    ~newtype() = default;
+  };
+
+  using just_sender_t = decltype(unifex::just(newtype{}));
+
+// MSVC incorrectly fails these assertions
+#ifndef _MSC_VER
+  // just_sender_t has a throwing move constructor...
+  static_assert(!noexcept(scope.nest(std::declval<just_sender_t>())));
+
+  // ...and a throwing copy constructor
+  static_assert(!noexcept(scope.nest(std::declval<just_sender_t&>())));
+#endif
+  auto sender = scope.nest(unifex::just(newtype{}));
+
+  using sender_t = decltype(sender);
+  using value_types = unifex::sender_value_types_t<sender_t, variant, tuple>;
+  using error_types = unifex::sender_error_types_t<sender_t, variant>;
+
+  // values_types is just the nested sender's value_types
+  static_assert(std::is_same_v<value_types, variant<tuple<newtype>>>);
+  // error_types is the nested sender's error_types
+  static_assert(std::is_same_v<error_types, variant<std::exception_ptr>>);
+  // sends_done is always true because the sender completes with done if nesting
+  // fails
+  static_assert(sender_t::sends_done);
+// MSVC incorrectly fails these assertions
+#ifndef _MSC_VER
+  static_assert(!std::is_nothrow_move_constructible_v<sender_t>);
+  static_assert(!std::is_nothrow_copy_constructible_v<sender_t>);
+#endif
+}
+#endif
+
+TEST_F(
+    async_scope_v2_test,
+    connect_of_nest_sender_has_expected_static_properties) {
+  using sender_t = decltype(scope.nest(unifex::just()));
+
+  static_assert(unifex::is_nothrow_connectable_v<sender_t, nothrow_receiver>);
+  static_assert(unifex::is_nothrow_connectable_v<sender_t, nothrow_receiver&>);
+
+  static_assert(unifex::is_nothrow_connectable_v<sender_t&, nothrow_receiver>);
+  static_assert(unifex::is_nothrow_connectable_v<sender_t&, nothrow_receiver&>);
+
+  static_assert(!unifex::is_nothrow_connectable_v<sender_t, allthrow_receiver>);
+  static_assert(
+      !unifex::is_nothrow_connectable_v<sender_t, allthrow_receiver&>);
+
+  static_assert(
+      !unifex::is_nothrow_connectable_v<sender_t&, allthrow_receiver>);
+  static_assert(
+      !unifex::is_nothrow_connectable_v<sender_t&, allthrow_receiver&>);
+
+  using throwing_sender_t = decltype(scope.nest(throwing_sender{}));
+
+  static_assert(
+      !unifex::is_nothrow_connectable_v<throwing_sender_t, nothrow_receiver>);
+  static_assert(
+      !unifex::is_nothrow_connectable_v<throwing_sender_t, nothrow_receiver&>);
+
+  static_assert(
+      !unifex::is_nothrow_connectable_v<throwing_sender_t&, nothrow_receiver>);
+  static_assert(
+      !unifex::is_nothrow_connectable_v<throwing_sender_t&, nothrow_receiver&>);
+}
+
+TEST_F(async_scope_v2_test, nest_owns_one_refcount) {
+  EXPECT_EQ(0, scope.use_count());
+
+  {
+    auto sender = scope.nest(unifex::just());
+
+    EXPECT_EQ(1, scope.use_count());
+  }
+
+  EXPECT_EQ(0, scope.use_count());
+}
+
+TEST_F(
+    async_scope_v2_test, nest_sender_move_constructor_transfers_its_reference) {
+  EXPECT_EQ(0, scope.use_count());
+
+  auto sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  auto sender2 = std::move(sender);
+
+  EXPECT_EQ(1, scope.use_count());
+}
+
+TEST_F(
+    async_scope_v2_test,
+    nest_sender_copy_constructor_increments_refcount_when_scope_is_open) {
+  EXPECT_EQ(0, scope.use_count());
+
+  auto sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  auto sender2 = sender;
+
+  EXPECT_EQ(2, scope.use_count());
+}
+
+TEST_F(
+    async_scope_v2_test,
+    nest_sender_copy_constructor_produces_ready_done_sender_when_scope_is_closed) {
+  EXPECT_EQ(0, scope.use_count());
+
+  unifex::optional sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  unifex::sync_wait(unifex::when_all(
+      scope.join(), unifex::just_from([&sender, this]() noexcept {
+        EXPECT_TRUE(scope.join_started());
+
+        EXPECT_EQ(1, scope.use_count());
+
+        auto sender2 = *sender;
+
+        EXPECT_EQ(1, scope.use_count());
+
+        auto ret = unifex::sync_wait(std::move(sender2));
+
+        EXPECT_FALSE(ret.has_value());
+
+        sender.reset();
+
+        EXPECT_EQ(0, scope.use_count());
+      })));
+}
+
+TEST_F(
+    async_scope_v2_test,
+    connect_of_rvalue_nest_sender_transfers_reference_to_nest_op) {
+  EXPECT_EQ(0, scope.use_count());
+
+  auto sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  {
+    auto op = unifex::connect(std::move(sender), nothrow_receiver{});
+
+    EXPECT_EQ(1, scope.use_count());
+  }
+
+  EXPECT_EQ(0, scope.use_count());
+}
+
+TEST_F(
+    async_scope_v2_test,
+    connect_of_lvalue_nest_sender_increments_refcount_when_scope_is_open) {
+  EXPECT_EQ(0, scope.use_count());
+
+  auto sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  {
+    auto op = unifex::connect(sender, nothrow_receiver{});
+
+    EXPECT_EQ(2, scope.use_count());
+  }
+
+  EXPECT_EQ(1, scope.use_count());
+}
+
+TEST_F(
+    async_scope_v2_test,
+    connect_of_lvalue_nest_sender_leaves_refcount_unchanged_when_scope_is_closed) {
+  EXPECT_EQ(0, scope.use_count());
+
+  unifex::optional sender = scope.nest(unifex::just());
+
+  EXPECT_EQ(1, scope.use_count());
+
+  unifex::sync_wait(unifex::when_all(
+      scope.join(), unifex::just_from([&sender, this]() noexcept {
+        EXPECT_TRUE(scope.join_started());
+
+        EXPECT_EQ(1, scope.use_count());
+
+        auto op = unifex::connect(*sender, nothrow_receiver{});
+
+        EXPECT_EQ(1, scope.use_count());
+
+        sender.reset();
+
+        EXPECT_EQ(0, scope.use_count());
+      })));
+}
+
+TEST_F(
+    async_scope_v2_test,
+    running_nest_sender_passes_through_wrapped_sender_behaviour) {
+  auto optInt = unifex::sync_wait(scope.nest(unifex::just(42)));
+
+  ASSERT_TRUE(optInt.has_value());
+  EXPECT_EQ(42, *optInt);
+
+  // TODO: factor this in terms of let_error so we can check this logic even
+  //       when exceptions are disabled
+  try {
+    unifex::sync_wait(scope.nest(unifex::just_error(42)));
+  } catch (int i) {
+    EXPECT_EQ(42, i);
+  } catch (...) {
+    EXPECT_FALSE(true) << "Shouldn't have caught anything but an int";
+  }
+
+  auto emptyOpt = unifex::sync_wait(scope.nest(unifex::just_done()));
+
+  EXPECT_FALSE(emptyOpt.has_value());
+}
+
+TEST_F(
+    async_scope_v2_test,
+    running_nest_senders_constructed_before_joining_sees_normal_completion_after_join_starts) {
+  auto intSender = scope.nest(unifex::just(42));
+  auto errorSender = scope.nest(unifex::just_error(42));
+  auto doneSender = scope.nest(unifex::just_done());
+
+  unifex::sync_wait(unifex::when_all(
+      scope.join(), unifex::just_from([&, this]() noexcept {
+        EXPECT_TRUE(scope.join_started());
+
+        auto optInt = unifex::sync_wait(std::move(intSender));
+
+        ASSERT_TRUE(optInt.has_value());
+        EXPECT_EQ(42, *optInt);
+
+        // TODO: factor this in terms of let_error so we can check this logic
+        //       even when exceptions are disabled
+        try {
+          unifex::sync_wait(std::move(errorSender));
+        } catch (int i) {
+          EXPECT_EQ(42, i);
+        } catch (...) {
+          EXPECT_FALSE(true) << "Shouldn't have caught anything but an int";
+        }
+
+        auto emptyOpt = unifex::sync_wait(std::move(doneSender));
+
+        EXPECT_FALSE(emptyOpt.has_value());
+      })));
+}
+
+TEST_F(
+    async_scope_v2_test,
+    starting_a_nest_sender_after_the_scope_has_ended_produces_done) {
+  unifex::sync_wait(unifex::when_all(
+      scope.join(), unifex::just_from([&, this]() noexcept {
+        EXPECT_TRUE(scope.join_started());
+
+        auto emptyOpt = unifex::sync_wait(scope.nest(unifex::just(42)));
+
+        EXPECT_FALSE(emptyOpt.has_value());
+      })));
+}
+
+}  // namespace


### PR DESCRIPTION
* simpler than `unifex::v1::async_scope` (`nest()` and `join()`)
* does not support cancellation