### PR TITLE
Replace incorrect std::forward usage

### DIFF
--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -161,7 +161,7 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
   template <typename Receiver>
   auto connect(Receiver&& receiver) && {
     return unifex::connect(
-        std::forward<Predecessor>(pred_),
+        std::move(pred_),
         _ifor::receiver_t<Policy, Range, Func, Receiver>{
             (Func &&) func_,
             (Policy &&) policy_,

--- a/include/unifex/let_value_with_stop_source.hpp
+++ b/include/unifex/let_value_with_stop_source.hpp
@@ -51,7 +51,7 @@ template<typename Operation, typename Receiver>
 class _stop_source_receiver<Operation, Receiver>::type {
 public:
     explicit type(Operation& op, Receiver&& r) :
-        op_(op), receiver_{std::forward<Receiver>(r)}
+        op_(op), receiver_{std::move(r)}
     {}
 
     template(typename... Values)

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -130,8 +130,8 @@ struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::type 
     auto& op = op_;
     unifex::deactivate_union_member(op.doneCleanup_);
     unifex::set_value(
-        static_cast<Receiver&&>(op.receiver_),
-        std::forward<State>(op.state_));
+        std::move(op.receiver_),
+        std::move(op.state_));
   }
 
   template(typename CPO)
@@ -198,7 +198,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
     UNIFEX_TRY {
       op.state_ = std::invoke(
           op.reducer_,
-          std::forward<State>(op.state_),
+          std::move(op.state_),
           (Values &&) values...);
       unifex::activate_union_member_with(op.next_, [&] {
         return unifex::connect(next(op.stream_), next_receiver_t{op});


### PR DESCRIPTION
Each of these looks like they were meant tobe a move.