### PR TITLE
add `<linux/io_uring.h>` support

### DIFF
--- a/cmake/FindLibUring.cmake
+++ b/cmake/FindLibUring.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(LIBURING_INCLUDE_DIR NAMES liburing/io_uring.h)
+find_path(LIBURING_INCLUDE_DIR NAMES liburing/io_uring.h linux/io_uring.h)
 mark_as_advanced(LIBURING_INCLUDE_DIR)
 
 #find_library(LIBURING_LIBRARY NAMES uring)

--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -84,8 +84,23 @@
 #endif
 
 #if !defined(UNIFEX_NO_LIBURING)
-#cmakedefine01 UNIFEX_NO_LIBURING
-#cmakedefine01 HAVE_LINUX_TIME_TYPES_H
+#  if __has_include(<liburing/io_uring.h>)
+#    define UNIFEX_LIBURING_HEADER <liburing/io_uring.h>
+#  elif __has_include(<linux/io_uring.h>)
+// some versions of gcc and clang: #define linux 1
+#    if defined(linux)
+#      undef linux
+#    endif
+#    define UNIFEX_LIBURING_HEADER <linux/io_uring.h>
+#  else
+#    undef UNIFEX_NO_LIBURING
+#    define UNIFEX_NO_LIBURING 1
+#  endif
+#  if __has_include(<linux/time_types.h>)
+#    define HAVE_LINUX_TIME_TYPES_H 1
+#  else
+#    define HAVE_LINUX_TIME_TYPES_H 0
+#  endif
 #endif
 
 #if !defined(UNIFEX_ENABLE_CONTINUATION_VISITATIONS)

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -41,7 +41,7 @@
 #include <system_error>
 #include <utility>
 
-#include <liburing/io_uring.h>
+#include UNIFEX_LIBURING_HEADER
 
 #include <sys/uio.h>
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -35,7 +35,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
       pthread)
 
 if (NOT UNIFEX_NO_LIBURING)
-  check_include_file_cxx("linux/time_types.h" HAVE_LINUX_TIME_TYPES_H)
 
   target_sources(unifex
     PRIVATE

--- a/source/linux/io_uring_syscall.hpp
+++ b/source/linux/io_uring_syscall.hpp
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <signal.h>
-#include <linux/io_uring.h>
+#include UNIFEX_LIBURING_HEADER
 
 namespace unifex::linuxos
 {


### PR DESCRIPTION
* prefer `<liburing/io_uring.h>` for backwards compatibility
* convert related `config.hpp.in` section from config time to compile time