### PR TITLE
Fix concat_type_lists_unique_t to be "more unique"

### DIFF
--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -102,20 +102,20 @@ namespace unifex
   template <typename... Ts>
   struct unique_type_list_elements;
 
-  template <typename... Ts>
-  using unique_type_list_elements_t = typename unique_type_list_elements<Ts...>::type;
+  template <typename List>
+  using unique_type_list_elements_t = typename unique_type_list_elements<List, type_list<>>::type;
 
-  template <>
-  struct unique_type_list_elements<type_list<>> {
+  template <typename... Ts>
+  struct unique_type_list_elements<type_list<>, type_list<Ts...>> {
     using type = type_list<>;
   };
 
-  template <typename T, typename... Ts>
-  struct unique_type_list_elements<type_list<T, Ts...>> {
+  template <typename T, typename... Ts, typename... Us>
+  struct unique_type_list_elements<type_list<T, Ts...>, type_list<Us...>> {
     using type = conditional_t<
-      is_one_of_v<T, Ts...>,
-      unique_type_list_elements_t<type_list<Ts...>>,
-      concat_type_lists_t<type_list<T>, unique_type_list_elements_t<type_list<Ts...>>>
+      is_one_of_v<T, Us...>,
+      typename unique_type_list_elements<type_list<Ts...>, type_list<Us..., T>>::type,
+      concat_type_lists_t<type_list<T>, typename unique_type_list_elements<type_list<Ts...>, type_list<Us..., T>>::type>
     >;
   };
 

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -114,7 +114,7 @@ namespace unifex
   struct unique_type_list_elements<type_list<T, Ts...>, type_list<SeenElements...>> {
     using type = conditional_t<
       is_one_of_v<T, SeenElements...>,
-      typename unique_type_list_elements<type_list<Ts...>, type_list<SeenElements..., T>>::type,
+      typename unique_type_list_elements<type_list<Ts...>, type_list<SeenElements...>>::type,
       concat_type_lists_t<type_list<T>, typename unique_type_list_elements<type_list<Ts...>, type_list<SeenElements..., T>>::type>
     >;
   };

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -110,12 +110,12 @@ namespace unifex
     using type = type_list<>;
   };
 
-  template <typename T, typename... Ts, typename... Us>
-  struct unique_type_list_elements<type_list<T, Ts...>, type_list<Us...>> {
+  template <typename T, typename... Ts, typename... SeenElements>
+  struct unique_type_list_elements<type_list<T, Ts...>, type_list<SeenElements...>> {
     using type = conditional_t<
-      is_one_of_v<T, Us...>,
-      typename unique_type_list_elements<type_list<Ts...>, type_list<Us..., T>>::type,
-      concat_type_lists_t<type_list<T>, typename unique_type_list_elements<type_list<Ts...>, type_list<Us..., T>>::type>
+      is_one_of_v<T, SeenElements...>,
+      typename unique_type_list_elements<type_list<Ts...>, type_list<SeenElements..., T>>::type,
+      concat_type_lists_t<type_list<T>, typename unique_type_list_elements<type_list<Ts...>, type_list<SeenElements..., T>>::type>
     >;
   };
 

--- a/include/unifex/type_list.hpp
+++ b/include/unifex/type_list.hpp
@@ -105,8 +105,10 @@ namespace unifex
   template <typename List>
   using unique_type_list_elements_t = typename unique_type_list_elements<List, type_list<>>::type;
 
-  template <typename... Ts>
-  struct unique_type_list_elements<type_list<>, type_list<Ts...>> {
+  // Base case: empty input type_list, with any number of elements that have
+  // already been seen
+  template <typename... SeenElements>
+  struct unique_type_list_elements<type_list<>, type_list<SeenElements...>> {
     using type = type_list<>;
   };
 

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -1,0 +1,45 @@
+#include <unifex/type_list.hpp>
+
+using namespace unifex;
+
+void verify_unique_type_list_elements() {
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<>>,
+    type_list<>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<int>>,
+    type_list<int>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<int, int>>,
+    type_list<int>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<int, double, int>>,
+    type_list<double, int>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<int, double, double, int>>,
+    type_list<double, int>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<int, double, float, double, int>>,
+    type_list<float, double, int>
+  >);
+  static_assert(std::is_same_v<
+    unique_type_list_elements_t<type_list<double, int>>,
+    type_list<double, int>
+  >);
+}
+
+void verify_concat_type_lists_unique() {
+  static_assert(std::is_same_v<
+    concat_type_lists_unique_t<type_list<int, int>, type_list<int>>,
+    type_list<int>
+  >);
+  static_assert(std::is_same_v<
+    concat_type_lists_unique_t<type_list<int>, type_list<int, int>>,
+    type_list<int>
+  >);
+}

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -42,4 +42,8 @@ void verify_concat_type_lists_unique() {
     concat_type_lists_unique_t<type_list<int>, type_list<int, int>>,
     type_list<int>
   >);
+  static_assert(std::is_same_v<
+    concat_type_lists_unique_t<type_list<bool, int, double>, type_list<double, int, float>>,
+    type_list<bool, int, double, float>
+  >);
 }

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -17,15 +17,15 @@ void verify_unique_type_list_elements() {
   >);
   static_assert(std::is_same_v<
     unique_type_list_elements_t<type_list<int, double, int>>,
-    type_list<double, int>
+    type_list<int, double>
   >);
   static_assert(std::is_same_v<
     unique_type_list_elements_t<type_list<int, double, double, int>>,
-    type_list<double, int>
+    type_list<int, double>
   >);
   static_assert(std::is_same_v<
     unique_type_list_elements_t<type_list<int, double, float, double, int>>,
-    type_list<float, double, int>
+    type_list<int, double, float>
   >);
   static_assert(std::is_same_v<
     unique_type_list_elements_t<type_list<double, int>>,

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -170,6 +170,16 @@ TEST(UponError, ManyErrorSender) {
   >);
 }
 
+TEST(UponError, ManyErrorSenderAllReturnInt) {
+  auto s = many_error_sender{} | upon_error([](auto) -> int {
+    return 0;
+  });
+  static_assert(std::is_same_v<
+    decltype(s)::value_types<std::variant, std::tuple>,
+    std::variant<std::tuple<double>, std::tuple<int>>
+  >);
+}
+
 TEST(UponError, ManyErrorSenderIntoVoid) {
   auto s = many_error_sender{} | upon_error([](auto e) {
     if constexpr (std::is_same_v<decltype(e), Error3>) {


### PR DESCRIPTION
The current behavior of concat_type_lists_unique_t is a little confusing.

```
concat_type_lists_unique_t<type_list<int, int>, type_list<int>> ->
    type_list<int, int>
concat_type_lists_unique_t<type_list<int>, type_list<int, int>> ->
    type_list<int>
```

In other words, concat_type_lists_unique_t is not commutative.

The docs seemed to indicate concat_type_lists_unique_t expected the lists to already contain unique elements (the comment seemed incomplete though). I am changing the behavior of concat_type_lists_unique_t to remove duplicate elements from the input lists,  since it conveniently fixes any sender algos that use it to construct the value_types of the output sender to not contain duplicate types.