### PR TITLE
Reimplement scheduler affinity

### DIFF
--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -318,6 +318,8 @@ namespace _at_coroutine_exit {
   } at_coroutine_exit{};
 } // namespace _at_coroutine_exit
 
+// TODO: verify that `at_coroutine_exit()` can't be used to break scheduler
+//       affinity by running an async task that reschedules
 using _at_coroutine_exit::at_coroutine_exit;
 
 } // namespace unifex

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -52,13 +52,6 @@ private:
     // Provide an awaiter interface in addition to the sender interface
     // because as an awaiter we can take advantage of symmetric transfer
     // to save stack space:
-    //
-    // TODO: the scheduler affinity changes have mooted this because we check
-    //       for sender-ness before awaitable-ness; two possible solutions:
-    //         - check for awaitable-ness first
-    //         - customize await_transform here to do something smarter than the
-    //           default implementation; perhaps just return *this, but perhaps
-    //           we could remove the branch in await_suspend
     bool await_ready() const noexcept {
       return false;
     }

--- a/include/unifex/stop_if_requested.hpp
+++ b/include/unifex/stop_if_requested.hpp
@@ -52,6 +52,13 @@ private:
     // Provide an awaiter interface in addition to the sender interface
     // because as an awaiter we can take advantage of symmetric transfer
     // to save stack space:
+    //
+    // TODO: the scheduler affinity changes have mooted this because we check
+    //       for sender-ness before awaitable-ness; two possible solutions:
+    //         - check for awaitable-ness first
+    //         - customize await_transform here to do something smarter than the
+    //           default implementation; perhaps just return *this, but perhaps
+    //           we could remove the branch in await_suspend
     bool await_ready() const noexcept {
       return false;
     }

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -23,17 +23,21 @@
 #include <unifex/continuations.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/coroutine_concepts.hpp>
+#include <unifex/defer.hpp>
 #include <unifex/finally.hpp>
 #include <unifex/inline_scheduler.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/invoke.hpp>
 #include <unifex/manual_lifetime.hpp>
+#include <unifex/on.hpp>
 #include <unifex/scope_guard.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
+#include <unifex/then.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/unstoppable.hpp>
+#include <unifex/with_scheduler_affinity.hpp>
 
 #if UNIFEX_NO_COROUTINES
 #  error "Coroutine support is required to use this header"
