### PR TITLE
Introduce unifex::nest()

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -38,6 +38,7 @@
   * `with_query_value()`
   * `with_allocator()`
   * `done_as_optional()`
+  * `nest()`
 * Sender Types
   * `async_trace_sender`
 * Sender Queries
@@ -710,6 +711,13 @@ task<void> g() {
   }
 }
 ```
+
+### `nest(Sender sender, Scope& scope) -> Sender`
+
+`nest` registers the given *Sender* with the given "scope", which should be of a
+type that works like `v1::async_scope` or `v2::async_scope`. A *Sender* that has
+been registered with a scope will prevent that scope from being joined until the
+*Sender* has either been discarded or executed.
 
 ## Sender Types
 

--- a/include/unifex/bind_back.hpp
+++ b/include/unifex/bind_back.hpp
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/type_traits.hpp>
 
 #include <tuple>
 #include <type_traits>

--- a/include/unifex/nest.hpp
+++ b/include/unifex/nest.hpp
@@ -39,26 +39,24 @@ private:
   struct deref;
 
 public:
-  // clang-format off
   template(typename Sender, typename Scope)  //
       (requires typed_sender<Sender> AND tag_invocable<_nest_fn, Sender, Scope&>
            AND typed_sender<tag_invoke_result_t<_nest_fn, Sender, Scope&>>)  //
-  auto operator()(Sender&& sender, Scope& scope) const
+      auto
+      operator()(Sender&& sender, Scope& scope) const
       noexcept(is_nothrow_tag_invocable_v<_nest_fn, Sender, Scope&>)
           -> tag_invoke_result_t<_nest_fn, Sender, Scope&> {
-    // clang-format on
     return tag_invoke(_nest_fn{}, static_cast<Sender&&>(sender), scope);
   }
 
-  // clang-format off
   template(typename Sender, typename Scope)  //
       (requires typed_sender<Sender> AND(
           !tag_invocable<_nest_fn, Sender, Scope&>)
            AND typed_sender<nest_member_result_t<Scope, Sender>>)  //
-  auto operator()(Sender&& sender, Scope& scope) const
+      auto
+      operator()(Sender&& sender, Scope& scope) const
       noexcept(is_nest_member_nothrow_v<Scope, Sender>)
           -> nest_member_result_t<Scope, Sender> {
-    // clang-format on
     return scope.nest(static_cast<Sender&&>(sender));
   }
 

--- a/include/unifex/nest.hpp
+++ b/include/unifex/nest.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+namespace _nest_cpo {
+
+inline const struct _nest_fn final {
+private:
+  template <typename Scope, typename Sender>
+  using nest_member_result_t =
+      decltype(UNIFEX_DECLVAL(Scope&).nest(UNIFEX_DECLVAL(Sender)));
+
+  template <typename Scope, typename Sender>
+  static constexpr bool is_nest_member_nothrow_v =
+      noexcept(UNIFEX_DECLVAL(Scope&).nest(UNIFEX_DECLVAL(Sender)));
+
+  struct deref;
+
+public:
+  // clang-format off
+  template(typename Sender, typename Scope)  //
+      (requires typed_sender<Sender> AND tag_invocable<_nest_fn, Sender, Scope&>
+           AND typed_sender<tag_invoke_result_t<_nest_fn, Sender, Scope&>>)  //
+  auto operator()(Sender&& sender, Scope& scope) const
+      noexcept(is_nothrow_tag_invocable_v<_nest_fn, Sender, Scope&>)
+          -> tag_invoke_result_t<_nest_fn, Sender, Scope&> {
+    // clang-format on
+    return tag_invoke(_nest_fn{}, static_cast<Sender&&>(sender), scope);
+  }
+
+  // clang-format off
+  template(typename Sender, typename Scope)  //
+      (requires typed_sender<Sender> AND(
+          !tag_invocable<_nest_fn, Sender, Scope&>)
+           AND typed_sender<nest_member_result_t<Scope, Sender>>)  //
+  auto operator()(Sender&& sender, Scope& scope) const
+      noexcept(is_nest_member_nothrow_v<Scope, Sender>)
+          -> nest_member_result_t<Scope, Sender> {
+    // clang-format on
+    return scope.nest(static_cast<Sender&&>(sender));
+  }
+
+  template <typename Scope>
+  constexpr auto operator()(Scope& scope) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, deref, Scope*>)
+          -> bind_back_result_t<deref, Scope*>;
+} nest{};
+
+struct _nest_fn::deref final {
+  template <typename Sender, typename Scope>
+  constexpr auto operator()(Sender&& sender, Scope* scope) const
+      noexcept(noexcept(_nest_fn{}(static_cast<Sender&&>(sender), *scope)))
+          -> decltype(_nest_fn{}(static_cast<Sender&&>(sender), *scope)) {
+    return _nest_fn{}(static_cast<Sender&&>(sender), *scope);
+  }
+};
+
+template <typename Scope>
+inline constexpr auto _nest_fn::operator()(Scope& scope) const
+    noexcept(is_nothrow_callable_v<tag_t<bind_back>, deref, Scope*>)
+        -> bind_back_result_t<deref, Scope*> {
+  // bind_back will try to store a copy of any lvalue references it's passed,
+  // which doesn't work for us here so we have to pass a scope pointer instead
+  // of a scope reference.  we don't, in general, want to expose a
+  // `nest(Sender&&, Scope*)` function so we use `_nest_fn::deref` to do the
+  // indirection for us in this scenario.
+  return bind_back(deref{}, &scope);
+}
+
+}  // namespace _nest_cpo
+
+using _nest_cpo::nest;
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/v1/async_scope.hpp
+++ b/include/unifex/v1/async_scope.hpp
@@ -1114,13 +1114,15 @@ private:
     }
   }
 
-  // clang-format off
   template(typename Sender, typename Scope)     //
       (requires same_as<async_scope&, Scope&>)  //
-  friend auto tag_invoke(tag_t<nest>, Sender&& sender, Scope& scope) noexcept(
-      noexcept(scope.attach(static_cast<Sender&&>(sender))))
-      -> decltype(scope.attach(static_cast<Sender&&>(sender))) {
-    // clang-format on
+      friend auto tag_invoke(
+          tag_t<nest>,
+          Sender&& sender,
+          Scope& scope) noexcept(noexcept(scope
+                                              .attach(static_cast<Sender&&>(
+                                                  sender))))
+          -> decltype(scope.attach(static_cast<Sender&&>(sender))) {
     return scope.attach(static_cast<Sender&&>(sender));
   }
 };

--- a/include/unifex/v1/async_scope.hpp
+++ b/include/unifex/v1/async_scope.hpp
@@ -23,6 +23,7 @@
 #include <unifex/let_value_with.hpp>
 #include <unifex/let_value_with_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/nest.hpp>
 #include <unifex/on.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
@@ -979,8 +980,8 @@ public:
   /**
    * Equivalent to attach(just_from((Fun&&)fun)).
    */
-  template(typename Fun)  //
-      (requires callable<Fun>)                //
+  template(typename Fun)        //
+      (requires callable<Fun>)  //
       [[nodiscard]] auto attach_call(Fun&& fun) noexcept(
           noexcept(attach(just_from((Fun &&) fun)))) {
     return attach(just_from((Fun &&) fun));
@@ -1111,6 +1112,16 @@ private:
       // there are no outstanding operations to wait for
       evt_.set();
     }
+  }
+
+  // clang-format off
+  template(typename Sender, typename Scope)     //
+      (requires same_as<async_scope&, Scope&>)  //
+  friend auto tag_invoke(tag_t<nest>, Sender&& sender, Scope& scope) noexcept(
+      noexcept(scope.attach(static_cast<Sender&&>(sender))))
+      -> decltype(scope.attach(static_cast<Sender&&>(sender))) {
+    // clang-format on
+    return scope.attach(static_cast<Sender&&>(sender));
   }
 };
 

--- a/test/nest_test.cpp
+++ b/test/nest_test.cpp
@@ -104,6 +104,9 @@ TEST(nest_test, nest_of_v1_scope_invokes_member) {
   unifex::sync_wait(scope.complete());
 }
 
+// gcc 9 fails to compute all the noexcept assertions in
+// nest_has_the_expected_noexcept_clause
+#if !defined(__GNUC__) || __GNUC__ > 9
 struct throwing_sender final {
   template <
       template <typename...>
@@ -159,5 +162,6 @@ TEST(nest_test, nest_has_the_expected_noexcept_clause) {
 
   unifex::sync_wait(v2scope.join());
 }
+#endif  // !defined(__GNUC__) || __GNUC__ > 9
 
 }  // namespace

--- a/test/nest_test.cpp
+++ b/test/nest_test.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/nest.hpp>
+
+#include <unifex/just.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/v1/async_scope.hpp>
+#include <unifex/v2/async_scope.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct tag_invocable_scope {
+  template <typename Sender>
+  friend auto tag_invoke(
+      unifex::tag_t<unifex::nest>,
+      Sender&& sender,
+      tag_invocable_scope& scope) noexcept {
+    scope.invoked = true;
+    return static_cast<Sender&&>(sender);
+  }
+
+  bool invoked{false};
+};
+
+struct member_invocable_scope {
+  template <typename Sender>
+  auto nest(Sender&& sender) noexcept {
+    invoked = true;
+    return static_cast<Sender&&>(sender);
+  }
+
+  bool invoked{false};
+};
+
+TEST(nest_test, nest_of_tag_invocable_scope_invokes_tag_invoke) {
+  tag_invocable_scope scope;
+
+  ASSERT_FALSE(scope.invoked);
+
+  unifex::sync_wait(unifex::nest(unifex::just(), scope));
+
+  EXPECT_TRUE(scope.invoked);
+}
+
+TEST(nest_test, nest_of_member_invocable_scope_invokes_member) {
+  member_invocable_scope scope;
+
+  ASSERT_FALSE(scope.invoked);
+
+  unifex::sync_wait(unifex::nest(unifex::just(), scope));
+
+  EXPECT_TRUE(scope.invoked);
+}
+
+TEST(nest_test, nest_is_pipeable) {
+  tag_invocable_scope tscope;
+  member_invocable_scope mscope;
+
+  unifex::sync_wait(unifex::just() | unifex::nest(tscope));
+  unifex::sync_wait(unifex::just() | unifex::nest(mscope));
+
+  EXPECT_TRUE(tscope.invoked);
+  EXPECT_TRUE(mscope.invoked);
+}
+
+TEST(nest_test, nest_of_v2_scope_invokes_member) {
+  unifex::v2::async_scope scope;
+
+  {
+    auto cpoSender = unifex::nest(unifex::just(), scope);
+    auto memberSender = scope.nest(unifex::just());
+
+    static_assert(unifex::same_as<decltype(cpoSender), decltype(memberSender)>);
+  }
+
+  unifex::sync_wait(scope.join());
+}
+
+TEST(nest_test, nest_of_v1_scope_invokes_member) {
+  unifex::v1::async_scope scope;
+
+  {
+    auto cpoSender = unifex::nest(unifex::just(), scope);
+    auto memberSender = scope.attach(unifex::just());
+
+    static_assert(unifex::same_as<decltype(cpoSender), decltype(memberSender)>);
+  }
+
+  unifex::sync_wait(scope.complete());
+}
+
+struct throwing_sender final {
+  template <
+      template <typename...>
+      typename Variant,
+      template <typename...>
+      typename Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> typename Variant>
+  using error_types = Variant<>;
+
+  static constexpr bool sends_done = false;
+
+  throwing_sender() noexcept(false) = default;
+
+  throwing_sender(const throwing_sender&) noexcept(false) = default;
+
+  ~throwing_sender() = default;
+
+  template <typename Receiver>
+  friend auto tag_invoke(
+      unifex::tag_t<unifex::connect>, throwing_sender, Receiver&& r) noexcept
+      -> decltype(unifex::connect(unifex::just(), static_cast<Receiver&&>(r))) {
+    return unifex::connect(unifex::just(), static_cast<Receiver&&>(r));
+  }
+};
+
+static_assert(unifex::typed_sender<throwing_sender>);
+
+TEST(nest_test, nest_has_the_expected_noexcept_clause) {
+  tag_invocable_scope tscope;
+  member_invocable_scope mscope;
+
+  unifex::v2::async_scope v2scope;
+
+  static_assert(noexcept(unifex::nest(unifex::just(), tscope)));
+  static_assert(noexcept(unifex::nest(unifex::just(), mscope)));
+  static_assert(noexcept(unifex::nest(unifex::just(), v2scope)));
+
+  static_assert(noexcept(unifex::nest(tscope)));
+  static_assert(noexcept(unifex::nest(mscope)));
+  static_assert(noexcept(unifex::nest(v2scope)));
+
+  static_assert(noexcept(unifex::just() | unifex::nest(tscope)));
+  static_assert(noexcept(unifex::just() | unifex::nest(mscope)));
+  static_assert(noexcept(unifex::just() | unifex::nest(v2scope)));
+
+  // the noexcept clause should adjust to the underlying scope's clause;
+  // v2::async_scope's noexcept clause should be false when nesting a
+  // throwing_sender
+  static_assert(!noexcept(unifex::nest(throwing_sender{}, v2scope)));
+  static_assert(!noexcept(throwing_sender{} | unifex::nest(v2scope)));
+
+  unifex::sync_wait(v2scope.join());
+}
+
+}  // namespace


### PR DESCRIPTION
`unifex::nest()` is a CPO that delegates to either a `tag_invoke` customization taking a *Sender* and a "scope" reference, or to a member function on the given scope that takes a *Sender*.  This diff wires `unifex::nest()` to the `nest()` member function on `v2::async_scope` and to the `attach()` member function on `v1::async_scope`.