### PR TITLE
Make scope_guard nodiscard

### DIFF
--- a/include/unifex/scope_guard.hpp
+++ b/include/unifex/scope_guard.hpp
@@ -23,7 +23,7 @@
 namespace unifex {
 
 template <typename Func>
-struct scope_guard {
+struct [[nodiscard]] scope_guard {
 private:
   static_assert(std::is_nothrow_move_constructible_v<Func>);
   UNIFEX_NO_UNIQUE_ADDRESS Func func_;


### PR DESCRIPTION
We don't want to mistakenly trigger the destructor before the end of the scope.