### PR TITLE
Make the connect_awaitable opstate immovable

### DIFF
--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -110,7 +110,7 @@ public:
   explicit type(coro::coroutine_handle<promise_type> coro) noexcept
     : coro_(coro) {}
 
-  type(type&& other) noexcept : coro_(std::exchange(other.coro_, {})) {}
+  type(type&&) = delete;
 
   ~type() {
     if (coro_)


### PR DESCRIPTION
I noticed while doing other things that the opstate returned from `connect_awaitable()` has a move constructor. This diff deletes it.