### PR TITLE
Clang format win32

### DIFF
--- a/include/unifex/win32/detail/ntapi.hpp
+++ b/include/unifex/win32/detail/ntapi.hpp
@@ -35,163 +35,164 @@
 #  define _Out_writes_to_(A, B)
 #endif
 
-namespace unifex::win32::ntapi
-{
-  using HANDLE = void*;
-  using PHANDLE = HANDLE*;
-  using LONG = long;
-  using NTSTATUS = LONG;
-  using ULONG_PTR = std::uintptr_t;
-  using LONG_PTR = std::intptr_t;
-  using PVOID = void*;
-  using USHORT = unsigned short;
-  using LONG = long;
-  using LONGLONG = long long;
-  using ULONG = unsigned long;
-  using PULONG = ULONG*;
-  using DWORD = unsigned long;
-  using WCHAR = wchar_t;
-  using PWSTR = WCHAR*;
-  using BYTE = unsigned char;
-  using BOOLEAN = BYTE;
+namespace unifex::win32::ntapi {
+using HANDLE = void*;
+using PHANDLE = HANDLE*;
+using LONG = long;
+using NTSTATUS = LONG;
+using ULONG_PTR = std::uintptr_t;
+using LONG_PTR = std::intptr_t;
+using PVOID = void*;
+using USHORT = unsigned short;
+using LONG = long;
+using LONGLONG = long long;
+using ULONG = unsigned long;
+using PULONG = ULONG*;
+using DWORD = unsigned long;
+using WCHAR = wchar_t;
+using PWSTR = WCHAR*;
+using BYTE = unsigned char;
+using BOOLEAN = BYTE;
 
-  union LARGE_INTEGER {
-    struct {
-      DWORD LowPart;
-      LONG HighPart;
-    } u;
-    LONGLONG QuadPart;
+union LARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    LONG HighPart;
+  } u;
+  LONGLONG QuadPart;
+};
+using PLARGE_INTEGER = LARGE_INTEGER*;
+
+struct UNICODE_STRING {
+  USHORT Length;
+  USHORT MaximumLength;
+  PWSTR Buffer;
+};
+using PUNICODE_STRING = UNICODE_STRING*;
+
+struct IO_STATUS_BLOCK {
+  // Corresponds to OVERLAPPED::Internal
+  union {
+    NTSTATUS Status;
+    void* Pointer;
   };
-  using PLARGE_INTEGER = LARGE_INTEGER*;
 
-  struct UNICODE_STRING {
-    USHORT Length;
-    USHORT MaximumLength;
-    PWSTR Buffer;
-  };
-  using PUNICODE_STRING = UNICODE_STRING*;
+  // Corresponds to OVERLAPPED::InternalHigh
+  ULONG_PTR Information;
+};
+using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
 
-  struct IO_STATUS_BLOCK {
-    // Corresponds to OVERLAPPED::Internal
-    union {
-      NTSTATUS Status;
-      void* Pointer;
-    };
+using ACCESS_MASK = DWORD;
+using PACCESS_MASK = ACCESS_MASK*;
 
-    // Corresponds to OVERLAPPED::InternalHigh
-    ULONG_PTR Information;
-  };
-  using PIO_STATUS_BLOCK = IO_STATUS_BLOCK*;
+struct OBJECT_ATTRIBUTES {
+  ULONG Length;
+  HANDLE RootDirectory;
+  PUNICODE_STRING ObjectName;
+  ULONG Attributes;
+  PVOID SecurityDescriptor;
+  PVOID SecurityQualityOfService;
+};
+using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
 
-  using ACCESS_MASK = DWORD;
-  using PACCESS_MASK = ACCESS_MASK*;
+struct FILE_COMPLETION_INFORMATION {
+  HANDLE Port;
+  PVOID Key;
+};
+using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
 
-  struct OBJECT_ATTRIBUTES {
-    ULONG Length;
-    HANDLE RootDirectory;
-    PUNICODE_STRING ObjectName;
-    ULONG Attributes;
-    PVOID SecurityDescriptor;
-    PVOID SecurityQualityOfService;
-  };
-  using POBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES*;
+struct FILE_IO_COMPLETION_INFORMATION {
+  PVOID KeyContext;
+  PVOID ApcContext;
+  IO_STATUS_BLOCK IoStatusBlock;
+};
+using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
 
-  struct FILE_COMPLETION_INFORMATION {
-    HANDLE Port;
-    PVOID Key;
-  };
-  using PFILE_COMPLETION_INFORMATION = FILE_COMPLETION_INFORMATION*;
+using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
+    _In_ PVOID ApcContext,
+    _In_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_ ULONG Reserved);
 
-  struct FILE_IO_COMPLETION_INFORMATION {
-    PVOID KeyContext;
-    PVOID ApcContext;
-    IO_STATUS_BLOCK IoStatusBlock;
-  };
-  using PFILE_IO_COMPLETION_INFORMATION = FILE_IO_COMPLETION_INFORMATION*;
+// From
+// http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
+using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _Out_ PHANDLE FileHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_ATTRIBUTES ObjectAttributes,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_opt_ PLARGE_INTEGER AllocationSize,
+    _In_ ULONG FileAttributes,
+    _In_ ULONG ShareAccess,
+    _In_ ULONG CreateDisposition,
+    _In_ ULONG CreateOptions,
+    _In_opt_ PVOID EaBuffer,
+    _In_ ULONG EaLength);
+extern NtCreateFile_t NtCreateFile;
 
-  using PIO_APC_ROUTINE = void(UNIFEX_NTAPI*)(
-      _In_ PVOID ApcContext,
-      _In_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_ ULONG Reserved);
+using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE hFile,
+    _Out_ PIO_STATUS_BLOCK iosb,
+    _Out_ PIO_STATUS_BLOCK io_status);
+extern NtCancelIoFileEx_t NtCancelIoFileEx;
 
-  // From
-  // http://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx
-  using NtCreateFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _Out_ PHANDLE FileHandle,
-      _In_ ACCESS_MASK DesiredAccess,
-      _In_ POBJECT_ATTRIBUTES ObjectAttributes,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_opt_ PLARGE_INTEGER AllocationSize,
-      _In_ ULONG FileAttributes,
-      _In_ ULONG ShareAccess,
-      _In_ ULONG CreateDisposition,
-      _In_ ULONG CreateOptions,
-      _In_opt_ PVOID EaBuffer,
-      _In_ ULONG EaLength);
-  extern NtCreateFile_t NtCreateFile;
+using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE FileHandle,
+    _In_opt_ HANDLE Event,
+    _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+    _In_opt_ PVOID ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _Out_ PVOID Buffer,
+    _In_ ULONG Length,
+    _In_opt_ PLARGE_INTEGER ByteOffset,
+    _In_opt_ PULONG Key);
+extern NtReadFile_t NtReadFile;
 
-  using NtCancelIoFileEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE hFile,
-      _Out_ PIO_STATUS_BLOCK iosb,
-      _Out_ PIO_STATUS_BLOCK io_status);
-  extern NtCancelIoFileEx_t NtCancelIoFileEx;
+using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE FileHandle,
+    _In_opt_ HANDLE Event,
+    _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+    _In_opt_ PVOID ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_ PVOID Buffer,
+    _In_ ULONG Length,
+    _In_opt_ PLARGE_INTEGER ByteOffset,
+    _In_opt_ PULONG Key);
+extern NtWriteFile_t NtWriteFile;
 
-  using NtReadFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE FileHandle,
-      _In_opt_ HANDLE Event,
-      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-      _In_opt_ PVOID ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _Out_ PVOID Buffer,
-      _In_ ULONG Length,
-      _In_opt_ PLARGE_INTEGER ByteOffset,
-      _In_opt_ PULONG Key);
-  extern NtReadFile_t NtReadFile;
+using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _In_ ULONG KeyContext,
+    _In_ PVOID ApcContext,
+    _In_ NTSTATUS IoStatus,
+    _In_ ULONG IoStatusInformation);
+extern NtSetIoCompletion_t NtSetIoCompletion;
 
-  using NtWriteFile_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE FileHandle,
-      _In_opt_ HANDLE Event,
-      _In_opt_ PIO_APC_ROUTINE ApcRoutine,
-      _In_opt_ PVOID ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_ PVOID Buffer,
-      _In_ ULONG Length,
-      _In_opt_ PLARGE_INTEGER ByteOffset,
-      _In_opt_ PULONG Key);
-  extern NtWriteFile_t NtWriteFile;
+using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _Out_ PVOID* CompletionKey,
+    _Out_ PVOID* ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_opt_ PLARGE_INTEGER Timeout);
+extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
 
-  using NtSetIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _In_ ULONG KeyContext,
-      _In_ PVOID ApcContext,
-      _In_ NTSTATUS IoStatus,
-      _In_ ULONG IoStatusInformation);
-  extern NtSetIoCompletion_t NtSetIoCompletion;
+using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
+    _In_ HANDLE IoCompletionHandle,
+    _Out_writes_to_(Count, *NumEntriesRemoved)
+        PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
+    _In_ ULONG Count,
+    _Out_ PULONG NumEntriesRemoved,
+    _In_opt_ PLARGE_INTEGER Timeout,
+    _In_ BOOLEAN Alertable);
+extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
 
-  using NtRemoveIoCompletion_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _Out_ PVOID* CompletionKey,
-      _Out_ PVOID* ApcContext,
-      _Out_ PIO_STATUS_BLOCK IoStatusBlock,
-      _In_opt_ PLARGE_INTEGER Timeout);
-  extern NtRemoveIoCompletion_t NtRemoveIoCompletion;
+using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(_In_ NTSTATUS Status);
+extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
 
-  using NtRemoveIoCompletionEx_t = NTSTATUS(UNIFEX_NTAPI*)(
-      _In_ HANDLE IoCompletionHandle,
-      _Out_writes_to_(Count, *NumEntriesRemoved)
-          PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation,
-      _In_ ULONG Count,
-      _Out_ PULONG NumEntriesRemoved,
-      _In_opt_ PLARGE_INTEGER Timeout,
-      _In_ BOOLEAN Alertable);
-  extern NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx;
+void ensure_initialised() noexcept;
 
-  using RtlNtStatusToDosError_t = ULONG(UNIFEX_NTAPI*)(_In_ NTSTATUS Status);
-  extern RtlNtStatusToDosError_t RtlNtStatusToDosError;
-
-  void ensure_initialised() noexcept;
-
-  constexpr bool ntstatus_success(NTSTATUS status) { return status >= 0; }
+constexpr bool ntstatus_success(NTSTATUS status) {
+  return status >= 0;
+}
 
 }  // namespace unifex::win32::ntapi
 

