### PR TITLE
Remove deprecated stuff

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -173,7 +173,7 @@ using callback_t = void(void* /*context*/, int /*result*/);
 void old_c_style_api(int a, int b, void* context, callback_t* callback_fn);
 
 // A sender-based async API implemented in terms of the C-style API (using C++20):
-unifex::typed_sender auto new_sender_api(int a, int b) {
+unifex::sender auto new_sender_api(int a, int b) {
   return unifex::create<int>([=](auto& rec) {
     old_c_style_api(a, b, &rec, [](void* context, int result) {
       unifex::void_cast<decltype(rec)>(context).set_value(result);
@@ -701,7 +701,7 @@ value channel as an empty `std::optional`. The value channel is also converted
 into an optional. The result is a sender that never completes with done,
 reporting cancellation by completing with an empty optional.
 
-This function only accepts `typed_sender`s that complete with either
+This function only accepts `sender`s that complete with either
 `void` or a single type.
 
 For example:
@@ -1172,7 +1172,7 @@ auto&& [state...] =
 
 **Arguments:**
 The first argument to `at_coroutine_exit` is a callable that returns an awaitable type
-(e.g., a `unifex::task<>` or a type that satisfies the `typed_sender` concept).
+(e.g., a `unifex::task<>` or a type that satisfies the `sender` concept).
 
 The other arguments are optional state that may be needed by the cleanup action. The
 cleanup action assumes ownership of the passed-in state by copying the state into separate

--- a/examples/coroutine_stream_consumer.cpp
+++ b/examples/coroutine_stream_consumer.cpp
@@ -26,7 +26,7 @@
 #include <unifex/take_until.hpp>
 #include <unifex/task.hpp>
 #include <unifex/timed_single_thread_context.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/let_done.hpp>
 #include <unifex/then.hpp>
 #include <unifex/just.hpp>

--- a/examples/delayed_stream_cancellation.cpp
+++ b/examples/delayed_stream_cancellation.cpp
@@ -19,7 +19,7 @@
 #include <unifex/range_stream.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/then.hpp>
 #include <unifex/stop_when.hpp>

--- a/examples/for_each_via_thread_scheduler.cpp
+++ b/examples/for_each_via_thread_scheduler.cpp
@@ -19,7 +19,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -30,7 +30,7 @@ int main() {
 
   sync_wait(then(
       for_each(
-          typed_via_stream(
+          via_stream(
               context.get_scheduler(),
               transform_stream(
                   range_stream{0, 10},

--- a/examples/for_each_via_trampoline.cpp
+++ b/examples/for_each_via_trampoline.cpp
@@ -19,7 +19,7 @@
 #include <unifex/trampoline_scheduler.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -28,7 +28,7 @@ using namespace unifex;
 int main() {
   sync_wait(then(
       for_each(
-          typed_via_stream(
+          via_stream(
               trampoline_scheduler{},
               transform_stream(
                   range_stream{0, 10},

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -21,7 +21,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/with_query_value.hpp>
 
 #include <atomic>
@@ -191,10 +191,10 @@ int main() {
   sync_wait(
       then(
           for_each(
-              typed_via_stream(
+              via_stream(
                   outer_delegating_ctx.get_scheduler(),
                   transform_stream(
-                      typed_via_stream(
+                      via_stream(
                           inner_delegating_ctx.get_scheduler(),
                           transform_stream(
                               range_stream{0, 10},

--- a/examples/get_scheduler.cpp
+++ b/examples/get_scheduler.cpp
@@ -20,7 +20,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/with_query_value.hpp>
 
 #include <chrono>
@@ -45,7 +45,7 @@ int main() {
   // composed operations.
   sync_wait(with_query_value(
       then(
-          for_each(typed_via_stream(current_scheduler,
+          for_each(via_stream(current_scheduler,
                               transform_stream(range_stream{0, 10},
                                                [](int value) {
                                                  return value * value;

--- a/examples/linux/io_epoll_test.cpp
+++ b/examples/linux/io_epoll_test.cpp
@@ -34,7 +34,7 @@
 #include <unifex/then.hpp>
 #include <unifex/when_all.hpp>
 #include <unifex/repeat_effect_until.hpp>
-#include <unifex/typed_via.hpp>
+#include <unifex/via.hpp>
 #include <unifex/with_query_value.hpp>
 #include <unifex/let_done.hpp>
 #include <unifex/stop_when.hpp>
@@ -113,7 +113,7 @@ int main() {
               ++reps;
             });
       })
-        | typed_via(scheduler)
+        | via(scheduler)
           // Repeat the reads:
         | repeat_effect()
           // stop reads after requested time
@@ -129,7 +129,7 @@ int main() {
       sequence(
         just_from([&]{ printf("writes starting!\n"); }),
         defer([&, databuffer] { return discard(async_write_some(wPipeRef, databuffer)); })
-          | typed_via(scheduler)
+          | via(scheduler)
           | repeat_effect()
           | let_done([]{return just();})
           | with_query_value(get_stop_token, stopToken),

--- a/examples/produce_on_consume_via.cpp
+++ b/examples/produce_on_consume_via.cpp
@@ -20,7 +20,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -32,7 +32,7 @@ int main() {
 
   sync_wait(then(
       for_each(
-          typed_via_stream(
+          via_stream(
               context1.get_scheduler(),
               on_stream(
                   context2.get_scheduler(),

--- a/examples/reduce_with_trampoline.cpp
+++ b/examples/reduce_with_trampoline.cpp
@@ -19,7 +19,7 @@
 #include <unifex/trampoline_scheduler.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -31,7 +31,7 @@ using namespace unifex;
 int main() {
   sync_wait(then(
       reduce_stream(
-          typed_via_stream(
+          via_stream(
               trampoline_scheduler{},
               transform_stream(
                   range_stream{0, 100'000},

--- a/examples/stop_immediately.cpp
+++ b/examples/stop_immediately.cpp
@@ -20,7 +20,7 @@
 #include <unifex/stop_immediately.hpp>
 #include <unifex/take_until.hpp>
 #include <unifex/thread_unsafe_event_loop.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <chrono>
 #include <cstdio>

--- a/examples/type_erased_stream.cpp
+++ b/examples/type_erased_stream.cpp
@@ -21,7 +21,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -34,7 +34,7 @@ int main() {
   sync_wait(then(
       for_each(
             type_erase<int>(
-                typed_via_stream(
+                via_stream(
                     context1.get_scheduler(),
                     on_stream(
                         context2.get_scheduler(),

--- a/include/unifex/bulk_join.hpp
+++ b/include/unifex/bulk_join.hpp
@@ -138,7 +138,7 @@ private:
 struct _fn {
     template(typename Source)
         (requires
-            typed_bulk_sender<Source> &&
+            bulk_sender<Source> &&
             tag_invocable<_fn, Source>)
     auto operator()(Source&& source) const
         noexcept(is_nothrow_tag_invocable_v<_fn, Source>)
@@ -148,7 +148,7 @@ struct _fn {
 
     template(typename Source)
         (requires
-            typed_bulk_sender<Source> &&
+            bulk_sender<Source> &&
             (!tag_invocable<_fn, Source>))
     auto operator()(Source&& source) const
         noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Source>, Source>)

--- a/include/unifex/bulk_transform.hpp
+++ b/include/unifex/bulk_transform.hpp
@@ -206,7 +206,7 @@ private:
 
 struct _fn {
     template(typename Source, typename Func, typename FuncPolicy = decltype(get_execution_policy(UNIFEX_DECLVAL(Func&))))
-        (requires typed_bulk_sender<Source>)
+        (requires bulk_sender<Source>)
     auto operator()(Source&& s, Func&& f) const
         noexcept(is_nothrow_callable_v<_fn, Source, Func, FuncPolicy>)
         -> callable_result_t<_fn, Source, Func, FuncPolicy> {
@@ -215,7 +215,7 @@ struct _fn {
 
     template(typename Source, typename Func, typename FuncPolicy)
         (requires
-            typed_bulk_sender<Source> AND
+            bulk_sender<Source> AND
             tag_invocable<_fn, Source, Func, FuncPolicy>)
     auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
         noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func, FuncPolicy>)
@@ -225,7 +225,7 @@ struct _fn {
 
     template(typename Source, typename Func, typename FuncPolicy)
         (requires
-            typed_bulk_sender<Source> AND
+            bulk_sender<Source> AND
             (!tag_invocable<_fn, Source, Func, FuncPolicy>))
     auto operator()(Source&& s, Func&& f, FuncPolicy policy) const
         noexcept(

--- a/include/unifex/create.hpp
+++ b/include/unifex/create.hpp
@@ -172,7 +172,7 @@ struct _fn {
  *  void old_c_style_api(int a, int b, void* context, callback_t* callback_fn);
  *
  *  // A sender-based async API implemented in terms of the C-style API (using C++20):
- *  unifex::typed_sender auto new_sender_api(int a, int b) {
+ *  unifex::sender auto new_sender_api(int a, int b) {
  *    return unifex::create<int>([=](auto& rec) {
  *      old_c_style_api(a, b, &rec, [](void* context, int result) {
  *        unifex::void_cast<decltype(rec)>(context).set_value(result);

--- a/include/unifex/done_as_optional.hpp
+++ b/include/unifex/done_as_optional.hpp
@@ -32,7 +32,7 @@ namespace _done_as_opt {
 namespace _cpo {
 inline const struct _fn {
   template(typename Sender) //
-    (requires _single_typed_sender<Sender>) //
+    (requires _single_sender<Sender>) //
   auto operator()(Sender&& predecessor) const {
     using optional_t = std::optional<
         non_void_t<std::decay_t<sender_single_value_return_type_t<Sender>>>>;

--- a/include/unifex/nest.hpp
+++ b/include/unifex/nest.hpp
@@ -40,8 +40,8 @@ private:
 
 public:
   template(typename Sender, typename Scope)  //
-      (requires typed_sender<Sender> AND tag_invocable<_nest_fn, Sender, Scope&>
-           AND typed_sender<tag_invoke_result_t<_nest_fn, Sender, Scope&>>)  //
+      (requires sender<Sender> AND tag_invocable<_nest_fn, Sender, Scope&>
+           AND sender<tag_invoke_result_t<_nest_fn, Sender, Scope&>>)  //
       auto
       operator()(Sender&& sender, Scope& scope) const
       noexcept(is_nothrow_tag_invocable_v<_nest_fn, Sender, Scope&>)
@@ -50,9 +50,9 @@ public:
   }
 
   template(typename Sender, typename Scope)  //
-      (requires typed_sender<Sender> AND(
+      (requires sender<Sender> AND(
           !tag_invocable<_nest_fn, Sender, Scope&>)
-           AND typed_sender<nest_member_result_t<Scope, Sender>>)  //
+           AND sender<nest_member_result_t<Scope, Sender>>)  //
       auto
       operator()(Sender&& sender, Scope& scope) const
       noexcept(is_nest_member_nothrow_v<Scope, Sender>)

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -179,9 +179,9 @@ UNIFEX_CONCEPT //
     detail::_has_sender_types<sender_traits<remove_cvref_t<S>>>;
 
 template <typename S>
-UNIFEX_CONCEPT        //
-  typed_bulk_sender = //
-    sender<S> &&      //
+UNIFEX_CONCEPT    //
+  bulk_sender =   //
+    sender<S> &&  //
     detail::_has_bulk_sender_types<sender_traits<remove_cvref_t<S>>>;
 
 namespace _start_cpo {

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -104,7 +104,7 @@ namespace detail {
       UNIFEX_FRAGMENT(detail::_has_bulk_sender_types_impl, S);
 
   template <typename S>
-  struct _typed_sender_traits {
+  struct _sender_traits {
     template <
         template <typename...> class Variant,
         template <typename...> class Tuple>
@@ -121,7 +121,7 @@ namespace detail {
   };
 
   template <typename S>
-  struct _typed_bulk_sender_traits : _typed_sender_traits<S> {
+  struct _bulk_sender_traits : _sender_traits<S> {
     template <
       template <typename...> class Variant,
       template <typename...> class Tuple>
@@ -159,9 +159,9 @@ namespace detail {
   template <typename S>
   constexpr auto _select_sender_traits() noexcept {
     if constexpr (_has_bulk_sender_types<S>) {
-      return _typed_bulk_sender_traits<S>{};
+      return _bulk_sender_traits<S>{};
     } else if constexpr (_has_sender_types<S>) {
-      return _typed_sender_traits<S>{};
+      return _sender_traits<S>{};
     } else {
       return _no_sender_traits{};
     }
@@ -177,11 +177,6 @@ UNIFEX_CONCEPT //
     move_constructible<remove_cvref_t<S>> &&
     detail::_has_sender_traits<remove_cvref_t<S>> && //
     detail::_has_sender_types<sender_traits<remove_cvref_t<S>>>;
-
-template <typename S>
-UNIFEX_CONCEPT   //
-  typed_sender = //
-    sender<S>;
 
 template <typename S>
 UNIFEX_CONCEPT        //
@@ -394,28 +389,28 @@ template <typename Sender>
 using sender_error_type_list_t = sender_error_types_t<Sender, type_list>;
 
 /// \cond
-namespace _single_sender {
+namespace _detail {
 template <typename... Types>
 using _is_single_valued_tuple = std::bool_constant<1 >= sizeof...(Types)>;
 
 template <typename... Types>
 using _is_single_valued_variant =
     std::bool_constant<sizeof...(Types) == 1 && (Types::value && ...)>;
-}  // namespace _single_sender
+}  // namespace _detail
 /// \endcond
 
 template <typename Sender>
-UNIFEX_CONCEPT_FRAGMENT(        //
-    _single_typed_sender_impl,  //
-    requires()(0) &&            //
+UNIFEX_CONCEPT_FRAGMENT(  //
+    _single_sender_impl,  //
+    requires()(0) &&      //
         sender_traits<remove_cvref_t<Sender>>::template value_types<
-            _single_sender::_is_single_valued_variant,
-            _single_sender::_is_single_valued_tuple>::value);
+            _detail::_is_single_valued_variant,
+            _detail::_is_single_valued_tuple>::value);
 
 template <typename Sender>
-UNIFEX_CONCEPT _single_typed_sender = //
-    typed_sender<Sender> &&
-    UNIFEX_FRAGMENT(unifex::_single_typed_sender_impl, Sender);
+UNIFEX_CONCEPT _single_sender = //
+    sender<Sender> &&
+    UNIFEX_FRAGMENT(unifex::_single_sender_impl, Sender);
 
 }  // namespace unifex
 

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -301,21 +301,6 @@ template <typename Sender, typename Receiver>
 using connect_result_t =
   decltype(connect(UNIFEX_DECLVAL(Sender), UNIFEX_DECLVAL(Receiver)));
 
-/// \cond
-template <typename Sender, typename Receiver>
-using operation_t [[deprecated("Use connect_result_t instead of operation_t")]] =
-    connect_result_t<Sender, Receiver>;
-
-template <typename Sender, typename Receiver>
-[[deprecated("Use sender_to instead of is_connectable_v")]]
-inline constexpr bool is_connectable_v =
-  is_callable_v<tag_t<connect>, Sender, Receiver>;
-
-template <typename Sender, typename Receiver>
-using is_connectable [[deprecated]] =
-  is_callable<tag_t<connect>, Sender, Receiver>;
-/// \endcond
-
 template <typename Sender, typename Receiver>
 inline constexpr bool is_nothrow_connectable_v =
   is_nothrow_callable_v<tag_t<connect>, Sender, Receiver>;

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -179,10 +179,18 @@ UNIFEX_CONCEPT //
     detail::_has_sender_types<sender_traits<remove_cvref_t<S>>>;
 
 template <typename S>
+[[deprecated("Use unifex::sender<S> instead")]]  //
+inline constexpr bool typed_sender = sender<S>;
+
+template <typename S>
 UNIFEX_CONCEPT    //
   bulk_sender =   //
     sender<S> &&  //
     detail::_has_bulk_sender_types<sender_traits<remove_cvref_t<S>>>;
+
+template <typename S>
+[[deprecated("Use unifex::bulk_sender<S> instead")]]  //
+inline constexpr bool typed_bulk_sender = bulk_sender<S>;
 
 namespace _start_cpo {
   inline const struct _fn {

--- a/include/unifex/spawn_future.hpp
+++ b/include/unifex/spawn_future.hpp
@@ -864,7 +864,7 @@ public:
       typename Sender,
       typename Scope,
       typename Alloc = std::allocator<std::byte>)  //
-      (requires typed_sender<remove_cvref_t<Sender>> AND
+      (requires sender<remove_cvref_t<Sender>> AND
            std::is_invocable_v<tag_t<nest>, Sender, Scope&> AND
                is_allocator_v<Alloc>)  //
       auto

--- a/include/unifex/sync_wait.hpp
+++ b/include/unifex/sync_wait.hpp
@@ -143,7 +143,7 @@ std::optional<Result> _impl(Sender&& sender) {
 namespace _sync_wait_cpo {
   struct _fn {
     template(typename Sender)
-      (requires typed_sender<Sender>)
+      (requires sender<Sender>)
     auto operator()(Sender&& sender) const
         -> std::optional<sender_single_value_result_t<remove_cvref_t<Sender>>> {
       using Result = sender_single_value_result_t<remove_cvref_t<Sender>>;

--- a/include/unifex/then_execute.hpp
+++ b/include/unifex/then_execute.hpp
@@ -17,7 +17,7 @@
 
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/then.hpp>
-#include <unifex/typed_via.hpp>
+#include <unifex/via.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -28,7 +28,7 @@ namespace _then_execute_cpo {
     template <typename Scheduler, typename Predecessor, typename Func>
     auto operator()(Scheduler&& s, Predecessor&& p, Func&& f) const {
       return then(
-          typed_via((Predecessor &&) p, (Scheduler&&)s),
+          via((Predecessor &&) p, (Scheduler&&)s),
           (Func &&) f);
     }
   };

--- a/include/unifex/typed_via.hpp
+++ b/include/unifex/typed_via.hpp
@@ -15,54 +15,11 @@
  */
 #pragma once
 
-#include <unifex/finally.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/tag_invoke.hpp>
-#include <unifex/bind_back.hpp>
-
-#include <type_traits>
-
-#include <unifex/detail/prologue.hpp>
+#include <unifex/via.hpp>
 
 namespace unifex {
-namespace _typed_via {
-  struct _fn {
-    template(typename Source, typename Scheduler)
-        (requires tag_invocable<_fn, Source, Scheduler>)
-    auto operator()(Source&& source, Scheduler&& scheduler) const
-        noexcept(is_nothrow_tag_invocable_v<_fn, Source, Scheduler>)
-            -> tag_invoke_result_t<_fn, Source, Scheduler> {
-      return tag_invoke(
-          *this,
-          static_cast<Source&&>(source),
-          static_cast<Scheduler&&>(scheduler));
-    }
 
-    template(typename Source, typename Scheduler)
-        (requires (!tag_invocable<_fn, Source, Scheduler>))
-    auto operator()(Source&& source, Scheduler&& scheduler) const
-        noexcept(noexcept(finally(
-            static_cast<Source&&>(source),
-            schedule(static_cast<Scheduler&&>(scheduler)))))
-            -> decltype(finally(
-                static_cast<Source&&>(source),
-                schedule(static_cast<Scheduler&&>(scheduler)))) {
-      return finally(
-          static_cast<Source&&>(source),
-          schedule(static_cast<Scheduler&&>(scheduler)));
-    }
-    template(typename Scheduler)
-        (requires scheduler<Scheduler>)
-    constexpr auto operator()(Scheduler&& scheduler) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Scheduler>)
-        -> bind_back_result_t<_fn, Scheduler> {
-      return bind_back(*this, (Scheduler&&)scheduler);
-    }
-  };
-} // namespace _typed_via
+[[deprecated(
+    "Use unifex::via instead")]] inline constexpr _via::_fn typed_via{};
 
-inline constexpr _typed_via::_fn typed_via {};
-} // namespace unifex
-
-#include <unifex/detail/epilogue.hpp>
+}  // namespace unifex

--- a/include/unifex/typed_via_stream.hpp
+++ b/include/unifex/typed_via_stream.hpp
@@ -17,7 +17,7 @@
 
 #include <unifex/adapt_stream.hpp>
 #include <unifex/scheduler_concepts.hpp>
-#include <unifex/typed_via.hpp>
+#include <unifex/via.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -30,7 +30,7 @@ namespace _typed_via_stream {
       return adapt_stream(
           (StreamSender &&) stream,
           [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
+            return via((decltype(sender))sender, s);
           });
     }
     template (typename StreamSender, typename Scheduler)
@@ -39,7 +39,7 @@ namespace _typed_via_stream {
       return adapt_stream(
           (StreamSender &&) stream,
           [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return typed_via((decltype(sender))sender, s);
+            return via((decltype(sender))sender, s);
           });
     }
     template(typename Scheduler)

--- a/include/unifex/typed_via_stream.hpp
+++ b/include/unifex/typed_via_stream.hpp
@@ -15,46 +15,12 @@
  */
 #pragma once
 
-#include <unifex/adapt_stream.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/via.hpp>
-
-#include <unifex/detail/prologue.hpp>
+#include <unifex/via_stream.hpp>
 
 namespace unifex {
-namespace _typed_via_stream {
-  struct _fn {
-    template (typename StreamSender, typename Scheduler)
-        (requires scheduler<Scheduler>)
-    auto operator()(Scheduler&& scheduler, StreamSender&& stream) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return via((decltype(sender))sender, s);
-          });
-    }
-    template (typename StreamSender, typename Scheduler)
-        (requires scheduler<Scheduler>)
-    auto operator()(StreamSender&& stream, Scheduler&& scheduler) const {
-      return adapt_stream(
-          (StreamSender &&) stream,
-          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
-            return via((decltype(sender))sender, s);
-          });
-    }
-    template(typename Scheduler)
-        (requires scheduler<Scheduler>)
-    constexpr auto operator()(Scheduler&& scheduler) const
-        noexcept(is_nothrow_callable_v<
-          tag_t<bind_back>, _fn, Scheduler>)
-        -> bind_back_result_t<_fn, Scheduler> {
-      return bind_back(*this, (Scheduler&&)scheduler);
-    }
-  };
-} // namespace _typed_via_stream
 
-inline constexpr _typed_via_stream::_fn typed_via_stream {};
+[[deprecated(
+    "Use unifex::via_stream instead")]] inline constexpr _via_stream::_fn
+    typed_via_stream{};
 
-} // namespace unifex
-
-#include <unifex/detail/epilogue.hpp>
+}  // namespace unifex

--- a/include/unifex/via.hpp
+++ b/include/unifex/via.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/finally.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/tag_invoke.hpp>
+#include <unifex/bind_back.hpp>
+
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _via {
+  struct _fn {
+    template(typename Source, typename Scheduler)
+        (requires tag_invocable<_fn, Source, Scheduler>)
+    auto operator()(Source&& source, Scheduler&& scheduler) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, Source, Scheduler>)
+            -> tag_invoke_result_t<_fn, Source, Scheduler> {
+      return tag_invoke(
+          *this,
+          static_cast<Source&&>(source),
+          static_cast<Scheduler&&>(scheduler));
+    }
+
+    template(typename Source, typename Scheduler)
+        (requires (!tag_invocable<_fn, Source, Scheduler>))
+    auto operator()(Source&& source, Scheduler&& scheduler) const
+        noexcept(noexcept(finally(
+            static_cast<Source&&>(source),
+            schedule(static_cast<Scheduler&&>(scheduler)))))
+            -> decltype(finally(
+                static_cast<Source&&>(source),
+                schedule(static_cast<Scheduler&&>(scheduler)))) {
+      return finally(
+          static_cast<Source&&>(source),
+          schedule(static_cast<Scheduler&&>(scheduler)));
+    }
+    template(typename Scheduler)
+        (requires scheduler<Scheduler>)
+    constexpr auto operator()(Scheduler&& scheduler) const
+        noexcept(is_nothrow_callable_v<
+          tag_t<bind_back>, _fn, Scheduler>)
+        -> bind_back_result_t<_fn, Scheduler> {
+      return bind_back(*this, (Scheduler&&)scheduler);
+    }
+  };
+} // namespace _via
+
+inline constexpr _via::_fn via {};
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/via_stream.hpp
+++ b/include/unifex/via_stream.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/adapt_stream.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/via.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _via_stream {
+  struct _fn {
+    template (typename StreamSender, typename Scheduler)
+        (requires scheduler<Scheduler>)
+    auto operator()(Scheduler&& scheduler, StreamSender&& stream) const {
+      return adapt_stream(
+          (StreamSender &&) stream,
+          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+            return via((decltype(sender))sender, s);
+          });
+    }
+    template (typename StreamSender, typename Scheduler)
+        (requires scheduler<Scheduler>)
+    auto operator()(StreamSender&& stream, Scheduler&& scheduler) const {
+      return adapt_stream(
+          (StreamSender &&) stream,
+          [s = (Scheduler &&) scheduler](auto&& sender) mutable {
+            return via((decltype(sender))sender, s);
+          });
+    }
+    template(typename Scheduler)
+        (requires scheduler<Scheduler>)
+    constexpr auto operator()(Scheduler&& scheduler) const
+        noexcept(is_nothrow_callable_v<
+          tag_t<bind_back>, _fn, Scheduler>)
+        -> bind_back_result_t<_fn, Scheduler> {
+      return bind_back(*this, (Scheduler&&)scheduler);
+    }
+  };
+} // namespace _via_stream
+
+inline constexpr _via_stream::_fn via_stream {};
+
+} // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -370,7 +370,7 @@ namespace _cpo {
       return tag_invoke(*this, (Senders &&) senders...);
     }
     template (typename... Senders)
-      (requires (typed_sender<Senders> &&...) AND (!tag_invocable<_fn, Senders...>))
+      (requires (unifex::sender<Senders> &&...) AND (!tag_invocable<_fn, Senders...>))
     auto operator()(Senders&&... senders) const
         -> _when_all::sender<Senders...> {
       return _when_all::sender<Senders...>{(Senders &&) senders...};

--- a/include/unifex/with_scheduler_affinity.hpp
+++ b/include/unifex/with_scheduler_affinity.hpp
@@ -123,7 +123,7 @@ struct _fn final {
                    remove_cvref_t<Scheduler>>,
                Sender,
                Scheduler>) {
-    // the default implementation for non-affine senders is a typed_via back to
+    // the default implementation for non-affine senders is a via back to
     // the given scheduler
     using sender_t =
         wsa_sender_wrapper<remove_cvref_t<Sender>, remove_cvref_t<Scheduler>>;
@@ -147,7 +147,7 @@ struct _fn final {
       return Awaitable{(Awaitable &&) awaitable};
     } else {
       // TODO: do this more efficiently; the current approach converts an
-      //       awaitable to a sender so we can pass it to typed_via, only to
+      //       awaitable to a sender so we can pass it to via, only to
       //       convert it back to an awaitable
       return unifex::await_transform(
           promise,

--- a/test/any_sender_of_test.cpp
+++ b/test/any_sender_of_test.cpp
@@ -37,7 +37,7 @@ using namespace testing;
 
 namespace {
 // We need to validate the following contract:
-//  - any_sender_of<T...> is a typed_sender
+//  - any_sender_of<T...> is a sender
 //  - sender_traits<any_sender_of<T...>>::value_types<std::variant, std::tuple>
 //    is std::variant<std::tuple<T...>>
 //  - sender_traits<any_sender_of<T...>>::error_types<std::variant> is
@@ -61,7 +61,7 @@ struct AnySenderOfTestImpl : Test {
 
   static constexpr size_t value_count = sizeof...(T);
 
-  static_assert(typed_sender<any_sender>);
+  static_assert(sender<any_sender>);
   static_assert(sender_to<any_sender, mock_receiver<void(T...) noexcept(NoExcept)>>);
   static_assert(std::is_same_v<std::variant<std::tuple<T...>>,
                                sender_value_types_t<any_sender, std::variant, std::tuple>>);

--- a/test/delay_test.cpp
+++ b/test/delay_test.cpp
@@ -19,7 +19,7 @@
 #include <unifex/range_stream.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/then.hpp>
 #include <unifex/stop_when.hpp>

--- a/test/for_each_test.cpp
+++ b/test/for_each_test.cpp
@@ -19,7 +19,7 @@
 #include <unifex/trampoline_scheduler.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 

--- a/test/get_scheduler_test.cpp
+++ b/test/get_scheduler_test.cpp
@@ -21,7 +21,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/timed_single_thread_context.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 #include <unifex/with_query_value.hpp>
 
 #include <chrono>
@@ -56,7 +56,7 @@ TEST(get_scheduler, current_scheduler) {
   // composed operations.
   sync_wait(with_query_value(
       then(
-          for_each(typed_via_stream(current_scheduler,
+          for_each(via_stream(current_scheduler,
                               transform_stream(range_stream{0, 10},
                                                [](int value) {
                                                  return value * value;
@@ -75,7 +75,7 @@ TEST(get_scheduler, Pipeable) {
     | transform_stream([](int value) {
         return value * value;
     })
-    | typed_via_stream(current_scheduler)
+    | via_stream(current_scheduler)
     | for_each([](int value) { std::printf("got %i\n", value); })
     | then([]() { std::printf("done\n"); })
     | with_query_value(get_scheduler, ctx.get_scheduler())

--- a/test/nest_test.cpp
+++ b/test/nest_test.cpp
@@ -163,7 +163,7 @@ struct throwing_sender final {
   }
 };
 
-static_assert(unifex::typed_sender<throwing_sender>);
+static_assert(unifex::sender<throwing_sender>);
 
 TEST(nest_test, nest_has_the_expected_noexcept_clause) {
   tag_invocable_scope tscope;

--- a/test/on_stream_test.cpp
+++ b/test/on_stream_test.cpp
@@ -21,7 +21,7 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <gtest/gtest.h>
 
@@ -35,7 +35,7 @@ TEST(on_stream, Smoke) {
 
   sync_wait(then(
       for_each(
-          typed_via_stream(
+          via_stream(
               context1.get_scheduler(),
               on_stream(
                   context2.get_scheduler(),
@@ -54,7 +54,7 @@ TEST(on_stream, Pipeable) {
     | transform_stream(
         [](int value) { return value * value; })
     | on_stream(context2.get_scheduler())
-    | typed_via_stream(context1.get_scheduler())
+    | via_stream(context1.get_scheduler())
     | for_each([](int value) { std::printf("got %i\n", value); })
     | then([]() { std::printf("done\n"); })
     | sync_wait();

--- a/test/single_test.cpp
+++ b/test/single_test.cpp
@@ -21,7 +21,7 @@
 #include <unifex/stop_immediately.hpp>
 #include <unifex/take_until.hpp>
 #include <unifex/thread_unsafe_event_loop.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <chrono>
 #include <cstdio>

--- a/test/type_erase_test.cpp
+++ b/test/type_erase_test.cpp
@@ -23,7 +23,7 @@
 #include <unifex/then.hpp>
 #include <unifex/transform_stream.hpp>
 #include <unifex/type_erased_stream.hpp>
-#include <unifex/typed_via_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <cstdio>
 
@@ -38,7 +38,7 @@ single_thread_context context2;
 
 TEST(type_erase, UseType) {
   auto functor = []() -> unifex::type_erased_stream<int> {
-    return type_erase<int>(typed_via_stream(
+    return type_erase<int>(via_stream(
         context1.get_scheduler(),
         on_stream(
             context2.get_scheduler(),
@@ -54,7 +54,7 @@ TEST(type_erase, UseType) {
 TEST(type_erase, Smoke) {
   sync_wait(then(
       for_each(
-          type_erase<int>(typed_via_stream(
+          type_erase<int>(via_stream(
               context1.get_scheduler(),
               on_stream(
                   context2.get_scheduler(),
@@ -70,7 +70,7 @@ TEST(type_erase, Pipeable) {
       | transform_stream(                                       //
             [](int value) { return value * value; })            //
       | on_stream(context2.get_scheduler())                     //
-      | typed_via_stream(context1.get_scheduler())              //
+      | via_stream(context1.get_scheduler())                    //
       | type_erase<int>()                                       //
       | for_each(                                               //
             [](int value) { std::printf("got %i\n", value); })  //

--- a/test/windows_iocp_context_test.cpp
+++ b/test/windows_iocp_context_test.cpp
@@ -28,7 +28,7 @@
 #include <unifex/span.hpp>
 #include <unifex/repeat_effect_until.hpp>
 #include <unifex/trampoline_scheduler.hpp>
-#include <unifex/typed_via.hpp>
+#include <unifex/via.hpp>
 #include <unifex/let_value_with.hpp>
 #include <unifex/finally.hpp>
 #include <unifex/on.hpp>
@@ -140,7 +140,7 @@ TEST(low_latency_iocp_context, read_write_pipe) {
 
 template<typename Sender>
 auto trampoline(Sender&& sender) {
-    return unifex::typed_via((Sender&&)sender, unifex::trampoline_scheduler{});
+    return unifex::via((Sender&&)sender, unifex::trampoline_scheduler{});
 }
 
 template<typename Sender>


### PR DESCRIPTION
This builds on PRs #538 and #539 to remove the concept of "untyped" _Senders_ and thus stop calling any _Senders_ "typed" (they're all typed).
 - #539 made `typed_sender<S>` an alias for `sender<S>` so now I can replace all uses of `typed_sender<>` with `sender<>` and deprecate `typed_sender<>`.
 - In the same spirit as #539, there's no need to refer to bulk _Senders_ as "typed" so I've renamed `typed_bulk_sender<>` to `bulk_sender<>` and deprecated `typed_bulk_sender<>`.
 - There's no need to call it `typed_via()` so `via()` now means what `typed_via()` meant and we retain `typed_via()` as a deprecated alias for `via()`.
 - Similarly for `typed_via_stream()`, `via_stream()` now means what `typed_via_stream()` meant and we retain `typed_via_stream()` as a deprecated alias for `via_stream()`.
 - I'm also deleting three things from `sender_concepts.hpp` that have been deprecated for a long time.