### PR TITLE
task<> scheduler affinity (#290)

### DIFF
--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -22,6 +22,7 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -103,6 +104,10 @@ namespace _alloc {
           connect_result_t<member_t<Self, Sender>, Receiver>,
           remove_cvref_t<get_allocator_t<Receiver>>>{
           static_cast<Self&&>(s).sender_, (Receiver &&) r};
+    }
+
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+      return blocking(self.sender_);
     }
 
     Sender sender_;

--- a/include/unifex/async_trace.hpp
+++ b/include/unifex/async_trace.hpp
@@ -103,7 +103,7 @@ namespace _async_trace {
       return operation<Receiver>{(Receiver &&) r};
     }
 
-    friend blocking_kind tag_invoke(tag_t<blocking>, const sender&) noexcept {
+    friend auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
       return blocking_kind::always_inline;
     }
   };

--- a/include/unifex/blocking.hpp
+++ b/include/unifex/blocking.hpp
@@ -22,10 +22,11 @@
 
 namespace unifex {
 
-enum class blocking_kind {
+namespace _block {
+enum class _enum {
   // No guarantees about the timing and context on which the receiver will
   // be called.
-  maybe,
+  maybe = 0,
 
   // Always completes asynchronously.
   // Guarantees that the receiver will not be called on the current thread
@@ -44,8 +45,46 @@ enum class blocking_kind {
   always_inline
 };
 
-namespace _blocking {
-inline const struct _fn {
+struct blocking_kind {
+  template <_enum Kind>
+  using constant = std::integral_constant<_enum, Kind>;
+
+  blocking_kind() = default;
+
+  constexpr blocking_kind(_enum kind) noexcept
+    : value(kind)
+  {}
+
+  template <_enum Kind>
+  constexpr blocking_kind(constant<Kind>) noexcept
+    : value(Kind)
+  {}
+
+  constexpr operator _enum() const noexcept {
+    return value;
+  }
+
+  constexpr _enum operator()() const noexcept {
+    return value;
+  }
+
+  friend constexpr bool operator==(blocking_kind a, blocking_kind b) noexcept {
+    return a.value == b.value;
+  }
+
+  friend constexpr bool operator!=(blocking_kind a, blocking_kind b) noexcept {
+    return a.value != b.value;
+  }
+
+  static constexpr constant<_enum::maybe> maybe {};
+  static constexpr constant<_enum::never> never {};
+  static constexpr constant<_enum::always> always {};
+  static constexpr constant<_enum::always_inline> always_inline {};
+
+  _enum value{};
+};
+
+struct _fn {
   template(typename Sender)
     (requires tag_invocable<_fn, const Sender&>)
   constexpr auto operator()(const Sender& s) const
@@ -55,12 +94,32 @@ inline const struct _fn {
   }
   template(typename Sender)
     (requires (!tag_invocable<_fn, const Sender&>))
-  constexpr blocking_kind operator()(const Sender&) const noexcept {
+  constexpr auto operator()(const Sender&) const noexcept {
     return blocking_kind::maybe;
   }
-} blocking{};
-} // namespace _blocking
-using _blocking::blocking;
+};
+
+namespace _cfn {
+  template <_enum Kind>
+  static constexpr auto _kind(blocking_kind::constant<Kind> kind) noexcept {
+    return kind;
+  }
+  static constexpr auto _kind(blocking_kind) noexcept {
+    return blocking_kind::maybe;
+  }
+
+  template <typename T>
+  constexpr auto cblocking() noexcept {
+    using blocking_t = remove_cvref_t<decltype(_fn{}(UNIFEX_DECLVAL(T&)))>;
+    return _cfn::_kind(blocking_t{});
+  }
+}
+
+} // namespace _block
+
+inline constexpr _block::_fn blocking {};
+using _block::_cfn::cblocking;
+using _block::blocking_kind;
 
 } // namespace unifex
 

--- a/include/unifex/coroutine_concepts.hpp
+++ b/include/unifex/coroutine_concepts.hpp
@@ -60,7 +60,8 @@ struct await_result_impl<
 
 } // namespace detail
 
-inline const struct _get_awaiter_fn {
+namespace _get_awaiter {
+struct _fn {
   template <typename Awaitable>
   constexpr decltype(auto) operator()(Awaitable&& awaitable) const noexcept {
     if constexpr (detail::has_member_operator_co_await_v<Awaitable>) {
@@ -71,7 +72,10 @@ inline const struct _get_awaiter_fn {
       return static_cast<Awaitable&&>(awaitable);
     }
   }
-} get_awaiter {};
+};
+} // namespace _get_awaiter
+
+inline constexpr _get_awaiter::_fn get_awaiter {};
 
 template <typename Awaitable>
 using awaiter_type_t = decltype(get_awaiter(std::declval<Awaitable>()));

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -24,6 +24,7 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/std_concepts.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/blocking.hpp>
 
 #include <type_traits>
 
@@ -179,6 +180,9 @@ namespace _demat {
           receiver_t<Receiver>{static_cast<Receiver&&>(r)});
     }
 
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const type& self) noexcept {
+      return blocking(self.source_);
+    }
   private:
     Source source_;
   };

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -29,7 +29,20 @@ namespace unifex {
     struct _empty {};
   } // namespace detail
 