--- a/include/unifex/win32/detail/safe_handle.hpp
+++ b/include/unifex/win32/detail/safe_handle.hpp
@@ -23,53 +23,52 @@ namespace unifex::win32 {
 
 class safe_handle {
 public:
-    safe_handle() noexcept : handle_(nullptr) {}
+  safe_handle() noexcept : handle_(nullptr) {}
 
-    explicit safe_handle(handle_t h) noexcept : handle_(h) {}
+  explicit safe_handle(handle_t h) noexcept : handle_(h) {}
 
-    safe_handle(safe_handle&& h) noexcept : handle_(std::exchange(h.handle_, nullptr)) {}
+  safe_handle(safe_handle&& h) noexcept
+    : handle_(std::exchange(h.handle_, nullptr)) {}
 
-    ~safe_handle() { reset(); }
+  ~safe_handle() { reset(); }
 
-    safe_handle(const safe_handle&) = delete;
+  safe_handle(const safe_handle&) = delete;
 
-    safe_handle& operator=(safe_handle h) noexcept {
-        swap(h);
-        return *this;
-    }
+  safe_handle& operator=(safe_handle h) noexcept {
+    swap(h);
+    return *this;
+  }
 
-    handle_t get() const noexcept { return handle_; }
+  handle_t get() const noexcept { return handle_; }
 
-    handle_t release() noexcept { return std::exchange(handle_, nullptr); }
+  handle_t release() noexcept { return std::exchange(handle_, nullptr); }
 
-    void reset() noexcept;
+  void reset() noexcept;
 
-    void swap(safe_handle& other) noexcept {
-        std::swap(handle_, other.handle_);
-    }
+  void swap(safe_handle& other) noexcept { std::swap(handle_, other.handle_); }
 
-    friend bool operator==(const safe_handle& a, const safe_handle& b) noexcept {
-        return a.handle_ == b.handle_;
-    }
-    friend bool operator==(const safe_handle& a, handle_t b) noexcept {
-        return a.handle_ == b;
-    }
-    friend bool operator==(handle_t a, const safe_handle& b) noexcept {
-        return a == b.handle_;
-    }
+  friend bool operator==(const safe_handle& a, const safe_handle& b) noexcept {
+    return a.handle_ == b.handle_;
+  }
+  friend bool operator==(const safe_handle& a, handle_t b) noexcept {
+    return a.handle_ == b;
+  }
+  friend bool operator==(handle_t a, const safe_handle& b) noexcept {
+    return a == b.handle_;
+  }
 
-    friend bool operator!=(const safe_handle& a, const safe_handle& b) noexcept {
-        return !(a == b);
-    }
-    friend bool operator!=(const safe_handle& a, handle_t b) noexcept {
-        return !(a == b);
-    }
-    friend bool operator!=(handle_t a, const safe_handle& b) noexcept {
-        return !(a == b);
-    }
+  friend bool operator!=(const safe_handle& a, const safe_handle& b) noexcept {
+    return !(a == b);
+  }
+  friend bool operator!=(const safe_handle& a, handle_t b) noexcept {
+    return !(a == b);
+  }
+  friend bool operator!=(handle_t a, const safe_handle& b) noexcept {
+    return !(a == b);
+  }
 
 private:
-    handle_t handle_;
+  handle_t handle_;
 };
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/include/unifex/win32/detail/types.hpp
+++ b/include/unifex/win32/detail/types.hpp
@@ -17,15 +17,14 @@
 
 #include <cstdint>
 
-namespace unifex::win32
-{
-  using handle_t = void*;              // HANDLE
-  using ulong_ptr_t = std::uintptr_t;  // ULONG_PTR
-  using long_ptr_t = std::intptr_t;    // LONG_PTR
-  using dword_t = unsigned long;       // DWORD
-  using socket_t = std::uintptr_t;     // SOCKET
-  using ulong_t = unsigned long;       // ULONG
-  using long_t = long;                 // LONG
+namespace unifex::win32 {
+using handle_t = void*;              // HANDLE
+using ulong_ptr_t = std::uintptr_t;  // ULONG_PTR
+using long_ptr_t = std::intptr_t;    // LONG_PTR
+using dword_t = unsigned long;       // DWORD
+using socket_t = std::uintptr_t;     // SOCKET
+using ulong_t = unsigned long;       // ULONG
+using long_t = long;                 // LONG
 
 #if defined(_MSC_VER)
 #  if defined(__clang__)
@@ -47,18 +46,18 @@ namespace unifex::win32
 #else
 #  define UNIFEX_NAMELESS_UNION
 #endif
-  struct overlapped {
-    ulong_ptr_t Internal;
-    ulong_ptr_t InternalHigh;
-    UNIFEX_NAMELESS_UNION union {
-      struct {
-        dword_t Offset;
-        dword_t OffsetHigh;
-      };
-      void* Pointer;
+struct overlapped {
+  ulong_ptr_t Internal;
+  ulong_ptr_t InternalHigh;
+  UNIFEX_NAMELESS_UNION union {
+    struct {
+      dword_t Offset;
+      dword_t OffsetHigh;
     };
-    handle_t hEvent;
+    void* Pointer;
   };
+  handle_t hEvent;
+};
 #undef UNIFEX_NAMELESS_UNION
 #if defined(_MSC_VER)
 #  if defined(__clang__)
@@ -68,15 +67,15 @@ namespace unifex::win32
 #  endif
 #endif
 
-  struct wsabuf {
-    constexpr wsabuf() noexcept : len(0), buf(nullptr) {}
+struct wsabuf {
+  constexpr wsabuf() noexcept : len(0), buf(nullptr) {}
 
-    wsabuf(void* p, ulong_t sz) noexcept
-      : len(sz)
-      , buf(reinterpret_cast<char*>(p)) {}
+  wsabuf(void* p, ulong_t sz) noexcept
+    : len(sz)
+    , buf(reinterpret_cast<char*>(p)) {}
 
-    ulong_t len;
-    char* buf;
-  };
+  ulong_t len;
+  char* buf;
+};
 
 }  // namespace unifex::win32

--- a/include/unifex/win32/filetime_clock.hpp
+++ b/include/unifex/win32/filetime_clock.hpp
@@ -24,99 +24,96 @@ namespace unifex::win32 {
 
 class filetime_clock {
 public:
-    using rep = std::int64_t;
-    using ratio = std::ratio<1, 10'000'000>; // 100ns
-    using duration = std::chrono::duration<rep, ratio>;
+  using rep = std::int64_t;
+  using ratio = std::ratio<1, 10'000'000>;  // 100ns
+  using duration = std::chrono::duration<rep, ratio>;
 
-    static constexpr bool is_steady = false;
+  static constexpr bool is_steady = false;
 
-    class time_point {
-    public:
-        using duration = filetime_clock::duration;
+  class time_point {
+  public:
+    using duration = filetime_clock::duration;
 
-        constexpr time_point() noexcept : ticks_(0) {}
+    constexpr time_point() noexcept : ticks_(0) {}
 
-        constexpr time_point(const time_point&) noexcept = default;
+    constexpr time_point(const time_point&) noexcept = default;
 
-        time_point& operator=(const time_point&) noexcept = default;
+    time_point& operator=(const time_point&) noexcept = default;
 
-        std::uint64_t get_ticks() const noexcept {
-            return ticks_;
-        }
+    std::uint64_t get_ticks() const noexcept { return ticks_; }
 
-        static constexpr time_point max() noexcept {
-            time_point tp;
-            tp.ticks_ = std::numeric_limits<std::int64_t>::max();
-            return tp;
-        }
+    static constexpr time_point max() noexcept {
+      time_point tp;
+      tp.ticks_ = std::numeric_limits<std::int64_t>::max();
+      return tp;
+    }
 
-        static constexpr time_point min() noexcept {
-            return time_point{};
-        }
+    static constexpr time_point min() noexcept { return time_point{}; }
 
-        static time_point from_ticks(std::uint64_t ticks) noexcept {
-            time_point tp;
-            tp.ticks_ = ticks;
-            return tp;
-        }
+    static time_point from_ticks(std::uint64_t ticks) noexcept {
+      time_point tp;
+      tp.ticks_ = ticks;
+      return tp;
+    }
 
-        template <typename Rep, typename Ratio>
-        time_point& operator+=(
-            const std::chrono::duration<Rep, Ratio>& d) noexcept {
-            ticks_ += std::chrono::duration_cast<duration>(d).count();
-            return *this;
-        }
+    template <typename Rep, typename Ratio>
+    time_point&
+    operator+=(const std::chrono::duration<Rep, Ratio>& d) noexcept {
+      ticks_ += std::chrono::duration_cast<duration>(d).count();
+      return *this;
+    }
 
-        template <typename Rep, typename Ratio>
-        time_point& operator-=(
-            const std::chrono::duration<Rep, Ratio>& d) noexcept {
-            ticks_ -= std::chrono::duration_cast<duration>(d).count();
-            return *this;
-        }
+    template <typename Rep, typename Ratio>
+    time_point&
+    operator-=(const std::chrono::duration<Rep, Ratio>& d) noexcept {
+      ticks_ -= std::chrono::duration_cast<duration>(d).count();
+      return *this;
+    }
 
-        friend duration operator-(time_point a, time_point b) noexcept {
-            return duration{a.ticks_} - duration{b.ticks_};
-        }
+    friend duration operator-(time_point a, time_point b) noexcept {
+      return duration{a.ticks_} - duration{b.ticks_};
+    }
 
-        template <typename Rep, typename Ratio>
-        friend time_point operator+(time_point t, std::chrono::duration<Rep, Ratio> d) noexcept {
-            time_point tp = t;
-            tp += d;
-            return tp;
-        }
+    template <typename Rep, typename Ratio>
+    friend time_point
+    operator+(time_point t, std::chrono::duration<Rep, Ratio> d) noexcept {
+      time_point tp = t;
+      tp += d;
+      return tp;
+    }
 
-        friend bool operator==(time_point a, time_point b) noexcept {
-            return a.ticks_ == b.ticks_;
-        }
+    friend bool operator==(time_point a, time_point b) noexcept {
+      return a.ticks_ == b.ticks_;
+    }
 
-        friend bool operator!=(time_point a, time_point b) noexcept {
-            return a.ticks_ != b.ticks_;
-        }
+    friend bool operator!=(time_point a, time_point b) noexcept {
+      return a.ticks_ != b.ticks_;
+    }
 
-        friend bool operator<(time_point a, time_point b) noexcept {
-            return a.ticks_ < b.ticks_;
-        }
+    friend bool operator<(time_point a, time_point b) noexcept {
+      return a.ticks_ < b.ticks_;
+    }
 
-        friend bool operator>(time_point a, time_point b) noexcept {
-            return a.ticks_ > b.ticks_;
-        }
+    friend bool operator>(time_point a, time_point b) noexcept {
+      return a.ticks_ > b.ticks_;
+    }
 
-        friend bool operator<=(time_point a, time_point b) noexcept {
-            return a.ticks_ <= b.ticks_;
-        }
+    friend bool operator<=(time_point a, time_point b) noexcept {
+      return a.ticks_ <= b.ticks_;
+    }
 
-        friend bool operator>=(time_point a, time_point b) noexcept {
-            return a.ticks_ >= b.ticks_;
-        }
+    friend bool operator>=(time_point a, time_point b) noexcept {
+      return a.ticks_ >= b.ticks_;
+    }
 
-    private:
-        // Ticks since Jan 1, 1601 (UTC)
-        std::uint64_t ticks_;
-    };
+  private:
+    // Ticks since Jan 1, 1601 (UTC)
+    std::uint64_t ticks_;
+  };
 
-    static time_point now() noexcept;
+  static time_point now() noexcept;
 };
 
-} // namespace unifex::win32
+}  // namespace unifex::win32
 
 #include <unifex/detail/epilogue.hpp>

--- a/include/unifex/win32/low_latency_iocp_context.hpp
+++ b/include/unifex/win32/low_latency_iocp_context.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <unifex/get_stop_token.hpp>
 #include <unifex/io_concepts.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/pipe_concepts.hpp>
@@ -23,7 +24,6 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/span.hpp>
 #include <unifex/std_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
 
 #include <unifex/detail/atomic_intrusive_queue.hpp>
 #include <unifex/detail/intrusive_list.hpp>
@@ -41,805 +41,812 @@
 
 #include <unifex/detail/prologue.hpp>
 
-namespace unifex::win32
-{
-  class low_latency_iocp_context {
-    class scheduler;
+namespace unifex::win32 {
+class low_latency_iocp_context {
+  class scheduler;
 
-    class readable_byte_stream;
-    class writable_byte_stream;
+  class readable_byte_stream;
+  class writable_byte_stream;
 
-    class schedule_sender;
-
-    template <typename Receiver>
-    struct _schedule_op {
-      class type;
-    };
-    template <typename Receiver>
-    using schedule_op = typename _schedule_op<Receiver>::type;
-
-    template <typename Buffer>
-    struct _read_file_sender {
-      class type;
-    };
-    template <typename Buffer>
-    using read_file_sender = typename _read_file_sender<Buffer>::type;
-
-    template <typename Buffer>
-    struct _write_file_sender {
-      class type;
-    };
-    template <typename Buffer>
-    using write_file_sender = typename _write_file_sender<Buffer>::type;
-
-    template <typename Buffer, typename Receiver>
-    struct _read_file_op {
-      class type;
-    };
-    template <typename Buffer, typename Receiver>
-    using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
-
-    template <typename Buffer, typename Receiver>
-    struct _write_file_op {
-      class type;
-    };
-    template <typename Buffer, typename Receiver>
-    using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
-
-  public:
-    // Initialise the IOCP context and pre-allocate storage for I/O
-    // state needed to support at most 'maxIoOperations' concurrent I/O
-    // operations.
-    explicit low_latency_iocp_context(std::size_t maxIoOperations);
-
-    low_latency_iocp_context(low_latency_iocp_context&&) = delete;
-    low_latency_iocp_context(const low_latency_iocp_context&) = delete;
-    low_latency_iocp_context&
-    operator=(const low_latency_iocp_context&) = delete;
-    low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
-
-    ~low_latency_iocp_context();
-
-    // Drive the event loop until a request to stop is communicated via
-    // the passed StopToken.
-    template <typename StopToken>
-    void run(StopToken st);
-
-    // Obtain a handle to this execution context that can be used to
-    // schedule work and open I/O resources.
-    scheduler get_scheduler() noexcept;
-
-  private:
-    struct vectored_io_state;
-
-    // This value chosen so that vectored_io_state is 512 bytes on 64-bit
-    // architectures and 256 bytes on 32-bit architectures.
-    static constexpr std::size_t max_vectored_io_size = 30;
-
-    struct operation_base {
-      explicit operation_base(low_latency_iocp_context& ctx) noexcept
-        : context(ctx) {}
-
-      using callback_t = void(operation_base*) noexcept;
-      low_latency_iocp_context& context;
-      callback_t* callback = nullptr;
-      operation_base* next = nullptr;
-      operation_base* prev = nullptr;
-    };
-
-    using operation_queue = intrusive_list<
-        operation_base,
-        &operation_base::next,
-        &operation_base::prev>;
-
-    struct io_operation : operation_base {
-      explicit io_operation(
-          low_latency_iocp_context& context,
-          handle_t fileHandle,
-          bool skipNotificationOnSuccess) noexcept
-        : operation_base(context)
-        , fileHandle(fileHandle)
-        , skipNotificationOnSuccess(skipNotificationOnSuccess)
-        , ioState(nullptr) {}
-
-      const handle_t fileHandle;
-      const bool skipNotificationOnSuccess;
-      vectored_io_state* ioState;
-
-      // Cancel outstanding I/O operations (if any)
-      void cancel_io() noexcept;
-
-      // Poll for whether or not the operation has completed.
-      // Returns 'true' if the operation is completed (in which case the
-      // operation has 'acquire' semantics), 'false' otherwise.
-      bool is_complete() noexcept;
-
-      // Start reading the next 'buffer.size()' bytes into 'buffer'.
-      //
-      // Returns 'true' if a additional read-operations can be submitted.
-      // This will only be the case if all of the following are true:
-      // - a read of the entirety of 'buffer' was successfully started
-      // - we haven't reached the maximum number of I/O operations in
-      //   this batch.
-      //
-      // Once all I/O operations have been started, the caller should
-      // schedule a 'poll' of this operation by setting this->callback
-      // and calling context.schedule_poll(this). This will schedule the
-      // callback to be run immediately (if it completed synchronously).
-      bool start_read(span<std::byte> buffer) noexcept;
-
-      // Start writing the context of 'buffer' to fileHandle.
-      bool start_write(span<const std::byte> buffer) noexcept;
-
-      std::size_t get_result(std::error_code& ec) noexcept;
-    };
-
-    struct vectored_io_state {
-      // Parent operation.
-      //
-      // May be nullptr if this operation already completed due to a poll.
-      // If this is the case then when all pending completion notifications
-      // are received then this will just go straight back on the free-list.
-      io_operation* parent = nullptr;
-
-      // Intrusive list ptr.
-      vectored_io_state* next = nullptr;
-      vectored_io_state* prev = nullptr;
-
-      // Total number of operations started
-      std::uint8_t operationCount = 0;
-
-      // Number of operations not yet received completion-notification
-      // via the IOCP. The vectored_io_state structure is not free to
-      // be reused until this number reaches zero.
-      std::uint8_t pendingCompletionNotifications = 0;
-
-      // Whether or not the 'parent' has already been notified of completion.
-      bool completed = false;
-
-      ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
-    };
-
-    struct stop_operation : operation_base {
-      explicit stop_operation(low_latency_iocp_context& ctx) noexcept
-        : operation_base(ctx) {
-        this->callback = &request_stop_callback;
-      }
-
-      ~stop_operation() {
-        if (isEnqueued) {
-          // Flush any items in the remote-queue into the ready queue
-          // just in case this operation is still in the remote queue.
-          (void)context.try_dequeue_remote_work();
-
-          // This operation should now be in the ready queue, remove it.
-          context.readyQueue_.remove(this);
-        }
-      }
-
-      void start() noexcept {
-        if (context.is_running_on_io_thread()) {
-          stopRequestedFlag = true;
-        } else {
-          isEnqueued = true;
-          context.schedule_remote(this);
-        }
-      }
-
-      static void request_stop_callback(operation_base* op) noexcept {
-        auto& self = *static_cast<stop_operation*>(op);
-        self.stopRequestedFlag = true;
-        self.isEnqueued = false;
-      }
-
-      bool stopRequestedFlag = false;
-
-    private:
-      bool isEnqueued = false;
-    };
-
-    struct stop_callback {
-      stop_operation& op;
-
-      void operator()() noexcept { op.start(); }
-    };
-
-    void run_impl(bool& stopFlag);
-
-    // Dequeue items from remote queue and move them to the
-    // ready-to-run queue.
-    // Returns true if any items were dequeued.
-    bool try_dequeue_remote_work() noexcept;
-
-    bool poll_is_complete(vectored_io_state& state) noexcept;
-
-    // Obtain the I/O state that contains a given io_status_block structure.
-    vectored_io_state* to_io_state(ntapi::IO_STATUS_BLOCK* io) noexcept;
-
-    bool is_running_on_io_thread() const noexcept {
-      return activeThreadId_.load(std::memory_order_relaxed) ==
-          std::this_thread::get_id();
-    }
-
-    void schedule(operation_base* op) noexcept;
-    void schedule_local(operation_base* op) noexcept;
-    void schedule_remote(operation_base* op) noexcept;
-
-    // If an I/O state is available, attaches an unused I/O state to
-    // op->ioState and returns true, otherwise returns false if no
-    // I/O state is currently available.
-    //
-    // If 'true' is returned then the caller can populate op->ioState
-    // and initiate the I/O using its IO_STATUS_BLOCK structures.
-    [[nodiscard]] bool try_allocate_io_state_for(io_operation* op) noexcept;
-
-    // Schedule the specified 'op' to be called back (calling op->callback)
-    // when an I/O state becomes available and has been allocated to 'op'.
-    //
-    // Do this only after an unsuccessful call to try_allocate_io_state_for()
-    // asynchronously wait until some other I/O operation completes and frees
-    // up an other I/O state.
-    void schedule_when_io_state_available(io_operation* op) noexcept;
-
-    // Mark the io state as released and let it return to the pool.
-    void release_io_state(vectored_io_state* state) noexcept;
-
-    // Schedule this operation to be polled next time we run out of work
-    // in the ready-queue before going back to the OS for completion-events.
-    void schedule_poll_io(io_operation* op) noexcept;
-
-    // Attempt to associate the specified file-handle with this I/O context
-    // so that its I/O completion events are posted to this context's IOCP.
-    void associate_file_handle(handle_t fileHandle);
-
-  private:
-    ////
-    // State that won't change after initialisation or that change rarely
-    // e.g. only on each call to run().
-
-    std::atomic<std::thread::id> activeThreadId_;
-    safe_handle iocp_;
-    std::size_t ioPoolSize_;
-    std::unique_ptr<vectored_io_state[]> ioPool_;
-
-    /////
-    // State that is accessed/modified by the I/O thread only.
-
-    alignas(64) intrusive_stack<
-        vectored_io_state,
-        &vectored_io_state::next> ioFreeList_;
-
-    // Newly launched operations that we want to poll for completion as soon as
-    // we run out of 'ready-to-run' work to do.
-    operation_queue pollQueue_;
-
-    // Operations waiting to acquire a vectored_io_operation.
-    // These will be resumed in-order as vectored_io_operations are returned to
-    // the pool.
-    operation_queue pendingIoQueue_;
-
-    // Operations that are ready to run.
-    operation_queue readyQueue_;
-
-    /////
-    // State that may be accessed/modified by other threads.
-
-    alignas(64) atomic_intrusive_queue<
-        operation_base,
-        &operation_base::next> remoteQueue_;
-  };
-
-  template <typename StopToken>
-  void low_latency_iocp_context::run(StopToken stopToken) {
-    stop_operation op{*this};
-    typename StopToken::template callback_type<stop_callback> cb{
-        std::move(stopToken), stop_callback{op}};
-    run_impl(op.stopRequestedFlag);
-  }
-
-  ///////////////////////////
-  // schedule
+  class schedule_sender;
 
   template <typename Receiver>
-  class low_latency_iocp_context::_schedule_op<Receiver>::type
-    : private low_latency_iocp_context::operation_base {
-  public:
-    template <typename Receiver2>
-    explicit type(low_latency_iocp_context& context, Receiver2&& r)
+  struct _schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_op = typename _schedule_op<Receiver>::type;
+
+  template <typename Buffer>
+  struct _read_file_sender {
+    class type;
+  };
+  template <typename Buffer>
+  using read_file_sender = typename _read_file_sender<Buffer>::type;
+
+  template <typename Buffer>
+  struct _write_file_sender {
+    class type;
+  };
+  template <typename Buffer>
+  using write_file_sender = typename _write_file_sender<Buffer>::type;
+
+  template <typename Buffer, typename Receiver>
+  struct _read_file_op {
+    class type;
+  };
+  template <typename Buffer, typename Receiver>
+  using read_file_op = typename _read_file_op<Buffer, Receiver>::type;
+
+  template <typename Buffer, typename Receiver>
+  struct _write_file_op {
+    class type;
+  };
+  template <typename Buffer, typename Receiver>
+  using write_file_op = typename _write_file_op<Buffer, Receiver>::type;
+
+public:
+  // Initialise the IOCP context and pre-allocate storage for I/O
+  // state needed to support at most 'maxIoOperations' concurrent I/O
+  // operations.
+  explicit low_latency_iocp_context(std::size_t maxIoOperations);
+
+  low_latency_iocp_context(low_latency_iocp_context&&) = delete;
+  low_latency_iocp_context(const low_latency_iocp_context&) = delete;
+  low_latency_iocp_context& operator=(const low_latency_iocp_context&) = delete;
+  low_latency_iocp_context& operator=(low_latency_iocp_context&&) = delete;
+
+  ~low_latency_iocp_context();
+
+  // Drive the event loop until a request to stop is communicated via
+  // the passed StopToken.
+  template <typename StopToken>
+  void run(StopToken st);
+
+  // Obtain a handle to this execution context that can be used to
+  // schedule work and open I/O resources.
+  scheduler get_scheduler() noexcept;
+
+private:
+  struct vectored_io_state;
+
+  // This value chosen so that vectored_io_state is 512 bytes on 64-bit
+  // architectures and 256 bytes on 32-bit architectures.
+  static constexpr std::size_t max_vectored_io_size = 30;
+
+  struct operation_base {
+    explicit operation_base(low_latency_iocp_context& ctx) noexcept
+      : context(ctx) {}
+
+    using callback_t = void(operation_base*) noexcept;
+    low_latency_iocp_context& context;
+    callback_t* callback = nullptr;
+    operation_base* next = nullptr;
+    operation_base* prev = nullptr;
+  };
+
+  using operation_queue = intrusive_list<
+      operation_base,
+      &operation_base::next,
+      &operation_base::prev>;
+
+  struct io_operation : operation_base {
+    explicit io_operation(
+        low_latency_iocp_context& context,
+        handle_t fileHandle,
+        bool skipNotificationOnSuccess) noexcept
       : operation_base(context)
-      , receiver_((Receiver2 &&) r) {
-      this->callback = &execute_callback;
+      , fileHandle(fileHandle)
+      , skipNotificationOnSuccess(skipNotificationOnSuccess)
+      , ioState(nullptr) {}
+
+    const handle_t fileHandle;
+    const bool skipNotificationOnSuccess;
+    vectored_io_state* ioState;
+
+    // Cancel outstanding I/O operations (if any)
+    void cancel_io() noexcept;
+
+    // Poll for whether or not the operation has completed.
+    // Returns 'true' if the operation is completed (in which case the
+    // operation has 'acquire' semantics), 'false' otherwise.
+    bool is_complete() noexcept;
+
+    // Start reading the next 'buffer.size()' bytes into 'buffer'.
+    //
+    // Returns 'true' if a additional read-operations can be submitted.
+    // This will only be the case if all of the following are true:
+    // - a read of the entirety of 'buffer' was successfully started
+    // - we haven't reached the maximum number of I/O operations in
+    //   this batch.
+    //
+    // Once all I/O operations have been started, the caller should
+    // schedule a 'poll' of this operation by setting this->callback
+    // and calling context.schedule_poll(this). This will schedule the
+    // callback to be run immediately (if it completed synchronously).
+    bool start_read(span<std::byte> buffer) noexcept;
+
+    // Start writing the context of 'buffer' to fileHandle.
+    bool start_write(span<const std::byte> buffer) noexcept;
+
+    std::size_t get_result(std::error_code& ec) noexcept;
+  };
+
+  struct vectored_io_state {
+    // Parent operation.
+    //
+    // May be nullptr if this operation already completed due to a poll.
+    // If this is the case then when all pending completion notifications
+    // are received then this will just go straight back on the free-list.
+    io_operation* parent = nullptr;
+
+    // Intrusive list ptr.
+    vectored_io_state* next = nullptr;
+    vectored_io_state* prev = nullptr;
+
+    // Total number of operations started
+    std::uint8_t operationCount = 0;
+
+    // Number of operations not yet received completion-notification
+    // via the IOCP. The vectored_io_state structure is not free to
+    // be reused until this number reaches zero.
+    std::uint8_t pendingCompletionNotifications = 0;
+
+    // Whether or not the 'parent' has already been notified of completion.
+    bool completed = false;
+
+    ntapi::IO_STATUS_BLOCK operations[max_vectored_io_size];
+  };
+
+  struct stop_operation : operation_base {
+    explicit stop_operation(low_latency_iocp_context& ctx) noexcept
+      : operation_base(ctx) {
+      this->callback = &request_stop_callback;
     }
 
-    void start() & noexcept { this->context.schedule(this); }
+    ~stop_operation() {
+      if (isEnqueued) {
+        // Flush any items in the remote-queue into the ready queue
+        // just in case this operation is still in the remote queue.
+        (void)context.try_dequeue_remote_work();
+
+        // This operation should now be in the ready queue, remove it.
+        context.readyQueue_.remove(this);
+      }
+    }
+
+    void start() noexcept {
+      if (context.is_running_on_io_thread()) {
+        stopRequestedFlag = true;
+      } else {
+        isEnqueued = true;
+        context.schedule_remote(this);
+      }
+    }
+
+    static void request_stop_callback(operation_base* op) noexcept {
+      auto& self = *static_cast<stop_operation*>(op);
+      self.stopRequestedFlag = true;
+      self.isEnqueued = false;
+    }
+
+    bool stopRequestedFlag = false;
 
   private:
-    static void execute_callback(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
+    bool isEnqueued = false;
+  };
 
+  struct stop_callback {
+    stop_operation& op;
+
+    void operator()() noexcept { op.start(); }
+  };
+
+  void run_impl(bool& stopFlag);
+
+  // Dequeue items from remote queue and move them to the
+  // ready-to-run queue.
+  // Returns true if any items were dequeued.
+  bool try_dequeue_remote_work() noexcept;
+
+  bool poll_is_complete(vectored_io_state& state) noexcept;
+
+  // Obtain the I/O state that contains a given io_status_block structure.
+  vectored_io_state* to_io_state(ntapi::IO_STATUS_BLOCK* io) noexcept;
+
+  bool is_running_on_io_thread() const noexcept {
+    return activeThreadId_.load(std::memory_order_relaxed) ==
+        std::this_thread::get_id();
+  }
+
+  void schedule(operation_base* op) noexcept;
+  void schedule_local(operation_base* op) noexcept;
+  void schedule_remote(operation_base* op) noexcept;
+
+  // If an I/O state is available, attaches an unused I/O state to
+  // op->ioState and returns true, otherwise returns false if no
+  // I/O state is currently available.
+  //
+  // If 'true' is returned then the caller can populate op->ioState
+  // and initiate the I/O using its IO_STATUS_BLOCK structures.
+  [[nodiscard]] bool try_allocate_io_state_for(io_operation* op) noexcept;
+
+  // Schedule the specified 'op' to be called back (calling op->callback)
+  // when an I/O state becomes available and has been allocated to 'op'.
+  //
+  // Do this only after an unsuccessful call to try_allocate_io_state_for()
+  // asynchronously wait until some other I/O operation completes and frees
+  // up an other I/O state.
+  void schedule_when_io_state_available(io_operation* op) noexcept;
+
+  // Mark the io state as released and let it return to the pool.
+  void release_io_state(vectored_io_state* state) noexcept;
+
+  // Schedule this operation to be polled next time we run out of work
+  // in the ready-queue before going back to the OS for completion-events.
+  void schedule_poll_io(io_operation* op) noexcept;
+
+  // Attempt to associate the specified file-handle with this I/O context
+  // so that its I/O completion events are posted to this context's IOCP.
+  void associate_file_handle(handle_t fileHandle);
+
+private:
+  ////
+  // State that won't change after initialisation or that change rarely
+  // e.g. only on each call to run().
+
+  std::atomic<std::thread::id> activeThreadId_;
+  safe_handle iocp_;
+  std::size_t ioPoolSize_;
+  std::unique_ptr<vectored_io_state[]> ioPool_;
+
+  /////
+  // State that is accessed/modified by the I/O thread only.
+
+  alignas(64)
+      intrusive_stack<vectored_io_state, &vectored_io_state::next> ioFreeList_;
+
+  // Newly launched operations that we want to poll for completion as soon as
+  // we run out of 'ready-to-run' work to do.
+  operation_queue pollQueue_;
+
+  // Operations waiting to acquire a vectored_io_operation.
+  // These will be resumed in-order as vectored_io_operations are returned to
+  // the pool.
+  operation_queue pendingIoQueue_;
+
+  // Operations that are ready to run.
+  operation_queue readyQueue_;
+
+  /////
+  // State that may be accessed/modified by other threads.
+
+  alignas(64) atomic_intrusive_queue<
+      operation_base,
+      &operation_base::next> remoteQueue_;
+};
+
+template <typename StopToken>
+void low_latency_iocp_context::run(StopToken stopToken) {
+  stop_operation op{*this};
+  typename StopToken::template callback_type<stop_callback> cb{
+      std::move(stopToken), stop_callback{op}};
+  run_impl(op.stopRequestedFlag);
+}
+
+///////////////////////////
+// schedule
+
+template <typename Receiver>
+class low_latency_iocp_context::_schedule_op<Receiver>::type
+  : private low_latency_iocp_context::operation_base {
+public:
+  template <typename Receiver2>
+  explicit type(low_latency_iocp_context& context, Receiver2&& r)
+    : operation_base(context)
+    , receiver_((Receiver2 &&) r) {
+    this->callback = &execute_callback;
+  }
+
+  void start() & noexcept { this->context.schedule(this); }
+
+private:
+  static void execute_callback(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+
+    if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      if (get_stop_token(self.receiver_).stop_requested()) {
+        unifex::set_done(std::move(self.receiver_));
+        return;
+      }
+    }
+
+    if constexpr (is_nothrow_callable_v<tag_t<unifex::set_value>, Receiver>) {
+      unifex::set_value(std::move(self.receiver_));
+    } else {
+      UNIFEX_TRY { unifex::set_value(std::move(self.receiver_)); }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(self.receiver_), std::current_exception());
+      }
+    }
+  }
+
+  Receiver receiver_;
+};
+
+class low_latency_iocp_context::schedule_sender {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
+
+  static constexpr bool sends_done = true;
+
+  explicit schedule_sender(low_latency_iocp_context& context) noexcept
+    : context_(context) {}
+
+  template(typename Receiver)           //
+      (requires receiver_of<Receiver>)  //
+      friend auto tag_invoke(
+          tag_t<connect>,
+          const schedule_sender& s,
+          Receiver&& r) noexcept(std::
+                                     is_nothrow_constructible_v<
+                                         remove_cvref_t<Receiver>,
+                                         Receiver>)
+          -> schedule_op<remove_cvref_t<Receiver>> {
+    return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver &&) r};
+  }
+
+private:
+  template <typename Receiver>
+  using schedule_op = schedule_op<Receiver>;
+  low_latency_iocp_context& context_;
+};
+
+///////////////////////////
+// read_file
+
+template <typename Buffer, typename Receiver>
+class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
+  : private low_latency_iocp_context::io_operation {
+public:
+  template <typename Receiver2, typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& ctx,
+      handle_t fileHandle,
+      bool skipNotificationOnSuccess,
+      Buffer2&& buffer,
+      Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2 &&) r)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  void start() & noexcept {
+    if (this->context.is_running_on_io_thread()) {
+      acquire_io_state(this);
+    } else {
+      this->callback = &acquire_io_state;
+      this->context.schedule_remote(this);
+    }
+  }
+
+private:
+  struct cancel_callback {
+    type& op;
+    void operator()() noexcept { op.cancel_io(); }
+  };
+
+  static void acquire_io_state(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    if (self.context.try_allocate_io_state_for(&self)) {
+      start_io(op);
+    } else {
+      // TODO: Add support for cancellation while waiting in the
+      // pendingIoQueue_.
+
+      self.callback = &start_io;
+      self.context.schedule_when_io_state_available(&self);
+    }
+  }
+
+  static void start_io(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    // TODO: Add support for a BufferSequence concept to allow
+    // vectorised I/O here.
+    // For now, just assume that 'Buffer' is convertible to a
+    // 'span<std::byte>'.
+
+    self.start_read(self.buffer_);
+
+    if (self.ioState->pendingCompletionNotifications == 0) {
+      self.ioState->completed = true;
+      self.callback = &on_complete;
+      self.context.readyQueue_.push_front(op);
+    } else {
       if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-        if (get_stop_token(self.receiver_).stop_requested()) {
-          unifex::set_done(std::move(self.receiver_));
-          return;
-        }
+        self.stopCallback_.construct(
+            get_stop_token(self.receiver_), cancel_callback{self});
+        self.callback = &on_cancellable_complete;
+      } else {
+        self.callback = &on_complete;
       }
 
+      self.context.schedule_poll_io(&self);
+    }
+  }
+
+  static void on_cancellable_complete(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    self.stopCallback_.destruct();
+
+    on_complete(op);
+  }
+
+  static void on_complete(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+
+    std::error_code ec;
+    std::size_t totalBytesTransferred = self.get_result(ec);
+
+    self.context.release_io_state(self.ioState);
+
+    // Treat partial failure as a success case.
+    // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+    // instead?
+    if (!ec || totalBytesTransferred > 0) {
       if constexpr (is_nothrow_callable_v<
-                        tag_t<unifex::set_value>,
-                        Receiver>) {
-        unifex::set_value(std::move(self.receiver_));
+                        tag_t<set_value>,
+                        Receiver,
+                        std::size_t>) {
+        unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
       } else {
         UNIFEX_TRY {
-          unifex::set_value(std::move(self.receiver_));
-        } UNIFEX_CATCH (...) {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+        }
+        UNIFEX_CATCH(...) {
           unifex::set_error(
               std::move(self.receiver_), std::current_exception());
         }
       }
+    } else if (ec == std::errc::operation_canceled) {
+      unifex::set_done(std::move(self.receiver_));
+    } else {
+      unifex::set_error(std::move(self.receiver_), std::move(ec));
     }
-
-    Receiver receiver_;
-  };
-
-  class low_latency_iocp_context::schedule_sender {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = true;
-
-    explicit schedule_sender(low_latency_iocp_context& context) noexcept
-      : context_(context) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver>) friend auto tag_invoke(
-        tag_t<connect>,
-        const schedule_sender& s,
-        Receiver&& r) noexcept(std::
-                                   is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> schedule_op<remove_cvref_t<Receiver>> {
-      return schedule_op<remove_cvref_t<Receiver>>{s.context_, (Receiver &&) r};
-    }
-
-  private:
-    template <typename Receiver>
-    using schedule_op = schedule_op<Receiver>;
-    low_latency_iocp_context& context_;
-  };
-
-  ///////////////////////////
-  // read_file
-
-  template <typename Buffer, typename Receiver>
-  class low_latency_iocp_context::_read_file_op<Buffer, Receiver>::type
-    : private low_latency_iocp_context::io_operation {
-  public:
-    template <typename Receiver2, typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& ctx,
-        handle_t fileHandle,
-        bool skipNotificationOnSuccess,
-        Buffer2&& buffer,
-        Receiver2&& r)
-      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-      , receiver_((Receiver2 &&) r)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    void start() & noexcept {
-      if (this->context.is_running_on_io_thread()) {
-        acquire_io_state(this);
-      } else {
-        this->callback = &acquire_io_state;
-        this->context.schedule_remote(this);
-      }
-    }
-
-  private:
-    struct cancel_callback {
-      type& op;
-      void operator()() noexcept { op.cancel_io(); }
-    };
-
-    static void acquire_io_state(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      if (self.context.try_allocate_io_state_for(&self)) {
-        start_io(op);
-      } else {
-        // TODO: Add support for cancellation while waiting in the
-        // pendingIoQueue_.
-
-        self.callback = &start_io;
-        self.context.schedule_when_io_state_available(&self);
-      }
-    }
-
-    static void start_io(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      // TODO: Add support for a BufferSequence concept to allow
-      // vectorised I/O here.
-      // For now, just assume that 'Buffer' is convertible to a
-      // 'span<std::byte>'.
-
-      self.start_read(self.buffer_);
-
-      if (self.ioState->pendingCompletionNotifications == 0) {
-        self.ioState->completed = true;
-        self.callback = &on_complete;
-        self.context.readyQueue_.push_front(op);
-      } else {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-          self.stopCallback_.construct(
-              get_stop_token(self.receiver_), cancel_callback{self});
-          self.callback = &on_cancellable_complete;
-        } else {
-          self.callback = &on_complete;
-        }
-
-        self.context.schedule_poll_io(&self);
-      }
-    }
-
-    static void on_cancellable_complete(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      self.stopCallback_.destruct();
-
-      on_complete(op);
-    }
-
-    static void on_complete(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-
-      std::error_code ec;
-      std::size_t totalBytesTransferred = self.get_result(ec);
-
-      self.context.release_io_state(self.ioState);
-
-      // Treat partial failure as a success case.
-      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
-      // instead?
-      if (!ec || totalBytesTransferred > 0) {
-        if constexpr (is_nothrow_callable_v<
-                          tag_t<set_value>,
-                          Receiver,
-                          std::size_t>) {
-          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                std::move(self.receiver_), std::current_exception());
-          }
-        }
-      } else if (ec == std::errc::operation_canceled) {
-        unifex::set_done(std::move(self.receiver_));
-      } else {
-        unifex::set_error(std::move(self.receiver_), std::move(ec));
-      }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver>::template callback_type<cancel_callback>>
-        stopCallback_;
-  };
-
-  template <typename Buffer>
-  class low_latency_iocp_context::_read_file_sender<Buffer>::type {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<std::size_t>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr, std::error_code>;
-
-    static constexpr bool sends_done = true;
-
-    template <typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& context,
-        handle_t fileHandle,
-        bool skipNotificationsOnSuccess,
-        Buffer2&& buffer)
-      : context_(context)
-      , fileHandle_(fileHandle)
-      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
-        tag_t<unifex::connect>,
-        type&& self,
-        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
-                                   std::is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
-      return read_file_op<Buffer, remove_cvref_t<Receiver>>{
-          self.context_,
-          self.fileHandle_,
-          self.skipNotificationsOnSuccess_,
-          std::move(self.buffer_),
-          (Receiver &&) r};
-    }
-
-  private:
-    template <typename Buf, typename Receiver>
-    using read_file_op = read_file_op<Buf, Receiver>;
-    low_latency_iocp_context& context_;
-    handle_t fileHandle_;
-    bool skipNotificationsOnSuccess_;
-    Buffer buffer_;
-  };
-
-  //////////////////////////
-  // write_file
-
-  template <typename Buffer, typename Receiver>
-  class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
-    : private low_latency_iocp_context::io_operation {
-  public:
-    template <typename Receiver2, typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& ctx,
-        handle_t fileHandle,
-        bool skipNotificationOnSuccess,
-        Buffer2&& buffer,
-        Receiver2&& r)
-      : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
-      , receiver_((Receiver2 &&) r)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    void start() & noexcept {
-      if (this->context.is_running_on_io_thread()) {
-        acquire_io_state(this);
-      } else {
-        this->callback = &acquire_io_state;
-        this->context.schedule_remote(this);
-      }
-    }
-
-  private:
-    struct cancel_callback {
-      type& op;
-      void operator()() noexcept { op.cancel_io(); }
-    };
-
-    static void acquire_io_state(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      if (self.context.try_allocate_io_state_for(&self)) {
-        start_io(op);
-      } else {
-        // TODO: Add support for cancellation while waiting in the
-        // pendingIoQueue_.
-
-        self.callback = &start_io;
-        self.context.schedule_when_io_state_available(&self);
-      }
-    }
-
-    static void start_io(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      // TODO: Add support for a BufferSequence concept to allow
-      // vectorised I/O here.
-      // For now, just assume that 'Buffer' is convertible to a
-      // 'span<std::byte>'.
-
-      self.start_write(self.buffer_);
-
-      if (self.ioState->pendingCompletionNotifications == 0) {
-        self.ioState->completed = true;
-        self.callback = &on_complete;
-        self.context.readyQueue_.push_front(op);
-      } else {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-          self.stopCallback_.construct(
-              get_stop_token(self.receiver_), cancel_callback{self});
-          self.callback = &on_cancellable_complete;
-        } else {
-          self.callback = &on_complete;
-        }
-
-        self.context.schedule_poll_io(&self);
-      }
-    }
-
-    static void on_cancellable_complete(operation_base* op) noexcept {
-      auto& self = *static_cast<type*>(op);
-      UNIFEX_ASSERT(self.context.is_running_on_io_thread());
-
-      self.stopCallback_.destruct();
-
-      on_complete(op);
-    }
-
-    static void on_complete(operation_base* op) noexcept {
-      type& self = *static_cast<type*>(op);
-
-      std::error_code ec;
-      std::size_t totalBytesTransferred = self.get_result(ec);
-
-      self.context.release_io_state(self.ioState);
-
-      // Treat partial failure as a success case.
-      // TODO: Should we be sending tuple of (bytesTransferred, ec) here
-      // instead?
-      if (!ec || totalBytesTransferred > 0) {
-        if constexpr (is_nothrow_callable_v<
-                          tag_t<set_value>,
-                          Receiver,
-                          std::size_t>) {
-          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-        } else {
-          UNIFEX_TRY {
-            unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
-          } UNIFEX_CATCH (...) {
-            unifex::set_error(
-                std::move(self.receiver_), std::current_exception());
-          }
-        }
-      } else if (ec == std::errc::operation_canceled) {
-        unifex::set_done(std::move(self.receiver_));
-      } else {
-        unifex::set_error(std::move(self.receiver_), std::move(ec));
-      }
-    }
-
-    UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
-    UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
-    UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
-        Receiver>::template callback_type<cancel_callback>>
-        stopCallback_;
-  };
-
-  template <typename Buffer>
-  class low_latency_iocp_context::_write_file_sender<Buffer>::type {
-  public:
-    template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
-    using value_types = Variant<Tuple<std::size_t>>;
-
-    template <template <typename...> class Variant>
-    using error_types = Variant<std::exception_ptr, std::error_code>;
-
-    static constexpr bool sends_done = true;
-
-    template <typename Buffer2>
-    explicit type(
-        low_latency_iocp_context& context,
-        handle_t fileHandle,
-        bool skipNotificationsOnSuccess,
-        Buffer2&& buffer)
-      : context_(context)
-      , fileHandle_(fileHandle)
-      , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
-      , buffer_((Buffer2 &&) buffer) {}
-
-    template(typename Receiver)(requires receiver_of<Receiver, std::size_t>) friend auto tag_invoke(
-        tag_t<unifex::connect>,
-        type&& self,
-        Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
-                                   std::is_nothrow_constructible_v<
-                                       remove_cvref_t<Receiver>,
-                                       Receiver>)
-        -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
-      return write_file_op<Buffer, remove_cvref_t<Receiver>>{
-          self.context_,
-          self.fileHandle_,
-          self.skipNotificationsOnSuccess_,
-          std::move(self.buffer_),
-          (Receiver &&) r};
-    }
-
-  private:
-    template <typename Buf, typename Receiver>
-    using write_file_op = write_file_op<Buf, Receiver>;
-    low_latency_iocp_context& context_;
-    handle_t fileHandle_;
-    bool skipNotificationsOnSuccess_;
-    Buffer buffer_;
-  };
-
-  class low_latency_iocp_context::readable_byte_stream {
-  public:
-    explicit readable_byte_stream(
-        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
-      : context_(context)
-      , fileHandle_(std::move(fileHandle)) {}
-
-    template(typename Buffer)(requires convertible_to<Buffer, span<std::byte>>) friend read_file_sender<
-        remove_cvref_t<
-            Buffer>> tag_invoke(tag_t<async_read_some>, readable_byte_stream& stream, Buffer&& buffer) {
-      return read_file_sender<remove_cvref_t<Buffer>>{
-          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
-    }
-
-  private:
-    template <typename Buffer>
-    using read_file_sender = read_file_sender<Buffer>;
-
-    low_latency_iocp_context& context_;
-    safe_handle fileHandle_;
-  };
-
-  class low_latency_iocp_context::writable_byte_stream {
-  public:
-    explicit writable_byte_stream(
-        low_latency_iocp_context& context, safe_handle fileHandle) noexcept
-      : context_(context)
-      , fileHandle_(std::move(fileHandle)) {}
-
-    template(typename Buffer)(requires convertible_to<Buffer, span<const std::byte>>) friend write_file_sender<
-        remove_cvref_t<
-            Buffer>> tag_invoke(tag_t<async_write_some>, writable_byte_stream& stream, Buffer&& buffer) {
-      return write_file_sender<remove_cvref_t<Buffer>>{
-          stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
-    }
-
-  private:
-    template <typename Buffer>
-    using write_file_sender = write_file_sender<Buffer>;
-
-    low_latency_iocp_context& context_;
-    safe_handle fileHandle_;
-  };
-
-  class low_latency_iocp_context::scheduler {
-  public:
-    explicit scheduler(low_latency_iocp_context& context) noexcept
-      : context_(&context) {}
-
-    schedule_sender schedule() const noexcept {
-      return schedule_sender{*context_};
-    }
-
-    friend std::tuple<readable_byte_stream, writable_byte_stream>
-    tag_invoke(tag_t<unifex::open_pipe>, scheduler s) {
-      return open_pipe_impl(*s.context_);
-    }
-
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-      return a.context_ == b.context_;
-    }
-
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-      return !(a == b);
-    }
-
-  private:
-    static std::tuple<readable_byte_stream, writable_byte_stream>
-    open_pipe_impl(low_latency_iocp_context& ctx);
-
-    low_latency_iocp_context* context_;
-  };
-
-  inline low_latency_iocp_context::scheduler
-  low_latency_iocp_context::get_scheduler() noexcept {
-    return scheduler{*this};
   }
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver>::template callback_type<cancel_callback>>
+      stopCallback_;
+};
+
+template <typename Buffer>
+class low_latency_iocp_context::_read_file_sender<Buffer>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<std::size_t>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr, std::error_code>;
+
+  static constexpr bool sends_done = true;
+
+  template <typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& context,
+      handle_t fileHandle,
+      bool skipNotificationsOnSuccess,
+      Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  template(typename Receiver)                        //
+      (requires receiver_of<Receiver, std::size_t>)  //
+      friend auto tag_invoke(
+          tag_t<unifex::connect>,
+          type&& self,
+          Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                     std::is_nothrow_constructible_v<
+                                         remove_cvref_t<Receiver>,
+                                         Receiver>)
+          -> read_file_op<Buffer, remove_cvref_t<Receiver>> {
+    return read_file_op<Buffer, remove_cvref_t<Receiver>>{
+        self.context_,
+        self.fileHandle_,
+        self.skipNotificationsOnSuccess_,
+        std::move(self.buffer_),
+        (Receiver &&) r};
+  }
+
+private:
+  template <typename Buf, typename Receiver>
+  using read_file_op = read_file_op<Buf, Receiver>;
+  low_latency_iocp_context& context_;
+  handle_t fileHandle_;
+  bool skipNotificationsOnSuccess_;
+  Buffer buffer_;
+};
+
+//////////////////////////
+// write_file
+
+template <typename Buffer, typename Receiver>
+class low_latency_iocp_context::_write_file_op<Buffer, Receiver>::type
+  : private low_latency_iocp_context::io_operation {
+public:
+  template <typename Receiver2, typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& ctx,
+      handle_t fileHandle,
+      bool skipNotificationOnSuccess,
+      Buffer2&& buffer,
+      Receiver2&& r)
+    : io_operation(ctx, fileHandle, skipNotificationOnSuccess)
+    , receiver_((Receiver2 &&) r)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  void start() & noexcept {
+    if (this->context.is_running_on_io_thread()) {
+      acquire_io_state(this);
+    } else {
+      this->callback = &acquire_io_state;
+      this->context.schedule_remote(this);
+    }
+  }
+
+private:
+  struct cancel_callback {
+    type& op;
+    void operator()() noexcept { op.cancel_io(); }
+  };
+
+  static void acquire_io_state(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    if (self.context.try_allocate_io_state_for(&self)) {
+      start_io(op);
+    } else {
+      // TODO: Add support for cancellation while waiting in the
+      // pendingIoQueue_.
+
+      self.callback = &start_io;
+      self.context.schedule_when_io_state_available(&self);
+    }
+  }
+
+  static void start_io(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    // TODO: Add support for a BufferSequence concept to allow
+    // vectorised I/O here.
+    // For now, just assume that 'Buffer' is convertible to a
+    // 'span<std::byte>'.
+
+    self.start_write(self.buffer_);
+
+    if (self.ioState->pendingCompletionNotifications == 0) {
+      self.ioState->completed = true;
+      self.callback = &on_complete;
+      self.context.readyQueue_.push_front(op);
+    } else {
+      if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+        self.stopCallback_.construct(
+            get_stop_token(self.receiver_), cancel_callback{self});
+        self.callback = &on_cancellable_complete;
+      } else {
+        self.callback = &on_complete;
+      }
+
+      self.context.schedule_poll_io(&self);
+    }
+  }
+
+  static void on_cancellable_complete(operation_base* op) noexcept {
+    auto& self = *static_cast<type*>(op);
+    UNIFEX_ASSERT(self.context.is_running_on_io_thread());
+
+    self.stopCallback_.destruct();
+
+    on_complete(op);
+  }
+
+  static void on_complete(operation_base* op) noexcept {
+    type& self = *static_cast<type*>(op);
+
+    std::error_code ec;
+    std::size_t totalBytesTransferred = self.get_result(ec);
+
+    self.context.release_io_state(self.ioState);
+
+    // Treat partial failure as a success case.
+    // TODO: Should we be sending tuple of (bytesTransferred, ec) here
+    // instead?
+    if (!ec || totalBytesTransferred > 0) {
+      if constexpr (is_nothrow_callable_v<
+                        tag_t<set_value>,
+                        Receiver,
+                        std::size_t>) {
+        unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+      } else {
+        UNIFEX_TRY {
+          unifex::set_value(std::move(self.receiver_), totalBytesTransferred);
+        }
+        UNIFEX_CATCH(...) {
+          unifex::set_error(
+              std::move(self.receiver_), std::current_exception());
+        }
+      }
+    } else if (ec == std::errc::operation_canceled) {
+      unifex::set_done(std::move(self.receiver_));
+    } else {
+      unifex::set_error(std::move(self.receiver_), std::move(ec));
+    }
+  }
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  UNIFEX_NO_UNIQUE_ADDRESS Buffer buffer_;
+  UNIFEX_NO_UNIQUE_ADDRESS manual_lifetime<typename stop_token_type_t<
+      Receiver>::template callback_type<cancel_callback>>
+      stopCallback_;
+};
+
+template <typename Buffer>
+class low_latency_iocp_context::_write_file_sender<Buffer>::type {
+public:
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<std::size_t>>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr, std::error_code>;
+
+  static constexpr bool sends_done = true;
+
+  template <typename Buffer2>
+  explicit type(
+      low_latency_iocp_context& context,
+      handle_t fileHandle,
+      bool skipNotificationsOnSuccess,
+      Buffer2&& buffer)
+    : context_(context)
+    , fileHandle_(fileHandle)
+    , skipNotificationsOnSuccess_(skipNotificationsOnSuccess)
+    , buffer_((Buffer2 &&) buffer) {}
+
+  template(typename Receiver)                        //
+      (requires receiver_of<Receiver, std::size_t>)  //
+      friend auto tag_invoke(
+          tag_t<unifex::connect>,
+          type&& self,
+          Receiver&& r) noexcept(std::is_nothrow_move_constructible_v<Buffer>&&
+                                     std::is_nothrow_constructible_v<
+                                         remove_cvref_t<Receiver>,
+                                         Receiver>)
+          -> write_file_op<Buffer, remove_cvref_t<Receiver>> {
+    return write_file_op<Buffer, remove_cvref_t<Receiver>>{
+        self.context_,
+        self.fileHandle_,
+        self.skipNotificationsOnSuccess_,
+        std::move(self.buffer_),
+        (Receiver &&) r};
+  }
+
+private:
+  template <typename Buf, typename Receiver>
+  using write_file_op = write_file_op<Buf, Receiver>;
+  low_latency_iocp_context& context_;
+  handle_t fileHandle_;
+  bool skipNotificationsOnSuccess_;
+  Buffer buffer_;
+};
+
+class low_latency_iocp_context::readable_byte_stream {
+public:
+  explicit readable_byte_stream(
+      low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle)) {}
+
+  template(typename Buffer)                               //
+      (requires convertible_to<Buffer, span<std::byte>>)  //
+      friend read_file_sender<remove_cvref_t<Buffer>> tag_invoke(
+          tag_t<async_read_some>,
+          readable_byte_stream& stream,
+          Buffer&& buffer) {
+    return read_file_sender<remove_cvref_t<Buffer>>{
+        stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
+  }
+
+private:
+  template <typename Buffer>
+  using read_file_sender = read_file_sender<Buffer>;
+
+  low_latency_iocp_context& context_;
+  safe_handle fileHandle_;
+};
+
+class low_latency_iocp_context::writable_byte_stream {
+public:
+  explicit writable_byte_stream(
+      low_latency_iocp_context& context, safe_handle fileHandle) noexcept
+    : context_(context)
+    , fileHandle_(std::move(fileHandle)) {}
+
+  template(typename Buffer)                                     //
+      (requires convertible_to<Buffer, span<const std::byte>>)  //
+      friend write_file_sender<remove_cvref_t<Buffer>> tag_invoke(
+          tag_t<async_write_some>,
+          writable_byte_stream& stream,
+          Buffer&& buffer) {
+    return write_file_sender<remove_cvref_t<Buffer>>{
+        stream.context_, stream.fileHandle_.get(), true, (Buffer &&) buffer};
+  }
+
+private:
+  template <typename Buffer>
+  using write_file_sender = write_file_sender<Buffer>;
+
+  low_latency_iocp_context& context_;
+  safe_handle fileHandle_;
+};
+
+class low_latency_iocp_context::scheduler {
+public:
+  explicit scheduler(low_latency_iocp_context& context) noexcept
+    : context_(&context) {}
+
+  schedule_sender schedule() const noexcept {
+    return schedule_sender{*context_};
+  }
+
+  friend std::tuple<readable_byte_stream, writable_byte_stream>
+  tag_invoke(tag_t<unifex::open_pipe>, scheduler s) {
+    return open_pipe_impl(*s.context_);
+  }
+
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.context_ == b.context_;
+  }
+
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return !(a == b);
+  }
+
+private:
+  static std::tuple<readable_byte_stream, writable_byte_stream>
+  open_pipe_impl(low_latency_iocp_context& ctx);
+
+  low_latency_iocp_context* context_;
+};
+
+inline low_latency_iocp_context::scheduler
+low_latency_iocp_context::get_scheduler() noexcept {
+  return scheduler{*this};
+}
 
 }  // namespace unifex::win32
 

