### PR TITLE
Allow copying/moving variant_sender

### DIFF
--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -174,7 +174,8 @@ public:
   static constexpr bool is_always_scheduler_affine =
       sender_traits<Source>::is_always_scheduler_affine;
 
-  template <typename Source2>
+  template (typename Source2)
+      (requires (!same_as<remove_cvref_t<Source2>, type>))
   explicit type(Source2&& source) noexcept(
       std::is_nothrow_constructible_v<Source, Source2>)
     : source_(static_cast<Source2&&>(source)) {}

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -198,7 +198,7 @@ public:
   template(typename Source2)  //
       (requires constructible_from<
           Source,
-          Source2>)  //
+          Source2> AND (!same_as<remove_cvref_t<Source2>, type>))  //
       explicit type(Source2&& source) noexcept(
           std::is_nothrow_constructible_v<Source, Source2>)
     : source_(static_cast<Source2&&>(source)) {}

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -118,7 +118,7 @@ public:
       (sender_traits<Senders>::is_always_scheduler_affine && ...);
 
   template (typename ConcreteSender)
-    (requires is_one_of_v<std::decay_t<ConcreteSender>, Senders...>)
+    (requires is_one_of_v<remove_cvref_t<ConcreteSender>, Senders...>)
   type(ConcreteSender&& concreteSender) noexcept(
       std::is_nothrow_constructible_v<
           std::variant<Senders...>,

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -117,7 +117,8 @@ public:
   static constexpr bool is_always_scheduler_affine =
       (sender_traits<Senders>::is_always_scheduler_affine && ...);
 
-  template <typename ConcreteSender>
+  template (typename ConcreteSender)
+    (requires is_one_of_v<std::decay_t<ConcreteSender>, Senders...>)
   type(ConcreteSender&& concreteSender) noexcept(
       std::is_nothrow_constructible_v<
           std::variant<Senders...>,

--- a/test/variant_sender_test.cpp
+++ b/test/variant_sender_test.cpp
@@ -283,3 +283,9 @@ TEST(Variant, TestMSVCCpp20RegressionScenario) {
 
   ASSERT_TRUE(ret.has_value());
 }
+
+TEST(Variant, CopyableAndMovable) {
+  variant_sender<decltype(just(5)), decltype(just(1.0))> just_variant_sender(just(5));
+  auto other = just_variant_sender;
+  other = std::move(just_variant_sender);
+}


### PR DESCRIPTION
variant_sender's perfect forwarding constructor hid the move and copy constructors.