### PR TITLE
Clang 15.0.7 unused logging variable fix

### DIFF
--- a/source/linux/io_uring_context.cpp
+++ b/source/linux/io_uring_context.cpp
@@ -531,16 +531,12 @@ void io_uring_context::execute_pending_local() noexcept {
 
   LOG("processing local queue items");
 
-#ifdef LOGGING_ENABLED // prevent -Wunused-but-set-variable
-  size_t count = 0;
-#endif
+  [[maybe_unused]] size_t count = 0;
   auto pending = std::move(localQueue_);
   while (!pending.empty()) {
     auto* item = pending.pop_front();
     item->execute_(item);
-#ifdef LOGGING_ENABLED
     ++count;
-#endif
   }
 
   LOGX("processed %zu local queue items\n", count);

--- a/source/linux/io_uring_context.cpp
+++ b/source/linux/io_uring_context.cpp
@@ -531,12 +531,16 @@ void io_uring_context::execute_pending_local() noexcept {
 
   LOG("processing local queue items");
 
+#ifdef LOGGING_ENABLED // prevent -Wunused-but-set-variable
   size_t count = 0;
+#endif
   auto pending = std::move(localQueue_);
   while (!pending.empty()) {
     auto* item = pending.pop_front();
     item->execute_(item);
+#ifdef LOGGING_ENABLED
     ++count;
+#endif
   }
 
   LOGX("processed %zu local queue items\n", count);


### PR DESCRIPTION
I am using the default build instructions `cmake -G Ninja -H. -Bbuild -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++`

Clang 15.0.7 on Linux refuses to build:
`~/github/libunifex/source/linux/io_uring_context.cpp:534:10:
error: variable 'count' set but not used [-Werror,-Wunused-but-set-variable]
  size_t count = 0;`


The `count` variable is only used by the LOGX call, so when LOGGING_ENABLED is not defined, clang correctly detects that the variable is set but not used.
This PR fixes the build error by applying the [[maybe_unused]] attribute to the count variable.

