### PR TITLE
Fix UB in cancelled tasks again

### DIFF
--- a/test/task_scheduler_affinity_test.cpp
+++ b/test/task_scheduler_affinity_test.cpp
@@ -18,20 +18,21 @@
 
 #if !UNIFEX_NO_COROUTINES
 
-#include <thread>
+#  include <thread>
 
-#include <unifex/just.hpp>
-#include <unifex/let_done.hpp>
-#include <unifex/let_value_with_stop_source.hpp>
-#include <unifex/never.hpp>
-#include <unifex/single_thread_context.hpp>
-#include <unifex/stop_if_requested.hpp>
-#include <unifex/stop_when.hpp>
-#include <unifex/sync_wait.hpp>
-#include <unifex/task.hpp>
-#include <unifex/then.hpp>
+#  include <unifex/just.hpp>
+#  include <unifex/let_done.hpp>
+#  include <unifex/let_value_with_stop_source.hpp>
+#  include <unifex/never.hpp>
+#  include <unifex/single_thread_context.hpp>
+#  include <unifex/static_thread_pool.hpp>
+#  include <unifex/stop_if_requested.hpp>
+#  include <unifex/stop_when.hpp>
+#  include <unifex/sync_wait.hpp>
+#  include <unifex/task.hpp>
+#  include <unifex/then.hpp>
 
-#include <gtest/gtest.h>
+#  include <gtest/gtest.h>
 
 using namespace unifex;
 
