### PR TITLE
Create switch for disabling callback logging

### DIFF
--- a/include/unifex/config.hpp.in
+++ b/include/unifex/config.hpp.in
@@ -278,3 +278,13 @@
 #else
   #define UNIFEX_DEPRECATED_HEADER(MSG) /**/
 #endif
+
+#if !defined(UNIFEX_LOG_DANGLING_STOP_CALLBACKS)
+#  if !defined(NDEBUG)
+// logging not already specified and this is a debug build so default on
+#    define UNIFEX_LOG_DANGLING_STOP_CALLBACKS 1
+#  else
+// logging not already specified and this is a release build so default off
+#    define UNIFEX_LOG_DANGLING_STOP_CALLBACKS 0
+#  endif
+#endif

--- a/source/inplace_stop_token.cpp
+++ b/source/inplace_stop_token.cpp
@@ -17,7 +17,7 @@
 
 #include <unifex/spin_wait.hpp>
 
-#ifndef NDEBUG
+#if UNIFEX_LOG_DANGLING_STOP_CALLBACKS
 #  include <stdio.h>
 #endif
 
@@ -25,7 +25,9 @@ namespace unifex {
 
 inplace_stop_source::~inplace_stop_source() {
   UNIFEX_ASSERT((state_.load(std::memory_order_relaxed) & locked_flag) == 0);
-#ifndef NDEBUG
+#if UNIFEX_LOG_DANGLING_STOP_CALLBACKS
+  // consume the last writes made under the lock
+  (void)state_.load(std::memory_order_acquire);
   for (auto* cb = callbacks_; cb != nullptr; cb = cb->next_) {
     printf("dangling inplace_stop_callback: %s\n", cb->type_name());
     fflush(stdout);


### PR DESCRIPTION
We're seeing reports of folks running into ODR issues when linking together TUs built with and without `NDEBUG` defined. The reason is that `unifex::inplace_stop_callback_base`'s size and layout depend on whether `NDEBUG` is defined, leading to incompatible ABIs between the two build modes.

This change introduces a new preprocessor macro,
`UNIFEX_LOG_DANGLING_STOP_CALLBACKS` that controls whether `inplace_stop_callback_base` knows a stringified typename of the deriving class and whether `inplace_stop_source` uses that knowledge to log the names of dangling stop callbacks in its destructor. I've also updated `config.hpp.in` to retain existing behaviour: the default state for `UNIFEX_LOG_DANGLING_STOP_CALLBACKS` is on when `NDEBUG` is not defined and off when `NDEBUG` is defined. The defaults can be overridden.

There's also a drive-by fix for a TSAN error that pops up if you ever actually log dangling callbacks.