### PR TITLE
Fix regression in task<>

### DIFF
--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -212,7 +212,12 @@ using _await_cpo::connect_awaitable;
 
 // as_sender, for adapting an awaitable to be a typed sender
 namespace _as_sender {
-  template <typename Awaitable, typename Result = await_result_t<Awaitable>>
+
+  template <typename Awaitable>
+  using _awaitable_single_value_result_t =
+    wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>;
+
+  template <typename Awaitable, typename Result = _awaitable_single_value_result_t<Awaitable>>
   struct _sndr {
     struct type {
       template <

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -144,7 +144,7 @@ namespace _await_cpo {
   private:
     template <typename Awaitable>
     using awaitable_single_value_result_t =
-        non_void_t<wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>>;
+        non_void_t<await_result_t<Awaitable>>;
 
     struct _comma_hack {
       template <typename T>
@@ -214,12 +214,7 @@ using _await_cpo::connect_awaitable;
 
 // as_sender, for adapting an awaitable to be a typed sender
 namespace _as_sender {
-
-  template <typename Awaitable>
-  using _awaitable_single_value_result_t =
-    wrap_reference_t<decay_rvalue_t<await_result_t<Awaitable>>>;
-
-  template <typename Awaitable, typename Result = _awaitable_single_value_result_t<Awaitable>>
+  template <typename Awaitable, typename Result = await_result_t<Awaitable>>
   struct _sndr {
     struct type {
       template <

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -29,12 +29,18 @@ using namespace unifex;
 
 int global;
 
+template <class Expected, class Actual>
+void check_is_type(Actual&&) {
+    static_assert(std::is_same_v<Expected, Actual>);
+}
+
 task<int&> await_reference_awaitable() {
   struct AwaitableGlobalRef {
     bool await_ready() noexcept { return true; }
     void await_suspend(coro::coroutine_handle<>) noexcept {};
     int& await_resume() noexcept { return global; }
   };
+  check_is_type<int&>(co_await AwaitableGlobalRef{});
   int& x = co_await AwaitableGlobalRef{};
   co_return x;
 }

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -51,14 +51,23 @@ task<int&> await_reference_sender() {
 }
 
 TEST(Task, AwaitAwaitableReturningReference) {
-  global = 0;
+  static_assert(std::is_same_v<
+    sender_value_types_t<decltype(await_reference_awaitable()), std::variant, std::tuple>,
+    std::variant<std::tuple<int&>>
+  >);
+
   int& ref = sync_wait(await_reference_awaitable()).value();
+  static_assert(std::is_same_v<
+    std::optional<std::reference_wrapper<int>>,
+    decltype(sync_wait(await_reference_awaitable()))>);
   EXPECT_EQ(&ref, &global);
 }
 
 TEST(Task, AwaitSenderReturningReference) {
-  global = 0;
   int& ref = sync_wait(await_reference_sender()).value();
+  static_assert(std::is_same_v<
+    std::optional<std::reference_wrapper<int>>,
+    decltype(sync_wait(await_reference_sender()))>);
   EXPECT_EQ(&ref, &global);
 }
 

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -18,12 +18,10 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <atomic>
 
-#include <unifex/just.hpp>
+#include <unifex/just_from.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/task.hpp>
-#include <unifex/then.hpp>
 
 #include <gtest/gtest.h>
 
@@ -42,7 +40,7 @@ task<int&> await_reference_awaitable() {
 }
 
 task<int&> await_reference_sender() {
-  int& x = co_await then(just(), []() -> int& { return global; });
+  int& x = co_await just_from([]() -> int& { return global; });
   co_return x;
 }
 

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/coroutine.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#include <atomic>
+
+#include <unifex/just.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/then.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+int global;
+
+task<int&> await_reference_awaitable() {
+  struct AwaitableGlobalRef {
+    bool await_ready() noexcept { return true; }
+    void await_suspend(coro::coroutine_handle<>) noexcept {};
+    int& await_resume() noexcept { return global; }
+  };
+  int& x = co_await AwaitableGlobalRef{};
+  co_return x;
+}
+
+task<int&> await_reference_sender() {
+  int& x = co_await then(just(), []() -> int& { return global; });
+  co_return x;
+}
+
+TEST(Task, AwaitAwaitableReturningReference) {
+  global = 0;
+  int& ref = sync_wait(await_reference_awaitable()).value();
+  EXPECT_EQ(ref, 0);
+  global = 10;
+  EXPECT_EQ(ref, 10);
+}
+
+TEST(Task, AwaitSenderReturningReference) {
+  global = 0;
+  int& ref = sync_wait(await_reference_sender()).value();
+  EXPECT_EQ(ref, 0);
+  global = 10;
+  EXPECT_EQ(ref, 10);
+}
+
+#endif // !UNIFEX_NO_COROUTINES

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -53,17 +53,13 @@ task<int&> await_reference_sender() {
 TEST(Task, AwaitAwaitableReturningReference) {
   global = 0;
   int& ref = sync_wait(await_reference_awaitable()).value();
-  EXPECT_EQ(ref, 0);
-  global = 10;
-  EXPECT_EQ(ref, 10);
+  EXPECT_EQ(&ref, &global);
 }
 
 TEST(Task, AwaitSenderReturningReference) {
   global = 0;
   int& ref = sync_wait(await_reference_sender()).value();
-  EXPECT_EQ(ref, 0);
-  global = 10;
-  EXPECT_EQ(ref, 10);
+  EXPECT_EQ(&ref, &global);
 }
 
 #endif // !UNIFEX_NO_COROUTINES

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -23,6 +23,9 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/task.hpp>
 
+#include <tuple>
+#include <variant>
+
 #include <gtest/gtest.h>
 
 using namespace unifex;


### PR DESCRIPTION
Prior to #290, task<> could co_await awaitables that returned references in await_resume.

Test plan: added test case that passes at the commit before #290, then fails after #290, and passes again with the changes in this commit. I also added a test for task<> awaiting a sender that sends a reference, but this was not actually broken.