### PR TITLE
Mark `ErrorValue` as l-value in `let_error`

### DIFF
--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -35,21 +35,21 @@ namespace unifex {
 
 namespace _let_e {
 template <typename Source, typename Func, typename Receiver>
-struct _op {
+struct _op final {
   class type;
 };
 template <typename Source, typename Func, typename Receiver>
 using operation_type = typename _op<Source, Func, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Func, typename Receiver>
-struct _rcvr {
+struct _rcvr final {
   class type;
 };
 template <typename Source, typename Func, typename Receiver>
 using receiver_type = typename _rcvr<Source, Func, remove_cvref_t<Receiver>>::type;
 
 template <typename Source, typename Func, typename Receiver, typename Error>
-struct _frcvr {
+struct _frcvr final {
   class type;
 };
 template <typename Source, typename Func, typename Receiver, typename Error>
@@ -57,7 +57,7 @@ using final_receiver_type =
     typename _frcvr<Source, Func, remove_cvref_t<Receiver>, Error>::type;
 
 template <typename Source, typename Func>
-struct _sndr {
+struct _sndr final {
   class type;
 };
 
@@ -101,28 +101,31 @@ public:
   }
 
   template <typename ErrorValue>
-  void set_error(ErrorValue e) noexcept {
+  void set_error(ErrorValue&& e) noexcept {
     // local copy, b/c deactivate_union_member deletes this
     auto op = op_;
     UNIFEX_ASSERT(op != nullptr);
 
-    using final_sender_t = callable_result_t<Func, ErrorValue>;
-    using final_op_t =
-        unifex::connect_result_t<final_sender_t, final_receiver<ErrorValue>>;
+    using final_sender_t = callable_result_t<Func, remove_cvref_t<ErrorValue>&>;
+    using final_op_t = connect_result_t<
+        final_sender_t,
+        final_receiver<remove_cvref_t<ErrorValue>>>;
 
     UNIFEX_TRY {
       scope_guard destroyPredOp = [&]() noexcept {
         unifex::deactivate_union_member(op->sourceOp_);
       };
-      auto& err = op->error_.template construct<ErrorValue>((ErrorValue &&) e);
+      auto& err = op->error_.template construct<remove_cvref_t<ErrorValue>>(
+          (ErrorValue &&) e);
       destroyPredOp.reset();
       scope_guard destroyErr = [&]() noexcept {
-        op->error_.template destruct<ErrorValue>();
+        op->error_.template destruct<remove_cvref_t<ErrorValue>>();
       };
       auto& finalOp =
           unifex::activate_union_member_with<final_op_t>(op->finalOp_, [&] {
             return unifex::connect(
-                std::move(op->func_)(err), final_receiver<ErrorValue>{op});
+                std::move(op->func_)(err),
+                final_receiver<remove_cvref_t<ErrorValue>>{op});
           });
       unifex::start(finalOp);
       destroyErr.release();
@@ -164,8 +167,9 @@ private:
 };
 
 template <typename Source, typename Func, typename Receiver, typename Error>
-class _frcvr<Source, Func, Receiver, Error>::type {
+class _frcvr<Source, Func, Receiver, Error>::type final {
   using operation = operation_type<Source, Func, Receiver>;
+  static_assert(!std::is_reference_v<Error>);
 
 public:
   explicit type(operation* op) noexcept : op_(op) {}
@@ -209,8 +213,8 @@ public:
 
 private:
   static void cleanup(operation* op) noexcept {
-    using final_sender_t = callable_result_t<Func, Error>;
-    using final_op_t = unifex::connect_result_t<final_sender_t, type>;
+    using final_sender_t = callable_result_t<Func, Error&>;
+    using final_op_t = connect_result_t<final_sender_t, type>;
     UNIFEX_ASSERT(op != nullptr);
     unifex::deactivate_union_member<final_op_t>(op->finalOp_);
     op->error_.template destruct<Error>();
@@ -246,7 +250,7 @@ private:
 };
 
 template <typename Source, typename Func, typename Receiver>
-class _op<Source, Func, Receiver>::type {
+class _op<Source, Func, Receiver>::type final {
   using source_receiver = receiver_type<Source, Func, Receiver>;
   template <typename Error>
   using final_receiver = final_receiver_type<Source, Func, Receiver, Error>;
@@ -289,10 +293,11 @@ private:
   using source_op_t = connect_result_t<Source, source_receiver>;
 
   template <typename Error>
-  using final_sender_t = callable_result_t<Func, remove_cvref_t<Error>>;
+  using final_sender_t = callable_result_t<Func, remove_cvref_t<Error>&>;
 
   template <typename Error>
-  using final_receiver_t = final_receiver_type<Source, Func, Receiver, Error>;
+  using final_receiver_t =
+      final_receiver_type<Source, Func, Receiver, remove_cvref_t<Error>>;
 
   template <typename Error>
   using final_op_t =
@@ -322,10 +327,10 @@ template<typename... Senders>
 using any_sends_done = std::disjunction<sends_done_impl<Senders>...>;
 
 template <typename Source, typename Func>
-class _sndr<Source, Func>::type {
+class _sndr<Source, Func>::type final {
 
   template <typename Error>
-  using final_sender = callable_result_t<Func, remove_cvref_t<Error>>;
+  using final_sender = callable_result_t<Func, remove_cvref_t<Error>&>;
 
   using final_senders_list =
       map_type_list_t<sender_error_type_list_t<Source>, final_sender>;
@@ -398,7 +403,7 @@ private:
 
 namespace _cpo
 {
-struct _fn {
+struct _fn final {
   template(typename Source, typename Func)
     (requires tag_invocable<_fn, Source, Func> AND
         sender<Source>)

--- a/test/let_error_test.cpp
+++ b/test/let_error_test.cpp
@@ -132,3 +132,37 @@ TEST(TransformError, JustError) {
   ASSERT_TRUE(one.has_value());
   EXPECT_EQ(*one, 42);
 }
+
+TEST(TransformError, SequenceRef) {
+  auto one = just_error(42)  //
+      | let_error([](auto& e) mutable {
+               return sequence(just_from([] {}), just_error(std::move(e)));
+             })                //
+      | let_error(just_int{})  //
+      | sync_wait();
+  ASSERT_TRUE(one.has_value());
+  EXPECT_EQ(*one, 42);
+}
+
+TEST(TransformError, SequenceVal) {
+  auto one = just_error(42)  //
+      | let_error([](auto e) mutable {
+               return sequence(just_from([] {}), just_error(std::move(e)));
+             })                //
+      | let_error(just_int{})  //
+      | sync_wait();
+  ASSERT_TRUE(one.has_value());
+  EXPECT_EQ(*one, 42);
+}
+
+TEST(TransformError, SequenceFwd) {
+  auto one = just_error(42)  //
+      | let_error([](auto&& e) mutable {
+               return sequence(
+                   just_from([] {}), just_error(static_cast<decltype(e)&&>(e)));
+             })                //
+      | let_error(just_int{})  //
+      | sync_wait();
+  ASSERT_TRUE(one.has_value());
+  EXPECT_EQ(*one, 42);
+}


### PR DESCRIPTION
- aligns with the expectation of a final `Receiver`
- add repro test case, which otherwise does not compile due to type mismatch