### PR TITLE
Fix signed integer overflow UB in reduce_with_trampoline example

### DIFF
--- a/examples/reduce_with_trampoline.cpp
+++ b/examples/reduce_with_trampoline.cpp
@@ -35,10 +35,10 @@ int main() {
               trampoline_scheduler{},
               transform_stream(
                   range_stream{0, 100'000},
-                  [](int value) { return value * value; })),
+                  [](unsigned value) { return value * value; })),
           0,
-          [](int state, int value) { return state + 10 * value; }),
-      [&](int result) { std::printf("result: %i\n", result); }));
+          [](unsigned state, unsigned value) { return state + 10 * value; }),
+      [&](unsigned result) { std::printf("result: %i\n", result); }));
 
   return 0;
 }


### PR DESCRIPTION
```
libunifex/examples/reduce_with_trampoline.cpp:40:51: runtime error:
signed integer overflow: 2146177440 + 7464960 cannot be represented in
type 'int'
```

I also ran into issues compiling w/ Clang 16 since `-Werror` is enabled, so there's a fix for that too. I guess Clang has gotten smarter about set-but-not-used variables.