@@ -41,18 +42,17 @@ struct TaskSchedulerAffinityTest : testing::Test {
 };
 
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::pair<std::thread::id, std::thread::id>> child(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<std::pair<std::thread::id, std::thread::id>> child(Scheduler s) {
   auto that_id =
-      co_await then(schedule(s), []{ return std::this_thread::get_id(); });
+      co_await then(schedule(s), [] { return std::this_thread::get_id(); });
   // Should have automatically transitioned back to the original thread:
   auto this_id = std::this_thread::get_id();
   co_return std::make_pair(this_id, that_id);
 }
 
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::thread::id> inner(Scheduler s) {
+(requires scheduler<Scheduler>)task<std::thread::id> inner(Scheduler s) {
   // Transition to the scheduler's context:
   co_await schedule(s);
   // Should return the new context
@@ -60,8 +60,8 @@ task<std::thread::id> inner(Scheduler s) {
 }
 
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
   // Call a nested coroutine that transitions context:
   auto that_id = co_await inner(s);
   // Should have automatically transitioned back to the correct context
@@ -72,8 +72,7 @@ task<std::pair<std::thread::id, std::thread::id>> outer(Scheduler s) {
 // Test that after a co_await schedule(), the coroutine's current
 // scheduler has changed:
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<bool> test_current_scheduler(Scheduler s) {
+(requires scheduler<Scheduler>)task<bool> test_current_scheduler(Scheduler s) {
   auto before = co_await current_scheduler();
   co_await schedule(s);
   auto after = co_await current_scheduler();
@@ -83,15 +82,17 @@ task<bool> test_current_scheduler(Scheduler s) {
 // Test that after a co_await schedule(), the coroutine's current
 // scheduler is inherited by child tasks:
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited_impl(Scheduler s) {
+(requires scheduler<Scheduler>)task<std::pair<
+    bool,
+    std::thread::id>> test_current_scheduler_is_inherited_impl(Scheduler s) {
   any_scheduler s2 = co_await current_scheduler();
   bool sameScheduler = (s2 == s);
   co_return std::make_pair(sameScheduler, std::this_thread::get_id());
 }
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(
+        Scheduler s) {
   co_await schedule(s);
   co_return co_await test_current_scheduler_is_inherited_impl(s);
 }
@@ -99,49 +100,48 @@ task<std::pair<bool, std::thread::id>> test_current_scheduler_is_inherited(Sched
 // Test that we properly transition back to the right context when
 // the task is cancelled.
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<void> test_context_restored_on_cancel_2(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<void> test_context_restored_on_cancel_2(Scheduler s) {
   co_await schedule(s);
   co_await stop();
   ADD_FAILURE() << "Coroutine did not stop!";
   co_return;
 }
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::thread::id> test_context_restored_on_cancel(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<std::thread::id> test_context_restored_on_cancel(Scheduler s) {
   // swallow the cancellation signal:
-  (void) co_await let_done(
-      test_context_restored_on_cancel_2(s),
-      []() noexcept { return just(); });
+  (void)co_await let_done(
+      test_context_restored_on_cancel_2(s), []() noexcept { return just(); });
   co_return std::this_thread::get_id();
 }
 
 // Test that we properly transition back to the right context when
 // the task fails.
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<void> test_context_restored_on_error_2(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<void> test_context_restored_on_error_2(Scheduler s) {
   co_await schedule(s);
   throw std::runtime_error("whoops");
 }
 UNIFEX_TEMPLATE(typename Scheduler)
-  (requires scheduler<Scheduler>)
-task<std::thread::id> test_context_restored_on_error(Scheduler s) {
+(requires scheduler<Scheduler>)
+    task<std::thread::id> test_context_restored_on_error(Scheduler s) {
   std::thread::id id;
   // swallow the cancellation signal:
   try {
     co_await test_context_restored_on_error_2(s);
     ADD_FAILURE() << "Was expecting a throw";
-  } catch(...) {
+  } catch (...) {
     id = std::this_thread::get_id();
   }
   co_return id;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
-  if(auto opt = sync_wait(child(thread_ctx.get_scheduler()))) {
+  if (auto opt = sync_wait(child(thread_ctx.get_scheduler()))) {
     auto [this_id, that_id] = *opt;
     ASSERT_EQ(this_id, std::this_thread::get_id());
     ASSERT_EQ(that_id, thread_ctx.get_thread_id());
@@ -151,7 +151,7 @@ TEST_F(TaskSchedulerAffinityTest, TransformSenderOnSeparateThread) {
 }
 
 TEST_F(TaskSchedulerAffinityTest, InlineThreadHopInCoroutine) {
-  if(auto opt = sync_wait(outer(thread_ctx.get_scheduler()))) {
+  if (auto opt = sync_wait(outer(thread_ctx.get_scheduler()))) {
     auto [this_id, that_id] = *opt;
     ASSERT_EQ(this_id, std::this_thread::get_id());
     ASSERT_EQ(that_id, thread_ctx.get_thread_id());
@@ -161,7 +161,8 @@ TEST_F(TaskSchedulerAffinityTest, InlineThreadHopInCoroutine) {
 }
 
 TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerTest) {
-  if(auto opt = sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
+  if (auto opt =
+          sync_wait(test_current_scheduler(thread_ctx.get_scheduler()))) {
     ASSERT_TRUE(opt.has_value());
     EXPECT_TRUE(*opt);
   } else {
@@ -170,7 +171,8 @@ TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerTest) {
 }
 
 TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerIsInheritedTest) {
-  if(auto opt = sync_wait(test_current_scheduler_is_inherited(thread_ctx.get_scheduler()))) {
+  if (auto opt = sync_wait(
+          test_current_scheduler_is_inherited(thread_ctx.get_scheduler()))) {
     ASSERT_TRUE(opt.has_value());
     auto [success, thread_id] = *opt;
     EXPECT_TRUE(success);
@@ -181,7 +183,8 @@ TEST_F(TaskSchedulerAffinityTest, CurrentSchedulerIsInheritedTest) {
 }
 
 TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnCancelTest) {
-  if(auto opt = sync_wait(test_context_restored_on_cancel(thread_ctx.get_scheduler()))) {
+  if (auto opt = sync_wait(
+          test_context_restored_on_cancel(thread_ctx.get_scheduler()))) {
     ASSERT_TRUE(opt.has_value());
     EXPECT_EQ(*opt, std::this_thread::get_id());
   } else {
@@ -190,7 +193,8 @@ TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnCancelTest) {
 }
 
 TEST_F(TaskSchedulerAffinityTest, ContextRestoredOnErrrorTest) {
-  if(auto opt = sync_wait(test_context_restored_on_error(thread_ctx.get_scheduler()))) {
+  if (auto opt = sync_wait(
+          test_context_restored_on_error(thread_ctx.get_scheduler()))) {
     ASSERT_TRUE(opt.has_value());
     EXPECT_EQ(*opt, std::this_thread::get_id());
   } else {
@@ -302,8 +306,6 @@ unifex::task<std::thread::id> reportCancellationThreadId() {
   });
 }
 
-}  // namespace
-
 TEST_F(TaskSchedulerAffinityTest, StopRequestsDeliveredOnExpectedScheduler) {
   unifex::single_thread_context ctx;
 
@@ -315,4 +317,19 @@ TEST_F(TaskSchedulerAffinityTest, StopRequestsDeliveredOnExpectedScheduler) {
   EXPECT_EQ(std::this_thread::get_id(), *ret);
 }
 
-#endif // !UNIFEX_NO_COROUTINES
+TEST_F(TaskSchedulerAffinityTest, NoRacesInCancellation) {
+  unifex::static_thread_pool pool{2};
+
+  unifex::sync_wait(unifex::on(
+      pool.get_scheduler(),
+      unifex::let_value_with_stop_source([](auto& source) noexcept {
+        source.request_stop();
+        return []() noexcept -> unifex::task<int> {
+          co_return co_await unifex::just(42);
+        }();
+      })));
+}
+
+}  // namespace
+
+#endif  // !UNIFEX_NO_COROUTINES


### PR DESCRIPTION
As reported in #577, #578 didn't fix the UB in cancelled tasks. There were two bugs in that "fix":
 1. we were writing the coroutine handle to resume *after* synchronizing between the two racing operation states, leading to a data race when the deferred stop source completed second; and
 2. it's wrong to call `continuation_.done()` to store the coroutine handle to be resumed later because `done()` completes the operation with `set_done()` as a side effect.

This diff fixes both issues. Instead of storing a coroutine handle to be resumed, we store an enum value that describes which coroutine handle to resume (so we don't eagerly invoke `done()`), and we do the store before synchronizing to eliminate the data race.

I've added a unit test that fails with a TSAN-detected data race without the fix, and the fix silences the TSAN error.

I also clang-formatted `task.hpp` and the modified test file.