### PR TITLE
Add filter_stream

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -851,6 +851,11 @@ of `tag_invoke(tag_t<for_each>, your_stream_type, Func)`.
 Returns a stream that produces values that are the result of calling
 `func(value)` on each value produced by the input stream.
 
+### `filter_stream(Stream stream, FilterFunc filterFunc) -> Stream`
+
+Returns a stream that contains the values from the input stream that evaluate 
+true on the predicate `filterFunc(val)`.
+
 ### `via_stream(Scheduler scheduler, Stream stream) -> Stream`
 
 Returns a stream that calls the receiver methods on the specified scheduler's

--- a/include/unifex/filter_stream.hpp
+++ b/include/unifex/filter_stream.hpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/async_trace.hpp>
+#include <unifex/bind_back.hpp>
+#include <unifex/exception.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/sender_concepts.hpp>
+#include <unifex/std_concepts.hpp>
+#include <unifex/stream_concepts.hpp>
+#include <unifex/type_list.hpp>
+#include <unifex/type_traits.hpp>
+#include <unifex/unstoppable_token.hpp>
+
+#include <exception>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _filter {
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _op {
+  struct type;
+};
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+using operation = typename _op<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<FilterFunc>,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _error_cleanup_receiver {
+  struct type;
+};
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+using error_cleanup_receiver = typename _error_cleanup_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<FilterFunc>,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _error_cleanup_receiver<StreamSender, FilterFunc, Receiver>::type {
+  operation<StreamSender, FilterFunc, Receiver>& op_;
+  std::exception_ptr ex_;
+
+  // No value() in cleanup receiver
+
+  template <typename Error>
+  void set_error(Error error) noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.errorCleanup_);
+    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+  }
+
+  void set_done() noexcept {
+    auto& op = op_;
+    auto ex = std::move(ex_);
+    unifex::deactivate_union_member(op.errorCleanup_);
+    unifex::set_error(static_cast<Receiver&&>(op.receiver_), std::move(ex));
+  }
+
+  template(typename CPO)                       //
+      (requires is_receiver_query_cpo_v<CPO>)  //
+      friend auto tag_invoke(CPO cpo, const type& r) noexcept(
+          is_nothrow_callable_v<CPO, const Receiver&>)
+          -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
+  }
+
+  friend unstoppable_token
+  tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
+    return {};
+  }
+
+#if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+    std::invoke(func, r.op_.receiver_);
+  }
+#endif
+};
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _done_cleanup_receiver {
+  struct type;
+};
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+using done_cleanup_receiver = typename _done_cleanup_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<FilterFunc>,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _done_cleanup_receiver<StreamSender, FilterFunc, Receiver>::type {
+  operation<StreamSender, FilterFunc, Receiver>& op_;
+
+  template <typename Error>
+  void set_error(Error error) && noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.doneCleanup_);
+    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+  }
+
+  void set_done() && noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.doneCleanup_);
+    unifex::set_done(std::move(op.receiver_));
+  }
+
+  template(typename CPO)                       //
+      (requires is_receiver_query_cpo_v<CPO>)  //
+      friend auto tag_invoke(CPO cpo, const type& r) noexcept(
+          is_nothrow_callable_v<CPO, const Receiver&>)
+          -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
+  }
+
+  friend unstoppable_token
+  tag_invoke(tag_t<get_stop_token>, const type&) noexcept {
+    return {};
+  }
+
+#if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+    std::invoke(func, r.op_.receiver_);
+  }
+#endif
+};
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _next_receiver {
+  struct type;
+};
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+using next_receiver = typename _next_receiver<
+    remove_cvref_t<StreamSender>,
+    remove_cvref_t<FilterFunc>,
+    remove_cvref_t<Receiver>>::type;
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _next_receiver<StreamSender, FilterFunc, Receiver>::type {
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+  using next_receiver_t = next_receiver<StreamSender, FilterFunc, Receiver>;
+  operation<StreamSender, FilterFunc, Receiver>& op_;
+
+  template(typename CPO)                       //
+      (requires is_receiver_query_cpo_v<CPO>)  //
+      friend auto tag_invoke(CPO cpo, const type& r) noexcept(
+          is_nothrow_callable_v<CPO, const Receiver&>)
+          -> callable_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(std::as_const(r.op_.receiver_));
+  }
+
+#if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+  template <typename Func>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Func&& func) {
+    std::invoke(func, r.op_.receiver_);
+  }
+#endif
+
+  template <typename... Values>
+  void set_value(Values... values) && noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.next_);
+    UNIFEX_TRY {
+      const bool doFilter = !std::invoke(op.filter_, (Values &&) values...);
+
+      if (doFilter) {
+        unifex::activate_union_member_with(op.next_, [&] {
+          return unifex::connect(next(op.stream_), next_receiver_t{op});
+        });
+        unifex::start(op.next_.get());
+      } else {
+        unifex::set_value(std::move(op.receiver_), std::move(values)...);
+      }
+    }
+    UNIFEX_CATCH(...) {
+      unifex::activate_union_member_with(op.errorCleanup_, [&] {
+        return unifex::connect(
+            cleanup(op.stream_),
+            error_cleanup_receiver_t{op, std::current_exception()});
+      });
+      unifex::start(op.errorCleanup_.get());
+    }
+  }
+
+  void set_done() && noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.next_);
+    unifex::activate_union_member_with(op.doneCleanup_, [&] {
+      return unifex::connect(cleanup(op.stream_), done_cleanup_receiver_t{op});
+    });
+    unifex::start(op.doneCleanup_.get());
+  }
+
+  void set_error(std::exception_ptr ex) && noexcept {
+    auto& op = op_;
+    unifex::deactivate_union_member(op.next_);
+    unifex::activate_union_member_with(op.errorCleanup_, [&] {
+      return unifex::connect(
+          cleanup(op.stream_), error_cleanup_receiver_t{op, std::move(ex)});
+    });
+    unifex::start(op.errorCleanup_.get());
+  }
+
+  template <typename Error>
+  void set_error(Error&& e) && noexcept {
+    std::move(*this).set_error(make_exception_ptr((Error &&) e));
+  }
+};
+
+template <typename StreamSender, typename FilterFunc, typename Receiver>
+struct _op<StreamSender, FilterFunc, Receiver>::type {
+  StreamSender& stream_;
+  FilterFunc filter_;
+  Receiver receiver_;
+
+  using next_receiver_t = next_receiver<StreamSender, FilterFunc, Receiver>;
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+
+  using next_op =
+      manual_lifetime<next_operation_t<StreamSender, next_receiver_t>>;
+  using error_op = manual_lifetime<
+      cleanup_operation_t<StreamSender, error_cleanup_receiver_t>>;
+  using done_op = manual_lifetime<
+      cleanup_operation_t<StreamSender, done_cleanup_receiver_t>>;
+
+  union {
+    next_op next_;
+    error_op errorCleanup_;
+    done_op doneCleanup_;
+  };
+
+  template <typename StreamSender2, typename FilterFunc2, typename Receiver2>
+  explicit type(
+      StreamSender2&& stream, FilterFunc2&& filter, Receiver2&& receiver)
+    : stream_(std::forward<StreamSender2>(stream))
+    , filter_(std::forward<FilterFunc2>(filter))
+    , receiver_(std::forward<Receiver2>(receiver)) {}
+
+  ~type() {}  // Due to the union member, this is load-bearing. DO NOT DELETE.
+
+  void start() noexcept {
+    UNIFEX_TRY {
+      unifex::activate_union_member_with(next_, [&] {
+        return unifex::connect(next(stream_), next_receiver_t{*this});
+      });
+      unifex::start(next_.get());
+    }
+    UNIFEX_CATCH(...) {
+      unifex::set_error(
+          static_cast<Receiver&&>(receiver_), std::current_exception());
+    }
+  }
+};
+
+template <typename StreamSender, typename FilterFunc>
+struct _sender {
+  struct type;
+};
+template <typename StreamSender, typename FilterFunc>
+using sender =
+    typename _sender<remove_cvref_t<StreamSender>, remove_cvref_t<FilterFunc>>::
+        type;
+
+template <typename StreamSender, typename FilterFunc>
+struct _sender<StreamSender, FilterFunc>::type {
+  using sender = type;
+  StreamSender& stream_;
+  FilterFunc& filter_;
+
+  // value and error types just point to the ones from the stream sender
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = typename next_sender_t<
+      StreamSender>::template value_types<Variant, Tuple>;
+
+  template <template <typename...> class Variant>
+  using error_types =
+      typename next_sender_t<StreamSender>::template error_types<Variant>;
+
+  static constexpr bool sends_done = false;
+
+  template <typename Receiver>
+  using operation_t = operation<StreamSender, FilterFunc, Receiver>;
+  template <typename Receiver>
+  using next_receiver_t = next_receiver<StreamSender, FilterFunc, Receiver>;
+  template <typename Receiver>
+  using error_cleanup_receiver_t =
+      error_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+  template <typename Receiver>
+  using done_cleanup_receiver_t =
+      done_cleanup_receiver<StreamSender, FilterFunc, Receiver>;
+
+  template(typename Self, typename Receiver)  //
+      (requires same_as<remove_cvref_t<Self>, type> AND receiver<Receiver> AND
+           sender_to<next_sender_t<StreamSender>, next_receiver_t<Receiver>> AND
+               sender_to<
+                   cleanup_sender_t<StreamSender>,
+                   error_cleanup_receiver_t<Receiver>> AND
+                   sender_to<
+                       cleanup_sender_t<StreamSender>,
+                       done_cleanup_receiver_t<Receiver>>)  //
+      friend operation_t<Receiver> tag_invoke(
+          tag_t<connect>, Self&& self, Receiver&& receiver) {
+    return operation_t<Receiver>{
+        self.stream_,
+        static_cast<Self&&>(self).filter_,
+        (Receiver &&) receiver};
+  }
+};
+}  // namespace _filter
+
+namespace _filter_stream {
+
+template <typename StreamSender, typename FilterFunc>
+struct _filter_stream {
+  struct type;
+};
+
+template <typename StreamSender, typename FilterFunc>
+struct _filter_stream<StreamSender, FilterFunc>::type {
+  StreamSender stream_;
+  FilterFunc filter_;
+
+  friend auto tag_invoke(tag_t<next>, type& s) {
+    return _filter::sender<StreamSender, FilterFunc>{s.stream_, s.filter_};
+  }
+
+  friend auto tag_invoke(tag_t<cleanup>, type& s) { return cleanup(s.stream_); }
+};
+
+struct _fn {
+  // TODO add a type requirement that filterFunc's return is boolean
+  template <typename StreamSender, typename FilterFunc>
+  auto operator()(StreamSender&& stream, FilterFunc&& filterFunc) const {
+    return typename _filter_stream<StreamSender, FilterFunc>::type{
+        (StreamSender &&) stream, (FilterFunc &&) filterFunc};
+  }
+
+  template <typename FilterFunc>
+  constexpr auto operator()(FilterFunc&& filterFunc) const
+      noexcept(is_nothrow_callable_v<tag_t<bind_back>, _fn, FilterFunc>)
+          -> bind_back_result_t<_fn, FilterFunc> {
+    return bind_back(*this, (FilterFunc &&) filterFunc);
+  }
+};
+
+}  // namespace _filter_stream
+
+inline constexpr _filter_stream::_fn filter_stream{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -8,7 +8,6 @@
 #include <unifex/task.hpp>
 #include <unifex/then.hpp>
 #include <unifex/trampoline_scheduler.hpp>
-#include <unifex/transform_stream.hpp>
 #include <unifex/via_stream.hpp>
 
 #include <gtest/gtest.h>

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -5,7 +5,6 @@
 #include <unifex/range_stream.hpp>
 #include <unifex/reduce_stream.hpp>
 #include <unifex/sync_wait.hpp>
-#include <unifex/task.hpp>
 #include <unifex/then.hpp>
 #include <unifex/trampoline_scheduler.hpp>
 #include <unifex/transform_stream.hpp>

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -1,0 +1,43 @@
+#include <unifex/filter_stream.hpp>
+
+#include <unifex/range_stream.hpp>
+#include <unifex/reduce_stream.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/transform_stream.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace unifex;
+
+TEST(reduce_stream, StepByStep) {
+  auto ints = range_stream{1, 11};
+  auto evens =
+      filter_stream(std::move(ints), [](int val) { return val % 2 == 0; });
+
+  auto sum = reduce_stream(
+      std::move(evens), 0, [](int state, int val) { return state + val; });
+
+  auto res = (sync_wait(std::move(sum)));
+  ASSERT_TRUE(res);
+  EXPECT_EQ(30, *res);
+}
+
+TEST(reduce_stream, Composition) {
+  auto res = sync_wait(reduce_stream(
+      filter_stream(range_stream{1, 11}, [](int val) { return val % 2 == 0; }),
+      0,
+      [](int state, int val) { return state + val; }));
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(30, *res);
+}
+
+TEST(reduce_stream, Pipeable) {
+  auto res = range_stream{1, 11} |
+      filter_stream([](int val) { return val % 2 == 0; }) |
+      reduce_stream(0, [](int state, int val) { return state + val; }) |
+      sync_wait();
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(30, *res);
+}

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -1,12 +1,20 @@
 #include <unifex/filter_stream.hpp>
 
 #include <unifex/for_each.hpp>
+#include <unifex/just_void_or_done.hpp>
 #include <unifex/range_stream.hpp>
 #include <unifex/reduce_stream.hpp>
 #include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/then.hpp>
+#include <unifex/trampoline_scheduler.hpp>
 #include <unifex/transform_stream.hpp>
+#include <unifex/via_stream.hpp>
 
 #include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
 
 using namespace unifex;
 
@@ -43,15 +51,106 @@ TEST(filter_stream, Pipeable) {
   EXPECT_EQ(30, *res);
 }
 
-TEST(filter_stream, TransformThrows) {
-  range_stream{1, 11} | transform_stream([](int val) {
-    if (val % 2 == 0) {
-      throw;
+TEST(filter_stream, FilterFuncThrows) {
+  auto st = range_stream{1, 11} | filter_stream([](int) -> bool { throw 42; });
+  EXPECT_THROW(sync_wait(next(st)), int);
+}
+
+struct ThrowingStream {
+  auto next() {
+    // Throw in the 2nd iteration
+    if (++i == 2) {
+      throw 42;
     }
-    return val * 2;
-  }) | for_each([](int el) { std::cout << "el=" << el << std::endl; }) |
+    return unifex::next(underlyingStream_);
+  }
+
+  auto cleanup() { unifex::cleanup(underlyingStream_); }
+
+  range_stream underlyingStream_{1, 10};
+  size_t i = 0;
+};
+
+TEST(filter_stream, StreamNextSenderThrows) {
+  auto st = ThrowingStream{} | filter_stream([](auto&&) { return true; });
+
+  // first iteration doesn't throw
+  EXPECT_EQ(1, sync_wait(next(st)));
+
+  // second iteration throws
+  EXPECT_THROW(sync_wait(next(st)), int);
+}
+
+// I tried to use "mock_receiver.hpp", but it seems gmock/gmock.h
+// isn't available in my set up. Below is a simple way to verify
+// set_error() is being called
+struct ThrowingReceiver {
+  template <typename V>
+  void set_value(V&&) {
+    throw 42;
+  }
+
+  void set_done() noexcept {}
+
+  template <typename E>
+  void set_error(E&&) noexcept {
+    errorCalled_ = true;
+  }
+
+  bool& errorCalled_;
+};
+
+TEST(filter_stream, ConnectedReceiverThrowsOnSetValue) {
+  auto st = range_stream{1, 11} |
+      filter_stream([](int val) -> bool { return val % 2 == 0; });
+  auto nextSender = next(st);
+
+  bool errorCalled = false;
+
+  auto rec = ThrowingReceiver{errorCalled};
+  auto op = unifex::connect(nextSender, rec);
+  unifex::start(op);
+
+  EXPECT_TRUE(errorCalled);
+}
+
+struct StreamOfMoveOnlyObjects {
+  StreamOfMoveOnlyObjects() {
+    pointers_.emplace_back(std::make_unique<int>(1));
+    pointers_.emplace_back(nullptr);
+    pointers_.emplace_back(nullptr);
+    pointers_.emplace_back(std::make_unique<int>(2));
+  }
+
+  auto next() {
+    return just_void_or_done(curr_ < pointers_.size()) |
+        then([this]() mutable noexcept {
+             return std::move(pointers_[curr_++]);
+           });
+  }
+
+  auto cleanup() { return just_done(); }
+
+  std::vector<std::unique_ptr<int>> pointers_{};
+  size_t curr_ = 0;
+};
+
+TEST(filter_stream, MoveOnlyObjects) {
+  auto sumOfNonNulls = StreamOfMoveOnlyObjects{} |
+      filter_stream([](auto&& ptr) { return ptr != nullptr; }) |
+      reduce_stream(0, [](int state, auto&& ptr) { return state + *ptr; }) |
       sync_wait();
 
-  // ASSERT_TRUE(res);
-  // EXPECT_EQ(30, *res);
+  ASSERT_TRUE(sumOfNonNulls);
+  EXPECT_EQ(3, *sumOfNonNulls);
+}
+
+TEST(filter_stream, StackExhaustion) {
+  auto res = range_stream{1, 100'000} | via_stream(trampoline_scheduler{}) |
+      filter_stream([](int) { return false; }) |
+      reduce_stream(0, [](int state, int val) { return state + val; }) |
+      sync_wait();
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(0, *res);
 }

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -1,10 +1,10 @@
 #include <unifex/filter_stream.hpp>
 
+#include <unifex/for_each.hpp>
 #include <unifex/range_stream.hpp>
 #include <unifex/reduce_stream.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/transform_stream.hpp>
-#include <unifex/for_each.hpp>
 
 #include <gtest/gtest.h>
 
@@ -43,18 +43,14 @@ TEST(filter_stream, Pipeable) {
   EXPECT_EQ(30, *res);
 }
 
-
 TEST(filter_stream, TransformThrows) {
-  range_stream{1, 11} |
-  transform_stream([](int val) {
+  range_stream{1, 11} | transform_stream([](int val) {
     if (val % 2 == 0) {
-      throw; 
+      throw;
     }
     return val * 2;
-  }) |
-  for_each([](int el){
-    std::cout << "el=" << el << std::endl;
-  }) | sync_wait();
+  }) | for_each([](int el) { std::cout << "el=" << el << std::endl; }) |
+      sync_wait();
 
   // ASSERT_TRUE(res);
   // EXPECT_EQ(30, *res);

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -152,6 +152,7 @@ TEST(filter_stream, StreamOfReferences) {
       transform_stream([&](int idx) -> int& { return ints[idx]; }) |
       filter_stream([](int val) { return val % 2 == 0; }) |
       transform_stream([&](int& val) {
+               // ensuring we're propagating the referenceness correctly
                if (val == 2) {
                  EXPECT_TRUE(&val == &ints[1]);
                } else if (val == 4) {

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
## Description
I did not see a `filter_stream` operation for streams, which is quite convenient when wanting to skip certain asynchronous values. An illustrative example below (something I encounter quite often in my work):

```C++
unifex::task<size_t> getFooSum(/* some params here */)
{
    auto request = /* build request from params */

    auto streamOfMultipartResponses = someRPCClient->sendRequest(request);

    auto fooValueSum = std::move(streamOfMultipartResponses)
         // heartbeat responses keep the connection alive, but they carry no useful data
         | unifex::filter_stream([](auto resp){ resp.isHeartbeatResponse(); })
         // actual data is in fooResponse
         | unifex::reduce_stream(0, [](auto resp){ resp.fooResponse().fooValue(); });
    co_return co_await fooValueSum;
}
```

Most of the code for the `filter_stream` is adapter from `reduce_stream`. The difference is the `next_receiver`. `reduce_stream` collapses everything into a single value within the `operation_state`:

``` C++
template <typename... Values>
void set_value(Values... values) && noexcept {
  // stuff happening before
  UNIFEX_TRY {
    // collapse (or reduce) all values into the op state & request the next value in the stream
    op.state_ =
        std::invoke(op.reducer_, std::move(op.state_), (Values &&) values...);
    unifex::activate_union_member_with(op.next_, [&] {
      return unifex::connect(next(op.stream_), next_receiver_t{op});
    });
    unifex::start(op.next_.get());
  }
  // stuff happening after
}
```

On the other hand, the `filter_stream`, either returns the current sender (if the predicate matches) or requests the next one:

```C++
template <typename... Values>
void set_value(Values... values) && noexcept {
  // stuff happening before
  UNIFEX_TRY {
    const bool doFilter = !std::invoke(op.filter_, (Values &&) values...);
    // if predicate matches, just return the sender
    if (doFilter) {
      unifex::activate_union_member_with(op.next_, [&] {
        return unifex::connect(next(op.stream_), next_receiver_t{op});
      });
      unifex::start(op.next_.get());
    } else {
      unifex::set_value(std::move(op.receiver_), std::move(values)...);
    }
  }
  // stuff happening after
}
```