### PR TITLE
Use tag_t in most places

### DIFF
--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -106,7 +106,7 @@
 // class foo_sender {
 //    template<
 //      typename Receiver,
-//      std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0>
+//      std::enable_if_t<is_callable_v<tag_t<set_value>, Receiver, foo>, int> = 0>
 //    friend auto tag_invoke(tag_t<connect>, foo_sender&& s, Receiver&& r) -> foo_operation<Receiver> {
 //      return ...;
 //    }
@@ -119,7 +119,7 @@
 //     typename Receiver,
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //     UNIFEX_DECLARE_NON_DEDUCED_TYPE(S, foo_sender),
-//     std::enable_if_t<is_callable_v<decltype(set_value), Receiver, foo>, int> = 0?
+//     std::enable_if_t<is_callable_v<tag_t<set_value>, Receiver, foo>, int> = 0?
 //   friend auto tag_invoke(
 //        UNIFEX_USE_NON_DEDUCED_TYPE(CPO, tag_t<connect>),
 //        UNIFEX_USE_NON_DEDUCED_TYPE(S, foo_sender)&& s,

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -81,7 +81,7 @@ using _get_stop_token::get_stop_token;
 
 template <typename T>
 using get_stop_token_result_t =
-    callable_result_t<decltype(get_stop_token), T>;
+    callable_result_t<tag_t<get_stop_token>, T>;
 
 template <typename Receiver>
 using stop_token_type_t =

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -49,10 +49,10 @@ namespace unifex
         : receiver_(static_cast<Receiver2&&>(receiver)) {}
 
       template(typename... Values)
-          (requires receiver_of<Receiver, decltype(unifex::set_value), Values...>)
+          (requires receiver_of<Receiver, tag_t<unifex::set_value>, Values...>)
       void
       set_value(Values&&... values) && noexcept(
-          is_nothrow_receiver_of_v<Receiver, decltype(unifex::set_value), Values...>) {
+          is_nothrow_receiver_of_v<Receiver, tag_t<unifex::set_value>, Values...>) {
         unifex::set_value(
             static_cast<Receiver&&>(receiver_),
             unifex::set_value,
@@ -60,11 +60,11 @@ namespace unifex
       }
 
       template(typename Error)
-          (requires receiver_of<Receiver, decltype(unifex::set_error), Error>)
+          (requires receiver_of<Receiver, tag_t<unifex::set_error>, Error>)
       void set_error(Error&& error) && noexcept {
         if constexpr (is_nothrow_receiver_of_v<
                           Receiver,
-                          decltype(unifex::set_error),
+                          tag_t<unifex::set_error>,
                           Error>) {
           unifex::set_value(
               static_cast<Receiver&&>(receiver_),
@@ -84,9 +84,9 @@ namespace unifex
       }
 
       template(typename R = Receiver)
-          (requires receiver_of<R, decltype(unifex::set_done)>)
+          (requires receiver_of<R, tag_t<unifex::set_done>>)
       void set_done() && noexcept {
-        if constexpr (is_nothrow_receiver_of_v<Receiver, decltype(unifex::set_done)>) {
+        if constexpr (is_nothrow_receiver_of_v<Receiver, tag_t<unifex::set_done>>) {
           unifex::set_value(
               static_cast<Receiver&&>(receiver_), unifex::set_done);
         } else {
@@ -137,8 +137,8 @@ namespace unifex
       template <typename... Errors>
       using apply = Variant<
           ValueTuples...,
-          Tuple<decltype(set_error), Errors>...,
-          Tuple<decltype(set_done)>>;
+          Tuple<tag_t<set_error>, Errors>...,
+          Tuple<tag_t<set_done>>>;
     };
 
     template <
@@ -147,7 +147,7 @@ namespace unifex
         template <typename...> class Tuple>
     struct value_types {
       template <typename... Values>
-      using value_tuple = Tuple<decltype(set_value), Values...>;
+      using value_tuple = Tuple<tag_t<set_value>, Values...>;
 
       template <typename... ValueTuples>
       using value_variant = sender_error_types_t<

--- a/include/unifex/receiver_concepts.hpp
+++ b/include/unifex/receiver_concepts.hpp
@@ -246,7 +246,7 @@ UNIFEX_CONCEPT //
 template <typename R, typename... An>
   inline constexpr bool is_nothrow_receiver_of_v =
     receiver_of<R, An...> &&
-    is_nothrow_callable_v<decltype(set_value), R, An...>;
+    is_nothrow_callable_v<tag_t<set_value>, R, An...>;
 
 //////////////////
 // Metafunctions for checking callability of specific receiver methods

--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -53,7 +53,7 @@ namespace _subschedule {
 
     template <typename Scheduler>
     using _default_result_t = _then::sender<
-        callable_result_t<decltype(schedule), Scheduler&>,
+        callable_result_t<tag_t<schedule>, Scheduler&>,
         _return_value<Scheduler>>;
     template <typename Scheduler>
     using _result_t =

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -285,19 +285,19 @@ using operation_t [[deprecated("Use connect_result_t instead of operation_t")]] 
 template <typename Sender, typename Receiver>
 [[deprecated("Use sender_to instead of is_connectable_v")]]
 inline constexpr bool is_connectable_v =
-  is_callable_v<decltype(connect), Sender, Receiver>;
+  is_callable_v<tag_t<connect>, Sender, Receiver>;
 
 template <typename Sender, typename Receiver>
 using is_connectable [[deprecated]] =
-  is_callable<decltype(connect), Sender, Receiver>;
+  is_callable<tag_t<connect>, Sender, Receiver>;
 /// \endcond
 
 template <typename Sender, typename Receiver>
 inline constexpr bool is_nothrow_connectable_v =
-  is_nothrow_callable_v<decltype(connect), Sender, Receiver>;
+  is_nothrow_callable_v<tag_t<connect>, Sender, Receiver>;
 
 template <typename Sender, typename Receiver>
-using is_nothrow_connectable = is_nothrow_callable<decltype(connect), Sender, Receiver>;
+using is_nothrow_connectable = is_nothrow_callable<tag_t<connect>, Sender, Receiver>;
 
 template <
     typename Sender,

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -365,7 +365,7 @@ namespace unifex::win32
       }
 
       if constexpr (is_nothrow_callable_v<
-                        decltype(unifex::set_value),
+                        tag_t<unifex::set_value>,
                         Receiver>) {
         unifex::set_value(std::move(self.receiver_));
       } else {
@@ -511,7 +511,7 @@ namespace unifex::win32
       // instead?
       if (!ec || totalBytesTransferred > 0) {
         if constexpr (is_nothrow_callable_v<
-                          decltype(set_value),
+                          tag_t<set_value>,
                           Receiver,
                           std::size_t>) {
           unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
@@ -686,7 +686,7 @@ namespace unifex::win32
       // instead?
       if (!ec || totalBytesTransferred > 0) {
         if constexpr (is_nothrow_callable_v<
-                          decltype(set_value),
+                          tag_t<set_value>,
                           Receiver,
                           std::size_t>) {
           unifex::set_value(std::move(self.receiver_), totalBytesTransferred);


### PR DESCRIPTION
Most places use `tag_t` to obtain the type of CPOs. This commit changes the few spots where decltype is used on CPO types like `set_value` or `connect`.