### PR TITLE
Fix let_value assertion bug and add test

### DIFF
--- a/test/let_value_test.cpp
+++ b/test/let_value_test.cpp
@@ -264,6 +264,13 @@ TEST(Let, SimpleLetValueErrorWithAllocate) {
   })), std::invalid_argument);
 }
 
+TEST(Let, LetValueSuccessorWithException) {
+  EXPECT_THROW(sync_wait(unifex::just() | unifex::let_value([]() {
+    throw std::runtime_error("Throwing error for testing purposes");
+    return unifex::just();
+  })), std::runtime_error);
+}
+
 namespace {
 struct TraitslessSender {
   template <typename Receiver>


### PR DESCRIPTION
While attempting to downstream unifex, a bug was discovered in the let_value assertion of op.cleanup_ != nullptr. This was coming from the given func throwing an exception. This fixes that error and adds a test case where the given func throws an exception.

I also validated that the test case fails without the fix.