### PR TITLE
Fix lvalue ref handling in let_value

### DIFF
--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -104,8 +104,7 @@ namespace unifex
             scope_guard g{[op]() noexcept {
               unifex::deactivate_union_member<std::tuple<Values...>>(op->value_);
             }};
-            return static_cast<std::tuple<Values...>&&>(
-              op->value_.template get<std::tuple<Values...>>());
+            return std::move(op->value_).template get<std::tuple<Values...>>();
           }
           ();
 

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -57,30 +57,22 @@ struct _successor_receiver<Operation, Values...>::type {
 
   template <typename... SuccessorValues>
   void set_value(SuccessorValues&&... values) && noexcept {
-    op_.cleanup_ = type::cleanup;
     unifex::set_value(
         std::move(op_.receiver_), std::forward<SuccessorValues>(values)...);
   }
 
   void set_done() && noexcept {
-    op_.cleanup_ = type::cleanup;
     unifex::set_done(std::move(op_.receiver_));
   }
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-    op_.cleanup_ = type::cleanup;
     unifex::set_error(std::move(op_.receiver_), std::forward<Error>(error));
   }
 
 private:
   template <typename... Values2>
   using successor_operation = typename Operation::template successor_operation<Values2...>;
-
-  static void cleanup(Operation* op) noexcept {
-    unifex::deactivate_union_member<successor_operation<Values...>>(op->succOp_);
-    op->values_.template destruct<decayed_tuple<Values...>>();
-  }
 
   template(typename CPO)
       (requires is_receiver_query_cpo_v<CPO>)
