### PR TITLE
Remove the cmake configuration machinery for config.hpp

### DIFF
--- a/cmake/unifex_flags.cmake
+++ b/cmake/unifex_flags.cmake
@@ -9,28 +9,6 @@ include(CMakePushCheckState)
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 
-# Probe for coroutine TS support
-find_package(Coroutines COMPONENTS Experimental Final)
-# MSVC's coroutines support is too broken to support here, sadly.
-if(CXX_COROUTINES_HAVE_COROUTINES AND NOT UNIFEX_CXX_COMPILER_MSVC)
-  set(UNIFEX_NO_COROUTINES FALSE)
-  set(UNIFEX_COROUTINES_HEADER ${CXX_COROUTINES_HEADER})
-  set(UNIFEX_COROUTINES_NAMESPACE ${CXX_COROUTINES_NAMESPACE})
-else()
-  set(UNIFEX_NO_COROUTINES TRUE)
-endif()
-
-# Probe for memory_resource support
-find_package(MemoryResource COMPONENTS Experimental Final)
-# Set some variables to be used by configure_file.
-if(CXX_MEMORY_RESOURCE_HAVE_PMR)
-  set(UNIFEX_NO_MEMORY_RESOURCE FALSE)
-  set(UNIFEX_MEMORY_RESOURCE_HEADER ${CXX_MEMORY_RESOURCE_HEADER})
-  set(UNIFEX_MEMORY_RESOURCE_NAMESPACE ${CXX_MEMORY_RESOURCE_NAMESPACE})
-else()
-  set(UNIFEX_NO_MEMORY_RESOURCE TRUE)
-endif()
-
 if(DEFINED UNIFEX_NO_LIBURING)
   message(WARNING "[unifex warning]: forcing no_liburing=${UNIFEX_NO_LIBURING} !")
 elseif(DEFINED ENV{UNIFEX_NO_LIBURING})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,10 +12,6 @@ foreach(file-path ${example-sources})
     add_test(NAME "example-${file-name}" COMMAND ${file-name})
 endforeach()
 
-if(CXX_MEMORY_RESOURCE_HAVE_PMR)
-  target_link_libraries(any_unique PUBLIC std::memory_resource)
-endif()
-
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   file(GLOB linux-example-sources "linux/*.cpp")
   foreach(file-path ${linux-example-sources})

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -24,13 +24,13 @@
 
 #include <cassert>
 
-// the configured options and settings for unifex
-#define UNIFEX_VERSION_MAJOR @libunifex_VERSION_MAJOR@
-#define UNIFEX_VERSION_MINOR @libunifex_VERSION_MINOR@
-
-#cmakedefine01 UNIFEX_NO_MEMORY_RESOURCE
-#cmakedefine UNIFEX_MEMORY_RESOURCE_HEADER <@UNIFEX_MEMORY_RESOURCE_HEADER@>
-#cmakedefine UNIFEX_MEMORY_RESOURCE_NAMESPACE @UNIFEX_MEMORY_RESOURCE_NAMESPACE@
+#if __has_include(<memory_resource>)
+#  define UNIFEX_NO_MEMORY_RESOURCE 0
+#  define UNIFEX_MEMORY_RESOURCE_HEADER <memory_resource>
+#  define UNIFEX_MEMORY_RESOURCE_NAMESPACE std::pmr
+#else
+#  define UNIFEX_NO_MEMORY_RESOURCE 1
+#endif
 
 #if !defined(__has_cpp_attribute)
 #define UNIFEX_NO_UNIQUE_ADDRESS
@@ -60,8 +60,7 @@
 #  if __has_include(<coroutine>) && defined(__cpp_lib_coroutine)
 #    define UNIFEX_COROUTINES_HEADER <coroutine>
 #    define UNIFEX_COROUTINES_NAMESPACE std
-#  elif __has_include(<experimental/coroutine>) && \
-        !(defined(_MSC_VER) && defined(__clang__)) // clang-cl.exe
+#  elif __has_include(<experimental/coroutine>)
 #    define UNIFEX_COROUTINES_HEADER <experimental/coroutine>
 #    define UNIFEX_COROUTINES_NAMESPACE std::experimental
 #  else
@@ -80,7 +79,11 @@
 #endif
 
 #if !defined(UNIFEX_NO_EPOLL)
-#cmakedefine01 UNIFEX_NO_EPOLL
+#  if __has_include(<sys/epoll.h>)
+#    define UNIFEX_NO_EPOLL 0
+#  else
+#    define UNIFEX_NO_EPOLL 1
+#  endif
 #endif
 
 #if !defined(UNIFEX_NO_LIBURING)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -65,10 +65,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 endif()
 
-configure_file(
-  ../include/unifex/config.hpp.in
-  "${PROJECT_BINARY_DIR}/include/unifex/config.hpp")
-
 include(GNUInstallDirs)
 target_include_directories(unifex
     PUBLIC
@@ -87,8 +83,6 @@ configure_file(unifex.pc.in unifex.pc @ONLY)
 # install unifex with its configure file into the default paths
 
 install(TARGETS unifex EXPORT unifexTargets)
-install(FILES ${PROJECT_BINARY_DIR}/include/unifex/config.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/unifex/)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
         TYPE INCLUDE
         PATTERN "*.in" EXCLUDE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,10 +12,6 @@ foreach(file-path ${test-sources})
     add_test(NAME "test-${file-name}" COMMAND ${file-name})
 endforeach()
 
-if(CXX_MEMORY_RESOURCE_HAVE_PMR)
-  target_link_libraries(any_unique_test PUBLIC std::memory_resource)
-endif()
-
 target_link_libraries(any_sender_of_test PUBLIC GTest::gmock_main)
 target_link_libraries(async_manual_reset_event_test PUBLIC GTest::gmock_main)
 target_link_libraries(async_scope_test PUBLIC GTest::gmock_main)


### PR DESCRIPTION
We can rely on the preprocessor for it instead since we only support C++17 and above.
Closes #510