### PR TITLE
Introduce spawn_detached(sender, scope, allocator)

### DIFF
--- a/include/unifex/spawn_detached.hpp
+++ b/include/unifex/spawn_detached.hpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/get_allocator.hpp>
+#include <unifex/nest.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scope_guard.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _spawn_detached {
+
+template <typename Alloc>
+struct _spawn_detached_receiver final {
+  struct type;
+};
+
+template <typename Alloc>
+struct _spawn_detached_receiver<Alloc>::type final {
+  static_assert(same_as<std::byte, typename Alloc::value_type>);
+
+  void set_value() noexcept { deleter_(std::move(alloc_), op_); }
+
+  [[noreturn]] void set_error(std::exception_ptr) noexcept { std::terminate(); }
+
+  void set_done() noexcept { set_value(); }
+
+  friend Alloc tag_invoke(tag_t<get_allocator>, const type& receiver) noexcept(
+      std::is_nothrow_copy_constructible_v<Alloc>) {
+    return receiver.alloc_;
+  }
+
+  void* op_;
+  void (*deleter_)(Alloc, void*) noexcept;
+  UNIFEX_NO_UNIQUE_ADDRESS Alloc alloc_;
+};
+
+template <typename Alloc>
+using spawn_detached_receiver_t =
+    typename _spawn_detached_receiver<typename std::allocator_traits<
+        Alloc>::template rebind_alloc<std::byte>>::type;
+
+template <typename Sender, typename Alloc>
+struct _spawn_detached_op final {
+  struct type;
+};
+
+template <typename Sender, typename Alloc>
+struct _spawn_detached_op<Sender, Alloc>::type final {
+  static_assert(same_as<std::byte, typename Alloc::value_type>);
+
+  explicit type(Sender&& sender, const Alloc& alloc) noexcept(
+      is_nothrow_connectable_v<Sender, spawn_detached_receiver_t<Alloc>>)
+    : op_{connect(
+          std::move(sender),
+          spawn_detached_receiver_t<Alloc>{this, destroy, alloc})} {}
+
+  type(type&&) = delete;
+
+  ~type() = default;
+
+  friend void tag_invoke(tag_t<start>, type& op) noexcept {
+    unifex::start(op.op_);
+  }
+
+private:
+  using op_t = connect_result_t<Sender, spawn_detached_receiver_t<Alloc>>;
+
+  op_t op_;
+
+  static void destroy(Alloc alloc, void* p) noexcept {
+    using allocator_t =
+        typename std::allocator_traits<Alloc>::template rebind_alloc<type>;
+    using traits_t = typename std::allocator_traits<allocator_t>;
+
+    auto typed = static_cast<type*>(p);
+    allocator_t allocator{std::move(alloc)};
+
+    traits_t::destroy(allocator, typed);
+    traits_t::deallocate(allocator, typed, 1);
+  }
+};
+
+template <typename Sender, typename Alloc>
+using spawn_detached_op_t = typename _spawn_detached_op<
+    Sender,
+    // standardize on a std::byte allocator to minimize template instantiations
+    typename std::allocator_traits<Alloc>::template rebind_alloc<std::byte>>::
+    type;
+
+struct _spawn_detached_fn {
+private:
+  struct deref;
+
+public:
+  template(
+      typename Sender,
+      typename Scope,
+      typename Alloc = std::allocator<std::byte>)  //
+      (requires sender<Sender> AND                 //
+           is_allocator_v<Alloc> AND               //
+               sender_to<
+                   decltype(nest(
+                       UNIFEX_DECLVAL(Sender), UNIFEX_DECLVAL(Scope&))),
+                   spawn_detached_receiver_t<Alloc>>)  //
+      void
+      operator()(Sender&& sender, Scope& scope, const Alloc& alloc = {}) const {
+    using sender_t = decltype(nest(static_cast<Sender&&>(sender), scope));
+
+    using op_t = spawn_detached_op_t<sender_t, Alloc>;
+
+    using allocator_t =
+        typename std::allocator_traits<Alloc>::template rebind_alloc<op_t>;
+    using traits = std::allocator_traits<allocator_t>;
+
+    allocator_t allocator{alloc};
+
+    // this could throw std::bad_alloc, in which case we can let the exception
+    // bubble out
+    auto op = traits::allocate(allocator, 1);
+
+    // prepare to deallocate what we just allocated in case of an exception in
+    // the operation state constructor
+    scope_guard g = [&]() noexcept {
+      traits::deallocate(allocator, op, 1);
+    };
+
+    // once this succeeds, the operation owns itself; the allocate is balanced
+    // by the deallocate in op_t::destroy
+    traits::construct(
+        allocator, op, nest(static_cast<Sender&&>(sender), scope), allocator);
+
+    // since construction succeeded, don't deallocate the memory
+    g.release();
+
+    unifex::start(*op);
+  }
+
+  template <typename Scope, typename Alloc = std::allocator<std::byte>>
+  constexpr auto operator()(Scope& scope, const Alloc& alloc = {}) const
+      noexcept(
+          is_nothrow_callable_v<tag_t<bind_back>, deref, Scope*, const Alloc&>)
+          -> std::enable_if_t<
+              is_allocator_v<Alloc>,
+              bind_back_result_t<deref, Scope*, const Alloc&>>;
+};
+
+struct _spawn_detached_fn::deref final {
+  template <typename Sender, typename Scope, typename Alloc>
+  auto operator()(Sender&& sender, Scope* scope, const Alloc& alloc) const
+      -> decltype(
+          _spawn_detached_fn{}(static_cast<Sender&&>(sender), *scope, alloc)) {
+    return _spawn_detached_fn{}(static_cast<Sender&&>(sender), *scope, alloc);
+  }
+};
+
+template <typename Scope, typename Alloc>
+inline constexpr auto
+_spawn_detached_fn::operator()(Scope& scope, const Alloc& alloc) const noexcept(
+    is_nothrow_callable_v<tag_t<bind_back>, deref, Scope*, const Alloc&>)
+    -> std::enable_if_t<
+        is_allocator_v<Alloc>,
+        bind_back_result_t<deref, Scope*, const Alloc&>> {
+  return bind_back(deref{}, &scope, alloc);
+}
+
+}  // namespace _spawn_detached
+
+inline constexpr _spawn_detached::_spawn_detached_fn spawn_detached{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/type_traits.hpp
+++ b/include/unifex/type_traits.hpp
@@ -161,6 +161,23 @@ inline constexpr bool is_nothrow_callable_v =
 template <typename Fn, typename... As>
 struct is_nothrow_callable : std::bool_constant<is_nothrow_callable_v<Fn, As...>> {};
 
+template <typename T, typename = void>
+struct is_allocator : std::false_type {};
+
+template <typename T>
+constexpr bool is_allocator_v = is_allocator<T>::value;
+
+template <typename T>
+struct is_allocator<
+    T,
+    std::void_t<typename T::value_type,
+                decltype(std::declval<T>().allocate(std::size_t{})),
+                decltype(std::declval<T>().deallocate(nullptr, std::size_t{})),
+                std::enable_if_t<std::is_copy_constructible_v<T>>,
+                decltype(std::declval<const T&>() == std::declval<const T&>()),
+                decltype(std::declval<const T&>() != std::declval<const T&>())>>
+    : std::true_type {};
+
 template <typename T>
 struct type_always {
   template <typename...>

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -63,7 +63,7 @@ TEST(spawn_detached_test, spawn_detached_increments_use_count) {
   bool lambdaHasExecuted{false};
 
   unifex::spawn_detached(
-      unifex::just_from([&, this]() noexcept {
+      unifex::just_from([&]() noexcept {
         EXPECT_EQ(1, scope.use_count());
         lambdaHasExecuted = true;
       }),

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -97,6 +97,7 @@ TEST(spawn_detached_test, spawn_detached_accepts_allocators_of_non_bytes) {
   unifex::spawn_detached(unifex::just(), idscope, std::allocator<int>{});
 }
 
+#if !UNIFEX_NO_EXCEPTIONS
 template <typename T>
 struct throwing_allocator final {
   using value_type = T;
@@ -184,5 +185,6 @@ TEST(
 
   unifex::sync_wait(scope.join());
 }
+#endif
 
 }  // namespace

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/spawn_detached.hpp>
+
+#include <unifex/just.hpp>
+#include <unifex/just_from.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/v1/async_scope.hpp>
+#include <unifex/v2/async_scope.hpp>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+TEST(spawn_detached_test, spawn_detached_of_just_and_v1_scope_compiles) {
+  unifex::v1::async_scope scope;
+
+  bool didExecute = false;
+  unifex::spawn_detached(
+      unifex::just(&didExecute) |
+          unifex::then([](auto* didExecute) noexcept { *didExecute = true; }),
+      scope);
+
+  unifex::sync_wait(scope.complete());
+
+  EXPECT_TRUE(didExecute);
+}
+
+TEST(spawn_detached_test, spawn_detached_of_just_and_v2_scope_compiles) {
+  unifex::v2::async_scope scope;
+
+  bool didExecute = false;
+  unifex::spawn_detached(
+      unifex::just(&didExecute) |
+          unifex::then([](auto* didExecute) noexcept { *didExecute = true; }),
+      scope);
+
+  unifex::sync_wait(scope.join());
+
+  EXPECT_TRUE(didExecute);
+}
+
+TEST(spawn_detached_test, spawn_detached_increments_use_count) {
+  unifex::v2::async_scope scope;
+
+  bool lambdaHasExecuted{false};
+
+  unifex::spawn_detached(
+      unifex::just_from([&, this]() noexcept {
+        EXPECT_EQ(1, scope.use_count());
+        lambdaHasExecuted = true;
+      }),
+      scope);
+
+  EXPECT_TRUE(lambdaHasExecuted);
+
+  unifex::sync_wait(scope.join());
+}
+
+struct identity_scope final {
+  template <typename Sender>
+  auto nest(Sender&& sender) noexcept(
+      std::is_nothrow_constructible_v<unifex::remove_cvref_t<Sender>, Sender>) {
+    return static_cast<Sender&&>(sender);
+  }
+};
+
+TEST(spawn_detached_test, spawn_detached_accepts_non_standard_scope_types) {
+  identity_scope idscope;
+  unifex::spawn_detached(unifex::just(), idscope);
+}
+
+TEST(spawn_detached_test, spawn_detached_is_pipeable) {
+  identity_scope idscope;
+  unifex::just() | unifex::spawn_detached(idscope);
+}
+
+TEST(spawn_detached_test, spawn_detached_accepts_allocators_of_non_bytes) {
+  identity_scope idscope;
+  unifex::spawn_detached(unifex::just(), idscope, std::allocator<int>{});
+}
+
+template <typename T>
+struct throwing_allocator final {
+  using value_type = T;
+
+  constexpr throwing_allocator() noexcept = default;
+
+  constexpr throwing_allocator(const throwing_allocator&) noexcept = default;
+
+  template <typename U>
+  constexpr throwing_allocator(const throwing_allocator<U>&) noexcept {}
+
+  ~throwing_allocator() = default;
+
+  constexpr throwing_allocator& operator=(throwing_allocator) noexcept {
+    return *this;
+  }
+
+  [[noreturn]] T* allocate(size_t) { throw std::bad_alloc{}; }
+
+  [[noreturn]] void deallocate(void*, size_t) noexcept {
+    // allocate never succeeds so calling deallocate is a bug
+    std::terminate();
+  }
+
+  static constexpr bool always_equal = true;
+
+  constexpr friend bool
+  operator==(throwing_allocator, throwing_allocator) noexcept {
+    return true;
+  }
+
+  constexpr friend bool
+  operator!=(throwing_allocator, throwing_allocator) noexcept {
+    return false;
+  }
+};
+
+static_assert(unifex::is_allocator_v<throwing_allocator<int>>);
+
+TEST(
+    spawn_detached_test,
+    spawn_detached_maintains_the_strong_exception_guarantee) {
+  unifex::v2::async_scope scope;
+
+  bool connected = false;
+  bool started = false;
+
+  auto sender = unifex::let_value_with(
+      [&]() -> int {
+        // this state factory runs upon connect
+        connected = true;
+        throw 42;
+      },
+      [&](auto&) noexcept {
+        // this successor factory doesn't run until start
+        started = true;
+        return unifex::just();
+      });
+
+  try {
+    unifex::spawn_detached(sender, scope, throwing_allocator<int>{});
+  } catch (std::bad_alloc&) {
+    // expected
+  } catch (std::exception& e) {
+    ADD_FAILURE() << "Unexpected exception: " << e.what();
+  } catch (...) {
+    ADD_FAILURE() << "Unexpected exception.";
+  }
+
+  EXPECT_FALSE(connected);
+  EXPECT_FALSE(started);
+
+  try {
+    unifex::spawn_detached(sender, scope);
+  } catch (int i) {
+    EXPECT_EQ(42, i);
+  } catch (std::exception& e) {
+    ADD_FAILURE() << "Unexpected exception: " << e.what();
+  } catch (...) {
+    ADD_FAILURE() << "Unexpected exception.";
+  }
+
+  EXPECT_TRUE(connected);
+  EXPECT_FALSE(started);
+
+  unifex::sync_wait(scope.join());
+}
+
+}  // namespace


### PR DESCRIPTION
This diff introduces a new algorithm, `unifex::spawn_detached()`. `spawn_detached` takes a sender, an "async scope", and an optional allocator.  It nests the sender in the scope with `unifex::nest`, allocates an operation state using the allocator, and starts that operation.  The given async scope may be anything that `nest()` supports, which currently includes both `v1::async_scope` and `v2::async_scope`.