### PR TITLE
liburing/io_uring.h depends on linux/time_types.h

### DIFF
--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -85,6 +85,7 @@
 
 #if !defined(UNIFEX_NO_LIBURING)
 #cmakedefine01 UNIFEX_NO_LIBURING
+#cmakedefine01 HAVE_LINUX_TIME_TYPES_H
 #endif
 
 #if !defined(UNIFEX_ENABLE_CONTINUATION_VISITATIONS)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -35,6 +35,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
       pthread)
 
 if (NOT UNIFEX_NO_LIBURING)
+  check_include_file_cxx("linux/time_types.h" HAVE_LINUX_TIME_TYPES_H)
 
   target_sources(unifex
     PRIVATE


### PR DESCRIPTION
It will fail to compile `io_uring_context.hpp` if no `HAVE_LINUX_TIME_TYPES_H` defined.

Another way to fix it is to include `<linux/io_uring.h>`, but I believe it is more reliable to define this macro, as it is clearly said that it will be used for detection of the time types presence (at least this is true for liburing 2.3, which comes with Fedora 38).

https://git.kernel.dk/cgit/liburing/tree/src/include/liburing/io_uring.h?h=liburing-2.3#n13
```c
/*
 * this file is shared with liburing and that has to autodetect
 * if linux/time_types.h is available
 */
#ifdef __KERNEL__
#define HAVE_LINUX_TIME_TYPES_H 1
#endif
#ifdef HAVE_LINUX_TIME_TYPES_H
#include <linux/time_types.h>
#endif
```

Next version will reverse this logic, and always include `linux/time_types.h`, but even then my patch here will be pretty safe and harmless, while being useful for older systems that still have liburing 2.3 (Fedora 38 been released just a month ago). This is the link to commit, where they fixed that on `master` branch: https://git.kernel.dk/cgit/liburing/commit/?id=f76924e7b28e433a623de7754034896c8f79163a