### PR TITLE
Use MSVC's warning as error parameters for clang-cl

### DIFF
--- a/cmake/unifex_env.cmake
+++ b/cmake/unifex_env.cmake
@@ -19,7 +19,7 @@ else()
   message(WARNING "[unifex warning]: unknown compiler ${CMAKE_CXX_COMPILER_ID} !")
 endif()
 
-if (UNIFEX_CXX_COMPILER_MSVC)
+if (UNIFEX_CXX_COMPILER_MSVC OR UNIFEX_CXX_COMPILER_CLANGCL)
     # warning level 3 and all warnings as errors
     add_compile_options(/W3 /WX)
 else()


### PR DESCRIPTION
... otherwise we will encounter a build error:

```
PS D:\src\libunifex\build> cmake .. -GNinja -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=Clang-Cl -DCMAKE_C_COMPILER=Clang-Cl
-- The CXX compiler identification is Clang 15.0.0 with MSVC-like command-line
...
PS D:\src\libunifex\build> ninja
[1/170] Building CXX object source\CMakeFiles\unifex.dir\timed_single_thread_context.cpp.obj
FAILED: source/CMakeFiles/unifex.dir/timed_single_thread_context.cpp.obj
C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo -TP  -ID:\src\libunifex\include -ID:\src\libunifex\build\include /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1 -Wall -Wextra -pedantic -Werror -std:c++20 /showIncludes /Fosource\CMakeFiles\unifex.dir\timed_single_thread_context.cpp.obj /Fdsource\CMakeFiles\unifex.dir\unifex.pdb -c -- D:\src\libunifex\source\timed_single_thread_context.cpp
clang-cl: error: unknown argument ignored in clang-cl: '-pedantic' [-Werror,-Wunknown-argument]
```