### PR TITLE
Handle many error predecessors in upon_error

### DIFF
--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -122,9 +122,9 @@ private:
    * This helper returns type_list<type_list<Result>> if invoking func returns
    * Result else if func returns void then helper returns type_list<type_list<>>
    */
-  template <typename Error>
+  template <typename... Error>
   using invoked_result_t =
-      type_list<detail::result_overload_t<std::invoke_result_t<Func, Error>>>;
+      type_list<detail::result_overload_t<std::invoke_result_t<Func, Error>>...>;
 
 public:
   template <


### PR DESCRIPTION
upon_error did not handle predecessor senders that send 0 or more than 2 possible error types. This commit brings upon_error into conformance with the P2300 proposal's upon_error.