--- a/include/unifex/win32/windows_thread_pool.hpp
+++ b/include/unifex/win32/windows_thread_pool.hpp
@@ -15,25 +15,28 @@
  */
 #pragma once
 
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/sender_concepts.hpp>
-#include <unifex/scheduler_concepts.hpp>
-#include <unifex/get_stop_token.hpp>
-#include <unifex/stop_token_concepts.hpp>
-#include <unifex/manual_lifetime.hpp>
 #include <unifex/exception.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/scheduler_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/stop_token_concepts.hpp>
 
 #include <unifex/win32/filetime_clock.hpp>
 
+// for some reason, we need windows.h included first
+// clang-format off
 #include <windows.h>
 #include <threadpoolapiset.h>
+// clang-format on
 
-#include <utility>
+#include <atomic>
+#include <cstdio>
 #include <exception>
 #include <new>
 #include <system_error>
-#include <atomic>
-#include <cstdio>
+#include <utility>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -41,84 +44,88 @@ namespace unifex {
 namespace win32 {
 
 class windows_thread_pool {
-    class scheduler;
-    class schedule_sender;
-    class schedule_op_base;
-    template<typename Receiver>
-    struct _schedule_op {
-        class type;
-    };
-    template<typename Receiver>
-    using schedule_op = typename _schedule_op<Receiver>::type;
+  class scheduler;
+  class schedule_sender;
+  class schedule_op_base;
+  template <typename Receiver>
+  struct _schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_op = typename _schedule_op<Receiver>::type;
 
-    template<typename StopToken>
-    struct _cancellable_schedule_op_base {
-        class type;
-    };
-    template<typename StopToken>
-    using cancellable_schedule_op_base = typename _cancellable_schedule_op_base<StopToken>::type;
+  template <typename StopToken>
+  struct _cancellable_schedule_op_base {
+    class type;
+  };
+  template <typename StopToken>
+  using cancellable_schedule_op_base =
+      typename _cancellable_schedule_op_base<StopToken>::type;
 
-    template<typename Receiver>
-    struct _cancellable_schedule_op {
-        class type;
-    };
-    template <typename Receiver>
-    using cancellable_schedule_op = typename _cancellable_schedule_op<Receiver>::type;
+  template <typename Receiver>
+  struct _cancellable_schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using cancellable_schedule_op =
+      typename _cancellable_schedule_op<Receiver>::type;
 
-    template<typename StopToken>
-    struct _time_schedule_op_base {
-        class type;
-    };
-    template<typename StopToken>
-    using time_schedule_op_base = typename _time_schedule_op_base<StopToken>::type;
+  template <typename StopToken>
+  struct _time_schedule_op_base {
+    class type;
+  };
+  template <typename StopToken>
+  using time_schedule_op_base =
+      typename _time_schedule_op_base<StopToken>::type;
 
-    template<typename Receiver>
-    struct _time_schedule_op {
-        class type;
-    };
-    template<typename Receiver>
-    using time_schedule_op = typename _time_schedule_op<Receiver>::type;
+  template <typename Receiver>
+  struct _time_schedule_op {
+    class type;
+  };
+  template <typename Receiver>
+  using time_schedule_op = typename _time_schedule_op<Receiver>::type;
 
-    template<typename Receiver>
-    struct _schedule_at_op {
-        class type;
-    };
-    template<typename Receiver>
-    using schedule_at_op = typename _schedule_at_op<Receiver>::type;
+  template <typename Receiver>
+  struct _schedule_at_op {
+    class type;
+  };
+  template <typename Receiver>
+  using schedule_at_op = typename _schedule_at_op<Receiver>::type;
 
-    template<typename Duration, typename Receiver>
-    struct _schedule_after_op {
-        class type;
-    };
-    template<typename Duration, typename Receiver>
-    using schedule_after_op = typename _schedule_after_op<Duration, Receiver>::type;
+  template <typename Duration, typename Receiver>
+  struct _schedule_after_op {
+    class type;
+  };
+  template <typename Duration, typename Receiver>
+  using schedule_after_op =
+      typename _schedule_after_op<Duration, Receiver>::type;
 
-    class schedule_at_sender;
+  class schedule_at_sender;
 
-    template<typename Duration>
-    struct _schedule_after_sender {
-        class type;
-    };
-    template<typename Duration>
-    using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
+  template <typename Duration>
+  struct _schedule_after_sender {
+    class type;
+  };
+  template <typename Duration>
+  using schedule_after_sender = typename _schedule_after_sender<Duration>::type;
 
-    using clock_type = filetime_clock;
+  using clock_type = filetime_clock;
 
 public:
+  // Initialise to use the process' default thread-pool.
+  windows_thread_pool() noexcept;
 
-    // Initialise to use the process' default thread-pool.
-    windows_thread_pool() noexcept;
+  // Construct to an independend thread-pool with a dynamic number of
+  // threads that varies between a min and a max number of threads.
+  explicit windows_thread_pool(
+      std::uint32_t minThreadCount, std::uint32_t maxThreadCount);
 
-    // Construct to an independend thread-pool with a dynamic number of
-    // threads that varies between a min and a max number of threads.
-    explicit windows_thread_pool(std::uint32_t minThreadCount, std::uint32_t maxThreadCount);
+  ~windows_thread_pool();
 
-    ~windows_thread_pool();
-
-    scheduler get_scheduler() noexcept;
+  scheduler get_scheduler() noexcept;
 
 private:
-    PTP_POOL threadPool_;
+  PTP_POOL threadPool_;
 };
 
 /////////////////////////
@@ -126,304 +133,313 @@ private:
 
 class windows_thread_pool::schedule_op_base {
 public:
-    schedule_op_base(schedule_op_base&&) = delete;
-    schedule_op_base& operator=(schedule_op_base&&) = delete;
+  schedule_op_base(schedule_op_base&&) = delete;
+  schedule_op_base& operator=(schedule_op_base&&) = delete;
 
-    ~schedule_op_base();
+  ~schedule_op_base();
 
-    void start() & noexcept;
+  void start() & noexcept;
 
 protected:
-    schedule_op_base(windows_thread_pool& pool, PTP_WORK_CALLBACK workCallback);
+  schedule_op_base(windows_thread_pool& pool, PTP_WORK_CALLBACK workCallback);
 
 private:
-    TP_CALLBACK_ENVIRON environ_;
-    PTP_WORK work_;
+  TP_CALLBACK_ENVIRON environ_;
+  PTP_WORK work_;
 };
 
-template<typename Receiver>
-class windows_thread_pool::_schedule_op<Receiver>::type final : public windows_thread_pool::schedule_op_base {
+template <typename Receiver>
+class windows_thread_pool::_schedule_op<Receiver>::type final
+  : public windows_thread_pool::schedule_op_base {
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Receiver2&& r)
     : schedule_op_base(pool, &work_callback)
-    , receiver_((Receiver2&&)r)
-    {}
+    , receiver_((Receiver2 &&) r) {}
 
 private:
-    static void CALLBACK work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
-        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(op.receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(op.receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(op.receiver_), std::current_exception());
-            }
-        }
+  static void CALLBACK
+  work_callback(PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+    if constexpr (is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(op.receiver_));
+    } else {
+      UNIFEX_TRY { unifex::set_value(std::move(op.receiver_)); }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(op.receiver_), std::current_exception());
+      }
     }
