### PR TITLE
Fix a race in spawn_future()

### DIFF
--- a/include/unifex/spawn_future.hpp
+++ b/include/unifex/spawn_future.hpp
@@ -323,7 +323,8 @@ struct _spawn_future_op_base {
 
         // reading evt_.ready() performs a load-acquire on the event so this is
         // how we consume the operation's last writes
-        (void)evt_.ready();
+        while (!evt_.ready())
+          ;
 
         // having synchronized with evt_, we can now clean up
         deleter_(this, state);


### PR DESCRIPTION
There's a race condition in `spawn_future()` between dropping a `future` and the completion of the spawned operation.  It's possible for the spawned operation to record the "state" of the future as complete, have the dropping future observe that, which leads to deleting the shared state, whereupon the completing operation touches a deleted object when trying to set the event.

This diff adds a unit test that repros the race (it crashed without the fix), and fixes the problem with a spin-wait.

I don't *really* like this solution because the spin-wait seems bad, but we're seeing production crashes so I need *something*.  We can reconsider the overall synchronization design once we've got the crashes fixed.  Maybe we need a refcount on top of the state machine.