### PR TITLE
Fix the constraints in let_value_with_stop_token

### DIFF
--- a/include/unifex/let_value_with_stop_token.hpp
+++ b/include/unifex/let_value_with_stop_token.hpp
@@ -192,12 +192,13 @@ struct _stop_token_operation<
 
     static constexpr bool successor_is_nothrow =
         std::is_nothrow_invocable_v<SuccessorFactory&, inplace_stop_token>;
+    template <typename Receiver2>
     static constexpr bool inner_receiver_nothrow_constructible =
         std::is_nothrow_constructible_v<
             receiver_t,
             type*,
             inplace_stop_token,
-            Receiver&&>;
+            Receiver2>;
     static constexpr bool nothrow_connectable =
         is_nothrow_connectable_v<inner_sender_t, receiver_t>;
 
@@ -209,8 +210,8 @@ struct _stop_token_operation<
         // we need to take r by reference to avoid problems at the call site
         // related to unsequenced function argument evaluation
         Receiver2&& r) noexcept(successor_is_nothrow&&
-                                    inner_receiver_nothrow_constructible&&
-                                        nothrow_connectable) {
+                                    inner_receiver_nothrow_constructible<
+                                        Receiver2>&& nothrow_connectable) {
       return unifex::connect(
           func(st), receiver_t{this, st, static_cast<Receiver2&&>(r)});
     }
@@ -267,12 +268,13 @@ struct _stop_token_operation<SuccessorFactory, Receiver, AlwaysVoid>::type {
 
   static constexpr bool successor_is_nothrow =
       std::is_nothrow_invocable_v<SuccessorFactory&, inplace_stop_token>;
+  template <typename Receiver2>
   static constexpr bool inner_receiver_nothrow_constructible =
       std::is_nothrow_constructible_v<
           receiver_t,
           type*,
           inplace_stop_token,
-          Receiver&&>;
+          Receiver2>;
   static constexpr bool nothrow_connectable =
       unifex::is_nothrow_connectable_v<inner_sender_t, receiver_t>;
 
@@ -282,8 +284,8 @@ private:
       SuccessorFactory& func,
       inplace_stop_token st,
       Receiver2&& r) noexcept(successor_is_nothrow&&
-                                  inner_receiver_nothrow_constructible&&
-                                      nothrow_connectable) {
+                                  inner_receiver_nothrow_constructible<
+                                      Receiver2>&& nothrow_connectable) {
     return unifex::connect(
         func(st), receiver_t{this, st, static_cast<Receiver2&&>(r)});
   }


### PR DESCRIPTION
When trying to nest a `let_value_with_stop_token()` *Sender* inside a `unifex::v2::async_scope`, I discovered there were problems checking the constraints on a `const Sender&` when `Sender` was a `let_value_with_stop_token` *Sender* constructed with a `mutable` lambda.

This diff fixes the above scenario and includes a regression test.  The fixes include:
 - fixing the type calculations on `SuccessFactory` (e.g. we invoke an lvalue reference not an rvalue reference)
 - correcting the `noexcept` calculations (e.g. although we *construct* our copy of the `SuccessorFactory` in a value category-sensitive way, we always *invoke* the factory as a mutable lvalue)
 - standardizing value category casts (i.e. using `std::move()` for moves and `static_cast<DestType&&>()` for forwards)
 - adding some `static_assert`s to confirm the validity of the above fixes
 - made the operation state immovable