+  }
 
-    Receiver receiver_;
+  Receiver receiver_;
 };
 
 ///////////////////////////
 // Cancellable schedule() operation
 
-template<typename StopToken>
+template <typename StopToken>
 class windows_thread_pool::_cancellable_schedule_op_base<StopToken>::type {
 public:
-    type(type&&) = delete;
-    type& operator=(type&&) = delete;
+  type(type&&) = delete;
+  type& operator=(type&&) = delete;
 
-    ~type() {
-        ::CloseThreadpoolWork(work_);
-        ::DestroyThreadpoolEnvironment(&environ_);
-        delete state_;
-    }
+  ~type() {
+    ::CloseThreadpoolWork(work_);
+    ::DestroyThreadpoolEnvironment(&environ_);
+    delete state_;
+  }
 
 protected:
-    explicit type(windows_thread_pool& pool, bool isStopPossible) {
-        ::InitializeThreadpoolEnvironment(&environ_);
-        ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
+  explicit type(windows_thread_pool& pool, bool isStopPossible) {
+    ::InitializeThreadpoolEnvironment(&environ_);
+    ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
 
-        work_ = ::CreateThreadpoolWork(
-            isStopPossible ? &stoppable_work_callback : &unstoppable_work_callback,
-            static_cast<void*>(this),
-            &environ_);
-        if (work_ == nullptr) {
-            DWORD errorCode = ::GetLastError();
-            ::DestroyThreadpoolEnvironment(&environ_);
-            throw_(
-                std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateThreadpoolWork()"});
-        }
-
-        if (isStopPossible) {
-            state_ = new (std::nothrow) std::atomic<std::uint32_t>(not_started);
-            if (state_ == nullptr) {
-                ::CloseThreadpoolWork(work_);
-                ::DestroyThreadpoolEnvironment(&environ_);
-                throw_(std::bad_alloc{});
-            }
-        } else {
-            state_ = nullptr;
-        }
+    work_ = ::CreateThreadpoolWork(
+        isStopPossible ? &stoppable_work_callback : &unstoppable_work_callback,
+        static_cast<void*>(this),
+        &environ_);
+    if (work_ == nullptr) {
+      DWORD errorCode = ::GetLastError();
+      ::DestroyThreadpoolEnvironment(&environ_);
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "CreateThreadpoolWork()"});
     }
 
-    void start_impl(const StopToken& stopToken) & noexcept {
-        if (state_ != nullptr) {
-            // Short-circuit all of this if stopToken.stop_requested() is already true.
-            //
-            // TODO: this means done can be delivered on "the wrong thread"
-            if (stopToken.stop_requested()) {
-                set_done_impl();
-                return;
-            }
-
-            stopCallback_.construct(stopToken, stop_requested_callback{*this});
-
-            // Take a copy of the 'state' pointer prior to submitting the
-            // work as the operation-state may have already been destroyed
-            // on another thread by the time SubmitThreadpoolWork() returns.
-            auto* state = state_;
-
-            ::SubmitThreadpoolWork(work_);
-
-            // Signal that SubmitThreadpoolWork() has returned and that it is
-            // now safe for the stop-request to request cancellation of the
-            // work items.
-            const auto prevState = state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
-            if ((prevState & stop_requested_flag) != 0) {
-                // stop was requested before the call to SubmitThreadpoolWork()
-                // returned and before the work started executing. It was not
-                // safe for the request_stop() method to cancel the work before
-                // it had finished being submitted so it has delegated responsibility
-                // for cancelling the just-submitted work to us to do once we
-                // finished submitting the work.
-                complete_with_done();
-            } else if ((prevState & running_flag) != 0) {
-                // Otherwise, it's possible that the work item may have started
-                // running on another thread already, prior to us returning.
-                // If this is the case then, to avoid leaving us with a
-                // dangling reference to the 'state' when the operation-state
-                // is destroyed, it will detach the 'state' from the operation-state
-                // and delegate the delete of the 'state' to us.
-                delete state;
-            }
-        } else {
-            // A stop-request is not possible so skip the extra
-            // synchronisation needed to support it.
-            ::SubmitThreadpoolWork(work_);
-        }
+    if (isStopPossible) {
+      state_ = new (std::nothrow) std::atomic<std::uint32_t>(not_started);
+      if (state_ == nullptr) {
+        ::CloseThreadpoolWork(work_);
+        ::DestroyThreadpoolEnvironment(&environ_);
+        throw_(std::bad_alloc{});
+      }
+    } else {
+      state_ = nullptr;
     }
+  }
+
+  void start_impl(const StopToken& stopToken) & noexcept {
+    if (state_ != nullptr) {
+      // Short-circuit all of this if stopToken.stop_requested() is already
+      // true.
+      //
+      // TODO: this means done can be delivered on "the wrong thread"
+      if (stopToken.stop_requested()) {
+        set_done_impl();
+        return;
+      }
+
+      stopCallback_.construct(stopToken, stop_requested_callback{*this});
+
+      // Take a copy of the 'state' pointer prior to submitting the
+      // work as the operation-state may have already been destroyed
+      // on another thread by the time SubmitThreadpoolWork() returns.
+      auto* state = state_;
+
+      ::SubmitThreadpoolWork(work_);
+
+      // Signal that SubmitThreadpoolWork() has returned and that it is
+      // now safe for the stop-request to request cancellation of the
+      // work items.
+      const auto prevState =
+          state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
+      if ((prevState & stop_requested_flag) != 0) {
+        // stop was requested before the call to SubmitThreadpoolWork()
+        // returned and before the work started executing. It was not
+        // safe for the request_stop() method to cancel the work before
+        // it had finished being submitted so it has delegated responsibility
+        // for cancelling the just-submitted work to us to do once we
+        // finished submitting the work.
+        complete_with_done();
+      } else if ((prevState & running_flag) != 0) {
+        // Otherwise, it's possible that the work item may have started
+        // running on another thread already, prior to us returning.
+        // If this is the case then, to avoid leaving us with a
+        // dangling reference to the 'state' when the operation-state
+        // is destroyed, it will detach the 'state' from the operation-state
+        // and delegate the delete of the 'state' to us.
+        delete state;
+      }
+    } else {
+      // A stop-request is not possible so skip the extra
+      // synchronisation needed to support it.
+      ::SubmitThreadpoolWork(work_);
+    }
+  }
 
 private:
-    static void CALLBACK unstoppable_work_callback(
-            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
-        op.set_value_impl();
+  static void CALLBACK unstoppable_work_callback(
+      PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+    op.set_value_impl();
+  }
+
+  static void CALLBACK stoppable_work_callback(
+      PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
+    auto& op = *static_cast<type*>(workContext);
+
+    // Signal that the work callback has started executing.
+    auto prevState =
+        op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
+    if ((prevState & stop_requested_flag) != 0) {
+      // request_stop() is already running and is waiting for this callback
+      // to finish executing. So we return immediately here without doing
+      // anything further so that we don't introduce a deadlock.
+      // In particular, we don't want to try to deregister the stop-callback
+      // which will block waiting for the request_stop() method to return.
+      return;
     }
 
-    static void CALLBACK stoppable_work_callback(
-            PTP_CALLBACK_INSTANCE, void* workContext, PTP_WORK) noexcept {
-        auto& op = *static_cast<type*>(workContext);
+    // Note that it's possible that stop might be requested after setting
+    // the 'starting' flag but before we deregister the stop callback.
+    // We're going to ignore these stop-requests as we already won the race
+    // in the fetch_add() above and ignoring them simplifies some of the
+    // cancellation logic.
 
-        // Signal that the work callback has started executing.
-        auto prevState = op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
-        if ((prevState & stop_requested_flag) != 0) {
-            // request_stop() is already running and is waiting for this callback
-            // to finish executing. So we return immediately here without doing
-            // anything further so that we don't introduce a deadlock.
-            // In particular, we don't want to try to deregister the stop-callback
-            // which will block waiting for the request_stop() method to return.
-            return;
-        }
+    op.stopCallback_.destruct();
 
-        // Note that it's possible that stop might be requested after setting
-        // the 'starting' flag but before we deregister the stop callback.
-        // We're going to ignore these stop-requests as we already won the race
-        // in the fetch_add() above and ignoring them simplifies some of the
-        // cancellation logic.
-
-        op.stopCallback_.destruct();
-
-        prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
-        if (prevState == starting_flag) {
-            // start() method has not yet finished submitting the work
-            // on another thread and so is still accessing the 'state'.
-            // This means we don't want to let the operation-state destructor
-            // free the state memory. Instead, we have just delegated
-            // responsibility for freeing this memory to the start() method
-            // and we clear the start_ member here to prevent the destructor
-            // from freeing it.
-            op.state_ = nullptr;
-        }
-
-        op.set_value_impl();
+    prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
+    if (prevState == starting_flag) {
+      // start() method has not yet finished submitting the work
+      // on another thread and so is still accessing the 'state'.
+      // This means we don't want to let the operation-state destructor
+      // free the state memory. Instead, we have just delegated
+      // responsibility for freeing this memory to the start() method
+      // and we clear the start_ member here to prevent the destructor
+      // from freeing it.
+      op.state_ = nullptr;
     }
 
-    void request_stop() noexcept {
-        auto prevState = state_->load(std::memory_order_relaxed);
-        do {
-            UNIFEX_ASSERT((prevState & running_flag) == 0);
-            if ((prevState & starting_flag) != 0) {
-                // Work callback won the race and will be waiting for
-                // us to return so it can deregister the stop-callback.
-                // Return immediately so we don't deadlock.
-                return;
-            }
-        } while (!state_->compare_exchange_weak(
-            prevState,
-            prevState | stop_requested_flag,
-            std::memory_order_acq_rel,
-            std::memory_order_relaxed));
+    op.set_value_impl();
+  }
 
-        UNIFEX_ASSERT((prevState & starting_flag) == 0);
+  void request_stop() noexcept {
+    auto prevState = state_->load(std::memory_order_relaxed);
+    do {
+      UNIFEX_ASSERT((prevState & running_flag) == 0);
+      if ((prevState & starting_flag) != 0) {
+        // Work callback won the race and will be waiting for
+        // us to return so it can deregister the stop-callback.
+        // Return immediately so we don't deadlock.
+        return;
+      }
+    } while (!state_->compare_exchange_weak(
+        prevState,
+        prevState | stop_requested_flag,
+        std::memory_order_acq_rel,
+        std::memory_order_relaxed));
 
-        if ((prevState & submit_complete_flag) != 0) {
-            // start() has finished calling SubmitThreadpoolWork() and the work has not
-            // yet started executing the work so it's safe for this method to now try
-            // and cancel the work. While it's possible that the work callback will start
-            // executing concurrently on a thread-pool thread, we are guaranteed that
-            // it will see our write of the stop_requested_flag and will promptly
-            // return without blocking.
-            complete_with_done();
-        } else {
-            // Otherwise, as the start() method has not yet finished calling
-            // SubmitThreadpoolWork() we can't safely call WaitForThreadpoolWorkCallbacks().
-            // In this case we are delegating responsibility for calling complete_with_done()
-            // to start() method when it eventually returns from SubmitThreadpoolWork().
-        }
+    UNIFEX_ASSERT((prevState & starting_flag) == 0);
+
+    if ((prevState & submit_complete_flag) != 0) {
+      // start() has finished calling SubmitThreadpoolWork() and the work has
+      // not yet started executing the work so it's safe for this method to now
+      // try and cancel the work. While it's possible that the work callback
+      // will start executing concurrently on a thread-pool thread, we are
+      // guaranteed that it will see our write of the stop_requested_flag and
+      // will promptly return without blocking.
+      complete_with_done();
+    } else {
+      // Otherwise, as the start() method has not yet finished calling
+      // SubmitThreadpoolWork() we can't safely call
+      // WaitForThreadpoolWorkCallbacks(). In this case we are delegating
+      // responsibility for calling complete_with_done() to start() method when
+      // it eventually returns from SubmitThreadpoolWork().
     }
+  }
 
-    void complete_with_done() noexcept {
-        const BOOL cancelPending = TRUE;
-        ::WaitForThreadpoolWorkCallbacks(work_, cancelPending);
+  void complete_with_done() noexcept {
+    const BOOL cancelPending = TRUE;
+    ::WaitForThreadpoolWorkCallbacks(work_, cancelPending);
 
-        // Destruct the stop-callback before calling set_done() as the call
-        // to set_done() will invalidate the stop-token and we need to
-        // make sure that
-        stopCallback_.destruct();
+    // Destruct the stop-callback before calling set_done() as the call
+    // to set_done() will invalidate the stop-token and we need to
+    // make sure that
+    stopCallback_.destruct();
 
-        // Now that the work has been successfully cancelled we can
-        // call the receiver's set_done().
-        set_done_impl();
-    }
+    // Now that the work has been successfully cancelled we can
+    // call the receiver's set_done().
+    set_done_impl();
+  }
 
-    virtual void set_done_impl() noexcept = 0;
-    virtual void set_value_impl() noexcept = 0;
+  virtual void set_done_impl() noexcept = 0;
+  virtual void set_value_impl() noexcept = 0;
 
-    struct stop_requested_callback {
-        type& op_;
+  struct stop_requested_callback {
+    type& op_;
 
-        void operator()() noexcept {
-            op_.request_stop();
-        }
-    };
+    void operator()() noexcept { op_.request_stop(); }
+  };
 
-    /////////////////
-    // Flags to use for state_ member
+  /////////////////
+  // Flags to use for state_ member
 
-    // Initial state. start() not yet called.
-    static constexpr std::uint32_t not_started = 0;
+  // Initial state. start() not yet called.
+  static constexpr std::uint32_t not_started = 0;
 
-    // Flag set once start() has finished calling ThreadpoolSubmitWork()
-    static constexpr std::uint32_t submit_complete_flag = 1;
+  // Flag set once start() has finished calling ThreadpoolSubmitWork()
+  static constexpr std::uint32_t submit_complete_flag = 1;
 
-    // Flag set by request_stop()
-    static constexpr std::uint32_t stop_requested_flag = 2;
+  // Flag set by request_stop()
+  static constexpr std::uint32_t stop_requested_flag = 2;
 
-    // Flag set by cancellable_work_callback() when it starts executing.
-    // This is before deregistering the stop-callback.
-    static constexpr std::uint32_t starting_flag = 4;
+  // Flag set by cancellable_work_callback() when it starts executing.
+  // This is before deregistering the stop-callback.
+  static constexpr std::uint32_t starting_flag = 4;
 
-    // Flag set by cancellable_work_callback() after having deregistered
-    // the stop-callback, just before it calls the receiver.
-    static constexpr std::uint32_t running_flag = 8;
+  // Flag set by cancellable_work_callback() after having deregistered
+  // the stop-callback, just before it calls the receiver.
+  static constexpr std::uint32_t running_flag = 8;
 
-    PTP_WORK work_;
-    TP_CALLBACK_ENVIRON environ_;
-    std::atomic<std::uint32_t>* state_;
-    manual_lifetime<typename StopToken::template callback_type<stop_requested_callback>> stopCallback_;
+  PTP_WORK work_;
+  TP_CALLBACK_ENVIRON environ_;
+  std::atomic<std::uint32_t>* state_;
+  manual_lifetime<
+      typename StopToken::template callback_type<stop_requested_callback>>
+      stopCallback_;
 };
 
-template<typename Receiver>
+template <typename Receiver>
 class windows_thread_pool::_cancellable_schedule_op<Receiver>::type final
-    : public windows_thread_pool::cancellable_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::cancellable_schedule_op_base<stop_token_type_t<Receiver>>;
-public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Receiver2&& r)
-    : base(pool, unifex::get_stop_token(r).stop_possible())
-    , receiver_((Receiver2&&)r)
-    {}
+  : public windows_thread_pool::cancellable_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base = windows_thread_pool::cancellable_schedule_op_base<
+      stop_token_type_t<Receiver>>;
 
-    void start() & noexcept {
-        this->start_impl(get_stop_token(receiver_));
-    }
+public:
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Receiver2&& r)
+    : base(pool, unifex::get_stop_token(r).stop_possible())
+    , receiver_((Receiver2 &&) r) {}
+
+  void start() & noexcept { this->start_impl(get_stop_token(receiver_)); }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY { unifex::set_value(std::move(receiver_)); }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
-            unifex::set_done(std::move(receiver_));
-        } else {
-            UNIFEX_ASSERT(false);
-        }
+  void set_done_impl() noexcept override {
+    if constexpr (!is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      unifex::set_done(std::move(receiver_));
+    } else {
+      UNIFEX_ASSERT(false);
     }
+  }
 
-    Receiver receiver_;
+  Receiver receiver_;
 };
 
 ////////////////////////////////////////////////////
