### PR TITLE
Fix dangling temporary warning in gcc 13

### DIFF
--- a/include/unifex/detail/with_forwarding_tag_invoke.hpp
+++ b/include/unifex/detail/with_forwarding_tag_invoke.hpp
@@ -58,8 +58,7 @@ namespace unifex
     struct _with_forwarding_tag_invoke<Derived, CPO, Ret(Args...)> {
       struct type {
         friend Ret tag_invoke(CPO cpo, replace_this_t<Args, Derived>... args) {
-          auto& wrapper = extract_this<Args...>{}(args...);
-          auto& wrapped = get_wrapped_object(wrapper);
+          auto& wrapped = get_wrapped_object(extract_this<Args...>{}(args...));
           return static_cast<CPO&&>(cpo)(replace_this<Args>::get(
               static_cast<decltype(args)&&>(args), wrapped)...);
         }
@@ -72,14 +71,12 @@ namespace unifex
       struct type {
         friend Ret
         tag_invoke(CPO cpo, replace_this_t<Args, Derived>... args) noexcept {
-          auto& wrapper = extract_this<Args...>{}(args...);
-          auto& wrapped = get_wrapped_object(wrapper);
+          auto& wrapped = get_wrapped_object(extract_this<Args...>{}(args...));
 
           // Sanity check that all of the component expressions here are
           // noexcept so we don't end up with exception tables being generated
           // for this function.
-          static_assert(noexcept(extract_this<Args...>{}(args...)));
-          static_assert(noexcept(get_wrapped_object(wrapper)));
+          static_assert(noexcept(get_wrapped_object(extract_this<Args...>{}(args...))));
           static_assert(
               noexcept(static_cast<CPO&&>(cpo)(replace_this<Args>::get(
                   static_cast<decltype(args)&&>(args), wrapped)...)));

--- a/include/unifex/detail/with_type_erased_tag_invoke.hpp
+++ b/include/unifex/detail/with_type_erased_tag_invoke.hpp
@@ -40,16 +40,15 @@ namespace unifex
         static_assert(
             !NoExcept ||
             noexcept(extract_this<Args...>{}((decltype(args)&&)args...)));
-        auto&& t = extract_this<Args...>{}((decltype(args)&&)args...);
-        void* objPtr = get_object_address(t);
-        auto* fnPtr = get_vtable(t)->template get<CPO>();
+        void* objPtr = get_object_address(extract_this<Args...>{}((decltype(args)&&)args...));
+        auto* fnPtr = get_vtable(extract_this<Args...>{}((decltype(args)&&)args...))->template get<CPO>();
 
         // Sanity check that all of the component expressions here are
         // noexcept so we don't end up with exception tables being generated
         // for this function.
-        static_assert(!NoExcept || noexcept(get_object_address(t)));
+        static_assert(!NoExcept || noexcept(get_object_address(extract_this<Args...>{}((decltype(args)&&)args...))));
         static_assert(
-            !NoExcept || noexcept(get_vtable(t)->template get<CPO>()));
+            !NoExcept || noexcept(get_vtable(extract_this<Args...>{}((decltype(args)&&)args...))->template get<CPO>()));
         static_assert(
             !NoExcept ||
             noexcept(fnPtr(


### PR DESCRIPTION
This diff inlines calls to `extract_this` to convince GCC 13 that there are no dangling temporaries.