### PR TITLE
Add is always scheduler affine

### DIFF
--- a/include/unifex/allocate.hpp
+++ b/include/unifex/allocate.hpp
@@ -95,6 +95,9 @@ namespace _alloc {
 
     static constexpr blocking_kind blocking = sender_traits<Sender>::blocking;
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<Sender>::is_always_scheduler_affine;
+
     template(typename Self, typename Receiver)
       (requires same_as<remove_cvref_t<Self>, type> AND
                 receiver<Receiver>)

--- a/include/unifex/async_manual_reset_event.hpp
+++ b/include/unifex/async_manual_reset_event.hpp
@@ -58,6 +58,8 @@ struct _sender {
 
   static constexpr blocking_kind blocking = blocking_kind::never;
 
+  static constexpr bool is_always_scheduler_affine = true;
+
   explicit _sender(async_manual_reset_event& evt) noexcept
     : evt_(&evt) {}
 

--- a/include/unifex/async_mutex.hpp
+++ b/include/unifex/async_mutex.hpp
@@ -63,6 +63,10 @@ private:
     // we complete inline if we manage to grab the lock immediately
     static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+    // if we have to wait for the lock, we'll be resumed on whichever scheduler
+    // happens to be running the unlock()
+    static constexpr bool is_always_scheduler_affine = false;
+
     lock_sender(const lock_sender &) = delete;
     lock_sender(lock_sender &&) = default;
 

--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -190,6 +190,9 @@ struct _die_on_done {
 
     static constexpr blocking_kind blocking = sender_traits<Sender>::blocking;
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<Sender>::is_always_scheduler_affine;
+
     template (typename Receiver)
       (requires sender_to<Sender, _die_on_done_rec_t<Receiver>>)
     auto connect(Receiver&& rec) &&

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -103,6 +103,9 @@ public:
 
     static constexpr blocking_kind blocking = sender_traits<Source>::blocking;
 
+    static constexpr bool is_always_scheduler_affine =
+        sender_traits<Source>::is_always_scheduler_affine;
+
     template<typename Source2>
     explicit type(Source2&& s)
         noexcept(std::is_nothrow_constructible_v<Source, Source2>)

--- a/include/unifex/bulk_schedule.hpp
+++ b/include/unifex/bulk_schedule.hpp
@@ -168,6 +168,9 @@ public:
 
     static constexpr blocking_kind blocking = sender_traits<schedule_sender_t>::blocking;
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<schedule_sender_t>::is_always_scheduler_affine;
+
     template<typename Scheduler2>
     explicit type(Scheduler2&& s, Integral count)
     : scheduler_(static_cast<Scheduler2&&>(s))

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -164,6 +164,9 @@ public:
 
     static constexpr blocking_kind blocking = sender_traits<Source>::blocking;
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<Source>::is_always_scheduler_affine;
+
     template<typename Source2, typename Func2>
     explicit type(Source2&& source, Func2&& func, Policy policy)
     : source_((Source2&&)source)

--- a/include/unifex/create.hpp
+++ b/include/unifex/create.hpp
@@ -94,6 +94,9 @@ struct _snd_base {
     // specify
     static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+    // no way to know, but maybe there should be
+    static constexpr bool is_always_scheduler_affine = false;
+
     template (typename Self, typename Receiver)
       (requires derived_from<remove_cvref_t<Self>, type> AND
         constructible_from<Fn, member_t<Self, Fn>> AND

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -165,6 +165,9 @@ namespace _demat {
 
     static constexpr blocking_kind blocking = sender_traits<Source>::blocking;
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<Source>::is_always_scheduler_affine;
+
     template <typename Source2>
     explicit type(Source2&& source)
         noexcept(std::is_nothrow_constructible_v<Source, Source2>)

--- a/include/unifex/detach_on_cancel.hpp
+++ b/include/unifex/detach_on_cancel.hpp
@@ -213,6 +213,9 @@ struct _sender<Sender>::type {
   static constexpr blocking_kind blocking =
       std::min(blocking_kind::maybe(), sender_traits<Sender>::blocking());
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Sender>::is_always_scheduler_affine;
+
   friend constexpr blocking_kind tag_invoke(tag_t<blocking>, const type& sender) noexcept {
     blocking_kind other{blocking(sender)};
     return std::min(blocking_kind::maybe(), other());

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -669,6 +669,10 @@ namespace unifex
           sender_traits<SourceSender>::blocking(),
           sender_traits<CompletionSender>::blocking());
 
+      static constexpr bool is_always_scheduler_affine
+          = sender_traits<SourceSender>::is_always_scheduler_affine &&
+          sender_traits<CompletionSender>::is_always_scheduler_affine;
+
       template <typename SourceSender2, typename CompletionSender2>
       explicit type(
           SourceSender2&& source, CompletionSender2&& completion)

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -149,6 +149,9 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
 
   static constexpr blocking_kind blocking = sender_traits<Predecessor>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Predecessor>::is_always_scheduler_affine;
+
   friend constexpr blocking_kind tag_invoke(
       tag_t<blocking>,
       const sender& sender) {

--- a/include/unifex/into_variant.hpp
+++ b/include/unifex/into_variant.hpp
@@ -98,6 +98,9 @@ struct _sender<Predecessor>::type {
 
   static constexpr blocking_kind blocking = sender_traits<Predecessor>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+       = sender_traits<Predecessor>::is_always_scheduler_affine;
+
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, sender_value_types_t<Predecessor, std::variant, std::tuple>>;
 

--- a/include/unifex/let_done.hpp
+++ b/include/unifex/let_done.hpp
@@ -292,6 +292,10 @@ public:
           sender_traits<final_sender_t>::blocking(),
           blocking_kind::maybe()));
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Source>::is_always_scheduler_affine &&
+      sender_traits<final_sender_t>::is_always_scheduler_affine;
+
   template <typename Source2, typename Done2>
   explicit type(Source2&& source, Done2&& done)
     noexcept(

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -282,6 +282,8 @@ struct sends_done_impl : std::bool_constant<sender_traits<Sender>::sends_done> {
 template <typename... Successors>
 using any_sends_done = std::disjunction<sends_done_impl<Successors>...>;
 
+template <typename... Senders>
+using all_always_scheduler_affine = std::conjunction<detail::_is_always_scheduler_affine<Senders>...>;
 
 template <typename First, typename... Rest>
 struct max_blocking_kind {
@@ -356,6 +358,10 @@ public:
       std::min(
           successor_types<_let_v::max_blocking_kind>{}(),
           blocking_kind::maybe()));
+
+  static constexpr bool is_always_scheduler_affine =
+    sender_traits<Predecessor>::is_always_scheduler_affine &&
+    successor_types<all_always_scheduler_affine>::value;
 
  public:
   template <typename Predecessor2, typename SuccessorFactory2>

--- a/include/unifex/let_value_with.hpp
+++ b/include/unifex/let_value_with.hpp
@@ -61,6 +61,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<InnerOp>::blocking;
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<InnerOp>::is_always_scheduler_affine;
+
   template<typename StateFactory2, typename SuccessorFactory2>
   explicit type(StateFactory2&& stateFactory, SuccessorFactory2&& func) :
     stateFactory_((StateFactory2&&)stateFactory),

--- a/include/unifex/let_value_with_stop_source.hpp
+++ b/include/unifex/let_value_with_stop_source.hpp
@@ -118,6 +118,11 @@ public:
 
     static constexpr blocking_kind blocking = sender_traits<InnerOp>::blocking;
 
+    // TODO: is this safe?  giving the user a stop source means they can invoke
+    //       stop callbacks and they could do it on the wrong thread
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<InnerOp>::is_always_scheduler_affine;
+
     template<typename SuccessorFactory2>
     explicit type(SuccessorFactory2&& func) : func_((SuccessorFactory2&&)func)
     {}

--- a/include/unifex/let_value_with_stop_token.hpp
+++ b/include/unifex/let_value_with_stop_token.hpp
@@ -145,6 +145,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<inner_sender_t>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<inner_sender_t>::is_always_scheduler_affine;
+
   template <typename SuccessorFactory2>
   explicit type(SuccessorFactory2&& func) noexcept(
       std::is_nothrow_constructible_v<SuccessorFactory, SuccessorFactory2&&>)

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -184,6 +184,9 @@ namespace unifex
 
       static constexpr blocking_kind blocking = sender_traits<Source>::blocking;
 
+      static constexpr bool is_always_scheduler_affine
+          = sender_traits<Source>::is_always_scheduler_affine;
+
       template(typename Source2)
           (requires constructible_from<Source, Source2>)
       explicit type(Source2&& source) noexcept(

--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -87,6 +87,10 @@ struct sender {
   // we'll complete inline if started with a stopped stop token
   static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+  // we complete wherever the stop callback is invoked, which must be on the
+  // receiver's scheduler if scheduler affinity is required
+  static constexpr bool is_always_scheduler_affine = true;
+
   template <typename Receiver>
   operation<Receiver> connect(Receiver&& receiver) {
     return operation<Receiver>{(Receiver &&) receiver};

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -204,6 +204,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<Source>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Source>::is_always_scheduler_affine;
+
   template <typename Source2, typename Predicate2>
   explicit type(Source2&& source, Predicate2&& predicate)
     noexcept(

--- a/include/unifex/scheduler_concepts.hpp
+++ b/include/unifex/scheduler_concepts.hpp
@@ -210,6 +210,10 @@ struct sender {
   // receiver's scheduler's type, which we don't know
   static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+  // rescheduling on the current scheduler necessarily completes on the current
+  // scheduler
+  static constexpr bool is_always_scheduler_affine = true;
+
   template(typename Receiver)
     (requires receiver<Receiver>)
   friend auto tag_invoke(tag_t<connect>, sender, Receiver &&r)
@@ -288,6 +292,10 @@ namespace _schedule_after {
     // never is very likely, but we don't actually know because it depends on the
     // receiver's scheduler's type, which we don't know
     static constexpr blocking_kind blocking = blocking_kind::maybe;
+
+    // rescheduling on the current scheduler necessarily completes on the current
+    // scheduler
+    static constexpr bool is_always_scheduler_affine = true;
 
     explicit type(Duration d)
       : duration_(d)
@@ -376,6 +384,10 @@ namespace _schedule_at {
     // never is very likely, but we don't actually know because it depends on the
     // receiver's scheduler's type, which we don't know
     static constexpr blocking_kind blocking = blocking_kind::maybe;
+
+    // rescheduling on the current scheduler necessarily completes on the current
+    // scheduler
+    static constexpr bool is_always_scheduler_affine = true;
 
     explicit type(TimePoint tp)
       : time_point_(tp)

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -322,6 +322,10 @@ namespace unifex
               sender_traits<Successor>::blocking(),
               blocking_kind::maybe()));
 
+      static constexpr bool is_always_scheduler_affine =
+        sender_traits<Predecessor>::is_always_scheduler_affine &&
+        sender_traits<Successor>::is_always_scheduler_affine;
+
       template(typename Predecessor2, typename Successor2)
           (requires constructible_from<Predecessor, Predecessor2> AND
               constructible_from<Successor, Successor2>)

--- a/include/unifex/single.hpp
+++ b/include/unifex/single.hpp
@@ -106,6 +106,9 @@ struct _stream<Sender>::type {
         sender_traits<Sender>::blocking(),
         blocking_kind::maybe());
 
+    static constexpr bool is_always_scheduler_affine
+        = sender_traits<Sender>::is_always_scheduler_affine;
+
     friend constexpr blocking_kind tag_invoke(tag_t<unifex::blocking>, const next_sender& s) noexcept {
       if (s.sender_) {
         return unifex::blocking(*s.sender_);

--- a/include/unifex/spawn_future.hpp
+++ b/include/unifex/spawn_future.hpp
@@ -821,6 +821,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<sender_t>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<sender_t>::is_always_scheduler_affine;
+
   explicit type(
       Scope& scope,
       typename _spawn_future_op<T...>::type*

--- a/include/unifex/static_thread_pool.hpp
+++ b/include/unifex/static_thread_pool.hpp
@@ -70,6 +70,8 @@ namespace _static_thread_pool {
 
         static constexpr blocking_kind blocking = blocking_kind::never;
 
+        static constexpr bool is_always_scheduler_affine = false;
+
       private:
         template <typename Receiver>
         operation<Receiver> make_operation_(Receiver&& r) const {

--- a/include/unifex/stop_when.hpp
+++ b/include/unifex/stop_when.hpp
@@ -331,6 +331,10 @@ public:
       sender_traits<Source>::blocking(),
       sender_traits<Trigger>::blocking());
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Source>::is_always_scheduler_affine &&
+      sender_traits<Trigger>::is_always_scheduler_affine;
+
   template <typename Source2, typename Trigger2>
   explicit type(Source2&& source, Trigger2&& trigger) noexcept(
       std::is_nothrow_constructible_v<Source, Source2>&&

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -397,6 +397,8 @@ struct _task<T>::type : _task_base, coro_holder {
   // points are async
   static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+  static constexpr bool is_always_scheduler_affine = true;
+
   type(type&& t) noexcept = default;
 
   type& operator=(type&& t) noexcept = default;

--- a/include/unifex/then.hpp
+++ b/include/unifex/then.hpp
@@ -160,6 +160,9 @@ public:
 
   static constexpr auto blocking = sender_traits<Predecessor>::blocking;
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Predecessor>::is_always_scheduler_affine;
+
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, Func>;
 

--- a/include/unifex/timed_single_thread_context.hpp
+++ b/include/unifex/timed_single_thread_context.hpp
@@ -145,6 +145,8 @@ namespace _timed_single_thread_context {
     // stop requests are always delivered on the context's thread
     static constexpr blocking_kind blocking = blocking_kind::never;
 
+    static constexpr bool is_always_scheduler_affine = false;
+
     template <typename Receiver>
     after_operation<Duration, Receiver> connect(Receiver&& receiver) const {
       return after_operation<Duration, Receiver>{
@@ -218,6 +220,8 @@ namespace _timed_single_thread_context {
 
     // stop requests are always delivered on the context's thread
     static constexpr blocking_kind blocking = blocking_kind::never;
+
+    static constexpr bool is_always_scheduler_affine = false;
 
     template <typename Receiver>
     at_operation<remove_cvref_t<Receiver>> connect(Receiver&& receiver) {

--- a/include/unifex/trampoline_scheduler.hpp
+++ b/include/unifex/trampoline_scheduler.hpp
@@ -142,6 +142,8 @@ class scheduler {
     // it's always_inline until we blow the stack, then it's never
     static constexpr blocking_kind blocking = blocking_kind::maybe;
 
+    static constexpr bool is_always_scheduler_affine = true;
+
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) const& {
       return operation<Receiver>{(Receiver &&) receiver, maxRecursionDepth_};

--- a/include/unifex/unstoppable.hpp
+++ b/include/unifex/unstoppable.hpp
@@ -49,6 +49,9 @@ struct _sender<Sender>::type final {
 
   static constexpr blocking_kind blocking = sender_traits<Sender>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Sender>::is_always_scheduler_affine;
+
   template(typename Self, typename Receiver)  //
       (requires same_as<type, remove_cvref_t<Self>> AND
            sender_to<member_t<Self, Sender>, Receiver>)  //

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -165,6 +165,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<Predecessor>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Predecessor>::is_always_scheduler_affine;
+
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, Func>;
 

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -146,6 +146,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<Predecessor>::blocking;
 
+  static constexpr bool is_always_scheduler_affine
+      = sender_traits<Predecessor>::is_always_scheduler_affine;
+
   template <typename Receiver>
   using receiver_t = receiver_t<Receiver, Func>;
 

--- a/include/unifex/v1/async_scope.hpp
+++ b/include/unifex/v1/async_scope.hpp
@@ -245,6 +245,9 @@ struct _attach_sender<Sender>::type final {
       blocking_kind::maybe(),
       sender_traits<Sender>::blocking());
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Sender>::is_always_scheduler_affine;
+
   template <typename Sender2>
   explicit type(inplace_stop_token stoken, Sender2&& sender) noexcept(
       std::is_nothrow_constructible_v<Sender, Sender2>)

--- a/include/unifex/v2/async_scope.hpp
+++ b/include/unifex/v2/async_scope.hpp
@@ -333,6 +333,9 @@ struct _nest_sender<Sender>::type final {
   static constexpr blocking_kind blocking =
       std::min(blocking_kind::maybe(), sender_traits<Sender>::blocking());
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Sender>::is_always_scheduler_affine;
+
   type() noexcept = default;
 
   template <typename Sender2>

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -112,6 +112,9 @@ class _sender<Senders...>::type {
 
   static constexpr blocking_kind blocking = compute_blocking();
 
+  static constexpr bool is_always_scheduler_affine
+      = (sender_traits<Senders>::is_always_scheduler_affine && ...);
+
   template<typename ConcreteSender>
   type(ConcreteSender&& concreteSender)
     noexcept(std::is_nothrow_constructible_v<std::variant<Senders...>, decltype(concreteSender)>)

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -329,6 +329,8 @@ public:
 
   static constexpr blocking_kind blocking = compute_blocking();
 
+  static constexpr bool is_always_scheduler_affine = (sender_traits<Senders>::is_always_scheduler_affine && ...);
+
   template <typename... Senders2>
   explicit type(Senders2&&... senders)
     : senders_((Senders2 &&) senders...) {}

--- a/include/unifex/when_all_range.hpp
+++ b/include/unifex/when_all_range.hpp
@@ -296,6 +296,9 @@ public:
       blocking_kind::maybe(),
       sender_traits<Sender>::blocking());
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Sender>::is_always_scheduler_affine;
+
 private:
   template(typename Sender2, typename Receiver)  //
       (requires unifex::same_as<unifex::remove_cvref_t<Sender2>, type> AND

--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -115,6 +115,9 @@ public:
 
   static constexpr blocking_kind blocking = sender_traits<Sender>::blocking;
 
+  static constexpr bool is_always_scheduler_affine =
+      sender_traits<Sender>::is_always_scheduler_affine;
+
   template <typename Sender2, typename Value2>
   explicit type(Sender2&& sender, Value2&& value)
     : sender_((Sender2 &&) sender)

--- a/test/just_tests.cpp
+++ b/test/just_tests.cpp
@@ -30,6 +30,7 @@ TEST(just_tests, just_void) {
   using just_t = decltype(just());
 
   static_assert(blocking_kind::always_inline == sender_traits<just_t>::blocking);
+  static_assert(sender_traits<just_t>::is_always_scheduler_affine);
 }
 
 }  // namespace


### PR DESCRIPTION
This diff introduces a new *Sender* trait called `is_always_scheduler_affine` that can be set by declaring a static `bool` member of the *Sender* class named `is_always_scheduler_affine`; the default is false.  This diff also updates all existing *Senders* in Unifex to declare their *Scheduler* affinity if the defaults are wrong.

A future diff will leverage this property to make `task<>`'s *Scheduler* affinity implementation more efficient.