@@ -431,381 +447,404 @@ private:
 
 class windows_thread_pool::schedule_sender {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    // it's *almost* never, but done is sometimes delivered inline, which should
-    // probably be fixed (see TODOs in start_impl())
-    static constexpr blocking_kind blocking = blocking_kind::maybe;
+  // it's *almost* never, but done is sometimes delivered inline, which should
+  // probably be fixed (see TODOs in start_impl())
+  static constexpr blocking_kind blocking = blocking_kind::maybe;
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver> AND
-            is_stop_never_possible_v<stop_token_type_t<Receiver>>)
-    schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_, (Receiver&&)r};
-    }
+  template(typename Receiver)  //
+      (requires receiver_of<Receiver> AND
+           is_stop_never_possible_v<stop_token_type_t<Receiver>>)  //
+      schedule_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, (Receiver &&) r};
+  }
 
-    template(typename Receiver)
-        (requires receiver_of<Receiver> AND
-            (!is_stop_never_possible_v<stop_token_type_t<Receiver>>))
-    cancellable_schedule_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return cancellable_schedule_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_, (Receiver&&)r};
-    }
+  template(typename Receiver)  //
+      (requires receiver_of<Receiver> AND(
+          !is_stop_never_possible_v<stop_token_type_t<Receiver>>))  //
+      cancellable_schedule_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return cancellable_schedule_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, (Receiver &&) r};
+  }
 
 private:
-    friend scheduler;
+  friend scheduler;
 
-    explicit schedule_sender(windows_thread_pool& pool) noexcept
-    : pool_(&pool)
-    {}
+  explicit schedule_sender(windows_thread_pool& pool) noexcept : pool_(&pool) {}
 
-    windows_thread_pool* pool_;
+  windows_thread_pool* pool_;
 };
 
 /////////////////////////////////
 // time_schedule_op
 
