### PR TITLE
Fix error_types in dematerialize sender

### DIFF
--- a/test/materialize_test.cpp
+++ b/test/materialize_test.cpp
@@ -32,6 +32,17 @@ using namespace unifex;
 TEST(Materialize, Smoke) {
   single_thread_context ctx;
 
+  using Sender =
+      std::decay_t<decltype(dematerialize(materialize(just_error(0))))>;
+  static_assert(std::is_same_v<
+                std::variant<>,
+                typename sender_traits<
+                    Sender>::template value_types<std::variant, std::tuple>>);
+  static_assert(
+      std::is_same_v<
+          std::variant<int, std::exception_ptr>,
+          typename sender_traits<Sender>::template error_types<std::variant>>);
+
   std::optional<int> result = sync_wait(dematerialize(
       materialize(then(schedule(ctx.get_scheduler()), []() { return 42; }))));
 


### PR DESCRIPTION
Hiyo, I found what looks like a bug in the `dematerialize` sender.

The issue is here: https://github.com/facebookexperimental/libunifex/issues/611

To summarize `error_types` of a sender created by `dematerialize` is usually an invalid type. For example the following code:
```cpp
#include <unifex/dematerialize.hpp>
#include <unifex/just.hpp>

#include <unifex/materialize.hpp>
#include <type_traits>
#include <variant>

using namespace unifex;

using Sender = std::decay_t<decltype(dematerialize(materialize(just())))>;
using Errors = typename sender_traits<Sender>::template error_types<std::variant>;
int main() {}
```
(here on [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:14,endLineNumber:12,positionColumn:1,positionLineNumber:1,selectionStartColumn:14,selectionStartLineNumber:12,startColumn:1,startLineNumber:1),source:'%23include+%3Cunifex/dematerialize.hpp%3E%0A%23include+%3Cunifex/just.hpp%3E%0A%0A%23include+%3Cunifex/materialize.hpp%3E%0A%23include+%3Ctype_traits%3E%0A%23include+%3Cvariant%3E%0A%0Ausing+namespace+unifex%3B%0A%0Ausing+Sender+%3D+std::decay_t%3Cdecltype(dematerialize(materialize(just())))%3E%3B%0Ausing+Errors+%3D+typename+sender_traits%3CSender%3E::template+error_types%3Cstd::variant%3E%3B%0Aint+main()+%7B%7D'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:49.763872491145214,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:gsnapshot,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!((name:unifex,ver:trunk)),options:'',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+gcc+(trunk)+(Editor+%231)',t:'0')),k:100,l:'4',m:43.64994663820704,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'x86-64+gcc+(trunk)',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+gcc+(trunk)+(Compiler+%231)',t:'0')),header:(),l:'4',m:56.35005336179295,n:'0',o:'',s:0,t:'0')),k:50.23612750885478,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4))
fails to compile and gives the error `error: no type named 'type' in 'struct unifex::single_type<>'`

When we use `std::conditional_t` to filter the source sender's `value_types` into ones that start with `set_error`, sometimes the `false` branch type isn't valid.

I think the easiest solution is to add a layer of indirection so that the template argument to `tuple` isn't evaluated when the condition is false, which I've done here.

After this the compiler complained about a missing `::type` so I updated that and switched a `::type` to `_t` for consistency.