### PR TITLE
enable `io_uring` in all ubuntu CI steps

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -19,18 +19,21 @@ jobs:
         - {
             name: "Linux GCC 9 Debug (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "gcc-9", cxx: "g++-9"
           }
         - {
             name: "Linux GCC 9 Optimised (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "gcc-9", cxx: "g++-9"
           }
         - {
             name: "Linux GCC 9 Debug (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "gcc-9", cxx: "g++-9",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20"
@@ -38,6 +41,7 @@ jobs:
         - {
             name: "Linux GCC 9 Optimised (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "gcc-9", cxx: "g++-9",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20"
@@ -45,18 +49,21 @@ jobs:
         - {
             name: "Linux GCC 10 Debug (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "gcc-10", cxx: "g++-10"
           }
         - {
             name: "Linux GCC 10 Optimised (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "gcc-10", cxx: "g++-10"
           }
         - {
             name: "Linux GCC 10 Debug (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "gcc-10", cxx: "g++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20"
@@ -64,6 +71,7 @@ jobs:
         - {
             name: "Linux GCC 10 Optimised (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "gcc-10", cxx: "g++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20"
@@ -71,6 +79,7 @@ jobs:
         - {
             name: "Linux GCC 10 Debug (C++20) w/coroutines", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "gcc-10", cxx: "g++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D CMAKE_CXX_FLAGS:STRING=-fcoroutines"
@@ -78,29 +87,15 @@ jobs:
         - {
             name: "Linux GCC 10 Optimised (C++20) w/coroutines", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
-            build_type: RelWithDebInfo,
-            cc: "gcc-10", cxx: "g++-10",
-            cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D CMAKE_CXX_FLAGS:STRING=-fcoroutines"
-          }
-        - {
-            name: "Linux GCC 10 Debug (C++20) w/coroutines w/liburing", artifact: "Linux.tar.xz",
-            os: ubuntu-20.04,
-            build_type: Debug,
-            io_sys: io_uring,            
-            cc: "gcc-10", cxx: "g++-10",
-            cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D CMAKE_CXX_FLAGS:STRING=-fcoroutines"
-          }
-        - {
-            name: "Linux GCC 10 Optimised (C++20) w/coroutines w/liburing", artifact: "Linux.tar.xz",
-            os: ubuntu-20.04,
-            build_type: RelWithDebInfo,
             io_sys: io_uring,
+            build_type: RelWithDebInfo,
             cc: "gcc-10", cxx: "g++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D CMAKE_CXX_FLAGS:STRING=-fcoroutines"
-          }          
+          }
         - {
             name: "Linux Clang 10 Debug (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-10", cxx: "clang++-10",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -108,6 +103,7 @@ jobs:
         - {
             name: "Linux Clang 10 Optimised (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-10", cxx: "clang++-10",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -115,6 +111,7 @@ jobs:
         - {
             name: "Linux Clang 10 Debug (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-10", cxx: "clang++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -122,6 +119,7 @@ jobs:
         - {
             name: "Linux Clang 10 Optimised (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-10", cxx: "clang++-10",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -129,6 +127,7 @@ jobs:
         - {
             name: "Linux Clang 11 Debug (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-11", cxx: "clang++-11",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -136,6 +135,7 @@ jobs:
         - {
             name: "Linux Clang 11 Optimised (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-11", cxx: "clang++-11",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -143,6 +143,7 @@ jobs:
         - {
             name: "Linux Clang 11 Debug (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-11", cxx: "clang++-11",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -150,6 +151,7 @@ jobs:
         - {
             name: "Linux Clang 11 Optimised (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-11", cxx: "clang++-11",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -157,6 +159,7 @@ jobs:
         - {
             name: "Linux Clang 12 Debug (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-12", cxx: "clang++-12",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -164,6 +167,7 @@ jobs:
         - {
             name: "Linux Clang 12 Optimised (C++17)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-12", cxx: "clang++-12",
             cmake_args: "-D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -171,6 +175,7 @@ jobs:
         - {
             name: "Linux Clang 12 Debug (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: Debug,
             cc: "clang-12", cxx: "clang++-12",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -178,6 +183,7 @@ jobs:
         - {
             name: "Linux Clang 12 Optimised (C++20)", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
+            io_sys: io_uring,
             build_type: RelWithDebInfo,
             cc: "clang-12", cxx: "clang++-12",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D \"CMAKE_CXX_FLAGS:STRING=-fsanitize=address -fno-omit-frame-pointer\""
@@ -352,8 +358,8 @@ jobs:
       shell: bash
       working-directory: ${{ env.HOME }}
       run: |
-        curl -L https://github.com/axboe/liburing/archive/refs/tags/liburing-2.1.tar.gz | tar zxvf -
-        cd liburing-liburing-2.1 && ./configure && make -j
+        curl -L https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz | tar zxvf -
+        cd liburing-liburing-2.3 && ./configure && make -j
         sudo make install
 
     - name: Configure


### PR DESCRIPTION
* pre-installed `<linux/io_uring.h>` predates `accept()` support
* `<liburing/io_uring.h>` takes precedence
* remove now redundant CI steps
* bump version to 2.3