-template<typename StopToken>
+template <typename StopToken>
 class windows_thread_pool::_time_schedule_op_base<StopToken>::type {
 protected:
-    explicit type(windows_thread_pool& pool, bool isStopPossible) {
-        ::InitializeThreadpoolEnvironment(&environ_);
-        ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
+  explicit type(windows_thread_pool& pool, bool isStopPossible) {
+    ::InitializeThreadpoolEnvironment(&environ_);
+    ::SetThreadpoolCallbackPool(&environ_, pool.threadPool_);
 
-        // Give the optimiser a hand for cases where the parameter
-        // can never be true.
-        if constexpr (is_stop_never_possible_v<StopToken>) {
-            isStopPossible = false;
-        }
-
-        timer_ = ::CreateThreadpoolTimer(
-            isStopPossible ? &stoppable_timer_callback : &timer_callback, static_cast<void*>(this), &environ_);
-        if (timer_ == nullptr) {
-            DWORD errorCode = ::GetLastError();
-            ::DestroyThreadpoolEnvironment(&environ_);
-            throw_(
-                std::system_error{static_cast<int>(errorCode), std::system_category(), "CreateThreadpoolTimer()"});
-        }
-
-        if (isStopPossible) {
-            state_ = new (std::nothrow) std::atomic<std::uint32_t>{not_started};
-            if (state_ == nullptr) {
-                ::CloseThreadpoolTimer(timer_);
-                ::DestroyThreadpoolEnvironment(&environ_);
-                throw_(std::bad_alloc{});
-            }
-        }
+    // Give the optimiser a hand for cases where the parameter
+    // can never be true.
+    if constexpr (is_stop_never_possible_v<StopToken>) {
+      isStopPossible = false;
     }
 
-public:
-    ~type() {
+    timer_ = ::CreateThreadpoolTimer(
+        isStopPossible ? &stoppable_timer_callback : &timer_callback,
+        static_cast<void*>(this),
+        &environ_);
+    if (timer_ == nullptr) {
+      DWORD errorCode = ::GetLastError();
+      ::DestroyThreadpoolEnvironment(&environ_);
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "CreateThreadpoolTimer()"});
+    }
+
+    if (isStopPossible) {
+      state_ = new (std::nothrow) std::atomic<std::uint32_t>{not_started};
+      if (state_ == nullptr) {
         ::CloseThreadpoolTimer(timer_);
         ::DestroyThreadpoolEnvironment(&environ_);
-        delete state_;
+        throw_(std::bad_alloc{});
+      }
     }
+  }
+
+public:
+  ~type() {
+    ::CloseThreadpoolTimer(timer_);
+    ::DestroyThreadpoolEnvironment(&environ_);
+    delete state_;
+  }
 
 protected:
-    void start_impl(const StopToken& stopToken, FILETIME dueTime) noexcept {
-        auto startTimer = [&]() noexcept {
-            const DWORD periodInMs = 0;   // Single-shot
-            const DWORD maxDelayInMs = 0; // Max delay to allow timer coalescing
-            ::SetThreadpoolTimer(timer_, &dueTime, periodInMs, maxDelayInMs);
-        };
-
-        if constexpr (!is_stop_never_possible_v<StopToken>) {
-            auto* const state = state_;
-            if (state != nullptr) {
-                // Short-circuit extra work submitting the
-                // timer if stop has already been requested.
-                //
-                // TODO: this means done can be delivered on "the wrong thread"
-                if (stopToken.stop_requested()) {
-                    set_done_impl();
-                    return;
-                }
-
-                stopCallback_.construct(stopToken, stop_requested_callback{*this});
-
-                startTimer();
-
-                const auto prevState = state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
-                if ((prevState & stop_requested_flag) != 0) {
-                    complete_with_done();
-                } else if ((prevState & running_flag) != 0) {
-                    delete state;
-                }
-
-                return;
-            }
-        }
-
-        startTimer();
-    }
-
- private:
-    virtual void set_value_impl() noexcept = 0;
-    virtual void set_done_impl() noexcept = 0;
-
-    static void CALLBACK timer_callback(
-            [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
-            void* timerContext,
-            [[maybe_unused]] PTP_TIMER timer) noexcept {
-        type& op = *static_cast<type*>(timerContext);
-        op.set_value_impl();
-    }
-
-    static void CALLBACK stoppable_timer_callback(
-            [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
-            void* timerContext,
-            [[maybe_unused]] PTP_TIMER timer) noexcept {
-        type& op = *static_cast<type*>(timerContext);
-
-        auto prevState = op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
-        if ((prevState & stop_requested_flag) != 0) {
-            return;
-        }
-
-        op.stopCallback_.destruct();
-
-        prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
-        if (prevState == starting_flag) {
-            op.state_ = nullptr;
-        }
-
-        op.set_value_impl();
-    }
-
-    void request_stop() noexcept {
-        auto prevState = state_->load(std::memory_order_relaxed);
-        do {
-            UNIFEX_ASSERT((prevState & running_flag) == 0);
-            if ((prevState & starting_flag) != 0) {
-                return;
-            }
-        } while (!state_->compare_exchange_weak(
-            prevState,
-            prevState | stop_requested_flag,
-            std::memory_order_acq_rel,
-            std::memory_order_relaxed));
-
-        UNIFEX_ASSERT((prevState & starting_flag) == 0);
-
-        if ((prevState & submit_complete_flag) != 0) {
-            complete_with_done();
-        }
-    }
-
-    void complete_with_done() noexcept {
-        const BOOL cancelPending = TRUE;
-        ::WaitForThreadpoolTimerCallbacks(timer_, cancelPending);
-
-        stopCallback_.destruct();
-
-        set_done_impl();
-    }
-
-    struct stop_requested_callback {
-        type& op_;
-        void operator()() noexcept {
-            op_.request_stop();
-        }
+  void start_impl(const StopToken& stopToken, FILETIME dueTime) noexcept {
+    auto startTimer = [&]() noexcept {
+      const DWORD periodInMs = 0;    // Single-shot
+      const DWORD maxDelayInMs = 0;  // Max delay to allow timer coalescing
+      ::SetThreadpoolTimer(timer_, &dueTime, periodInMs, maxDelayInMs);
     };
 
-    /////////////////
-    // Flags to use for state_ member
+    if constexpr (!is_stop_never_possible_v<StopToken>) {
+      auto* const state = state_;
+      if (state != nullptr) {
+        // Short-circuit extra work submitting the
+        // timer if stop has already been requested.
+        //
+        // TODO: this means done can be delivered on "the wrong thread"
+        if (stopToken.stop_requested()) {
+          set_done_impl();
+          return;
+        }
 
-    // Initial state. start() not yet called.
-    static constexpr std::uint32_t not_started = 0;
+        stopCallback_.construct(stopToken, stop_requested_callback{*this});
 
-    // Flag set once start() has finished calling ThreadpoolSubmitWork()
-    static constexpr std::uint32_t submit_complete_flag = 1;
+        startTimer();
 
-    // Flag set by request_stop()
-    static constexpr std::uint32_t stop_requested_flag = 2;
+        const auto prevState =
+            state->fetch_add(submit_complete_flag, std::memory_order_acq_rel);
+        if ((prevState & stop_requested_flag) != 0) {
+          complete_with_done();
+        } else if ((prevState & running_flag) != 0) {
+          delete state;
+        }
 
-    // Flag set by cancellable_work_callback() when it starts executing.
-    // This is before deregistering the stop-callback.
-    static constexpr std::uint32_t starting_flag = 4;
+        return;
+      }
+    }
 
-    // Flag set by cancellable_work_callback() after having deregistered
-    // the stop-callback, just before it calls the receiver.
-    static constexpr std::uint32_t running_flag = 8;
+    startTimer();
+  }
 
-    PTP_TIMER timer_;
-    TP_CALLBACK_ENVIRON environ_;
-    std::atomic<std::uint32_t>* state_{nullptr};
-    manual_lifetime<typename StopToken::template callback_type<stop_requested_callback>> stopCallback_;
+private:
+  virtual void set_value_impl() noexcept = 0;
+  virtual void set_done_impl() noexcept = 0;
+
+  static void CALLBACK timer_callback(
+      [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
+      void* timerContext,
+      [[maybe_unused]] PTP_TIMER timer) noexcept {
+    type& op = *static_cast<type*>(timerContext);
+    op.set_value_impl();
+  }
+
+  static void CALLBACK stoppable_timer_callback(
+      [[maybe_unused]] PTP_CALLBACK_INSTANCE instance,
+      void* timerContext,
+      [[maybe_unused]] PTP_TIMER timer) noexcept {
+    type& op = *static_cast<type*>(timerContext);
+
+    auto prevState =
+        op.state_->fetch_add(starting_flag, std::memory_order_acq_rel);
+    if ((prevState & stop_requested_flag) != 0) {
+      return;
+    }
+
+    op.stopCallback_.destruct();
+
+    prevState = op.state_->fetch_add(running_flag, std::memory_order_acq_rel);
+    if (prevState == starting_flag) {
+      op.state_ = nullptr;
+    }
+
+    op.set_value_impl();
+  }
+
+  void request_stop() noexcept {
+    auto prevState = state_->load(std::memory_order_relaxed);
+    do {
+      UNIFEX_ASSERT((prevState & running_flag) == 0);
+      if ((prevState & starting_flag) != 0) {
+        return;
+      }
+    } while (!state_->compare_exchange_weak(
+        prevState,
+        prevState | stop_requested_flag,
+        std::memory_order_acq_rel,
+        std::memory_order_relaxed));
+
+    UNIFEX_ASSERT((prevState & starting_flag) == 0);
+
+    if ((prevState & submit_complete_flag) != 0) {
+      complete_with_done();
+    }
+  }
+
+  void complete_with_done() noexcept {
+    const BOOL cancelPending = TRUE;
+    ::WaitForThreadpoolTimerCallbacks(timer_, cancelPending);
+
+    stopCallback_.destruct();
+
+    set_done_impl();
+  }
+
+  struct stop_requested_callback {
+    type& op_;
+    void operator()() noexcept { op_.request_stop(); }
+  };
+
+  /////////////////
+  // Flags to use for state_ member
+
+  // Initial state. start() not yet called.
+  static constexpr std::uint32_t not_started = 0;
+
+  // Flag set once start() has finished calling ThreadpoolSubmitWork()
+  static constexpr std::uint32_t submit_complete_flag = 1;
+
+  // Flag set by request_stop()
+  static constexpr std::uint32_t stop_requested_flag = 2;
+
+  // Flag set by cancellable_work_callback() when it starts executing.
+  // This is before deregistering the stop-callback.
+  static constexpr std::uint32_t starting_flag = 4;
+
+  // Flag set by cancellable_work_callback() after having deregistered
+  // the stop-callback, just before it calls the receiver.
+  static constexpr std::uint32_t running_flag = 8;
+
+  PTP_TIMER timer_;
+  TP_CALLBACK_ENVIRON environ_;
+  std::atomic<std::uint32_t>* state_{nullptr};
+  manual_lifetime<
+      typename StopToken::template callback_type<stop_requested_callback>>
+      stopCallback_;
 };
 
 /////////////////////////////////
 // schedule_at() operation
 
-template<typename Receiver>
+template <typename Receiver>
 class windows_thread_pool::_schedule_at_op<Receiver>::type final
-    : public windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+  : public windows_thread_pool::time_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base =
+      windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, windows_thread_pool::clock_type::time_point dueTime, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(
+      windows_thread_pool& pool,
+      windows_thread_pool::clock_type::time_point dueTime,
+      Receiver2&& r)
     : base(pool, get_stop_token(r).stop_possible())
     , dueTime_(dueTime)
-    , receiver_((Receiver2&&)r) {}
+    , receiver_((Receiver2 &&) r) {}
 
-    void start() & noexcept {
-        ULARGE_INTEGER ticks;
-        ticks.QuadPart = dueTime_.get_ticks();
+  void start() & noexcept {
+    ULARGE_INTEGER ticks;
+    ticks.QuadPart = dueTime_.get_ticks();
 
-        FILETIME ft;
-        ft.dwLowDateTime = ticks.LowPart;
-        ft.dwHighDateTime = ticks.HighPart;
+    FILETIME ft;
+    ft.dwLowDateTime = ticks.LowPart;
+    ft.dwHighDateTime = ticks.HighPart;
 
-        this->start_impl(get_stop_token(receiver_), ft);
-    }
+    this->start_impl(get_stop_token(receiver_), ft);
+  }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (unifex::is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY { unifex::set_value(std::move(receiver_)); }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        unifex::set_done(std::move(receiver_));
-    }
+  void set_done_impl() noexcept override {
+    unifex::set_done(std::move(receiver_));
+  }
 
-    windows_thread_pool::clock_type::time_point dueTime_;
-    Receiver receiver_;
+  windows_thread_pool::clock_type::time_point dueTime_;
+  Receiver receiver_;
 };
 
 class windows_thread_pool::schedule_at_sender {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    // it's *almost* never, but done is sometimes delivered inline, which should
-    // probably be fixed (see TODOs in start_impl())
-    static constexpr blocking_kind blocking = blocking_kind::maybe;
+  // it's *almost* never, but done is sometimes delivered inline, which should
+  // probably be fixed (see TODOs in start_impl())
+  static constexpr blocking_kind blocking = blocking_kind::maybe;
 
-    explicit schedule_at_sender(windows_thread_pool& pool, filetime_clock::time_point dueTime)
+  explicit schedule_at_sender(
+      windows_thread_pool& pool, filetime_clock::time_point dueTime)
     : pool_(&pool)
-    , dueTime_(dueTime)
-    {}
+    , dueTime_(dueTime) {}
 
-    template(typename Receiver)
-        (requires unifex::receiver_of<Receiver>)
-    schedule_at_op<unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_at_op<unifex::remove_cvref_t<Receiver>>{
-            *pool_,
-            dueTime_,
-            (Receiver&&)r
-        };
-    }
+  template(typename Receiver)                   //
+      (requires unifex::receiver_of<Receiver>)  //
+      schedule_at_op<unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_at_op<unifex::remove_cvref_t<Receiver>>{
+        *pool_, dueTime_, (Receiver &&) r};
+  }
 
 private:
-    windows_thread_pool* pool_;
-    filetime_clock::time_point dueTime_;
+  windows_thread_pool* pool_;
+  filetime_clock::time_point dueTime_;
 };
 
 //////////////////////////////////
 // schedule_after()
 
-template<typename Duration, typename Receiver>
+template <typename Duration, typename Receiver>
 class windows_thread_pool::_schedule_after_op<Duration, Receiver>::type final
-    : public windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>> {
-    using base = windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+  : public windows_thread_pool::time_schedule_op_base<
+        stop_token_type_t<Receiver>> {
+  using base =
+      windows_thread_pool::time_schedule_op_base<stop_token_type_t<Receiver>>;
+
 public:
-    template<typename Receiver2>
-    explicit type(windows_thread_pool& pool, Duration duration, Receiver2&& r)
+  template <typename Receiver2>
+  explicit type(windows_thread_pool& pool, Duration duration, Receiver2&& r)
     : base(pool, get_stop_token(r).stop_possible())
     , duration_(duration)
-    , receiver_((Receiver2&&)r) {}
+    , receiver_((Receiver2 &&) r) {}
 
-    void start() & noexcept {
-        auto dueTime = filetime_clock::now() + duration_;
+  void start() & noexcept {
+    auto dueTime = filetime_clock::now() + duration_;
 
-        ULARGE_INTEGER ticks;
-        ticks.QuadPart = dueTime.get_ticks();
+    ULARGE_INTEGER ticks;
+    ticks.QuadPart = dueTime.get_ticks();
 
-        FILETIME ft;
-        ft.dwLowDateTime = ticks.LowPart;
-        ft.dwHighDateTime = ticks.HighPart;
+    FILETIME ft;
+    ft.dwLowDateTime = ticks.LowPart;
+    ft.dwHighDateTime = ticks.HighPart;
 
-        this->start_impl(get_stop_token(receiver_), ft);
-    }
+    this->start_impl(get_stop_token(receiver_), ft);
+  }
 
 private:
-    void set_value_impl() noexcept override {
-        if constexpr (unifex::is_nothrow_callable_v<decltype(unifex::set_value), Receiver>) {
-            unifex::set_value(std::move(receiver_));
-        } else {
-            UNIFEX_TRY {
-                unifex::set_value(std::move(receiver_));
-            } UNIFEX_CATCH (...) {
-                unifex::set_error(std::move(receiver_), std::current_exception());
-            }
-        }
+  void set_value_impl() noexcept override {
+    if constexpr (unifex::is_nothrow_callable_v<
+                      decltype(unifex::set_value),
+                      Receiver>) {
+      unifex::set_value(std::move(receiver_));
+    } else {
+      UNIFEX_TRY { unifex::set_value(std::move(receiver_)); }
+      UNIFEX_CATCH(...) {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
     }
+  }
 
-    void set_done_impl() noexcept override {
-        unifex::set_done(std::move(receiver_));
-    }
+  void set_done_impl() noexcept override {
+    unifex::set_done(std::move(receiver_));
+  }
 
-    Duration duration_;
-    Receiver receiver_;
+  Duration duration_;
+  Receiver receiver_;
 };
 
-
-template<typename Duration>
+template <typename Duration>
 class windows_thread_pool::_schedule_after_sender<Duration>::type {
 public:
-    template<template<typename...> class Variant, template<typename...> class Tuple>
-    using value_types = Variant<Tuple<>>;
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<Tuple<>>;
 
-    template<template<typename...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
+  template <template <typename...> class Variant>
+  using error_types = Variant<std::exception_ptr>;
 
-    static constexpr bool sends_done = true;
+  static constexpr bool sends_done = true;
 
-    // it's *almost* never, but done is sometimes delivered inline, which should
-    // probably be fixed (see TODOs in start_impl())
-    static constexpr blocking_kind blocking = blocking_kind::maybe;
+  // it's *almost* never, but done is sometimes delivered inline, which should
+  // probably be fixed (see TODOs in start_impl())
+  static constexpr blocking_kind blocking = blocking_kind::maybe;
 
-    explicit type(windows_thread_pool& pool, Duration duration)
+  explicit type(windows_thread_pool& pool, Duration duration)
     : pool_(&pool)
-    , duration_(duration)
-    {}
+    , duration_(duration) {}
 
-    template(typename Receiver)
-        (requires unifex::receiver_of<Receiver>)
-    schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>> connect(Receiver&& r) const {
-        return schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>>{
-            *pool_,
-            duration_,
-            (Receiver&&)r
-        };
-    }
+  template(typename Receiver)                   //
+      (requires unifex::receiver_of<Receiver>)  //
+      schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>> connect(
+          Receiver&& r) const {
+    return schedule_after_op<Duration, unifex::remove_cvref_t<Receiver>>{
+        *pool_, duration_, (Receiver &&) r};
+  }
 
 private:
-    windows_thread_pool* pool_;
-    Duration duration_;
+  windows_thread_pool* pool_;
+  Duration duration_;
 };
 
 /////////////////////////////////
@@ -813,52 +852,47 @@ private:
 
 class windows_thread_pool::scheduler {
 public:
-    using time_point = filetime_clock::time_point;
+  using time_point = filetime_clock::time_point;
 
-    schedule_sender schedule() const noexcept {
-        return schedule_sender{*pool_};
-    }
+  schedule_sender schedule() const noexcept { return schedule_sender{*pool_}; }
 
-    time_point now() const noexcept {
-        return filetime_clock::now();
-    }
+  time_point now() const noexcept { return filetime_clock::now(); }
 
-    schedule_at_sender schedule_at(time_point tp) const noexcept {
-        return schedule_at_sender{*pool_, tp};
-    }
+  schedule_at_sender schedule_at(time_point tp) const noexcept {
+    return schedule_at_sender{*pool_, tp};
+  }
 
-    template<typename Duration>
-    schedule_after_sender<Duration> schedule_after(Duration d) const
-            noexcept(std::is_nothrow_move_constructible_v<Duration>) {
-        return schedule_after_sender<Duration>{*pool_, std::move(d)};
-    }
+  template <typename Duration>
+  schedule_after_sender<Duration> schedule_after(Duration d) const
+      noexcept(std::is_nothrow_move_constructible_v<Duration>) {
+    return schedule_after_sender<Duration>{*pool_, std::move(d)};
+  }
 
-    friend bool operator==(scheduler a, scheduler b) noexcept {
-        return a.pool_ == b.pool_;
-    }
+  friend bool operator==(scheduler a, scheduler b) noexcept {
+    return a.pool_ == b.pool_;
+  }
 
-    friend bool operator!=(scheduler a, scheduler b) noexcept {
-        return a.pool_ != b.pool_;
-    }
+  friend bool operator!=(scheduler a, scheduler b) noexcept {
+    return a.pool_ != b.pool_;
+  }
 
 private:
-    friend windows_thread_pool;
+  friend windows_thread_pool;
 
-    explicit scheduler(windows_thread_pool& pool) noexcept
-    : pool_(&pool)
-    {}
+  explicit scheduler(windows_thread_pool& pool) noexcept : pool_(&pool) {}
 
-    windows_thread_pool* pool_;
+  windows_thread_pool* pool_;
 };
 
 /////////////////////////
 // scheduler methods
 
-inline windows_thread_pool::scheduler windows_thread_pool::get_scheduler() noexcept {
-    return scheduler{*this};
+inline windows_thread_pool::scheduler
+windows_thread_pool::get_scheduler() noexcept {
+  return scheduler{*this};
 }
 
-} // namespace win32
-} // namespace unifex
+}  // namespace win32
+}  // namespace unifex
 
 #include <unifex/detail/epilogue.hpp>

--- a/source/win32/filetime_clock.cpp
+++ b/source/win32/filetime_clock.cpp
@@ -22,14 +22,14 @@
 namespace unifex::win32 {
 
 filetime_clock::time_point filetime_clock::now() noexcept {
-    FILETIME filetime;
-    ::GetSystemTimeAsFileTime(&filetime);
+  FILETIME filetime;
+  ::GetSystemTimeAsFileTime(&filetime);
 
-    ULARGE_INTEGER ticks;
-    ticks.HighPart = filetime.dwHighDateTime;
-    ticks.LowPart = filetime.dwLowDateTime;
+  ULARGE_INTEGER ticks;
+  ticks.HighPart = filetime.dwHighDateTime;
+  ticks.LowPart = filetime.dwLowDateTime;
 
-    return time_point::from_ticks(ticks.QuadPart);
+  return time_point::from_ticks(ticks.QuadPart);
 }
 
-} // namespace unifex::win32
+}  // namespace unifex::win32

--- a/source/win32/low_latency_iocp_context.cpp
+++ b/source/win32/low_latency_iocp_context.cpp
@@ -16,709 +16,701 @@
 
 #include <unifex/win32/low_latency_iocp_context.hpp>
 
-#include <unifex/scope_guard.hpp>
 #include <unifex/exception.hpp>
+#include <unifex/scope_guard.hpp>
 
 #include <atomic>
 #include <random>
 #include <system_error>
 
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
+#  define WIN32_LEAN_AND_MEAN 1
 #endif
 
 #include <Windows.h>
 
-namespace unifex::win32
-{
-  namespace
-  {
-    static safe_handle create_iocp() {
-      HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
-      if (h == NULL) {
-        DWORD errorCode = ::GetLastError();
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "CreateIoCompletionPort()"});
-      }
-
-      return safe_handle{h};
-    }
-
-  }  // namespace
-
-  low_latency_iocp_context::low_latency_iocp_context(
-      std::size_t maxIoOperations)
-    : activeThreadId_(std::thread::id())
-    , iocp_(create_iocp())
-    , ioPoolSize_(maxIoOperations)
-    , ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
-    // Make sure the WinNT APIs are initialised and available.
-    // Only need to do this on construction as this will be guaranteed
-    // to run before anything else needs to call them.
-    ntapi::ensure_initialised();
-
-    // Build the I/O free-list in reverse so front of free-list
-    // is first element in array.
-    for (std::size_t i = 0; i < maxIoOperations; ++i) {
-      ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
-    }
+namespace unifex::win32 {
+namespace {
+static safe_handle create_iocp() {
+  HANDLE h = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+  if (h == NULL) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "CreateIoCompletionPort()"});
   }
 
-  low_latency_iocp_context::~low_latency_iocp_context() {
-    // Wait until the completion-event for every io-state has been
-    // received before we free the memory for the io-states.
-    std::size_t remaining = ioPoolSize_;
-    while (!ioFreeList_.empty()) {
-      (void)ioFreeList_.pop_front();
-      --remaining;
-    }
+  return safe_handle{h};
+}
 
-    if (remaining > 0) {
-      constexpr std::uint32_t completionBufferSize = 128;
-      ntapi::FILE_IO_COMPLETION_INFORMATION
-          completionBuffer[completionBufferSize];
-      std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+}  // namespace
 
-      do {
-        ntapi::ULONG numEntriesRemoved = 0;
-        ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
-            iocp_.get(),
-            completionBuffer,
-            completionBufferSize,
-            &numEntriesRemoved,
-            NULL,    // no timeout
-            FALSE);  // not alertable
-        if (!ntapi::ntstatus_success(ntstat)) {
-          std::terminate();
-        }
+low_latency_iocp_context::low_latency_iocp_context(std::size_t maxIoOperations)
+  : activeThreadId_(std::thread::id())
+  , iocp_(create_iocp())
+  , ioPoolSize_(maxIoOperations)
+  , ioPool_(std::make_unique<vectored_io_state[]>(maxIoOperations)) {
+  // Make sure the WinNT APIs are initialised and available.
+  // Only need to do this on construction as this will be guaranteed
+  // to run before anything else needs to call them.
+  ntapi::ensure_initialised();
 
-        for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
-          auto& entry = completionBuffer[i];
-          if (entry.ApcContext != nullptr) {
-            ntapi::IO_STATUS_BLOCK* iosb =
-                reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-            auto* state = to_io_state(iosb);
-            UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-            --state->pendingCompletionNotifications;
-            if (state->pendingCompletionNotifications == 0) {
-              --remaining;
-            }
-          }
-        }
-      } while (remaining > 0);
-    }
+  // Build the I/O free-list in reverse so front of free-list
+  // is first element in array.
+  for (std::size_t i = 0; i < maxIoOperations; ++i) {
+    ioFreeList_.push_front(&ioPool_[maxIoOperations - 1 - i]);
+  }
+}
+
+low_latency_iocp_context::~low_latency_iocp_context() {
+  // Wait until the completion-event for every io-state has been
+  // received before we free the memory for the io-states.
+  std::size_t remaining = ioPoolSize_;
+  while (!ioFreeList_.empty()) {
+    (void)ioFreeList_.pop_front();
+    --remaining;
   }
 
-  void low_latency_iocp_context::run_impl(bool& stopFlag) {
-    ntapi::LARGE_INTEGER zero;
-    zero.QuadPart = 0;
-
-    const ntapi::PLARGE_INTEGER zeroTimeout = &zero;
-    const ntapi::PLARGE_INTEGER infiniteTimeout = nullptr;
-
-    [[maybe_unused]] auto prevId = activeThreadId_.exchange(
-        std::this_thread::get_id(), std::memory_order_relaxed);
-    UNIFEX_ASSERT(prevId == std::thread::id());
-
-    scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
-      activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
-    };
-
+  if (remaining > 0) {
     constexpr std::uint32_t completionBufferSize = 128;
     ntapi::FILE_IO_COMPLETION_INFORMATION
         completionBuffer[completionBufferSize];
     std::memset(&completionBuffer, 0, sizeof(completionBuffer));
 
-    bool shouldCheckRemoteQueue = true;
-
-    // Make sure that we leave the remote queue in a
-    // state such that the  'shouldCheckRemoteQueue = true'
-    // is a valid initial state for the next caller to run().
-    scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
-      if (!shouldCheckRemoteQueue) {
-        (void)remoteQueue_.try_mark_active();
-      }
-    };
-
-    while (!stopFlag) {
-process_ready_queue:
-      // Process/drain all ready-to-run work.
-      while (!readyQueue_.empty()) {
-        operation_base* task = readyQueue_.pop_front();
-        task->callback(task);
-      }
-
-      // Check whether the stop request was processed
-      // when draining the ready queue.
-      if (stopFlag) {
-        break;
-      }
-
-      // Check the poll-queue for I/O operations that might have completed
-      // already but where we have not yet seen the IOCP event.
-
-      while (!pollQueue_.empty()) {
-        io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
-        auto* state = op->ioState;
-        UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-        UNIFEX_ASSERT(!state->completed);
-
-        if (poll_is_complete(*state)) {
-          // Completed before we received any notifications via IOCP.
-          // Schedule it to resume now, before polling any other I/Os
-          // to give those other I/Os time to complete.
-          state->completed = true;
-          schedule_local(state->parent);
-          goto process_ready_queue;
-        }
-      }
-
-process_remote_queue:
-      if (shouldCheckRemoteQueue) {
-        if (try_dequeue_remote_work()) {
-          goto process_ready_queue;
-        }
-      }
-
-      // Now check if there are any IOCP events.
-get_iocp_entries:
-      const ntapi::BOOLEAN alertable = FALSE;
-      ntapi::ULONG completionEntriesRetrieved = 0;
+    do {
+      ntapi::ULONG numEntriesRemoved = 0;
       ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
           iocp_.get(),
           completionBuffer,
           completionBufferSize,
-          &completionEntriesRetrieved,
-          shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
-          alertable);
-      if (ntstat == STATUS_TIMEOUT) {
-        UNIFEX_ASSERT(shouldCheckRemoteQueue);
-
-        // Previous call was non-blocking.
-        // About to transition to blocking-call, but first need to
-        // mark remote queue inactive so that remote threads know
-        // they need to post an event to wake this thread up.
-        if (remoteQueue_.try_mark_inactive()) {
-          shouldCheckRemoteQueue = false;
-          goto get_iocp_entries;
-        } else {
-          goto process_remote_queue;
-        }
-      } else if (!ntapi::ntstatus_success(ntstat)) {
-        DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "NtRemoveIoCompletionEx()"});
+          &numEntriesRemoved,
+          NULL,    // no timeout
+          FALSE);  // not alertable
+      if (!ntapi::ntstatus_success(ntstat)) {
+        std::terminate();
       }
 