@@ -116,6 +108,9 @@ struct _predecessor_receiver<Operation>::type {
   template <typename... Values>
   using successor_operation = typename Operation::template successor_operation<Values...>;
 
+  template <typename... Values>
+  using successor_type = typename Operation::template successor_type<Values...>;
+
   Operation& op_;
 
   receiver_type& get_receiver() const noexcept {
@@ -126,14 +121,26 @@ struct _predecessor_receiver<Operation>::type {
   void set_value(Values&&... values) && noexcept {
     auto& op = op_;
     UNIFEX_TRY {
-      scope_guard destroyPredOp =
-        [&]() noexcept { unifex::deactivate_union_member(op.predOp_); };
+      // if we throw while constructing values_ then the default
+      // cleanup_ will destroy predOp_
       auto& valueTuple =
-        op.values_.template construct<decayed_tuple<Values...>>((Values &&) values...);
-      destroyPredOp.reset();
-      scope_guard destroyValues = [&]() noexcept {
-        op.values_.template destruct<decayed_tuple<Values...>>();
-      };
+          op.values_.template construct<decayed_tuple<Values...>>(
+              std::forward<Values>(values)...);
+
+      // ok, values_ initialized; next step is to construct the
+      // successor operation, but we need to destroy predOp_ first
+      // to make room
+      unifex::deactivate_union_member(op.predOp_);
+
+      if constexpr (!is_nothrow_connectable_v<successor_type<Values...>,
+                          successor_receiver<Operation, Values...>>) {
+        // setup a cleanup_ that will only destroy values_ in case
+        // we throw while constructing succOp_
+        op.cleanup_ = [](Operation* op) noexcept {
+          op->values_.template destruct<decayed_tuple<Values...>>();
+        };
+      }
+
       auto& succOp =
           unifex::activate_union_member_with<successor_operation<Values...>>(
             op.succOp_,
@@ -142,27 +149,27 @@ struct _predecessor_receiver<Operation>::type {
                   std::apply(std::move(op.func_), valueTuple),
                   successor_receiver<Operation, Values...>{op});
             });
+
+      // now that succOp_ has been successfully constructed, the
+      // op's cleanup_ needs to destroy both values_ and succOp_
+      op.cleanup_ = [](Operation* op) noexcept {
+        unifex::deactivate_union_member<successor_operation<Values...>>(op->succOp_);
+        op->values_.template destruct<decayed_tuple<Values...>>();
+      };
+
       unifex::start(succOp);
-      destroyValues.release();
     } UNIFEX_CATCH (...) {
       unifex::set_error(std::move(op.receiver_), std::current_exception());
     }
   }
 
   void set_done() && noexcept {
-    auto& op = op_;
-    unifex::deactivate_union_member(op.predOp_);
-    unifex::set_done(std::move(op.receiver_));
+    unifex::set_done(std::move(op_.receiver_));
   }
 
-  // Taking by value here to force a copy on the offchange the error
-  // object lives in the operation state, in which case destroying the
-  // predecessor operation state would invalidate it.
   template <typename Error>
-  void set_error(Error error) && noexcept {
-    auto& op = op_;
-    unifex::deactivate_union_member(op.predOp_);
-    unifex::set_error(std::move(op.receiver_), (Error &&) error);
+  void set_error(Error&& error) && noexcept {
+    unifex::set_error(std::move(op_.receiver_), std::forward<Error>(error));
   }
 
   template(typename CPO)
@@ -233,9 +240,6 @@ struct _op<Predecessor, SuccessorFactory, Receiver>::type {
   }
 
 private:
-  template <typename O, typename... V>
-  friend struct _successor_receiver;
-
   using predecessor_type = remove_cvref_t<Predecessor>;
   UNIFEX_NO_UNIQUE_ADDRESS SuccessorFactory func_;
   UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -57,23 +57,29 @@ struct _successor_receiver<Operation, Values...>::type {
 
   template <typename... SuccessorValues>
   void set_value(SuccessorValues&&... values) && noexcept {
-    UNIFEX_ASSERT(op_.cleanup_ == op_.template deactivateSuccOpAndDestructValues<Values...>);
+    UNIFEX_ASSERT(op_.cleanup_ == expectedCleanup);
+
     unifex::set_value(
         std::move(op_.receiver_), std::forward<SuccessorValues>(values)...);
   }
 
   void set_done() && noexcept {
-    UNIFEX_ASSERT(op_.cleanup_ == op_.template deactivateSuccOpAndDestructValues<Values...>);
+    UNIFEX_ASSERT(op_.cleanup_ == expectedCleanup);
+
     unifex::set_done(std::move(op_.receiver_));
   }
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-    UNIFEX_ASSERT(op_.cleanup_ == op_.template deactivateSuccOpAndDestructValues<Values...>);
+    UNIFEX_ASSERT(op_.cleanup_ == expectedCleanup);
+
     unifex::set_error(std::move(op_.receiver_), std::forward<Error>(error));
   }
 
 private:
+  [[maybe_unused]] static constexpr void (*expectedCleanup)(Operation*) noexcept
+      = Operation::template deactivateSuccOpAndDestructValues<Values...>;
+
   template <typename... Values2>
   using successor_operation = typename Operation::template successor_operation<Values2...>;
 

--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -15,17 +15,18 @@
  */
 #include <unifex/let_value.hpp>
 
+#include <unifex/allocate.hpp>
 #include <unifex/just.hpp>
+#include <unifex/just_done.hpp>
+#include <unifex/just_error.hpp>
+#include <unifex/just_void_or_done.hpp>
 #include <unifex/let_error.hpp>
 #include <unifex/let_value_with.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/then.hpp>
+#include <unifex/timed_single_thread_context.hpp>
 #include <unifex/when_all.hpp>
-#include <unifex/allocate.hpp>
-#include <unifex/just_done.hpp>
-#include <unifex/just_error.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -285,7 +286,10 @@ TEST(Let, LetValueWithTraitlessPredecessor) {
 }
 
 TEST(Let, PredecessorCancels) {
-  auto ret = let_value(just_done(), []() { return just(42); }) | sync_wait();
+  // TODO: MSVC doesn't like the type computations if we use just_done() here;
+  //       seems worth fixing, but in a later PR
+  auto ret = let_value(just_void_or_done(false), []() { return just(42); }) |
+      sync_wait();
 
   EXPECT_FALSE(ret.has_value());
 }


### PR DESCRIPTION
This diff addresses #556 by deferring the destruction of `let_value`'s successor operation state to the destruction of the whole operation state, which allows us to safely perfectly forward references without a decay-copy.