### PR TITLE
Introduce `stop_on_request` algorithm

### DIFF
--- a/include/unifex/stop_on_request.hpp
+++ b/include/unifex/stop_on_request.hpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/get_stop_token.hpp>
+#include <unifex/just_done.hpp>
+#include <unifex/manual_lifetime.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/stop_token_concepts.hpp>
+#include <unifex/stream_concepts.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _stop_on_request {
+
+// These states allow us to keep track of when the stop callbacks are created
+// and called
+enum class _callback_state : char {
+  INIT = 0,
+  ALL_CONSTRUCTED_NOT_CALLED = 1,
+  AT_LEAST_ONE_CALLED = 2,
+};
+
+template <typename Receiver, typename... StopTokens>
+struct _op {
+  struct type;
+};
+template <typename Receiver, typename... StopTokens>
+using operation = typename _op<remove_cvref_t<Receiver>, StopTokens...>::type;
+
+template <typename Receiver, typename... StopTokens>
+struct _op<Receiver, StopTokens...>::type {
+  struct cancel_callback {
+    type& op_;
+    void operator()() noexcept { op_.request_stop(); }
+  };
+
+  void request_stop() noexcept {
+    // update state to mark that at least one callback has been called
+    auto oldState = callbackState_.exchange(
+        _callback_state::AT_LEAST_ONE_CALLED, std::memory_order_acq_rel);
+
+    if (oldState == _callback_state::ALL_CONSTRUCTED_NOT_CALLED) {
+      // if this is the first callback that is called, then we can complete
+      complete();
+    } else {
+      // otherwise, it means that either
+      // 1. a stop callback was already called, so let that callback clean up or
+      // 2. we're still constructing the callbacks, so let start() handle the
+      // completion
+      UNIFEX_ASSERT(
+          oldState == _callback_state::AT_LEAST_ONE_CALLED ||
+          oldState == _callback_state::INIT);
+    }
+  }
+
+  void complete() noexcept {
+    std::apply(
+        [&](auto&... callbacks) noexcept { (callbacks.destruct(), ...); },
+        stopCallbacks_);
+    receiverStopCallback_.destruct();
+    unifex::set_done(std::move(receiver_));
+  }
+
+  using stop_token_type = stop_token_type_t<Receiver&>;
+
+  // All external stop tokens must be stoppable
+  static_assert(
+      (... && !is_stop_never_possible_v<StopTokens>),
+      "stop_on_request should not be used with any stop-token "
+      "types that can never be stopped.");
+
+  // If no external stop tokens are provided, then the receiver must be
+  // stoppable
+  static_assert(
+      (sizeof...(StopTokens) > 0 || !is_stop_never_possible_v<stop_token_type>),
+      "stop_on_request should not be used with an unstoppable receiver "
+      "if no stop-tokens are provided.");
+
+  UNIFEX_NO_UNIQUE_ADDRESS std::tuple<StopTokens...> stopTokens_;
+  template <typename StopToken>
+  using callback_t = manual_lifetime<
+      typename StopToken::template callback_type<cancel_callback>>;
+
+  UNIFEX_NO_UNIQUE_ADDRESS callback_t<stop_token_type> receiverStopCallback_;
+  UNIFEX_NO_UNIQUE_ADDRESS std::tuple<callback_t<StopTokens>...> stopCallbacks_;
+
+  UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
+  std::atomic<_callback_state> callbackState_{_callback_state::INIT};
+
+  template(typename Receiver2)                            //
+      (requires constructible_from<Receiver, Receiver2>)  //
+      type(Receiver2&& receiver, std::tuple<StopTokens...> stopTokens)
+    : stopTokens_(std::move(stopTokens))
+    , receiver_(std::forward<Receiver2>(receiver)) {}
+
+  template <size_t index = 0>
+  constexpr void constructCallbacks() {
+    if constexpr (std::tuple_size<decltype(stopTokens_)>::value == index) {
+      // hit the end of the tuple, exit
+      return;
+    } else {
+      std::get<index>(stopCallbacks_)
+          .construct(std::get<index>(stopTokens_), cancel_callback{*this});
+      scope_guard destructOnError = [this]() noexcept {
+        // If the following callback failed to construct, then we need to clean
+        // up the current callback, eventually cleaning up all of the callbacks
+        // that have been constructed so far
+        std::get<index>(stopCallbacks_).destruct();
+      };
+
+      constructCallbacks<index + 1>();
+
+      destructOnError.release();
+    }
+  }
+
+  void start() noexcept {
+    UNIFEX_ASSERT(
+        sizeof...(StopTokens) > 0 || get_stop_token(receiver_).stop_possible());
+
+    UNIFEX_TRY {
+      // construct a callback for the receiver stop token
+      receiverStopCallback_.construct(
+          get_stop_token(receiver_), cancel_callback{*this});
+
+      scope_guard destructOnError = [this]() noexcept {
+        receiverStopCallback_.destruct();
+      };
+
+      // construct a callback for each stop token
+      // Note: if any of these tokens are already stopped, then its
+      // corresponding callback will be immediately invoked
+      constructCallbacks();
+
+      destructOnError.release();
+    }
+    UNIFEX_CATCH(...) {
+      if (callbackState_.load(std::memory_order_acquire) ==
+          _callback_state::AT_LEAST_ONE_CALLED) {
+        // we received a stop request before we experienced an error
+        unifex::set_done(std::move(receiver_));
+      } else {
+        unifex::set_error(std::move(receiver_), std::current_exception());
+      }
+
+      return;
+    }
+
+    // update state to mark that all callbacks have been constructed
+    auto oldState = callbackState_.exchange(
+        _callback_state::ALL_CONSTRUCTED_NOT_CALLED, std::memory_order_acq_rel);
+    if (oldState == _callback_state::AT_LEAST_ONE_CALLED) {
+      // if a stop callback was already called, then we can handle completion
+      complete();
+    } else {
+      // otherwise, let the callback eventually handle completion in
+      // request_stopped()
+      UNIFEX_ASSERT(oldState == _callback_state::INIT);
+    }
+  }
+};
+
+template <typename... StopTokens>
+struct _sender final {
+  struct type;
+};
+
+template <typename... StopTokens>
+using sender = typename _sender<StopTokens...>::type;
+
+template <typename... StopTokens>
+struct _sender<StopTokens...>::type final {
+  template <
+      template <typename...>
+      class Variant,
+      template <typename...>
+      class Tuple>
+  using value_types = Variant<>;
+
+  template <template <typename...> class Variant>
+  using error_types = Variant<>;
+
+  static constexpr bool sends_done = true;
+
+  // we'll complete inline if started with a stopped stop token
+  static constexpr blocking_kind blocking = blocking_kind::maybe;
+
+  // we complete wherever the stop callback is invoked, which may not be the
+  // thread we started on
+  static constexpr bool is_always_scheduler_affine = false;
+
+  template(typename Self, typename Receiver)          //
+      (requires same_as<remove_cvref_t<Self>, type>)  //
+      friend operation<Receiver, StopTokens...> tag_invoke(
+          tag_t<connect>,
+          Self&& self,
+          Receiver&&
+              receiver) noexcept(std::
+                                     is_nothrow_constructible_v<
+                                         operation<Receiver, StopTokens...>,
+                                         Receiver,
+                                         member_t<
+                                             Self,
+                                             std::tuple<StopTokens...>>>) {
+    return operation<Receiver, StopTokens...>{
+        std::forward<Receiver>(receiver), std::forward<Self>(self).stopTokens_};
+  }
+
+  explicit type(StopTokens... stopTokens) noexcept(
+      std::is_nothrow_constructible_v<std::tuple<StopTokens...>, StopTokens...>)
+    : stopTokens_{std::move(stopTokens)...} {}
+
+private:
+  std::tuple<StopTokens...> stopTokens_;
+};
+
+struct _fn {
+  template <typename... StopTokens>
+  auto operator()(StopTokens... stopTokens) const
+      noexcept(std::is_nothrow_constructible_v<
+               _stop_on_request::sender<StopTokens...>,
+               StopTokens...>) {
+    return _stop_on_request::sender<StopTokens...>{std::move(stopTokens)...};
+  }
+};
+}  // namespace _stop_on_request
+
+inline constexpr _stop_on_request::_fn stop_on_request{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/test/stop_on_request_test.cpp
+++ b/test/stop_on_request_test.cpp
@@ -27,6 +27,7 @@
 #include <unifex/when_all.hpp>
 #include <unifex/when_all_range.hpp>
 
+#include <array>
 #include <exception>
 #include <optional>
 

--- a/test/stop_on_request_test.cpp
+++ b/test/stop_on_request_test.cpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unifex/stop_when.hpp>
+
+#include <unifex/defer.hpp>
+#include <unifex/let_done.hpp>
+#include <unifex/let_value_with_stop_source.hpp>
+#include <unifex/single_thread_context.hpp>
+#include <unifex/stop_on_request.hpp>
+#include <unifex/sync_wait.hpp>
+#include <unifex/task.hpp>
+#include <unifex/then.hpp>
+#include <unifex/when_all.hpp>
+#include <unifex/when_all_range.hpp>
+
+#include <exception>
+#include <optional>
+
+#include <gtest/gtest.h>
+
+// Dummy stop source and token class to test callback construction exception
+// handling
+namespace {
+template <typename test_stop_token, typename F>
+struct test_stop_callback final {
+  explicit test_stop_callback(test_stop_token, F&&) { throw std::exception(); }
+};
+
+struct test_stop_token {
+  template <typename F>
+  using callback_type = test_stop_callback<test_stop_token, F>;
+};
+}  // namespace
+
+TEST(StopOnRequest, UnstoppableReceiverWithExternalStopSource) {
+  bool wasCancelled = false;
+  unifex::inplace_stop_source externalStopSource;
+
+  unifex::sync_wait(unifex::when_all(
+      unifex::stop_on_request(externalStopSource.get_token()) |
+          unifex::let_done([&]() {
+            wasCancelled = true;
+            return unifex::just();
+          }),
+      unifex::defer([&]() {
+        externalStopSource.request_stop();
+        return unifex::just();
+      })));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, NoExternalStopSourceCancelledByReceiver) {
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    return unifex::when_all(
+        unifex::stop_on_request() | unifex::let_done([&]() {
+          wasCancelled = true;
+          return unifex::just();
+        }),
+        unifex::defer([&]() {
+          stopSource.request_stop();
+          return unifex::just();
+        }));
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, SingleExternalStopSourceCancelledBySource) {
+  unifex::inplace_stop_source externalStopSource;
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::when_all(
+      unifex::stop_on_request(externalStopSource.get_token()) |
+          unifex::let_done([&]() {
+            wasCancelled = true;
+            return unifex::just();
+          }),
+      unifex::defer([&]() {
+        externalStopSource.request_stop();
+        return unifex::just();
+      })));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, SingleStopSourceCancelledByReceiver) {
+  unifex::inplace_stop_source externalStopSource;
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    return unifex::when_all(
+        unifex::stop_on_request(externalStopSource.get_token()) |
+            unifex::let_done([&]() {
+              wasCancelled = true;
+              return unifex::just();
+            }),
+        unifex::defer([&]() {
+          stopSource.request_stop();
+          return unifex::just();
+        }));
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, SingleStopSourceCancelledBySourceAndReceiver) {
+  unifex::inplace_stop_source externalStopSource;
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    return unifex::when_all(
+        unifex::stop_on_request(externalStopSource.get_token()) |
+            unifex::let_done([&]() {
+              wasCancelled = true;
+              return unifex::just();
+            }),
+        unifex::defer([&]() {
+          stopSource.request_stop();
+          externalStopSource.request_stop();
+          return unifex::just();
+        }));
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, ReceiverCancelledBeforeConstruction) {
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    stopSource.request_stop();
+    return unifex::stop_on_request() | unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, StopSourceCancelledBeforeConstruction) {
+  unifex::inplace_stop_source externalStopSource;
+  externalStopSource.request_stop();
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto&) {
+    return unifex::stop_on_request(externalStopSource.get_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, SingleExternalStopSourceCancellationBeforeConstruction) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+  externalStopSource1.request_stop();
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto&) {
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, MultipleExternalStopSourceCancellationsBeforeConstruction) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+  unifex::inplace_stop_source externalStopSource3;
+  externalStopSource2.request_stop();
+  externalStopSource3.request_stop();
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto&) {
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token(),
+               externalStopSource3.get_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(
+    StopOnRequest,
+    ReceiverCancellationWithMultipleExternalStopSourcesBeforeConstruction) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    stopSource.request_stop();
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, ReceiverAndStopSourceCancellationsBeforeConstruction) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+  externalStopSource1.request_stop();
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    stopSource.request_stop();
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, MultiThreadedCancellations) {
+  constexpr size_t iterations = 10;
+  constexpr size_t numSources = 5;
+  unifex::inplace_stop_source stopSources[iterations * numSources];
+
+  auto makeTask = [](unifex::inplace_stop_source& stopSource)
+      -> unifex::nothrow_task<void> {
+    stopSource.request_stop();
+    co_return;
+  };
+
+  bool wasCancelled = false;
+
+  for (size_t i = 0; i < iterations; i++) {
+    std::vector<unifex::any_sender_of<>> tasks;
+    unifex::single_thread_context threads[numSources];
+    for (size_t j = 0; j < numSources; j++) {
+      tasks.emplace_back(unifex::on(
+          threads[j].get_scheduler(),
+          makeTask(stopSources[i * numSources + j])));
+    }
+    auto cancellationSender = unifex::stop_on_request(
+                                  stopSources[i * numSources].get_token(),
+                                  stopSources[i * numSources + 1].get_token(),
+                                  stopSources[i * numSources + 2].get_token(),
+                                  stopSources[i * numSources + 3].get_token(),
+                                  stopSources[i * numSources + 4].get_token()) |
+        unifex::let_done([&]() {
+                                wasCancelled = true;
+                                return unifex::just();
+                              });
+    unifex::sync_wait(unifex::when_all(
+        unifex::when_all_range(std::move(tasks)), cancellationSender));
+    EXPECT_TRUE(wasCancelled);
+    wasCancelled = false;
+  }
+}
+
+TEST(StopOnRequest, StopAfterComplete) {
+  unifex::inplace_stop_source externalStopSource;
+
+  bool wasCancelled = false;
+
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    return unifex::when_all(
+        unifex::stop_on_request(externalStopSource.get_token()) |
+            unifex::let_done([&]() {
+              wasCancelled = true;
+              return unifex::just();
+            }),
+        unifex::defer([&]() {
+          stopSource.request_stop();
+          return unifex::just();
+        }));
+  }));
+
+  externalStopSource.request_stop();
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, SingleCallbackConstructionErrorHandling) {
+  EXPECT_THROW(
+      { unifex::sync_wait(unifex::stop_on_request(test_stop_token())); },
+      std::exception);
+}
+
+TEST(StopOnRequest, MultipleCallbackConstructionErrorHandling_First) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+
+  EXPECT_THROW(
+      {
+        unifex::sync_wait(unifex::stop_on_request(
+            test_stop_token(),
+            externalStopSource1.get_token(),
+            externalStopSource2.get_token()));
+      },
+      std::exception);
+}
+
+TEST(StopOnRequest, MultipleCallbackConstructionErrorHandling_Last) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+
+  EXPECT_THROW(
+      {
+        unifex::sync_wait(unifex::stop_on_request(
+            externalStopSource1.get_token(),
+            externalStopSource2.get_token(),
+            test_stop_token()));
+      },
+      std::exception);
+}
+
+TEST(StopOnRequest, MultipleCallbackConstructionErrorsHandling) {
+  unifex::inplace_stop_source externalStopSource;
+
+  EXPECT_THROW(
+      {
+        unifex::sync_wait(unifex::stop_on_request(
+            externalStopSource.get_token(),
+            test_stop_token(),
+            test_stop_token()));
+      },
+      std::exception);
+}
+
+TEST(StopOnRequest, StopSourceCancellationBeforeCallbackConstructionError) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+
+  externalStopSource2.request_stop();
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto&) {
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token(),
+               test_stop_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}
+
+TEST(StopOnRequest, ReceiverCancellationBeforeCallbackConstructionError) {
+  unifex::inplace_stop_source externalStopSource1;
+  unifex::inplace_stop_source externalStopSource2;
+
+  bool wasCancelled = false;
+  unifex::sync_wait(unifex::let_value_with_stop_source([&](auto& stopSource) {
+    stopSource.request_stop();
+    return unifex::stop_on_request(
+               externalStopSource1.get_token(),
+               externalStopSource2.get_token(),
+               test_stop_token()) |
+        unifex::let_done([&]() {
+             wasCancelled = true;
+             return unifex::just();
+           });
+  }));
+
+  EXPECT_TRUE(wasCancelled);
+}


### PR DESCRIPTION
`stop_on_request` is a sender algorithm that allows external stop sources to cancel the composed sender. It takes in `N` stop tokens and if any one of them or the receiver receives a stop signal, the resulting sender will be cancelled. 