-      // Process completion-entries we received from the OS.
-      for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
-        ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
+      for (std::uint32_t i = 0; i < numEntriesRemoved; ++i) {
+        auto& entry = completionBuffer[i];
         if (entry.ApcContext != nullptr) {
           ntapi::IO_STATUS_BLOCK* iosb =
               reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
-          // TODO: Do we need to store the error-code/bytes-transferred here?
-          // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
-          // Should we be copying entry.IoStatusBlock to '*iosb'?
-
-          UNIFEX_ASSERT(iosb->Status != STATUS_PENDING);
-
-          vectored_io_state* state = to_io_state(iosb);
-
+          auto* state = to_io_state(iosb);
           UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
-          if (--state->pendingCompletionNotifications == 0) {
-            // This was the last pending notification for this state.
-            if (state->parent != nullptr) {
-              // An operation is still attached to this state.
-              // Notify it if we hadn't already done so.
-              if (!state->completed) {
-                state->completed = true;
-                schedule_local(state->parent);
-              }
-            } else {
-              // Otherwise the operation has already detached
-              // from this I/O state and so we can immediately
-              // return it to the pool.
-              release_io_state(state);
-            }
+          --state->pendingCompletionNotifications;
+          if (state->pendingCompletionNotifications == 0) {
+            --remaining;
           }
-        } else {
-          // A remote-thread wake-up notification.
-          shouldCheckRemoteQueue = true;
         }
       }
+    } while (remaining > 0);
+  }
+}
+
+void low_latency_iocp_context::run_impl(bool& stopFlag) {
+  ntapi::LARGE_INTEGER zero;
+  zero.QuadPart = 0;
+
+  const ntapi::PLARGE_INTEGER zeroTimeout = &zero;
+  const ntapi::PLARGE_INTEGER infiniteTimeout = nullptr;
+
+  [[maybe_unused]] auto prevId = activeThreadId_.exchange(
+      std::this_thread::get_id(), std::memory_order_relaxed);
+  UNIFEX_ASSERT(prevId == std::thread::id());
+
+  scope_guard resetActiveThreadIdOnExit = [&]() noexcept {
+    activeThreadId_.store(std::thread::id(), std::memory_order_relaxed);
+  };
+
+  constexpr std::uint32_t completionBufferSize = 128;
+  ntapi::FILE_IO_COMPLETION_INFORMATION completionBuffer[completionBufferSize];
+  std::memset(&completionBuffer, 0, sizeof(completionBuffer));
+
+  bool shouldCheckRemoteQueue = true;
+
+  // Make sure that we leave the remote queue in a
+  // state such that the  'shouldCheckRemoteQueue = true'
+  // is a valid initial state for the next caller to run().
+  scope_guard ensureRemoteQueueActiveOnExit = [&]() noexcept {
+    if (!shouldCheckRemoteQueue) {
+      (void)remoteQueue_.try_mark_active();
     }
-  }
+  };
 
-  bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
-    auto items = remoteQueue_.dequeue_all_reversed();
-    if (items.empty()) {
-      return false;
-    }
-
-    // Note that this ends up enqueueing entries in reverse.
-    // TODO: Modify this so it enqueues items in a way that
-    // preserves order.
-    do {
-      schedule_local(items.pop_front());
-    } while (!items.empty());
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::poll_is_complete(
-      vectored_io_state& state) noexcept {
-    // TODO: Double check the memory barriers/atomics we need to use
-    // here to ensure we perform this read, that it doesn't tear and
-    // that it has the appropriate memory semantics.
-
-    for (std::size_t i = 0; i < state.operationCount; ++i) {
-      // Mark volatile to indicate to the compiler that it might change in the
-      // background. The kernel might update it as the I/O completes.
-      volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
-      if (iosb->Status == STATUS_PENDING) {
-        return false;
-      }
-    }
-
-    // Make sure that we have visibility of the results of the I/O operations
-    // (assuming that the OS used a "release" memory semantic when writing
-    // to the 'Status' field).
-    std::atomic_thread_fence(std::memory_order_acquire);
-
-    return true;
-  }
-
-  low_latency_iocp_context::vectored_io_state*
-  low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
-    vectored_io_state* const pool = ioPool_.get();
-
-    std::ptrdiff_t offset =
-        reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
-    UNIFEX_ASSERT(offset >= 0);
-
-    std::ptrdiff_t index = offset / sizeof(vectored_io_state);
-    UNIFEX_ASSERT(index < static_cast<std::ptrdiff_t>(ioPoolSize_));
-
-    return &pool[index];
-  }
-
-  void low_latency_iocp_context::schedule(operation_base* op) noexcept {
-    if (is_running_on_io_thread()) {
-      schedule_local(op);
-    } else {
-      schedule_remote(op);
-    }
-  }
-
-  void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    readyQueue_.push_back(op);
-  }
-
-  void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
-    UNIFEX_ASSERT(!is_running_on_io_thread());
-    if (remoteQueue_.enqueue(op)) {
-      // I/O thread is potentially sleeping.
-      // Post a wake-up NOP event to the queue.
-
-      // BUGBUG: This could potentially fail and if it does then
-      // the I/O thread might never respond to remote enqueues.
-      // For now we just treat this as a (hopefully rare) unrecoverable error.
-      ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
-          iocp_.get(),
-          0,        // KeyContext
-          nullptr,  // ApcContext
-          0,        // NTSTATUS (0 = success)
-          0);       // IoStatusInformation
-      if (!ntapi::ntstatus_success(ntstat)) {
-        // Failed to post an event to the I/O completion port.
-        std::terminate();
-      }
-    }
-  }
-
-  bool low_latency_iocp_context::try_allocate_io_state_for(
-      io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-
-    if (ioFreeList_.empty()) {
-      return false;
+  while (!stopFlag) {
+process_ready_queue:
+    // Process/drain all ready-to-run work.
+    while (!readyQueue_.empty()) {
+      operation_base* task = readyQueue_.pop_front();
+      task->callback(task);
     }
 
-    UNIFEX_ASSERT(pendingIoQueue_.empty());
-
-    // An operation is already available
-    auto* state = ioFreeList_.pop_front();
-    state->parent = op;
-    state->completed = false;
-    state->operationCount = 0;
-    state->pendingCompletionNotifications = 0;
-    op->ioState = state;
-
-    return true;
-  }
-
-  void low_latency_iocp_context::schedule_when_io_state_available(
-      io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    UNIFEX_ASSERT(ioFreeList_.empty());
-    pendingIoQueue_.push_back(op);
-  }
-
-  void low_latency_iocp_context::release_io_state(
-      vectored_io_state* state) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-
-    if (state->pendingCompletionNotifications == 0) {
-      // Can be freed immediately.
-
-      if (pendingIoQueue_.empty()) {
-        ioFreeList_.push_front(state);
-      } else {
-        UNIFEX_ASSERT(ioFreeList_.empty());
-
-        // Another operation was waiting for an I/O state.
-        // Give the I/O state directly to the operation instead
-        // of adding it to the free-list. This prevents some other
-        // operation from skipping the queue and acquiring it
-        // before this I/O operation can run.
-        auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
-
-        state->parent = op;
-        state->completed = false;
-        state->operationCount = 0;
-        state->pendingCompletionNotifications = 0;
-        op->ioState = state;
-
-        schedule_local(op);
-      }
-    } else {
-      // Mark it to be freed once all of its I/O completion
-      // notifications have been received.
-      state->parent = nullptr;
-    }
-  }
-
-  void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
-    UNIFEX_ASSERT(is_running_on_io_thread());
-    UNIFEX_ASSERT(op != nullptr);
-    UNIFEX_ASSERT(op->ioState != nullptr);
-
-    if (op->ioState->pendingCompletionNotifications > 0) {
-      pollQueue_.push_back(op);
-    } else {
-      // No need to poll, schedule straight to the front of the ready-to-run
-      // queue.
-      readyQueue_.push_front(op);
-    }
-  }
-
-  void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
-    const HANDLE result =
-        ::CreateIoCompletionPort(fileHandle, iocp_.get(), 0, 0);
-    if (result == nullptr) {
-      DWORD errorCode = ::GetLastError();
-      throw_(std::system_error{
-          static_cast<int>(errorCode),
-          std::system_category(),
-          "CreateIoCompletionPort"});
-    }
-
-    const BOOL ok = ::SetFileCompletionNotificationModes(
-        fileHandle,
-        FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE);
-    if (!ok) {
-      DWORD errorCode = ::GetLastError();
-      throw_(std::system_error{
-          static_cast<int>(errorCode),
-          std::system_category(),
-          "SetFileCompletionNotificationModes"});
-    }
-  }
-
-  void low_latency_iocp_context::io_operation::cancel_io() noexcept {
-    UNIFEX_ASSERT(ioState != nullptr);
-
-    // Cancel operations in reverse order so that later operations
-    // are cancelled first and don't accidentally end up with earlier
-    // operations being cancelled and later ones completing due to
-    // a race.
-    for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
-      ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
-      ntapi::IO_STATUS_BLOCK ioStatus;
-      [[maybe_unused]] ntapi::NTSTATUS ntstat =
-          ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
-      // TODO: Check ntstat for failure.
-      // Can't really do much here even if there is failure, anyway.
-    }
-  }
-
-  bool low_latency_iocp_context::io_operation::is_complete() noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-
-    if (ioState->pendingCompletionNotifications == 0) {
-      return true;
-    }
-
-    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-      volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
-
-      // Mark volatile to indicate to the compiler that it might change in the
-      // background. The kernel might update it as the I/O completes.
-      if (iosb->Status == STATUS_PENDING) {
-        return false;
-      }
-    }
-
-    // Make sure that we have visibility of the results of all of the I/O
-    // operations.
-    // Assuming that the OS used a "release" memory semantic when writing
-    // to the 'Status' field here.
-    std::atomic_thread_fence(std::memory_order_acquire);
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::io_operation::start_read(
-      span<std::byte> buffer) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
-
-    std::size_t offset = 0;
-    while (offset < buffer.size()) {
-      ntapi::IO_STATUS_BLOCK& iosb =
-          ioState->operations[ioState->operationCount];
-      ++ioState->operationCount;
-
-      iosb.Status = STATUS_PENDING;
-      iosb.Information = 0;
-
-      // Truncate over-large chunks to a number of bytes that will still
-      // preserve alignment requirements of the underlying device if this
-      // happens to be an unbuffered storage device.
-      // In this case we truncate to the largest multiple of 64k less than
-      // 2^32 to allow for up to 64k alignment.
-      // TODO: Ideally we'd just use the underlying alignment of the
-      // file-handle.
-      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
-
-      std::size_t chunkSize = buffer.size() - offset;
-      if (chunkSize > maxChunkSize) {
-        chunkSize = truncatedChunkSize;
-      }
-
-      ntapi::NTSTATUS status = ntapi::NtReadFile(
-          fileHandle,
-          NULL,                                  // Event
-          NULL,                                  // ApcRoutine
-          &iosb,                                 // ApcContext
-          &iosb,                                 // IoStatusBlock
-          buffer.data() + offset,                // Buffer
-          static_cast<ntapi::ULONG>(chunkSize),  // Length
-          nullptr,                               // ByteOffset
-          nullptr);                              // Key
-      if (status == STATUS_PENDING) {
-        ++ioState->pendingCompletionNotifications;
-      } else if (ntapi::ntstatus_success(status)) {
-        // Succeeded synchronously.
-        if (!skipNotificationOnSuccess) {
-          ++ioState->pendingCompletionNotifications;
-        }
-      } else {
-        // Immediate failure.
-        // Don't launch any more operations.
-        // TODO: Should we cancel any prior launched operations?
-        return false;
-      }
-
-      if (ioState->operationCount == max_vectored_io_size) {
-        // We've launched as many operations as we can.
-        return false;
-      }
-
-      offset += chunkSize;
-    }
-
-    return true;
-  }
-
-  bool low_latency_iocp_context::io_operation::start_write(
-      span<const std::byte> buffer) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
-
-    std::size_t offset = 0;
-    while (offset < buffer.size()) {
-      ntapi::IO_STATUS_BLOCK& iosb =
-          ioState->operations[ioState->operationCount];
-      ++ioState->operationCount;
-
-      iosb.Status = STATUS_PENDING;
-      iosb.Information = 0;
-
-      // Truncate over-large chunks to a number of bytes that will still
-      // preserve alignment requirements of the underlying device if this
-      // happens to be an unbuffered storage device.
-      // In this case we truncate to the largest multiple of 64k less than
-      // 2^32 to allow for up to 64k alignment.
-      // TODO: Ideally we'd just use the underlying alignment of the
-      // file-handle.
-      static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
-      static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
-
-      std::size_t chunkSize = buffer.size() - offset;
-      if (chunkSize > maxChunkSize) {
-        chunkSize = truncatedChunkSize;
-      }
-
-      ntapi::NTSTATUS status = ntapi::NtWriteFile(
-          fileHandle,
-          NULL,                                            // Event
-          NULL,                                            // ApcRoutine
-          &iosb,                                           // ApcContext
-          &iosb,                                           // IoStatusBlock
-          const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
-          static_cast<ntapi::ULONG>(chunkSize),            // Length
-          nullptr,                                         // ByteOffset
-          nullptr);                                        // Key
-      if (status == STATUS_PENDING) {
-        ++ioState->pendingCompletionNotifications;
-      } else if (ntapi::ntstatus_success(status)) {
-        // Succeeded synchronously.
-        if (!skipNotificationOnSuccess) {
-          ++ioState->pendingCompletionNotifications;
-        }
-      } else {
-        // Immediate failure.
-        // Don't launch any more operations.
-        // TODO: Should we cancel any prior launched operations?
-        return false;
-      }
-
-      if (ioState->operationCount == max_vectored_io_size) {
-        return false;
-      }
-
-      offset += chunkSize;
-    }
-
-    return true;
-  }
-
-  std::size_t low_latency_iocp_context::io_operation::get_result(
-      std::error_code& ec) noexcept {
-    UNIFEX_ASSERT(context.is_running_on_io_thread());
-    UNIFEX_ASSERT(ioState != nullptr);
-    UNIFEX_ASSERT(ioState->completed);
-
-    ec = std::error_code{};
-
-    std::size_t totalBytesTransferred = 0;
-    for (std::size_t i = 0; i < ioState->operationCount; ++i) {
-      const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
-
-      UNIFEX_ASSERT(iosb.Status != STATUS_PENDING);
-
-      totalBytesTransferred += iosb.Information;
-
-      if (!ntapi::ntstatus_success(iosb.Status)) {
-        ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
-        ec = std::error_code(
-            static_cast<int>(errorCode), std::system_category());
-        break;
-      }
-    }
-
-    return totalBytesTransferred;
-  }
-
-  std::tuple<
-      low_latency_iocp_context::readable_byte_stream,
-      low_latency_iocp_context::writable_byte_stream>
-  low_latency_iocp_context::scheduler::open_pipe_impl(
-      low_latency_iocp_context& context) {
-    std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
-
-    safe_handle serverHandle;
-
-    auto toHex = [](std::uint8_t value) noexcept -> char {
-      return value < 10 ? char('0' + value) : char('a' - 10 + value);
-    };
-
-    char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
-
-    // Try to create the server side of a new named pipe
-    // Use a randomly generated name to ensure uniqueness.
-
-    const DWORD pipeBufferSize = 16 * 1024;
-    const int maxAttempts = 100;
-
-    for (int attempt = 1;; ++attempt) {
-      const std::uint64_t randomNumber = rand();
-      for (int i = 0; i < 16; ++i) {
-        pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
-      }
-      pipeName[25] = '\0';
-
-      HANDLE pipe = ::CreateNamedPipeA(
-          pipeName,
-          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED |
-              FILE_FLAG_FIRST_PIPE_INSTANCE,
-          PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS |
-              PIPE_WAIT,
-          1,               // nMaxInstances
-          0,               // nOutBufferSize
-          pipeBufferSize,  // nInBufferSize
-          0,               // nDefaultTimeout
-          nullptr);        // lpSecurityAttributes
-      if (pipe == INVALID_HANDLE_VALUE) {
-        DWORD errorCode = ::GetLastError();
-        if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
-          // Try again with a different random name
-          continue;
-        }
-
-        throw_(std::system_error{
-            static_cast<int>(errorCode),
-            std::system_category(),
-            "open_pipe: CreateNamedPipe"});
-      }
-
-      serverHandle = safe_handle{pipe};
+    // Check whether the stop request was processed
+    // when draining the ready queue.
+    if (stopFlag) {
       break;
     }
 
-    // Open the client-side of this named-pipe
-    safe_handle clientHandle{::CreateFileA(
-        pipeName,
-        GENERIC_WRITE,
-        0,              // dwShareMode
-        nullptr,        // lpSecurityAttributes
-        OPEN_EXISTING,  // dwCreationDisposition
-        FILE_FLAG_OVERLAPPED,
-        nullptr)};
-    if (clientHandle == INVALID_HANDLE_VALUE) {
-      DWORD errorCode = ::GetLastError();
+    // Check the poll-queue for I/O operations that might have completed
+    // already but where we have not yet seen the IOCP event.
+
+    while (!pollQueue_.empty()) {
+      io_operation* op = static_cast<io_operation*>(pollQueue_.pop_front());
+      auto* state = op->ioState;
+      UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
+      UNIFEX_ASSERT(!state->completed);
+
+      if (poll_is_complete(*state)) {
+        // Completed before we received any notifications via IOCP.
+        // Schedule it to resume now, before polling any other I/Os
+        // to give those other I/Os time to complete.
+        state->completed = true;
+        schedule_local(state->parent);
+        goto process_ready_queue;
+      }
+    }
+
+process_remote_queue:
+    if (shouldCheckRemoteQueue) {
+      if (try_dequeue_remote_work()) {
+        goto process_ready_queue;
+      }
+    }
+
+    // Now check if there are any IOCP events.
+get_iocp_entries:
+    const ntapi::BOOLEAN alertable = FALSE;
+    ntapi::ULONG completionEntriesRetrieved = 0;
+    ntapi::NTSTATUS ntstat = ntapi::NtRemoveIoCompletionEx(
+        iocp_.get(),
+        completionBuffer,
+        completionBufferSize,
+        &completionEntriesRetrieved,
+        shouldCheckRemoteQueue ? zeroTimeout : infiniteTimeout,
+        alertable);
+    if (ntstat == STATUS_TIMEOUT) {
+      UNIFEX_ASSERT(shouldCheckRemoteQueue);
+
+      // Previous call was non-blocking.
+      // About to transition to blocking-call, but first need to
+      // mark remote queue inactive so that remote threads know
+      // they need to post an event to wake this thread up.
+      if (remoteQueue_.try_mark_inactive()) {
+        shouldCheckRemoteQueue = false;
+        goto get_iocp_entries;
+      } else {
+        goto process_remote_queue;
+      }
+    } else if (!ntapi::ntstatus_success(ntstat)) {
+      DWORD errorCode = ntapi::RtlNtStatusToDosError(ntstat);
       throw_(std::system_error{
           static_cast<int>(errorCode),
           std::system_category(),
-          "open_pipe: CreateFile"});
+          "NtRemoveIoCompletionEx()"});
     }
 
