### PR TITLE
Add <iterator> to when_all_range.hpp

### DIFF
--- a/include/unifex/when_all_range.hpp
+++ b/include/unifex/when_all_range.hpp
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <cstddef>
 #include <functional>
+#include <iterator>
 #include <numeric>
 #include <optional>
 #include <type_traits>


### PR DESCRIPTION
`when_all_range` uses `std::back_inserter`, which requires `<iterator>`.