### PR TITLE
Check concept earlier in let_error

### DIFF
--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -379,7 +379,8 @@ public:
     typename Receiver,
     typename...,
     typename SourceReceiver = receiver_type<member_t<Sender, Source>, Func, Receiver>)
-      (requires same_as<remove_cvref_t<Sender>, type> AND
+      (requires receiver<Receiver> AND
+          same_as<remove_cvref_t<Sender>, type> AND
           constructible_from<Func, member_t<Sender, Func>> AND
           constructible_from<remove_cvref_t<Receiver>, Receiver> AND
           sender_to<Source, SourceReceiver>)


### PR DESCRIPTION
Re-apply #438 to fix compilation on GCC11/12 after merging a subset of the broken-stdlib changes.