-  using detail::_ignore;
+  namespace _kv
+  {
+    template <typename Key, typename Value>
+    struct _kv {
+      struct type {
+        using key_type = Key;
+        using value_type = Value;
+        UNIFEX_NO_UNIQUE_ADDRESS Key key;
+        Value value;
+      };
+    };
+  } // namespace _kv
+  template <typename Key, typename Value>
+  using kv = typename _kv::_kv<Key, Value>::type;
 
   namespace _execute::_cpo {
     struct _fn;
@@ -48,9 +61,31 @@ namespace unifex {
 
 #if !UNIFEX_NO_COROUTINES
   namespace _await_tfx {
-    extern const struct _fn await_transform;
-  }
-  using _await_tfx::await_transform;
+    struct _fn;
+  } // namespace _await_tfx
+  extern const _await_tfx::_fn await_transform;
 #endif
+
+  namespace _schedule {
+    struct _fn;
+  } // namespace _schedule
+  extern const _schedule::_fn schedule;
+
+  namespace _sf {
+    template <const auto&, typename, typename>
+    struct sender_for;
+  } // namespace _sf
+  using _sf::sender_for;
+
+  namespace _xchg_cont {
+    extern const struct _fn exchange_continuation;
+  } // _xchg_cont
+  using _xchg_cont::exchange_continuation;
+
+  template <typename>
+  struct sender_traits;
+
+  template <const auto& CPO, typename Sender, typename Context>
+  struct sender_traits<sender_for<CPO, Sender, Context>>;
 
 } // namespace unifex

--- a/include/unifex/get_stop_token.hpp
+++ b/include/unifex/get_stop_token.hpp
@@ -22,6 +22,7 @@
 #include <unifex/type_traits.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/unstoppable_token.hpp>
+#include <unifex/blocking.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -41,6 +42,10 @@ namespace _get_stop_token {
         }
         StopToken await_resume() noexcept {
           return (StopToken&&) stoken_;
+        }
+
+        friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _awaiter&) noexcept {
+          return blocking_kind::always_inline;
         }
       };
 