@@ -47,6 +51,9 @@ namespace unifex {
 namespace _task {
 using namespace _util;
 
+/**
+ * An RAII owner of a coroutine_handle<>.
+ */
 struct coro_holder {
   explicit coro_holder(coro::coroutine_handle<> h) noexcept
     : coro_(std::move(h)) {}
@@ -69,9 +76,13 @@ protected:
   coro::coroutine_handle<> coro_;
 };
 
+/**
+ * An RAII owner of a coroutine_handle<> that steals a low bit for an extra
+ * flag.
+ */
 struct tagged_coro_holder {
   explicit tagged_coro_holder(coro::coroutine_handle<> h) noexcept
-    : coro_((std::uintptr_t)h.address()) {
+    : coro_(reinterpret_cast<std::uintptr_t>(h.address())) {
     UNIFEX_ASSERT(coro_);
   }
 
@@ -96,40 +107,58 @@ protected:
 
 template <typename T>
 struct _task {
+  /**
+   * The "public facing" task<> type.
+   */
   struct [[nodiscard]] type;
 };
 
+template <typename T>
+struct _sa_task final {
+  /**
+   * A "scheduler-affine" task that's used as an implementation detail to mark a
+   * given task<> as running with the scheduler-affinity invariant maintained by
+   * the caller.
+   */
+  struct [[nodiscard]] type;
+};
+
+template <typename T>
+struct _sr_thunk_task final {
+  /**
+   * A special coroutine type that gets interposed between a task<> and its
+   * caller to guarantee that stop requests are delivered to the task<> on the
+   * task<>'s scheduler.
+   *
+   * "sr thunk" refers to "stop request thunk".
+   */
+  struct [[nodiscard]] type;
+};
+
+/**
+ * A base class for both task<> and sr_thunk_task<>'s promises' final-suspend
+ * awaitable.
+ */
+struct _final_suspend_awaiter_base {
+  bool await_ready() noexcept { return false; }
+
+  void await_resume() noexcept {}
+
+  // TODO: we need to address always-inline awaitables
+  friend constexpr auto tag_invoke(
+      tag_t<unifex::blocking>, const _final_suspend_awaiter_base&) noexcept {
+    return blocking_kind::always_inline;
+  }
+};
+
+/**
+ * Common behaviour and data for task<> and sr_thunk_task<>'s promise types.
+ */
 struct _promise_base {
-  struct _final_suspend_awaiter_base {
-    bool await_ready() noexcept { return false; }
-    void await_resume() noexcept {}
-
-    friend constexpr auto tag_invoke(
-        tag_t<unifex::blocking>, const _final_suspend_awaiter_base&) noexcept {
-      return blocking_kind::always_inline;
-    }
-  };
-
-  void transform_schedule_sender_impl_(any_scheduler newSched);
-
+  /**
+   * Our coroutine types are lazy so initial_suspend() returns suspend_always.
+   */
   coro::suspend_always initial_suspend() noexcept { return {}; }
-
-  coro::coroutine_handle<> unhandled_done() noexcept {
-    return continuation_.done();
-  }
-
-#ifdef UNIFEX_ENABLE_CONTINUATION_VISITATIONS
-  template <typename Func>
-  friend void
-  tag_invoke(tag_t<visit_continuations>, const _promise_base& p, Func&& func) {
-    visit_continuations(p.continuation_, (Func &&) func);
-  }
-#endif
-
-  friend inplace_stop_token
-  tag_invoke(tag_t<get_stop_token>, const _promise_base& p) noexcept {
-    return p.stoken_;
-  }
 
   friend any_scheduler
   tag_invoke(tag_t<get_scheduler>, const _promise_base& p) noexcept {
@@ -140,54 +169,125 @@ struct _promise_base {
       const tag_t<exchange_continuation>&,
       _promise_base& p,
       continuation_handle<> action) noexcept {
-    return std::exchange(p.continuation_, (continuation_handle<> &&) action);
+    return std::exchange(p.continuation_, std::move(action));
   }
+
+#ifdef UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const _promise_base& p, Func&& func) {
+    visit_continuations(p.continuation_, static_cast<Func&&>(func));
+  }
+#endif
 
   inline static constexpr inline_scheduler _default_scheduler{};
 
+  // the coroutine awaiting our completion
   continuation_handle<> continuation_;
-  inplace_stop_token stoken_;
+  // the scheduler we run on
   any_scheduler sched_{_default_scheduler};
+  // a stop token from our receiver, possibly adapted through an adapter
+  inplace_stop_token stoken_;
+};
+
+/**
+ * The parts of a task<T>'s promise that don't depend on T.
+ */
+struct _task_promise_base : _promise_base {
+  // the implementation of the magic of co_await schedule(s); this is to be
+  // ripped out and replaced with something more explicit
+  void transform_schedule_sender_impl_(any_scheduler newSched);
+
+  coro::coroutine_handle<> unhandled_done() noexcept {
+    return continuation_.done();
+  }
+
+  void register_stop_callback() noexcept {}
+
+  friend inplace_stop_token
+  tag_invoke(tag_t<get_stop_token>, const _task_promise_base& p) noexcept {
+    return p.stoken_;
+  }
+
+  // has this task<> been rescheduled onto a new scheduler?
   bool rescheduled_ = false;
 };
 
 template <typename T>
-struct _return_value_or_void {
+struct _result_and_unhandled_exception final {
+  /**
+   * Storage for a task<T> or sr_thunk_task<T>'s result, plus handling for
+   * unhandled exceptions.
+   *
+   * This is used to share the implementation of result handling between
+   * type-specific promise types.
+   */
   struct type {
-    template(typename Value = T)(
-        requires convertible_to<Value, T> AND constructible_from<
-            T,
-            Value>) void return_value(Value&&
-                                          value) noexcept(std::
-                                                              is_nothrow_constructible_v<
-                                                                  T,
-                                                                  Value>) {
+    void unhandled_exception() noexcept {
       expected_.reset_value();
-      unifex::activate_union_member(expected_.value_, (Value &&) value);
-      expected_.state_ = _state::value;
+      unifex::activate_union_member(
+          expected_.exception_, std::current_exception());
+      expected_.state_ = _state::exception;
     }
+
+    decltype(auto) result() {
+      if (expected_.state_ == _state::exception) {
+        std::rethrow_exception(std::move(expected_.exception_).get());
+      }
+      return std::move(expected_.value_).get();
+    }
+
     _expected<T> expected_;
+  };
+};
+
+template <typename T>
+struct _return_value_or_void {
+  /**
+   * Provides a type-specific return_value() method to meet a promise type's
+   * requirements.
+   */
+  struct type : _result_and_unhandled_exception<T>::type {
+    template(typename Value = T)                                              //
+        (requires convertible_to<Value, T> AND constructible_from<T, Value>)  //
+        void return_value(Value&& value) noexcept(
+            std::is_nothrow_constructible_v<T, Value>) {
+      this->expected_.reset_value();
+      unifex::activate_union_member(
+          this->expected_.value_, static_cast<Value&&>(value));
+      this->expected_.state_ = _state::value;
+    }
   };
 };
 
 template <>
 struct _return_value_or_void<void> {
-  struct type {
+  /**
+   * Provides a return_void() method to meet a promise type's requirements.
+   */
+  struct type : _result_and_unhandled_exception<void>::type {
     void return_void() noexcept {
       expected_.reset_value();
       unifex::activate_union_member(expected_.value_);
       expected_.state_ = _state::value;
     }
-    _expected<void> expected_;
   };
 };
 
+/**
+ * A marker type that task<> inherits from.  I'd like to deprecate and remove
+ * this but, Hyrum's law.
+ */
 struct _task_base {};
 
 template <typename T>
-struct _promise {
-  struct type
-    : _promise_base
+struct _promise final {
+  /**
+   * The promise_type for task<>; inherits _task_promise_base for common
+   * funcitonality, and _return_value_or_void<T> for result handling.
+   */
+  struct type final
+    : _task_promise_base
     , _return_value_or_void<T>::type {
     using result_type = T;
 
@@ -197,7 +297,7 @@ struct _promise {
     }
 
     auto final_suspend() noexcept {
-      struct awaiter : _final_suspend_awaiter_base {
+      struct awaiter final : _final_suspend_awaiter_base {
 #if (defined(_MSC_VER) && !defined(__clang__)) || defined(__EMSCRIPTEN__)
         // MSVC doesn't seem to like symmetric transfer in this final awaiter
         // and the Emscripten (WebAssembly) compiler doesn't support tail-calls
@@ -213,68 +313,31 @@ struct _promise {
       return awaiter{};
     }
 
-    void unhandled_exception() noexcept {
-      this->expected_.reset_value();
-      unifex::activate_union_member(
-          this->expected_.exception_, std::current_exception());
-      this->expected_.state_ = _state::exception;
-    }
-
     template <typename Value>
     decltype(auto) await_transform(Value&& value) {
-      if constexpr (derived_from<remove_cvref_t<Value>, _task_base>) {
-        // We are co_await-ing a unifex::task, which completes inline because of
-        // task scheduler affinity. We don't need an additional transition.
-        return unifex::await_transform(*this, (Value &&) value);
+      if constexpr (is_sender_for_v<remove_cvref_t<Value>, schedule>) {
+        // TODO: rip this out and replace it with something more explicit
+
+        // If we are co_await'ing a sender that is the result of calling
+        // schedule, do something special
+        return transform_schedule_sender_(static_cast<Value&&>(value));
+      } else if constexpr (unifex::sender<Value>) {
+        return unifex::await_transform(*this,
+            with_scheduler_affinity(static_cast<Value&&>(value), this->sched_));
       } else if constexpr (
           tag_invocable<tag_t<unifex::await_transform>, type&, Value> ||
           detail::_awaitable<Value>) {
         // Either await_transform has been customized or Value is an awaitable.
         // Either way, we can dispatch to the await_transform CPO, then insert a
         // transition back to the correct execution context if necessary.
-        return transform_awaitable_(
-            unifex::await_transform(*this, (Value &&) value));
-      } else if constexpr (unifex::sender<Value>) {
-        return transform_sender_((Value &&) value);
+        return with_scheduler_affinity(
+            *this,
+            unifex::await_transform(*this, static_cast<Value&&>(value)),
+            this->sched_);
       } else {
         // Otherwise, we don't know how to await this type. Just return it and
         // let the compiler issue a diagnostic.
         return (Value &&) value;
-      }
-    }
-
-    template <typename Awaitable>
-    decltype(auto) transform_awaitable_(Awaitable&& awaitable) {
-      using blocking_t = decltype(blocking(awaitable));
-
-      if constexpr (
-          !same_as<blocking_kind, blocking_t> &&
-          (blocking_kind::always_inline == blocking_t{})) {
-        return Awaitable{(Awaitable &&) awaitable};
-      } else {
-        return unifex::await_transform(
-            *this,
-            finally(
-                as_sender((Awaitable &&) awaitable),
-                unstoppable(schedule(this->sched_))));
-      }
-    }
-
-    template <typename Sender>
-    decltype(auto) transform_sender_(Sender&& sndr) {
-      if constexpr (sender_traits<
-                        remove_cvref_t<Sender>>::is_always_scheduler_affine) {
-        return unifex::await_transform(*this, (Sender &&) sndr);
-      } else if constexpr (is_sender_for_v<remove_cvref_t<Sender>, schedule>) {
-        // If we are co_await'ing a sender that is the result of calling
-        // schedule, do something special
-        return transform_schedule_sender_((Sender &&) sndr);
-      } else {
-        // Otherwise, append a transition to the correct execution context and
-        // wrap the result in an awaiter:
-        return unifex::await_transform(
-            *this,
-            finally((Sender &&) sndr, unstoppable(schedule(this->sched_))));
       }
     }
 
@@ -295,18 +358,165 @@ struct _promise {
       // Return the inner sender, appropriately wrapped in an awaitable:
       return unifex::await_transform(*this, std::move(snd).base());
     }
+  };
+};
 
-    decltype(auto) result() {
-      if (this->expected_.state_ == _state::exception) {
-        std::rethrow_exception(std::move(this->expected_.exception_).get());
+struct _sr_thunk_promise_base : _promise_base {
+  coro::coroutine_handle<> unhandled_done() noexcept {
+    callback_.reset();
+
+    if (refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      return continuation_.done();
+    } else {
+      return coro::noop_coroutine();
+    }
+  }
+
+  friend inplace_stop_token
+  tag_invoke(tag_t<get_stop_token>, const _sr_thunk_promise_base& p) noexcept {
+    return p.stopSource_.get_token();
+  }
+
+  mutable inplace_stop_source stopSource_;
+
+  struct deferred_stop_request final {
+    _sr_thunk_promise_base* self;
+
+    auto operator()() noexcept -> decltype(unstoppable(on(
+        self->sched_,
+        just(&self->stopSource_) | then(&inplace_stop_source::request_stop)))) {
+      return unstoppable(on(
+          self->sched_,
+          just(&self->stopSource_) | then(&inplace_stop_source::request_stop)));
+    }
+  };
+
+  using sender_t =
+      decltype(unifex::defer(UNIFEX_DECLVAL(deferred_stop_request)));
+
+  struct receiver_t {
+    _sr_thunk_promise_base* self;
+
+    void set_value(bool) noexcept {
+      if (self->refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        self->continuation_.handle().resume();
       }
-      return std::move(this->expected_.value_).get();
+    }
+    void set_error(std::exception_ptr) noexcept { std::terminate(); }
+    void set_done() noexcept { std::terminate(); }
+  };
+
+  using op_t = connect_result_t<sender_t, receiver_t>;
+
+  op_t stopOperation_{
+      connect(unifex::defer(deferred_stop_request{this}), receiver_t{this})};
+
+  struct stop_callback {
+    _sr_thunk_promise_base* self;
+
+    void operator()() noexcept {
+      if (self->refCount_.fetch_add(1, std::memory_order_relaxed) == 0) {
+        return;
+      }
+
+      unifex::start(self->stopOperation_);
+    }
+  };
+
+  using stop_callback_t =
+      typename inplace_stop_token::callback_type<stop_callback>;
+
+  std::optional<stop_callback_t> callback_;
+
+  std::atomic<uint8_t> refCount_{1};
+
+  void register_stop_callback() noexcept {
+    callback_.emplace(stoken_, stop_callback{this});
+  }
+};
+
+template <typename T>
+struct _sr_thunk_promise final {
+  /**
+   * The promise_type for an sr_thunk_task<T>.
+   *
+   * This type has two main responsibilities:
+   *  - register a stop callback on our receiver's stop token that, when
+   *    invoked, executes an async operation that forwards the request to the
+   *    nested stop source on the correct scheduler; and
+   *  - ensure that, if the async stop request is ever started, we wait for
+   *    *both* the async stop request *and* the nested operation to complete
+   *    before continuating our continuation.
+   *
+   * The async stop request delivery is handled in _sr_thunk_promise_base (our
+   * base class), and our final-awaiter handles coordinating who continues our
+   * continuation.
+   */
+  struct type final
+    : _sr_thunk_promise_base
+    , _return_value_or_void<T>::type {
+    using result_type = T;
+
+    typename _sr_thunk_task<T>::type get_return_object() noexcept {
+      return typename _sr_thunk_task<T>::type{
+          coro::coroutine_handle<type>::from_promise(*this)};
+    }
+
+    auto final_suspend() noexcept {
+      struct awaiter final : _final_suspend_awaiter_base {
+#if (defined(_MSC_VER) && !defined(__clang__)) || defined(__EMSCRIPTEN__)
+        // MSVC doesn't seem to like symmetric transfer in this final awaiter
+        // and the Emscripten (WebAssembly) compiler doesn't support tail-calls
+        void await_suspend(coro::coroutine_handle<type> h) noexcept {
+          auto& p = h.promise();
+
+          p.callback_.reset();
+
+          // if we're last to complete, continue our continuation; otherwise do
+          // nothing and wait for the async stop request to do it
+          if (p.refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            return h.promise().continuation_.handle().resume();
+          }
+          // nothing
+        }
+#else
+        coro::coroutine_handle<>
+        await_suspend(coro::coroutine_handle<type> h) noexcept {
+          auto& p = h.promise();
+
+          p.callback_.reset();
+
+          // if we're last to complete, continue our continuation; otherwise do
+          // nothing and wait for the async stop request to do it
+          if (p.refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            return h.promise().continuation_.handle();
+          } else {
+            return coro::noop_coroutine();
+          }
+        }
+#endif
+      };
+
+      return awaiter{};
+    }
+
+    template <typename Value>
+    decltype(auto) await_transform(Value&& value) {
+      return unifex::await_transform(*this, static_cast<Value&&>(value));
     }
   };
 };
 
 template <typename ThisPromise, typename OtherPromise>
-struct _awaiter {
+struct _awaiter final {
+  /**
+   * An awaitable type that knows how to await a task<>, sa_task<>, or
+   * sr_thunk_task<> from a coroutine whose promise_type is OtherPromise.
+   *
+   * We inherit tagged_coro_holder to be able to distinguish whether or not the
+   * awaited task has been started, and thus whether we need to clean it up in
+   * our destructor.
+   */
   struct type : tagged_coro_holder {
     using result_type = typename ThisPromise::result_type;
 
@@ -349,6 +559,9 @@ struct _awaiter {
       } else {
         promise.stoken_ = get_stop_token(h.promise());
       }
+
+      promise.register_stop_callback();
+
       return thisCoro;
     }
 
@@ -391,6 +604,40 @@ struct _awaiter {
   };
 };
 
+/**
+ * The coroutine type that ensures stop requests are delivered to nested task<>s
+ * on the right scheduler.
+ */
+template <typename T>
+struct _sr_thunk_task<T>::type final : coro_holder {
+  using promise_type = typename _sr_thunk_promise<T>::type;
+  friend promise_type;
+
+private:
+  template <typename OtherPromise>
+  using awaiter = typename _awaiter<promise_type, OtherPromise>::type;
+
+  explicit type(coro::coroutine_handle<promise_type> h) noexcept
+    : coro_holder(h) {}
+
+  template <typename Promise>
+  friend awaiter<Promise>
+  tag_invoke(tag_t<unifex::await_transform>, Promise&, type&& t) noexcept {
+    return awaiter<Promise>{std::exchange(t.coro_, {})};
+  }
+};
+
+/**
+ * Await the given sa_task<> in a context that will deliver stop requests from
+ * the receiver on the expected scheduler.
+ */
+template <typename T>
+typename _sr_thunk_task<T>::type
+inject_stop_request_thunk(typename _sa_task<T>::type awaitable) {
+  // I wonder if we could do better than hopping through this extra coroutine
+  co_return co_await std::move(awaitable);
+}
+
 template <typename T>
 struct _task<T>::type
   : _task_base
@@ -418,7 +665,7 @@ struct _task<T>::type
   // points are async
   static constexpr blocking_kind blocking = blocking_kind::maybe;
 
-  static constexpr bool is_always_scheduler_affine = true;
+  static constexpr bool is_always_scheduler_affine = false;
 
   type(type&& t) noexcept = default;
 
@@ -431,11 +678,67 @@ struct _task<T>::type
   }
 
 private:
-  template <typename OtherPromise>
-  using awaiter = typename _awaiter<promise_type, OtherPromise>::type;
-
   explicit type(coro::coroutine_handle<promise_type> h) noexcept
     : coro_holder(h) {}
+
+  template <typename Promise>
+  friend auto
+  tag_invoke(tag_t<unifex::await_transform>, Promise& p, type&& t) noexcept {
+    // we don't know whether our consumer will enforce the scheduler-affinity
+    // invariants so we need to ensure that stop requests are delivered on the
+    // right scheduler
+    return unifex::await_transform(
+        p, inject_stop_request_thunk<T>(std::move(t)));
+  }
+
+  template <typename Receiver>
+  friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
+    using stoken_t = stop_token_type_t<Receiver>;
+
+    if constexpr (is_stop_never_possible_v<stoken_t>) {
+      // NOTE: we *don't* need to worry about stop requests if the receiver's
+      //       stop token can't make such requests!
+      using sa_task = typename _sa_task<T>::type;
+
+      return connect(sa_task{std::move(t)}, static_cast<Receiver&&>(r));
+    } else {
+      // connect_awaitable will get the awaitable to connect by invoking
+      // await_transform so we can guarantee stop requests are delivered
+      // on the right scheduler by relying on await_transform to do that
+      return connect_awaitable(std::move(t), static_cast<Receiver&&>(r));
+    }
+  }
+
+  template <typename Scheduler>
+  friend typename _sa_task<T>::type tag_invoke(
+      tag_t<with_scheduler_affinity>, type&& task, Scheduler&&) noexcept {
+    return {std::move(task)};
+  }
+};
+
+/**
+ * A "sheduler-affine" task<>; an sa_task<> is the same as a task<> except that
+ * it expects its consumer to maintain the scheduler-affinity invariant and so
+ * it can avoid the overhead required to establish the invariant itself.
+ *
+ * The main difference is that await_transform doesn't indirect through
+ * inject_stop_request_thunk.
+ */
+template <typename T>
+struct _sa_task<T>::type final : public _task<T>::type {
+  using base = typename _task<T>::type;
+
+  friend base;
+
+  type(base&& t) noexcept : base(std::move(t)) {}
+
+  template <typename OtherPromise>
+  using awaiter =
+      typename _awaiter<typename base::promise_type, OtherPromise>::type;
+
+  // given that we're awaited in a scheduler-affine context, we are ourselves
+  // scheduler-affine
+  static constexpr bool is_always_scheduler_affine = true;
 
   template <typename Promise>
   friend awaiter<Promise>
@@ -444,8 +747,10 @@ private:
   }
 
   template <typename Receiver>
-  friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-    return unifex::connect_awaitable((type &&) t, (Receiver &&) r);
+  friend auto
+  tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) noexcept(
+      noexcept(connect_awaitable(std::move(t), static_cast<Receiver&&>(r)))) {
+    return connect_awaitable(std::move(t), static_cast<Receiver&&>(r));
   }
 };
 

--- a/include/unifex/with_scheduler_affinity.hpp
+++ b/include/unifex/with_scheduler_affinity.hpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/await_transform.hpp>
+#include <unifex/connect_awaitable.hpp>
+#include <unifex/finally.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/type_traits.hpp>
+#include <unifex/unstoppable.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _wsa {
+
+template <typename Sender, typename Scheduler>
+struct _wsa_sender_wrapper final {
+  class type;
+};
+
+template <typename Sender, typename Scheduler>
+static auto
+_make_sender(Sender&& sender, Scheduler&& scheduler) noexcept(noexcept(finally(
+    static_cast<Sender&&>(sender),
+    unstoppable(schedule(static_cast<Scheduler&&>(scheduler)))))) {
+  return finally(
+      static_cast<Sender&&>(sender),
+      unstoppable(schedule(static_cast<Scheduler&&>(scheduler))));
+}
+
+template <typename Sender, typename Scheduler>
+using wsa_sender_wrapper =
+    typename _wsa_sender_wrapper<Sender, Scheduler>::type;
+
+template <typename Sender, typename Scheduler>
+class _wsa_sender_wrapper<Sender, Scheduler>::type final {
+  using sender_t =
+      decltype(_make_sender(UNIFEX_DECLVAL(Sender), UNIFEX_DECLVAL(Scheduler)));
+
+  sender_t sender_;
+
+public:
+  template <
+      template <typename...>
+      typename Variant,
+      template <typename...>
+      typename Tuple>
+  using value_types = sender_value_types_t<sender_t, Variant, Tuple>;
+
+  template <template <typename...> typename Variant>
+  using error_types = sender_error_types_t<sender_t, Variant>;
+
+  static constexpr bool sends_done = sender_traits<sender_t>::sends_done;
+
+  static constexpr blocking_kind blocking = sender_traits<sender_t>::blocking;
+
+  static constexpr bool is_always_scheduler_affine = true;
+
+  template <typename Sender2, typename Scheduler2>
+  type(Sender2&& sender, Scheduler2 scheduler) noexcept(noexcept(_make_sender(
+      static_cast<Sender2&&>(sender), static_cast<Scheduler2&&>(scheduler))))
+    : sender_(_make_sender(
+          static_cast<Sender2&&>(sender),
+          static_cast<Scheduler2&&>(scheduler))) {}
+
+  template(typename Self, typename Receiver)          //
+      (requires same_as<remove_cvref_t<Self>, type>)  //
+      friend auto tag_invoke(tag_t<connect>, Self&& sender, Receiver&& receiver) noexcept(
+          is_nothrow_connectable_v<member_t<Self, sender_t>, Receiver>) {
+    return connect(
+        static_cast<Self&&>(sender).sender_, static_cast<Receiver&&>(receiver));
+  }
+};
+
+struct _fn final {
+  template(typename Sender, typename Scheduler)  //
+      (requires sender<Sender> AND sender_traits<
+          remove_cvref_t<Sender>>::is_always_scheduler_affine)  //
+      constexpr Sender&&
+      operator()(Sender&& s, Scheduler&&) const noexcept {
+    // this is the identity function for statically-affine senders
+    return static_cast<Sender&&>(s);
+  }
+
+  template(typename Sender, typename Scheduler)                              //
+      (requires sender<Sender> AND scheduler<Scheduler> AND                  //
+       (!sender_traits<remove_cvref_t<Sender>>::is_always_scheduler_affine)  //
+       AND tag_invocable<_fn, Sender, Scheduler>)                            //
+      constexpr auto
+      operator()(Sender&& s, Scheduler&& sched) const
+      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Scheduler>)
+          -> tag_invoke_result_t<_fn, Sender, Scheduler> {
+    // allow customization
+    return tag_invoke(
+        _fn{}, static_cast<Sender&&>(s), static_cast<Scheduler&&>(sched));
+  }
+
+  template(typename Sender, typename Scheduler)                              //
+      (requires sender<Sender> AND scheduler<Scheduler> AND                  //
+       (!sender_traits<remove_cvref_t<Sender>>::is_always_scheduler_affine)  //
+       AND(!tag_invocable<_fn, Sender, Scheduler>))                          //
+      constexpr auto
+      operator()(Sender&& s, Scheduler&& sched) const
+      noexcept(std::is_nothrow_constructible_v<
+               wsa_sender_wrapper<
+                   remove_cvref_t<Sender>,
+                   remove_cvref_t<Scheduler>>,
+               Sender,
+               Scheduler>) {
+    // fall back to assuming we need, effectively, a typed_via
+    using sender_t =
+        wsa_sender_wrapper<remove_cvref_t<Sender>, remove_cvref_t<Scheduler>>;
+
+    return sender_t{static_cast<Sender&&>(s), static_cast<Scheduler&&>(sched)};
+  }
+
+  template(typename Promise, typename Awaitable, typename Scheduler)  //
+      (requires detail::_awaitable<Awaitable> AND(!sender<Awaitable>)
+           AND scheduler<Scheduler>)  //
+      constexpr decltype(auto)
+      operator()(
+          Promise& promise, Awaitable&& awaitable, Scheduler&& sched) const {
+    using blocking_t = decltype(blocking(awaitable));
+
+    // TODO: detect statically-affine awaitables
+    // HACK: this is a hacky implementation of what used to be cblocking<>()
+    if constexpr (
+        !same_as<blocking_kind, blocking_t> &&
+        (blocking_kind::always_inline == blocking_t{})) {
+      return Awaitable{(Awaitable &&) awaitable};
+    } else {
+      // TODO: do this more efficiently; the current approach converts an
+      //       awaitable to a sender so we can pass it to typed_via, only to
+      //       convert it back to an awaitable
+      return unifex::await_transform(
+          promise,
+          operator()(
+              as_sender(static_cast<Awaitable&&>(awaitable)),
+              static_cast<Scheduler&&>(sched)));
+    }
+  }
+};
+
+}  // namespace _wsa
+
+inline constexpr _wsa::_fn with_scheduler_affinity{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/source/task.cpp
+++ b/source/task.cpp
@@ -21,7 +21,7 @@
 #include <unifex/at_coroutine_exit.hpp>
 
 namespace unifex::_task {
-void _promise_base::transform_schedule_sender_impl_(any_scheduler newSched) {
+void _task_promise_base::transform_schedule_sender_impl_(any_scheduler newSched) {
   // If we haven't already inserted a cleanup action to take us back to the correct
   // scheduler, do so now:
   if (!std::exchange(this->rescheduled_, true)) {

--- a/test/task_cancel_test.cpp
+++ b/test/task_cancel_test.cpp
@@ -26,6 +26,7 @@
 #include <unifex/let_done.hpp>
 #include <unifex/just.hpp>
 #include <unifex/stop_if_requested.hpp>
+#include <unifex/with_scheduler_affinity.hpp>
 
 #include <gtest/gtest.h>
 
@@ -129,7 +130,7 @@ TEST(TaskCancel, PropagatesStopToken) {
   std::optional<inplace_stop_token> i =
     sync_wait(
       with_query_value(
-        get_token_outer(),
+        with_scheduler_affinity(get_token_outer(), current_scheduler),
         get_stop_token,
         stopSource.get_token()));
   EXPECT_TRUE(i);
@@ -141,7 +142,7 @@ TEST(TaskCancel, StopIfRequested) {
   std::optional<int> i =
     sync_wait(
       with_query_value(
-        test_stop_if_requested(stopSource),
+        with_scheduler_affinity(test_stop_if_requested(stopSource), current_scheduler),
         get_stop_token,
         stopSource.get_token()));
   EXPECT_TRUE(!i);


### PR DESCRIPTION
This diff changes how `unifex::task<>` implements *Scheduler* affinity to work more like `folly::coro::Task<>`.  What Folly calls `co_viaIfAsync`, this diff calls `with_scheduler_affinity`, which is a new CPO.

`with_scheduler_affinity` is a *Sender* algorithm that maps the given *Sender* to another *Sender* that must meet new postconditions if the *Receiver* that it's connected to meets certain preconditions.  The new preconditions are:
 - the eventual *Receiver* must provide a "current *Scheduler*";
 - the result of `with_scheduler_affinity` must be started on the *Receiver's* current *Scheduler*; and
 - stop requests delivered to the new *Sender* must be delivered on the *Receiver's* current *Scheduler*.

The *Sender* returned from `with_scheduler_affinity` must complete on its *Receiver's* current *Scheduler* (i.e. must complete where it was started) so long as all the above preconditions are met.

`with_scheduler_affinity` has two default implementations for a _Sender_ type `S`:
 - if `sender_traits<S>::is_always_scheduler_affine` is `true`, the default is the identity;
 - if `sender_traits<S>::is_always_scheduler_affine` is `false`, the default is, essentially, a `typed_via` back to the correct scheduler.
 
Any _Sender_ can customize `with_scheduler_affinity`, regardless of its `is_always_scheduler_affine` property.