### PR TITLE
add `cleanup_adapt_stream` algorithm

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -52,6 +52,7 @@
 * [Stream Algorithms](#stream-algorithms)
   * [`adapt_stream()`](#adapt_streamstream-stream-func-adaptor---stream)
   * [`next_adapt_stream()`](#next_adapt_streamstream-stream-func-adaptor---stream)
+  * [`cleanup_adapt_stream()`](#cleanup_adapt_streamstream-stream-func-adaptor---stream)
   * [`reduce_stream()`](#reduce_streamstream-stream-t-initialstate-func-reducer---sendert)
   * [`for_each()`](#for_eachstream-stream-func-func---sendervoid)
   * [`transform_stream()`](#transform_streamstream-stream-func-func---stream)
@@ -826,6 +827,11 @@ applies `cleanupAdaptor()` to `cleanup(stream)`.
 
 Applies `adaptor()` to `next(stream)` only.
 The `cleanup(stream)` Sender is passed through unchanged.
+
+### `cleanup_adapt_stream(Stream stream, Func adaptor) -> Stream`
+
+Applies `adaptor()` to `cleanup(stream)` only.
+The `next(stream)` Sender is passed through unchanged.
 
 ### `reduce_stream(Stream stream, T initialState, Func reducer) -> Sender<T>`
 

--- a/include/unifex/cleanup_adapt_stream.hpp
+++ b/include/unifex/cleanup_adapt_stream.hpp
@@ -1,0 +1,57 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <unifex/stream_concepts.hpp>
+
+#include <functional>
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _cleanup_adapt {
+template <typename Stream, typename AdaptFunc>
+struct _stream final {
+  struct type;
+};
+template <typename Stream, typename AdaptFunc>
+using stream =
+    typename _stream<remove_cvref_t<Stream>, std::decay_t<AdaptFunc>>::type;
+
+template <typename Stream, typename AdaptFunc>
+struct _stream<Stream, AdaptFunc>::type final {
+  UNIFEX_NO_UNIQUE_ADDRESS Stream innerStream_;
+  UNIFEX_NO_UNIQUE_ADDRESS AdaptFunc adapter_;
+
+  friend auto
+  tag_invoke(tag_t<next>, type& s) noexcept(noexcept(next(s.innerStream_)))
+      -> next_sender_t<Stream> {
+    return next(s.innerStream_);
+  }
+
+  friend auto tag_invoke(tag_t<cleanup>, type& s) noexcept(
+      noexcept(std::invoke(s.adapter_, cleanup(s.innerStream_))))
+      -> std::invoke_result_t<AdaptFunc&, cleanup_sender_t<Stream>> {
+    return std::invoke(s.adapter_, cleanup(s.innerStream_));
+  }
+};
+}  // namespace _cleanup_adapt
+
+namespace _cleanup_adapt_cpo {
+inline constexpr struct _fn final {
+  template <typename Stream, typename AdaptFunc>
+  constexpr auto operator()(Stream&& stream, AdaptFunc&& adapt) const noexcept(
+      std::is_nothrow_constructible_v<remove_cvref_t<Stream>, Stream>&&
+          std::is_nothrow_constructible_v<std::decay_t<AdaptFunc>, AdaptFunc>) {
+    return _cleanup_adapt::stream<Stream, AdaptFunc>{
+        (Stream &&) stream, (AdaptFunc &&) adapt};
+  }
+} cleanup_adapt_stream{};
+}  // namespace _cleanup_adapt_cpo
+
+using _cleanup_adapt_cpo::cleanup_adapt_stream;
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/test/cleanup_adapt_stream_test.cpp
+++ b/test/cleanup_adapt_stream_test.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/cleanup_adapt_stream.hpp>
+
+#include <unifex/for_each.hpp>
+#include <unifex/on_stream.hpp>
+#include <unifex/range_stream.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/timed_single_thread_context.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+TEST(CompleteAdaptStream, Smoke) {
+  timed_single_thread_context thread;
+
+  bool completed = false;
+
+  auto stream = cleanup_adapt_stream(
+                    on_stream(current_scheduler, range_stream{0, 20}),
+                    [&](auto&& cleanup) noexcept {
+                      completed = true;
+                      return std::forward<decltype(cleanup)>(cleanup);
+                    }) |
+      for_each([&](auto&&) { EXPECT_FALSE(completed); });
+
+  sync_wait(on(thread.get_scheduler(), std::move(stream)));
+
+  EXPECT_TRUE(completed);
+}


### PR DESCRIPTION
* applies `adaptor()` to `cleanup(stream)` only
* the `next(stream)` _Sender_ is passed through unchanged.

replaces #411