--- a/include/unifex/inline_scheduler.hpp
+++ b/include/unifex/inline_scheduler.hpp
@@ -76,7 +76,7 @@ namespace _inline_sched {
 
       static constexpr bool sends_done = true;
 
-      friend constexpr blocking_kind tag_invoke(
+      friend constexpr auto tag_invoke(
           tag_t<blocking>,
           const schedule_task&) noexcept {
         return blocking_kind::always_inline;

--- a/include/unifex/just.hpp
+++ b/include/unifex/just.hpp
@@ -95,7 +95,7 @@ class _sender<Values...>::type {
     return {static_cast<This&&>(that).values_, static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const type&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/just_done.hpp
+++ b/include/unifex/just_done.hpp
@@ -68,7 +68,7 @@ class sender {
     return {static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const sender&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/just_error.hpp
+++ b/include/unifex/just_error.hpp
@@ -85,7 +85,7 @@ class _sender<Error>::type {
     return {static_cast<This&&>(that).error_, static_cast<Receiver&&>(r)};
   }
 
-  friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const type&) noexcept {
+  friend constexpr auto tag_invoke(tag_t<blocking>, const type&) noexcept {
     return blocking_kind::always_inline;
   }
 };

--- a/include/unifex/manual_event_loop.hpp
+++ b/include/unifex/manual_event_loop.hpp
@@ -89,7 +89,7 @@ class context {
  public:
   class scheduler {
     class schedule_task {
-      friend constexpr blocking_kind tag_invoke(
+      friend constexpr auto tag_invoke(
           tag_t<blocking>,
           const schedule_task&) noexcept {
         return blocking_kind::never;

--- a/include/unifex/range_stream.hpp
+++ b/include/unifex/range_stream.hpp
@@ -57,7 +57,7 @@ struct next_sender {
 
   static constexpr bool sends_done = true;
 
-  friend constexpr blocking_kind tag_invoke(
+  friend constexpr auto tag_invoke(
       tag_t<blocking>,
       const stream&) noexcept {
     return blocking_kind::always_inline;

--- a/include/unifex/ready_done_sender.hpp
+++ b/include/unifex/ready_done_sender.hpp
@@ -52,7 +52,7 @@ namespace _ready_done {
 
     static constexpr bool sends_done = true;
 
-    friend constexpr blocking_kind tag_invoke(
+    friend constexpr auto tag_invoke(
         tag_t<blocking>,
         const sender&) {
       return blocking_kind::always_inline;

--- a/include/unifex/sender_for.hpp
+++ b/include/unifex/sender_for.hpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_traits.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex
+{
+  namespace _sf
+  {
+    template <typename Query>
+    struct _property {
+      const typename Query::value_type& operator()(const typename Query::key_type &) const noexcept {
+        return query_.value;
+      }
+      UNIFEX_NO_UNIQUE_ADDRESS Query query_;
+    };
+    template <typename... Queries>
+    struct _ctx {
+      struct type : _property<Queries>... {
+        using _property<Queries>::operator()...;
+      };
+    };
+    template <typename... Queries>
+    using _context = typename _ctx<Queries...>::type;
+
+    template <const auto& C, typename Sender, typename Context>
+    struct sender_for {
+      explicit sender_for(Sender snd, Context ctx)
+          noexcept(
+              std::is_nothrow_move_constructible_v<Sender> &&
+              std::is_nothrow_move_constructible_v<Context>)
+        : snd_((Sender&&) snd), ctx_{(Context&&) ctx} {}
+
+      // Forward all tag_invokes:
+      template (typename CPO, typename Self, typename... Args)
+        (requires same_as<sender_for, remove_cvref_t<Self>> AND
+            (!callable<const Context&, CPO>) AND
+            callable<CPO, member_t<Self, Sender>, Args...>)
+      UNIFEX_ALWAYS_INLINE
+      friend decltype(auto) tag_invoke(CPO cpo, Self&& self, Args&&... args)
+          noexcept(is_nothrow_callable_v<CPO, member_t<Self, Sender>, Args...>) {
+        return ((CPO&&) cpo)(((Self&&) self).snd_, (Args&&) args...);
+      }
+
+      // Handle custom property queries by consulting the context:
+      template (typename CPO)
+        (requires callable<const Context&, CPO>)
+      UNIFEX_ALWAYS_INLINE
+      friend decltype(auto) tag_invoke(CPO cpo, const sender_for& self) noexcept {
+        return self.ctx_(cpo);
+      }
+
+      const Sender& base() const & noexcept {
+        return snd_;
+      }
+
+      Sender&& base() && noexcept {
+        return (Sender&&) snd_;
+      }
+     private:
+      Sender snd_;
+      UNIFEX_NO_UNIQUE_ADDRESS Context ctx_;
+    };
+
+    template <auto& CPO>
+    struct _make_sender_for {
+      template (typename Sender, typename... Queries)
+        (requires sender<Sender>)
+      sender_for<CPO, remove_cvref_t<Sender>, _context<remove_cvref_t<Queries>...>>
+      operator()(Sender&& snd, Queries&&... queries) const
+          noexcept(
+              std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender> &&
+              (std::is_nothrow_constructible_v<remove_cvref_t<Queries>, Queries> &&...)) {
+        return sender_for<CPO, remove_cvref_t<Sender>, _context<remove_cvref_t<Queries>...>>{
+            (Sender&&) snd, _context<remove_cvref_t<Queries>...>{{(Queries&&) queries}...}};
+      }
+    };
+  } // namespace _sf
+
+  using _sf::sender_for;
+
+  template <const auto& CPO>
+  inline constexpr _sf::_make_sender_for<CPO> make_sender_for {};
+
+  template <typename T, const auto& CPO>
+  inline constexpr bool is_sender_for_v = false;
+
+  template <typename Sender, typename Context, const auto& CPO>
+  inline constexpr bool is_sender_for_v<sender_for<CPO, Sender, Context>, CPO> = true;
+
+  template <const auto& CPO, typename Sender, typename Context>
+  struct sender_traits<sender_for<CPO, Sender, Context>>
+    : sender_traits<Sender>
+  {};
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -19,6 +19,7 @@
 #include <unifex/coroutine.hpp>
 #include <unifex/just_done.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/blocking.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -81,6 +82,10 @@ private:
     auto connect(Receiver&& rec) const
       -> typename _op<remove_cvref_t<Receiver>>::type {
       return typename _op<remove_cvref_t<Receiver>>::type{(Receiver&&) rec};
+    }
+
+    friend constexpr auto tag_invoke(tag_t<unifex::blocking>, const _sender&) noexcept {
+      return blocking_kind::always_inline;
     }
   };
 

--- a/include/unifex/tag_invoke.hpp
+++ b/include/unifex/tag_invoke.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <unifex/config.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/detail/concept_macros.hpp>
 
@@ -56,13 +57,11 @@ namespace unifex {
       using type = T<Args...>;
     };
 
-    struct empty {};
-  }  // namespace _tag_invoke
-
-  namespace _tag_invoke_cpo {
-    inline constexpr _tag_invoke::_fn tag_invoke{};
-  }
-  using namespace _tag_invoke_cpo;
+    namespace _cpo {
+      inline constexpr _fn tag_invoke{};
+    }
+  } // namespace _tag_invoke
+  using namespace _tag_invoke::_cpo;
 
   template <auto& CPO>
   using tag_t = remove_cvref_t<decltype(CPO)>;
@@ -85,7 +84,7 @@ namespace unifex {
     : conditional_t<
           is_tag_invocable_v<CPO, Args...>,
           _tag_invoke::defer<tag_invoke_result_t, CPO, Args...>,
-          _tag_invoke::empty> 
+          detail::_empty<>>
   {};
 
   template <typename CPO, typename... Args>

--- a/include/unifex/this.hpp
+++ b/include/unifex/this.hpp
@@ -49,7 +49,7 @@ struct _replace_this<void> {
   using apply = Arg;
 
   template <typename Arg>
-  static Arg&& get(Arg&& arg, _ignore) noexcept {
+  static Arg&& get(Arg&& arg, detail::_ignore) noexcept {
     return (Arg &&) arg;
   }
 };
@@ -60,7 +60,7 @@ struct _replace_this<this_> {
   using apply = T;
 
   template <typename T>
-  static T&& get(_ignore, T& obj) noexcept {
+  static T&& get(detail::_ignore, T& obj) noexcept {
     return (T &&) obj;
   }
 };
@@ -71,7 +71,7 @@ struct _replace_this<this_&> {
   using apply = T&;
 
   template <typename T>
-  static T& get(_ignore, T& obj) noexcept {
+  static T& get(detail::_ignore, T& obj) noexcept {
     return obj;
   }
 };
@@ -82,7 +82,7 @@ struct _replace_this<this_&&> {
   using apply = T&&;
 
   template <typename T>
-  static T&& get(_ignore, T& obj) noexcept {
+  static T&& get(detail::_ignore, T& obj) noexcept {
     return (T &&) obj;
   }
 };
@@ -93,7 +93,7 @@ struct _replace_this<const this_&> {
   using apply = const T&;
 
   template <typename T>
-  static const T& get(_ignore, T& obj) noexcept {
+  static const T& get(detail::_ignore, T& obj) noexcept {
     return obj;
   }
 };
@@ -104,7 +104,7 @@ struct _replace_this<const this_&&> {
   using type = const T&&;
 
   template <typename T>
-  static const T&& get(_ignore, T& obj) noexcept {
+  static const T&& get(detail::_ignore, T& obj) noexcept {
     return (const T&&) obj;
   }
 };
@@ -132,7 +132,7 @@ struct _extract_this {
 template <bool... IsThis>
 struct _extract_this<false, IsThis...> {
   template <typename... TRest>
-  decltype(auto) operator()(_ignore, TRest&&... rest) const noexcept {
+  decltype(auto) operator()(detail::_ignore, TRest&&... rest) const noexcept {
     static_assert(sizeof...(IsThis) > 0, "Arguments to extract_this");
     return _extract_this<IsThis...>{}((TRest &&) rest...);
   }

--- a/include/unifex/v2/async_scope.hpp
+++ b/include/unifex/v2/async_scope.hpp
@@ -431,6 +431,17 @@ struct _nest_sender<Sender>::type final {
     }
   }
 
+  friend constexpr auto
+  tag_invoke(tag_t<unifex::blocking>, const type&) noexcept {
+    if constexpr (
+        cblocking<Sender>() == blocking_kind::always_inline ||
+        cblocking<Sender>() == blocking_kind::always) {
+      return cblocking<Sender>();
+    } else {
+      return blocking_kind::maybe;
+    }
+  }
+
 private:
   scope_reference scope_;
   UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<Sender> sender_;

--- a/include/unifex/when_all_range.hpp
+++ b/include/unifex/when_all_range.hpp
@@ -305,6 +305,19 @@ private:
         std::move((static_cast<Sender2&&>(sender)).senders_)};
   }
 
+  // Combine the blocking-nature of each of the child operations.
+  friend constexpr auto tag_invoke(
+      unifex::tag_t<unifex::blocking> /* unused */, const type&) noexcept {
+    if constexpr (
+        unifex::cblocking<Sender>() == unifex::blocking_kind::always_inline ||
+        unifex::cblocking<Sender>() == unifex::blocking_kind::always) {
+      return unifex::cblocking<Sender>();
+    } else {
+      // we complete inline if the input is empty so every other case is "maybe"
+      return unifex::blocking_kind::maybe;
+    }
+  }
+
   std::vector<Sender> senders_;
 };
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -17,10 +17,10 @@ target_sources(unifex
     inplace_stop_token.cpp
     manual_event_loop.cpp
     static_thread_pool.cpp
+    task.cpp
     thread_unsafe_event_loop.cpp
     timed_single_thread_context.cpp
-    trampoline_scheduler.cpp
-    async_manual_reset_event.cpp)
+    trampoline_scheduler.cpp)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_sources(unifex

--- a/source/task.cpp
+++ b/source/task.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <unifex/task.hpp>
+#include <unifex/at_coroutine_exit.hpp>
+
+namespace unifex::_task {
+void _promise_base::transform_schedule_sender_impl_(any_scheduler newSched) {
+  // If we haven't already inserted a cleanup action to take us back to the correct
+  // scheduler, do so now:
+  if (!std::exchange(this->rescheduled_, true)) {
+    // Create a cleanup action that transitions back onto the current scheduler:
+    auto cleanupTask = at_coroutine_exit(schedule, this->sched_);
+    // Insert the cleanup action into the head of the continuation chain by making
+    // direct calls to the cleanup task's awaiter member functions. See type
+    // _cleanup_task in at_coroutine_exit.hpp:
+    cleanupTask.await_suspend_impl_(*this);
+    (void) cleanupTask.await_resume();
+  }
+
+  // Update the current scheduler. (Don't do this before we have inserted the
+  // cleanup action because the insertion of the cleanup action reads this task's
+  // current scheduler.)
+  this->sched_ = std::move(newSched);
+}
+} // unifex::_task
+
+#endif

--- a/test/finally_test.cpp
+++ b/test/finally_test.cpp
@@ -68,3 +68,15 @@ TEST(Finally, Error) {
   ASSERT_TRUE(res.has_value());
   EXPECT_EQ(*res, context.get_thread_id());
 }
+
+TEST(Finally, BlockingKind) {
+  auto snd1 = finally(just(), just());
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::always_inline == cblocking<Snd1>());
+
+  timed_single_thread_context context;
+  
+  auto snd2 = finally(just(), schedule(context.get_scheduler()));
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -49,6 +49,55 @@ constexpr auto asyncVector = [](auto& context) {
         return std::vector<int>{1, 2, 3, 4};
     });
 };
+
+namespace _never_block {
+template <typename... Values>
+struct sender {
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = Variant<Tuple<Values...>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = false;
+
+  friend constexpr auto tag_invoke(tag_t<blocking>, const sender&) noexcept {
+    return blocking_kind::never;
+  }
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&... values) const noexcept {
+    return _never_block::sender{(Values&&)values...};
+  }
+
+} never_block{};
+} // namespace _never_block
+
+using _never_block::never_block;
+
+namespace _multi {
+struct _multi_sender {
+  template <
+      template <typename...> class Variant,
+      template <typename...> class Tuple>
+  using value_types = Variant<Tuple<int>, Tuple<double>>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+  static constexpr bool sends_done = false;
+};
+
+inline const struct _fn {
+  template <typename... Values>
+  constexpr auto operator()(Values&&...) const noexcept {
+    return _multi::_multi_sender{};
+  }
+} multi_sender{};
+} // namespace _multi
+using _multi::multi_sender;
 } // anonymous namespace
 
 TEST(Let, Simple) {
@@ -125,6 +174,70 @@ TEST(Let, Pipeable) {
   EXPECT_TRUE(!!result);
   EXPECT_EQ(*result, 42);
   std::cout << "let_value done " << *result << "\n";
+}
+
+TEST(Let, InlineBlockingKind) {
+  auto snd = let_value(just(), just);
+  using Snd = decltype(snd);
+  static_assert(blocking_kind::always_inline == cblocking<Snd>());
+}
+
+TEST(Let, PipeInlineBlockingKind) {
+  auto snd = just() | let_value(just);
+  using Snd = decltype(snd);
+  static_assert(blocking_kind::always_inline == cblocking<Snd>());
+}
+
+TEST(Let, MaybeBlockingKind) {
+  timed_single_thread_context context;
+
+  auto snd1 = let_value(schedule(context.get_scheduler()), just);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::maybe == cblocking<Snd1>());
+
+  auto snd2 = let_value(multi_sender(), just);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}
+
+TEST(Let, PipeMaybeBlockingKind) {
+  timed_single_thread_context context;
+
+  auto snd1 = just() | let_value([&] {
+    return schedule(context.get_scheduler());
+  });
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::maybe == cblocking<Snd1>());
+
+  auto snd2 = just() | let_value(multi_sender);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::maybe == cblocking<Snd2>());
+}
+
+TEST(Let, NeverBlockingKind) {
+  auto snd1 = let_value(never_block(), never_block);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::never == cblocking<Snd1>());
+
+  timed_single_thread_context context;
+
+  auto snd2 = let_value(schedule(context.get_scheduler()), never_block);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::never == cblocking<Snd2>());
+
+  auto snd3 = let_value(never_block(), multi_sender);
+  using Snd3 = decltype(snd3);
+  static_assert(blocking_kind::never == cblocking<Snd3>());
+}
+
+TEST(Let, PipeNeverBlockingKind) {
+  auto snd1 = never_block() | let_value(never_block);
+  using Snd1 = decltype(snd1);
+  static_assert(blocking_kind::never == cblocking<Snd1>());
+
+  auto snd2 = never_block() | let_value(multi_sender);
+  using Snd2 = decltype(snd2);
+  static_assert(blocking_kind::never == cblocking<Snd2>());
 }
 
 TEST(Let, SimpleLetValueWithAllocate) {

--- a/test/let_value_with_stop_token_test.cpp
+++ b/test/let_value_with_stop_token_test.cpp
@@ -20,10 +20,12 @@
 #include <unifex/let_value_with.hpp>
 #include <unifex/let_value_with_stop_source.hpp>
 #include <unifex/let_value_with_stop_token.hpp>
+#include <unifex/nest.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/timed_single_thread_context.hpp>
+#include <unifex/v2/async_scope.hpp>
 #include <unifex/when_all.hpp>
 
 #include <chrono>
@@ -373,3 +375,16 @@ TEST_F(LetWithStopToken, PreserveOperationStateNonInPlaceStoppable) {
   });
 }
 
+TEST_F(LetWithStopToken, NestingWithAMutableFactoryWorks) {
+  unifex::v2::async_scope scope;
+
+  auto result = unifex::sync_wait(unifex::nest(
+      unifex::let_value_with_stop_token(
+          [](auto) mutable noexcept { return unifex::just(1); }),
+      scope));
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 1);
+
+  unifex::sync_wait(scope.join());
+}

--- a/test/task_scheduler_affinity_test.cpp
+++ b/test/task_scheduler_affinity_test.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <thread>
+
+#include <unifex/just.hpp>
+#include <unifex/let_done.hpp>
+#include <unifex/let_value_with_stop_source.hpp>
+#include <unifex/never.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/stop_if_requested.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/then.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+namespace {
+struct TaskSchedulerAffinityTest : testing::Test {
+  single_thread_context thread_ctx;
+};
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<std::thread::id, std::thread::id>> child(Scheduler s) {
+  auto that_id =
+      co_await then(schedule(s), []{ return std::this_thread::get_id(); });
+  // Should have automatically transitioned back to the original thread:
+  auto this_id = std::this_thread::get_id();
+  co_return std::make_pair(this_id, that_id);
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> inner(Scheduler s) {
+  // Transition to the scheduler's context:
+  co_await schedule(s);
+  // Should return the new context
+  co_return std::this_thread::get_id();
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
+  // Call a nested coroutine that transitions context:
+  auto that_id = co_await inner(s);
+  // Should have automatically transitioned back to the correct context
+  auto this_id = std::this_thread::get_id();
+  co_return std::make_pair(this_id, that_id);
+}
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler has changed:
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<bool> test_current_scheduler(Scheduler s) {
+  auto before = co_await current_scheduler();
+  co_await schedule(s);
+  auto after = co_await current_scheduler();
+  co_return before != after;
+}
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler is inherited by child tasks:
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited_impl(Scheduler s) {
+  any_scheduler s2 = co_await current_scheduler();
+  bool sameScheduler = (s2 == s);
+  co_return std::make_pair(sameScheduler, std::this_thread::get_id());
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Scheduler s) {
+  co_await schedule(s);
+  co_return co_await test_current_scheduler_is_inherited_impl(s);
+}
+
+// Test that we properly transition back to the right context when
+// the task is cancelled.
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<void> test_context_restored_on_cancel_2(Scheduler s) {
+  co_await schedule(s);
+  co_await stop();
+  ADD_FAILURE() << "Coroutine did not stop!";
+  co_return;
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> test_context_restored_on_cancel(Scheduler s) {
+  // swallow the cancellation signal:
+  (void) co_await let_done(
+      test_context_restored_on_cancel_2(s),
+      []() noexcept { return just(); });
+  co_return std::this_thread::get_id();
+}
+
+// Test that we properly transition back to the right context when
+// the task fails.
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<void> test_context_restored_on_error_2(Scheduler s) {
+  co_await schedule(s);
+  throw std::runtime_error("whoops");
+}
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+task<std::thread::id> test_context_restored_on_error(Scheduler s) {
+  std::thread::id id;
+  // swallow the cancellation signal:
+  try {
+    co_await test_context_restored_on_error_2(s);
+    ADD_FAILURE() << "Was expecting a throw";
+  } catch(...) {
+    id = std::this_thread::get_id();
+  }
+  co_return id;
+}
+} // anonymous namespace
+
+TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
+  if(auto opt = sync_wait(child(thread_ctx.get_scheduler()))) {
+    auto [this_id, that_id] = *opt;
+    ASSERT_EQ(this_id, std::this_thread::get_id());
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, InlineThreadHopInCoroutine) {
+  if(auto opt = sync_wait(outer(thread_ctx.get_scheduler()))) {
+    auto [this_id, that_id] = *opt;
+    ASSERT_EQ(this_id, std::this_thread::get_id());
+    ASSERT_EQ(that_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerTest) {
+  if(auto opt = sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_TRUE(*opt);
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerIsInheritedTest) {
+  if(auto opt = sync_wait(test_current_scheduler_is_inherited(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    auto [success, thread_id] = *opt;
+    EXPECT_TRUE(success);
+    EXPECT_EQ(thread_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnCancelTest) {
+  if(auto opt = sync_wait(test_context_restored_on_cancel(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ(*opt, std::this_thread::get_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnErrrorTest) {
+  if(auto opt = sync_wait(test_context_restored_on_error(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ(*opt, std::this_thread::get_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+namespace {
+
+unifex::task<void>
+awaitSenderThatIgnoresDone(unifex::inplace_stop_source& stopSource) {
+  stopSource.request_stop();
+
+  // swallowing a done signal here should be effective
+  co_await unifex::let_done(unifex::never_sender{}, unifex::just);
+}
+
+}  // namespace
+
+TEST_F(
+    TaskSchedulerAffinityTest,
+    LetDoneCanSwallowCancellationSignalsFromAsyncSenders) {
+  auto ret = unifex::sync_wait(
+      unifex::let_value_with_stop_source(awaitSenderThatIgnoresDone));
+
+  EXPECT_TRUE(ret.has_value());
+}
+
+namespace {
+
+// a custom awaitable that is, effectively, let_done(never_sender{}, just)
+struct awaitable final {
+  struct receiver final {
+    awaitable* awaitable_;
+    unifex::inplace_stop_token stoken_;
+    coro::coroutine_handle<> continuation_;
+
+    // never invoked, but necessary to model unifex::receiver
+    void set_value() noexcept { std::terminate(); }
+
+    // never invoked, but necessary to model unifex::receiver
+    void set_error(std::exception_ptr) noexcept { std::terminate(); }
+
+    void set_done() noexcept {
+      auto continuation = continuation_;
+      awaitable_->op_.destruct();
+
+      // "swallow" the done signal by resuming and returning void
+      continuation.resume();
+    }
+
+    friend inplace_stop_token tag_invoke(
+        unifex::tag_t<unifex::get_stop_token>, const receiver& r) noexcept {
+      return r.stoken_;
+    }
+  };
+
+  using op_t = unifex::connect_result_t<unifex::never_sender, receiver>;
+
+  unifex::manual_lifetime<op_t> op_;
+
+  awaitable() noexcept = default;
+
+  // we get copied before being awaited so we can just ignore op_
+  awaitable(const awaitable&) noexcept {}
+
+  constexpr bool await_ready() const noexcept { return false; }
+
+  template <typename Promise>
+  void await_suspend(coro::coroutine_handle<Promise> h) noexcept {
+    unifex::inplace_stop_token stoken = unifex::get_stop_token(h.promise());
+
+    op_.construct_with([&]() noexcept {
+      return unifex::connect(unifex::never_sender{}, receiver{this, stoken, h});
+    });
+
+    unifex::start(op_.get());
+  }
+
+  constexpr void await_resume() const noexcept {}
+};
+
+unifex::task<void>
+awaitAwaitableThatIgnoresDone(unifex::inplace_stop_source& stopSource) {
+  stopSource.request_stop();
+
+  // this expression only completes because the current stop token has had stop
+  // requested, however, awaitable swallows the resulting done signal and
+  // returns void so this coroutine should return normally
+  co_await awaitable{};
+}
+
+}  // namespace
+
+TEST_F(
+    TaskSchedulerAffinityTest,
+    DoneSwallowingAwaitableCanSwallowCancellationSignals) {
+  auto ret = unifex::sync_wait(
+      unifex::let_value_with_stop_source(awaitAwaitableThatIgnoresDone));
+
+  EXPECT_TRUE(ret.has_value());
+}
+
+#endif // !UNIFEX_NO_COROUTINES

--- a/test/variant_sender_test.cpp
+++ b/test/variant_sender_test.cpp
@@ -187,11 +187,15 @@ TEST(Variant, CombineJustAndJust_Invalid) {
   IntAndStringReceiver rec;
 
   auto just_variant_sender = func(true);
+  using JustInt = decltype(just_variant_sender);
+  static_assert(blocking_kind::always_inline == cblocking<JustInt>());
   EXPECT_FALSE(just_variant_sender.sends_done);
   auto op = unifex::connect(just_variant_sender, rec);
   unifex::start(op);
 
   auto just_string_sender = func(false);
+  using JustString = decltype(just_variant_sender);
+  static_assert(blocking_kind::always_inline == cblocking<JustString>());
   EXPECT_FALSE(just_variant_sender.sends_done);
   auto op2 = unifex::connect(just_string_sender, rec);
   unifex::start(op2);
@@ -207,6 +211,11 @@ using conditionally_lvalue_t = std::conditional_t<lvalue, std::add_lvalue_refere
 template<bool lvalueConnectNoexcept, bool rvalueConnectNoexcept, bool isLvalueReference = true>
 using is_noexcept = unifex::is_nothrow_connectable<conditionally_lvalue_t<test_sender_t<lvalueConnectNoexcept, rvalueConnectNoexcept>, isLvalueReference>, IntAndStringReceiver>;
 } // namespace
+
+TEST(Variant, BlockingKind) {
+  // default
+  static_assert(blocking_kind::maybe == cblocking<test_sender_t<true, true>>());
+}
 
 TEST(Variant, TestNoexcept) {
   auto both_no_except = is_noexcept<true, true>::value;


### PR DESCRIPTION
This commit implements scheduler affinity -- aka "sticky" scheduling -- in `unifex::task<>`. The idea is that it is impossible for a child operation to cause the current coroutine to resume on the wrong execution context.

* `task<>`-based coroutines track and propagate the current scheduler
* `at_coroutine_exit` remembers current scheduler from when the cleanup action is scheduled
* `schedule` always returns an instance of `sender_for<schedule, the_sender>`, which is also a `scheduler_provider`
* scheduler affinity when co_await-ing senders in a `task<>`-returning coroutine
* scheduler affinity when co_await-ing awaitables in a `task<>`-returning coroutine
* awaitables and senders that are `blocking_kind::always_inline` don't get a thunk
* More senders and awaitables support compile-time blocking queries
* `co_await schedule(sched)` is magic in a `task<>`-returning coroutine: it changes execution context and schedules a cleanup action to transition back to the original scheduler

Move implementation of special co_await behavior of scheduler senders out of task.hpp

Hoist untyped RAII containers for coroutine_handle<> out of task<> and its awaiter (#329)

While looking at the binary size impact of adopting coroutines with `unifex::task<>`, I noticed that a number of operations on `coroutine_handle<T>` are expressed in `unifex::task<>` as if they depend on `T` when they don't.  The consequence is extra code.

This diff creates a `coro_holder` class that uniquely owns a `coroutine_handle<>` and makes `unifex::task<>` inherit from it.  We technically lose some type safety, but it's still correct by construction.  This change saves about 1.5 kilobytes in one of our apps.

Similar to the above, I noticed binary duplication due to false template parameter dependencies in `unifex::task<>`'s awaiter type.

This diff hoists a non-type-specific RAII container for a `coroutine_handle<>` that stores the handle as a `std::uintptr_t` so that `task`'s awaiter can use the low bit as a dirty flag.  This change saves another ~1.5 kilobytes in one of our apps.

Fix scheduler affinity (#405)

* Fix scheduler affinity

We have been storing a `task<>`'s scheduler as an `any_scheduler_ref`, which has proven to be a source of use-after-free bugs.  This change switches all the `any_scheduler_ref`s to `any_scheduler`s, fixing the lifetime issues.

Make task<>'s thunk-on-resume unstoppable (#495)

* Make task<>'s thunk-on-resume unstoppable

When awaiting an async Sender that swallows done signals (such as let_done(never_sender{}, just)), the user-level code looks like it swallows done signals:
```
// never cancels
co_await let_done(never_sender{}, just);
```

However, `task<>`'s Scheduler affinity implementation transforms the above code into this:
```
co_await typed_via(let_done(never_sender{}, just), <current scheduler>);
```

The `schedule()` operation inside the injected `typed_via` can emit done if the current stop token has had stop requested, leading to very non-obvious cancellation behaviour that can't be worked around.

This diff introduces a pair of regression tests that capture the above scenario, and the analogous scenario of awaiting an async Awaitable that completes with done.  The next diff will fix these failing tests.

* Change task<>'s thunk-on-resume to be unstoppable

This diff fixes the broken tests in the previous diff.

Respect blocking_kind in `let_value()` (#381)

* `let_value()` would always assume `blocking_kind::maybe`, which results in potentially unnecessary reschedule on resumption
* replicate `blocking_kind` customization from `finally()`

fix `variant_sender` blocking kind (#474)

add `unifex::v2::async_scope` (#463)

* simpler than `unifex::v1::async_scope` (`nest()` and `join()`)
* does not support cancellation

fixing linter error (#414)

move deduction guide to namespace scope for gcc-10

in scheduler concept, check copy_constructability after requiring call to schedule()

work around gcc-10 bugs

avoid warning about missing braces in initializer