-    context.associate_file_handle(serverHandle.get());
-    context.associate_file_handle(clientHandle.get());
+    // Process completion-entries we received from the OS.
+    for (ULONG i = 0; i < completionEntriesRetrieved; ++i) {
+      ntapi::FILE_IO_COMPLETION_INFORMATION& entry = completionBuffer[i];
+      if (entry.ApcContext != nullptr) {
+        ntapi::IO_STATUS_BLOCK* iosb =
+            reinterpret_cast<ntapi::IO_STATUS_BLOCK*>(entry.ApcContext);
+        // TODO: Do we need to store the error-code/bytes-transferred here?
+        // Is entry.IoStatusBlock just a copy of what is already in 'iosb'.
+        // Should we be copying entry.IoStatusBlock to '*iosb'?
 
-    return {
-        readable_byte_stream{context, std::move(serverHandle)},
-        writable_byte_stream{context, std::move(clientHandle)}};
+        UNIFEX_ASSERT(iosb->Status != STATUS_PENDING);
+
+        vectored_io_state* state = to_io_state(iosb);
+
+        UNIFEX_ASSERT(state->pendingCompletionNotifications > 0);
+        if (--state->pendingCompletionNotifications == 0) {
+          // This was the last pending notification for this state.
+          if (state->parent != nullptr) {
+            // An operation is still attached to this state.
+            // Notify it if we hadn't already done so.
+            if (!state->completed) {
+              state->completed = true;
+              schedule_local(state->parent);
+            }
+          } else {
+            // Otherwise the operation has already detached
+            // from this I/O state and so we can immediately
+            // return it to the pool.
+            release_io_state(state);
+          }
+        }
+      } else {
+        // A remote-thread wake-up notification.
+        shouldCheckRemoteQueue = true;
+      }
+    }
   }
+}
+
+bool low_latency_iocp_context::try_dequeue_remote_work() noexcept {
+  auto items = remoteQueue_.dequeue_all_reversed();
+  if (items.empty()) {
+    return false;
+  }
+
+  // Note that this ends up enqueueing entries in reverse.
+  // TODO: Modify this so it enqueues items in a way that
+  // preserves order.
+  do {
+    schedule_local(items.pop_front());
+  } while (!items.empty());
+
+  return true;
+}
+
+bool low_latency_iocp_context::poll_is_complete(
+    vectored_io_state& state) noexcept {
+  // TODO: Double check the memory barriers/atomics we need to use
+  // here to ensure we perform this read, that it doesn't tear and
+  // that it has the appropriate memory semantics.
+
+  for (std::size_t i = 0; i < state.operationCount; ++i) {
+    // Mark volatile to indicate to the compiler that it might change in the
+    // background. The kernel might update it as the I/O completes.
+    volatile ntapi::IO_STATUS_BLOCK* iosb = &state.operations[i];
+    if (iosb->Status == STATUS_PENDING) {
+      return false;
+    }
+  }
+
+  // Make sure that we have visibility of the results of the I/O operations
+  // (assuming that the OS used a "release" memory semantic when writing
+  // to the 'Status' field).
+  std::atomic_thread_fence(std::memory_order_acquire);
+
+  return true;
+}
+
+low_latency_iocp_context::vectored_io_state*
+low_latency_iocp_context::to_io_state(ntapi::IO_STATUS_BLOCK* iosb) noexcept {
+  vectored_io_state* const pool = ioPool_.get();
+
+  std::ptrdiff_t offset =
+      reinterpret_cast<char*>(iosb) - reinterpret_cast<char*>(pool);
+  UNIFEX_ASSERT(offset >= 0);
+
+  std::ptrdiff_t index = offset / sizeof(vectored_io_state);
+  UNIFEX_ASSERT(index < static_cast<std::ptrdiff_t>(ioPoolSize_));
+
+  return &pool[index];
+}
+
+void low_latency_iocp_context::schedule(operation_base* op) noexcept {
+  if (is_running_on_io_thread()) {
+    schedule_local(op);
+  } else {
+    schedule_remote(op);
+  }
+}
+
+void low_latency_iocp_context::schedule_local(operation_base* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  readyQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::schedule_remote(operation_base* op) noexcept {
+  UNIFEX_ASSERT(!is_running_on_io_thread());
+  if (remoteQueue_.enqueue(op)) {
+    // I/O thread is potentially sleeping.
+    // Post a wake-up NOP event to the queue.
+
+    // BUGBUG: This could potentially fail and if it does then
+    // the I/O thread might never respond to remote enqueues.
+    // For now we just treat this as a (hopefully rare) unrecoverable error.
+    ntapi::NTSTATUS ntstat = ntapi::NtSetIoCompletion(
+        iocp_.get(),
+        0,        // KeyContext
+        nullptr,  // ApcContext
+        0,        // NTSTATUS (0 = success)
+        0);       // IoStatusInformation
+    if (!ntapi::ntstatus_success(ntstat)) {
+      // Failed to post an event to the I/O completion port.
+      std::terminate();
+    }
+  }
+}
+
+bool low_latency_iocp_context::try_allocate_io_state_for(
+    io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+
+  if (ioFreeList_.empty()) {
+    return false;
+  }
+
+  UNIFEX_ASSERT(pendingIoQueue_.empty());
+
+  // An operation is already available
+  auto* state = ioFreeList_.pop_front();
+  state->parent = op;
+  state->completed = false;
+  state->operationCount = 0;
+  state->pendingCompletionNotifications = 0;
+  op->ioState = state;
+
+  return true;
+}
+
+void low_latency_iocp_context::schedule_when_io_state_available(
+    io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  UNIFEX_ASSERT(ioFreeList_.empty());
+  pendingIoQueue_.push_back(op);
+}
+
+void low_latency_iocp_context::release_io_state(
+    vectored_io_state* state) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+
+  if (state->pendingCompletionNotifications == 0) {
+    // Can be freed immediately.
+
+    if (pendingIoQueue_.empty()) {
+      ioFreeList_.push_front(state);
+    } else {
+      UNIFEX_ASSERT(ioFreeList_.empty());
+
+      // Another operation was waiting for an I/O state.
+      // Give the I/O state directly to the operation instead
+      // of adding it to the free-list. This prevents some other
+      // operation from skipping the queue and acquiring it
+      // before this I/O operation can run.
+      auto* op = static_cast<io_operation*>(pendingIoQueue_.pop_front());
+
+      state->parent = op;
+      state->completed = false;
+      state->operationCount = 0;
+      state->pendingCompletionNotifications = 0;
+      op->ioState = state;
+
+      schedule_local(op);
+    }
+  } else {
+    // Mark it to be freed once all of its I/O completion
+    // notifications have been received.
+    state->parent = nullptr;
+  }
+}
+
+void low_latency_iocp_context::schedule_poll_io(io_operation* op) noexcept {
+  UNIFEX_ASSERT(is_running_on_io_thread());
+  UNIFEX_ASSERT(op != nullptr);
+  UNIFEX_ASSERT(op->ioState != nullptr);
+
+  if (op->ioState->pendingCompletionNotifications > 0) {
+    pollQueue_.push_back(op);
+  } else {
+    // No need to poll, schedule straight to the front of the ready-to-run
+    // queue.
+    readyQueue_.push_front(op);
+  }
+}
+
+void low_latency_iocp_context::associate_file_handle(handle_t fileHandle) {
+  const HANDLE result = ::CreateIoCompletionPort(fileHandle, iocp_.get(), 0, 0);
+  if (result == nullptr) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "CreateIoCompletionPort"});
+  }
+
+  const BOOL ok = ::SetFileCompletionNotificationModes(
+      fileHandle,
+      FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE);
+  if (!ok) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "SetFileCompletionNotificationModes"});
+  }
+}
+
+void low_latency_iocp_context::io_operation::cancel_io() noexcept {
+  UNIFEX_ASSERT(ioState != nullptr);
+
+  // Cancel operations in reverse order so that later operations
+  // are cancelled first and don't accidentally end up with earlier
+  // operations being cancelled and later ones completing due to
+  // a race.
+  for (std::uint16_t i = ioState->operationCount; i != 0; --i) {
+    ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i - 1];
+    ntapi::IO_STATUS_BLOCK ioStatus;
+    [[maybe_unused]] ntapi::NTSTATUS ntstat =
+        ntapi::NtCancelIoFileEx(fileHandle, iosb, &ioStatus);
+    // TODO: Check ntstat for failure.
+    // Can't really do much here even if there is failure, anyway.
+  }
+}
+
+bool low_latency_iocp_context::io_operation::is_complete() noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+
+  if (ioState->pendingCompletionNotifications == 0) {
+    return true;
+  }
+
+  for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+    volatile ntapi::IO_STATUS_BLOCK* iosb = &ioState->operations[i];
+
+    // Mark volatile to indicate to the compiler that it might change in the
+    // background. The kernel might update it as the I/O completes.
+    if (iosb->Status == STATUS_PENDING) {
+      return false;
+    }
+  }
+
+  // Make sure that we have visibility of the results of all of the I/O
+  // operations.
+  // Assuming that the OS used a "release" memory semantic when writing
+  // to the 'Status' field here.
+  std::atomic_thread_fence(std::memory_order_acquire);
+
+  return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_read(
+    span<std::byte> buffer) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
+
+  std::size_t offset = 0;
+  while (offset < buffer.size()) {
+    ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[ioState->operationCount];
+    ++ioState->operationCount;
+
+    iosb.Status = STATUS_PENDING;
+    iosb.Information = 0;
+
+    // Truncate over-large chunks to a number of bytes that will still
+    // preserve alignment requirements of the underlying device if this
+    // happens to be an unbuffered storage device.
+    // In this case we truncate to the largest multiple of 64k less than
+    // 2^32 to allow for up to 64k alignment.
+    // TODO: Ideally we'd just use the underlying alignment of the
+    // file-handle.
+    static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+    static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+    std::size_t chunkSize = buffer.size() - offset;
+    if (chunkSize > maxChunkSize) {
+      chunkSize = truncatedChunkSize;
+    }
+
+    ntapi::NTSTATUS status = ntapi::NtReadFile(
+        fileHandle,
+        NULL,                                  // Event
+        NULL,                                  // ApcRoutine
+        &iosb,                                 // ApcContext
+        &iosb,                                 // IoStatusBlock
+        buffer.data() + offset,                // Buffer
+        static_cast<ntapi::ULONG>(chunkSize),  // Length
+        nullptr,                               // ByteOffset
+        nullptr);                              // Key
+    if (status == STATUS_PENDING) {
+      ++ioState->pendingCompletionNotifications;
+    } else if (ntapi::ntstatus_success(status)) {
+      // Succeeded synchronously.
+      if (!skipNotificationOnSuccess) {
+        ++ioState->pendingCompletionNotifications;
+      }
+    } else {
+      // Immediate failure.
+      // Don't launch any more operations.
+      // TODO: Should we cancel any prior launched operations?
+      return false;
+    }
+
+    if (ioState->operationCount == max_vectored_io_size) {
+      // We've launched as many operations as we can.
+      return false;
+    }
+
+    offset += chunkSize;
+  }
+
+  return true;
+}
+
+bool low_latency_iocp_context::io_operation::start_write(
+    span<const std::byte> buffer) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->operationCount < max_vectored_io_size);
+
+  std::size_t offset = 0;
+  while (offset < buffer.size()) {
+    ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[ioState->operationCount];
+    ++ioState->operationCount;
+
+    iosb.Status = STATUS_PENDING;
+    iosb.Information = 0;
+
+    // Truncate over-large chunks to a number of bytes that will still
+    // preserve alignment requirements of the underlying device if this
+    // happens to be an unbuffered storage device.
+    // In this case we truncate to the largest multiple of 64k less than
+    // 2^32 to allow for up to 64k alignment.
+    // TODO: Ideally we'd just use the underlying alignment of the
+    // file-handle.
+    static constexpr std::size_t truncatedChunkSize = 0xFFFF0000u;
+    static constexpr std::size_t maxChunkSize = 0xFFFFFFFFu;
+
+    std::size_t chunkSize = buffer.size() - offset;
+    if (chunkSize > maxChunkSize) {
+      chunkSize = truncatedChunkSize;
+    }
+
+    ntapi::NTSTATUS status = ntapi::NtWriteFile(
+        fileHandle,
+        NULL,                                            // Event
+        NULL,                                            // ApcRoutine
+        &iosb,                                           // ApcContext
+        &iosb,                                           // IoStatusBlock
+        const_cast<std::byte*>(buffer.data()) + offset,  // Buffer
+        static_cast<ntapi::ULONG>(chunkSize),            // Length
+        nullptr,                                         // ByteOffset
+        nullptr);                                        // Key
+    if (status == STATUS_PENDING) {
+      ++ioState->pendingCompletionNotifications;
+    } else if (ntapi::ntstatus_success(status)) {
+      // Succeeded synchronously.
+      if (!skipNotificationOnSuccess) {
+        ++ioState->pendingCompletionNotifications;
+      }
+    } else {
+      // Immediate failure.
+      // Don't launch any more operations.
+      // TODO: Should we cancel any prior launched operations?
+      return false;
+    }
+
+    if (ioState->operationCount == max_vectored_io_size) {
+      return false;
+    }
+
+    offset += chunkSize;
+  }
+
+  return true;
+}
+
+std::size_t low_latency_iocp_context::io_operation::get_result(
+    std::error_code& ec) noexcept {
+  UNIFEX_ASSERT(context.is_running_on_io_thread());
+  UNIFEX_ASSERT(ioState != nullptr);
+  UNIFEX_ASSERT(ioState->completed);
+
+  ec = std::error_code{};
+
+  std::size_t totalBytesTransferred = 0;
+  for (std::size_t i = 0; i < ioState->operationCount; ++i) {
+    const ntapi::IO_STATUS_BLOCK& iosb = ioState->operations[i];
+
+    UNIFEX_ASSERT(iosb.Status != STATUS_PENDING);
+
+    totalBytesTransferred += iosb.Information;
+
+    if (!ntapi::ntstatus_success(iosb.Status)) {
+      ntapi::ULONG errorCode = ntapi::RtlNtStatusToDosError(iosb.Status);
+      ec = std::error_code(static_cast<int>(errorCode), std::system_category());
+      break;
+    }
+  }
+
+  return totalBytesTransferred;
+}
+
+std::tuple<
+    low_latency_iocp_context::readable_byte_stream,
+    low_latency_iocp_context::writable_byte_stream>
+low_latency_iocp_context::scheduler::open_pipe_impl(
+    low_latency_iocp_context& context) {
+  std::mt19937_64 rand{::GetTickCount64() + ::GetCurrentThreadId()};
+
+  safe_handle serverHandle;
+
+  auto toHex = [](std::uint8_t value) noexcept -> char {
+    return value < 10 ? char('0' + value) : char('a' - 10 + value);
+  };
+
+  char pipeName[10 + 16] = {'\\', '\\', '.', '\\', 'p', 'i', 'p', 'e', '\\'};
+
+  // Try to create the server side of a new named pipe
+  // Use a randomly generated name to ensure uniqueness.
+
+  const DWORD pipeBufferSize = 16 * 1024;
+  const int maxAttempts = 100;
+
+  for (int attempt = 1;; ++attempt) {
+    const std::uint64_t randomNumber = rand();
+    for (int i = 0; i < 16; ++i) {
+      pipeName[9 + i] = toHex((randomNumber >> (4 * i)) & 0xFu);
+    }
+    pipeName[25] = '\0';
+
+    HANDLE pipe = ::CreateNamedPipeA(
+        pipeName,
+        PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED |
+            FILE_FLAG_FIRST_PIPE_INSTANCE,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_REJECT_REMOTE_CLIENTS |
+            PIPE_WAIT,
+        1,               // nMaxInstances
+        0,               // nOutBufferSize
+        pipeBufferSize,  // nInBufferSize
+        0,               // nDefaultTimeout
+        nullptr);        // lpSecurityAttributes
+    if (pipe == INVALID_HANDLE_VALUE) {
+      DWORD errorCode = ::GetLastError();
+      if (errorCode == ERROR_ALREADY_EXISTS && attempt < maxAttempts) {
+        // Try again with a different random name
+        continue;
+      }
+
+      throw_(std::system_error{
+          static_cast<int>(errorCode),
+          std::system_category(),
+          "open_pipe: CreateNamedPipe"});
+    }
+
+    serverHandle = safe_handle{pipe};
+    break;
+  }
+
+  // Open the client-side of this named-pipe
+  safe_handle clientHandle{::CreateFileA(
+      pipeName,
+      GENERIC_WRITE,
+      0,              // dwShareMode
+      nullptr,        // lpSecurityAttributes
+      OPEN_EXISTING,  // dwCreationDisposition
+      FILE_FLAG_OVERLAPPED,
+      nullptr)};
+  if (clientHandle == INVALID_HANDLE_VALUE) {
+    DWORD errorCode = ::GetLastError();
+    throw_(std::system_error{
+        static_cast<int>(errorCode),
+        std::system_category(),
+        "open_pipe: CreateFile"});
+  }
+
+  context.associate_file_handle(serverHandle.get());
+  context.associate_file_handle(clientHandle.get());
+
+  return {
+      readable_byte_stream{context, std::move(serverHandle)},
+      writable_byte_stream{context, std::move(clientHandle)}};
+}
 
 }  // namespace unifex::win32

--- a/source/win32/ntapi.cpp
+++ b/source/win32/ntapi.cpp
@@ -21,45 +21,44 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-namespace unifex::win32::ntapi
-{
-  NtCreateFile_t NtCreateFile = nullptr;
-  NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
-  NtReadFile_t NtReadFile = nullptr;
-  NtWriteFile_t NtWriteFile = nullptr;
-  NtSetIoCompletion_t NtSetIoCompletion = nullptr;
-  NtRemoveIoCompletion_t NtRemoveIoCompletion = nullptr;
-  NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx = nullptr;
-  RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
+namespace unifex::win32::ntapi {
+NtCreateFile_t NtCreateFile = nullptr;
+NtCancelIoFileEx_t NtCancelIoFileEx = nullptr;
+NtReadFile_t NtReadFile = nullptr;
+NtWriteFile_t NtWriteFile = nullptr;
+NtSetIoCompletion_t NtSetIoCompletion = nullptr;
+NtRemoveIoCompletion_t NtRemoveIoCompletion = nullptr;
+NtRemoveIoCompletionEx_t NtRemoveIoCompletionEx = nullptr;
+RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
 
-  static void do_initialisation() noexcept {
-    HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
-    if (ntdll == NULL) {
+static void do_initialisation() noexcept {
+  HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) {
+    std::terminate();
+  }
+
+  auto init = [&](auto& fnPtr, const char* name) noexcept {
+    FARPROC p = ::GetProcAddress(ntdll, name);
+    if (p == NULL) {
       std::terminate();
     }
+    fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
+        reinterpret_cast<void (*)()>(p));
+  };
 
-    auto init = [&](auto& fnPtr, const char* name) noexcept {
-      FARPROC p = ::GetProcAddress(ntdll, name);
-      if (p == NULL) {
-        std::terminate();
-      }
-      fnPtr = reinterpret_cast<std::remove_reference_t<decltype(fnPtr)>>(
-        reinterpret_cast<void(*)()>(p));
-    };
+  init(NtCreateFile, "NtCreateFile");
+  init(NtCancelIoFileEx, "NtCancelIoFileEx");
+  init(NtReadFile, "NtReadFile");
+  init(NtWriteFile, "NtWriteFile");
+  init(NtSetIoCompletion, "NtSetIoCompletion");
+  init(NtRemoveIoCompletion, "NtRemoveIoCompletion");
+  init(NtRemoveIoCompletionEx, "NtRemoveIoCompletionEx");
+  init(RtlNtStatusToDosError, "RtlNtStatusToDosError");
+}
 
-    init(NtCreateFile, "NtCreateFile");
-    init(NtCancelIoFileEx, "NtCancelIoFileEx");
-    init(NtReadFile, "NtReadFile");
-    init(NtWriteFile, "NtWriteFile");
-    init(NtSetIoCompletion, "NtSetIoCompletion");
-    init(NtRemoveIoCompletion, "NtRemoveIoCompletion");
-    init(NtRemoveIoCompletionEx, "NtRemoveIoCompletionEx");
-    init(RtlNtStatusToDosError, "RtlNtStatusToDosError");
-  }
-
-  void ensure_initialised() noexcept {
-    static struct initialiser {
-      initialiser() noexcept { do_initialisation(); }
-    } dummy;
-  }
+void ensure_initialised() noexcept {
+  static struct initialiser {
+    initialiser() noexcept { do_initialisation(); }
+  } dummy;
+}
 }  // namespace unifex::win32::ntapi

--- a/source/win32/safe_handle.cpp
+++ b/source/win32/safe_handle.cpp
@@ -22,10 +22,10 @@
 namespace unifex::win32 {
 
 void safe_handle::reset() noexcept {
-    handle_t h = std::exchange(handle_, nullptr);
-    if (h != nullptr && h != INVALID_HANDLE_VALUE) {
-        ::CloseHandle(h);
-    }
+  handle_t h = std::exchange(handle_, nullptr);
+  if (h != nullptr && h != INVALID_HANDLE_VALUE) {
+    ::CloseHandle(h);
+  }
 }
 
-} // namespace unifex::win32
+}  // namespace unifex::win32


### PR DESCRIPTION
This stack of changes applies `clang-format` to the Win32-specific files that were left out of #580.