### PR TITLE
Create a nothrow task with tests

### DIFF
--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -76,12 +76,13 @@ public:
 
     template <typename Func>
     auto yield_value(Func&& func) noexcept {
+      static constexpr bool isNothrowInvocable = std::is_nothrow_invocable_v<Func>;
       struct awaiter {
         Func&& func_;
         bool await_ready() noexcept {
           return false;
         }
-        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(std::is_nothrow_invocable_v<Func>) {
+        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(isNothrowInvocable) {
           ((Func &&) func_)();
         }
         [[noreturn]] void await_resume() noexcept {

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -81,7 +81,7 @@ public:
         bool await_ready() noexcept {
           return false;
         }
-        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(noexcept(((Func &&) func_)())) {
+        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(std::is_nothrow_invocable_v<Func>) {
           ((Func &&) func_)();
         }
         [[noreturn]] void await_resume() noexcept {

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -75,21 +75,22 @@ public:
     }
 
     template <typename Func>
+    struct awaiter {
+      Func&& func_;
+      bool await_ready() noexcept {
+        return false;
+      }
+      void await_suspend(coro::coroutine_handle<promise_type>) noexcept(std::is_nothrow_invocable_v<Func>) {
+        ((Func &&) func_)();
+      }
+      [[noreturn]] void await_resume() noexcept {
+        std::terminate();
+      }
+    };
+
+    template <typename Func>
     auto yield_value(Func&& func) noexcept {
-      static constexpr bool isNothrowInvocable = std::is_nothrow_invocable_v<Func>;
-      struct awaiter {
-        Func&& func_;
-        bool await_ready() noexcept {
-          return false;
-        }
-        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(isNothrowInvocable) {
-          ((Func &&) func_)();
-        }
-        [[noreturn]] void await_resume() noexcept {
-          std::terminate();
-        }
-      };
-      return awaiter{(Func &&) func};
+      return awaiter<Func&&>{static_cast<Func&&>(func)};
     }
 
     template <typename Value>

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -81,7 +81,7 @@ public:
         bool await_ready() noexcept {
           return false;
         }
-        void await_suspend(coro::coroutine_handle<promise_type>) {
+        void await_suspend(coro::coroutine_handle<promise_type>) noexcept(noexcept(((Func &&) func_)())) {
           ((Func &&) func_)();
         }
         [[noreturn]] void await_resume() noexcept {
@@ -193,7 +193,7 @@ namespace _await_cpo {
       } catch (...) {
         ex = std::current_exception();
       }
-      co_yield[&] {
+      co_yield[&]() noexcept {
         unifex::set_error(std::move(receiver), std::move(ex));
       };
 #endif // !UNIFEX_NO_EXCEPTIONS

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -227,21 +227,21 @@ struct _result_and_unhandled_exception final {
       if constexpr (nothrow) {
         std::terminate();
       } else {
-        expected_.reset_value();
+        result_.reset_value();
         unifex::activate_union_member(
-            expected_.exception_, std::current_exception());
-        expected_.state_ = _state::exception;
+            result_.exception_, std::current_exception());
+        result_.state_ = _state::exception;
       }
     }
 
     decltype(auto) result() noexcept(nothrow) {
       if constexpr (nothrow) {
-        return std::move(expected_).get();
+        return std::move(result_).get();
       } else {
-        if (expected_.state_ == _state::exception) {
-          std::rethrow_exception(std::move(expected_.exception_).get());
+        if (result_.state_ == _state::exception) {
+          std::rethrow_exception(std::move(result_.exception_).get());
         }
-        return std::move(expected_.value_).get();
+        return std::move(result_.value_).get();
       }
     }
 
@@ -249,16 +249,16 @@ struct _result_and_unhandled_exception final {
     // todo: consider if this should be nothrow or not
     void set_value(Args&&... values) {
       if constexpr (nothrow) {
-        expected_.construct(static_cast<Args&&>(values)...);
+        result_.construct(static_cast<Args&&>(values)...);
       } else {
-        this->expected_.reset_value();
+        this->result_.reset_value();
         unifex::activate_union_member(
-            this->expected_.value_, static_cast<Args&&>(values)...);
-        this->expected_.state_ = _state::value;
+            this->result_.value_, static_cast<Args&&>(values)...);
+        this->result_.state_ = _state::value;
       }
     }
 
-    std::conditional_t<nothrow, manual_lifetime<T>, _expected<T>> expected_;
+    std::conditional_t<nothrow, manual_lifetime<T>, _expected<T>> result_;
   };
 };
 
@@ -454,6 +454,7 @@ struct _sr_thunk_promise_base : _promise_base {
   }
 };
 
+//TODO: determine if this should also be nothrow
 template <typename T>
 struct _sr_thunk_promise final {
   /**

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -332,8 +332,10 @@ struct _promise final {
 
     template <typename Value>
     // todo: consider if this should be nothrow or not
+    // NOTE: Magic rescheduling is not currently supported by nothrow tasks
     decltype(auto) await_transform(Value&& value) {
-      if constexpr (!nothrow && is_sender_for_v<remove_cvref_t<Value>, schedule>) {
+      if constexpr (is_sender_for_v<remove_cvref_t<Value>, schedule>) {
+        static_assert(!nothrow, "Magic rescheduling isn't supported by no-throw tasks");
         // TODO: rip this out and replace it with something more explicit
 
         // If we are co_await'ing a sender that is the result of calling

--- a/test/noexcept_task_test.cpp
+++ b/test/noexcept_task_test.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <atomic>
+
+#include <unifex/static_thread_pool.hpp>
+#include <unifex/when_all.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/just_error.hpp>
+#include <unifex/stop_if_requested.hpp>
+
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+nothrow_task<void> child(Scheduler s, std::atomic<int>& x) {
+  co_await schedule(s);
+  ++x;
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+nothrow_task<void> example(Scheduler s, std::atomic<int>& x) {
+  ++x;
+  co_await when_all(child(s, x), child(s, x));
+}
+
+nothrow_task<void> nothrowThrowsException() {
+  throw std::exception{};
+  co_return;
+}
+
+nothrow_task<void> nothrowJustError() {
+  co_await unifex::just_error(std::exception_ptr());
+}
+
+task<void> nothrowTaskBody() {
+  co_await nothrowJustError();
+}
+
+task<int> foo() {
+  co_await stop(); // sends a done signal, unwinds the coroutine stack
+  ADD_FAILURE();
+  co_return 42;
+}
+
+nothrow_task<int> bar() {
+  try {
+    co_await foo();
+    ADD_FAILURE();
+  }
+  catch (...) {
+    ADD_FAILURE();
+  }
+  co_return -1;
+}
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler has NOT changed. Note that this behavior is different
+// for nothrow_task compared to regular task
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+nothrow_task<bool> test_current_scheduler(Scheduler s) {
+  auto before = co_await current_scheduler();
+  co_await schedule(s);
+  auto after = co_await current_scheduler();
+  co_return before == after;
+}
+
+// Test that after a co_await schedule(), the coroutine's current
+// scheduler is NOT inherited by child tasks. Note that this behavior
+// is different for nothrow_task compared to regular task
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+nothrow_task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited_impl(Scheduler s) {
+  any_scheduler s2 = co_await current_scheduler();
+  bool sameScheduler = (s2 != s);
+  co_return std::make_pair(sameScheduler, std::this_thread::get_id());
+}
+
+UNIFEX_TEMPLATE(typename Scheduler)
+  (requires scheduler<Scheduler>)
+nothrow_task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Scheduler s) {
+  co_await schedule(s);
+  co_return co_await test_current_scheduler_is_inherited_impl(s);
+}
+
+TEST(NothrowTask, WhenAll) {
+  std::atomic<int> x{42};
+  // A work-stealing thread pool with two worker threads:
+  static_thread_pool context(2);
+
+  // Take a handle to the thread pool for scheduling work:
+  auto sched = context.get_scheduler();
+
+  auto task = example(sched, x);
+  sync_wait(std::move(task));
+  EXPECT_EQ(x.load(), 45);
+}
+
+TEST(NothrowTaskDeathTest, ExceptionCausesProgramTermination) {
+  ASSERT_DEATH(sync_wait(nothrowThrowsException()), "");
+}
+
+TEST(NothrowTaskDeathTest, JustErrorCausesProgramTermination) {
+  ASSERT_DEATH(sync_wait(nothrowJustError()), "");
+}
+
+TEST(NoThrowTaskSchedulerAffinityTest, CurrentSchedulerTest) {
+  single_thread_context thread_ctx;
+  if(auto opt = sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_TRUE(*opt);
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST(NothrowTaskSchedulerAffinityTest, CurrentSchedulerIsInheritedTest) {
+  single_thread_context thread_ctx;
+  if(auto opt = sync_wait(test_current_scheduler_is_inherited(thread_ctx.get_scheduler()))) {
+    ASSERT_TRUE(opt.has_value());
+    auto [differentScheduler, thread_id] = *opt;
+    EXPECT_TRUE(differentScheduler);
+    EXPECT_NE(thread_id, thread_ctx.get_thread_id());
+  } else {
+    ADD_FAILURE() << "child coroutine completed unexpectedly";
+  }
+}
+
+TEST(NoThrowTaskDeathTest, NoThrowTaskNestedInTaskStillTerminates) {
+  ASSERT_DEATH(sync_wait(nothrowTaskBody()), "");
+}
+
+TEST(NoThrowTaskTest, BasicCancellationStillWorks) {
+  std::optional<int> j = sync_wait(bar());
+  EXPECT_TRUE(!j);
+}
+
+#endif // !UNIFEX_NO_COROUTINES

--- a/test/nothrow_task_test.cpp
+++ b/test/nothrow_task_test.cpp
@@ -36,7 +36,7 @@ using namespace unifex;
 UNIFEX_TEMPLATE(typename Scheduler)
   (requires scheduler<Scheduler>)
 nothrow_task<void> child(Scheduler s, std::atomic<int>& x) {
-  co_await schedule(s);
+  co_await unifex::then(schedule(s), []() noexcept {});
   ++x;
 }
 
@@ -92,7 +92,7 @@ UNIFEX_TEMPLATE(typename Scheduler)
   (requires scheduler<Scheduler>)
 nothrow_task<bool> test_current_scheduler(Scheduler s) {
   auto before = co_await current_scheduler();
-  co_await schedule(s);
+  co_await unifex::then(schedule(s), []() noexcept {});
   auto after = co_await current_scheduler();
   co_return before == after;
 }
@@ -111,7 +111,7 @@ nothrow_task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherit
 UNIFEX_TEMPLATE(typename Scheduler)
   (requires scheduler<Scheduler>)
 nothrow_task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Scheduler s) {
-  co_await schedule(s);
+  co_await unifex::then(schedule(s), []() noexcept {});
   co_return co_await test_current_scheduler_is_inherited_impl(s);
 }
 
@@ -136,7 +136,7 @@ TEST(NothrowTaskDeathTest, JustErrorCausesProgramTermination) {
   ASSERT_DEATH(sync_wait(nothrowJustError()), "");
 }
 
-TEST(NoThrowTaskSchedulerAffinityTest, CurrentSchedulerTest) {
+TEST(NothrowTaskSchedulerAffinityTest, CurrentSchedulerTest) {
   single_thread_context thread_ctx;
   if(auto opt = sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
     ASSERT_TRUE(opt.has_value());


### PR DESCRIPTION
Modifies task.hpp to include nothrow_task. The behavior for nothrow_task and task.hpp is mostly the same, with the difference being nothrow_task calling std::terminate when an exception is thrown. Part of the motivation is to create a task that's smaller in binary size compared to task by minimizing the use of exceptions.

The other difference is that the scheduler affinity in nothrow_task and task is slightly different, as illustrated by the tests.