### PR TITLE
Add initial support for async stack traces to Unifex

### DIFF
--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -293,7 +293,21 @@
 #endif
 
 #if defined(__has_builtin)
-#define UNIFEX_HAS_BUILTIN(...) __has_builtin(__VA_ARGS__)
+#  define UNIFEX_HAS_BUILTIN(...) __has_builtin(__VA_ARGS__)
 #else
-#define UNIFEX_HAS_BUILTIN(...) 0
+#  define UNIFEX_HAS_BUILTIN(...) 0
 #endif
+
+#if !defined(UNIFEX_NO_ASYNC_STACKS)
+// default:
+//  - release builds do not have async stacks
+//  - Windows builds do not have async stacks
+//
+// adding async stacks adds non-trivial binary size at the moment, and I can't
+// figure out how to make all the relevant Windows builds succeed
+#  if defined(NDEBUG) || defined(_MSC_VER)
+#    define UNIFEX_NO_ASYNC_STACKS 1
+#  else
+#    define UNIFEX_NO_ASYNC_STACKS 0
+#  endif
+#endif  // !defined(UNIFEX_NO_ASYNC_STACKS)

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -291,3 +291,9 @@
 #    define UNIFEX_LOG_DANGLING_STOP_CALLBACKS 0
 #  endif
 #endif
+
+#if defined(__has_builtin)
+#define UNIFEX_HAS_BUILTIN(...) __has_builtin(__VA_ARGS__)
+#else
+#define UNIFEX_HAS_BUILTIN(...) 0
+#endif

--- a/include/unifex/detail/unifex_fwd.hpp
+++ b/include/unifex/detail/unifex_fwd.hpp
@@ -53,6 +53,11 @@ extern const struct _fn submit;
 }  // namespace _submit_cpo
 using _submit_cpo::submit;
 
+namespace _start_cpo {
+struct _fn;
+}
+extern const _start_cpo::_fn start;
+
 namespace _connect::_cpo {
 struct _fn;
 }  // namespace _connect::_cpo

--- a/include/unifex/sender_concepts.hpp
+++ b/include/unifex/sender_concepts.hpp
@@ -18,11 +18,15 @@
 #include <unifex/config.hpp>
 
 #include <unifex/blocking.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
+#include <unifex/tracing/async_stack.hpp>
+#include <unifex/tracing/get_async_stack_frame.hpp>
+#include <unifex/tracing/get_return_address.hpp>
+#include <unifex/tracing/inject_async_stack.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
-#include <unifex/detail/unifex_fwd.hpp>
 
 #if !UNIFEX_NO_COROUTINES
 #  include <unifex/coroutine_concepts.hpp>
@@ -195,7 +199,7 @@ template <typename S>
 inline constexpr bool typed_bulk_sender = bulk_sender<S>;
 
 namespace _start_cpo {
-inline const struct _fn {
+struct _fn {
   template(typename Operation)                   //
       (requires tag_invocable<_fn, Operation&>)  //
       auto
@@ -214,35 +218,73 @@ inline const struct _fn {
         noexcept(op.start()), "start() customisation must be noexcept");
     return op.start();
   }
-} start{};
+};
 }  // namespace _start_cpo
-using _start_cpo::start;
+inline const _start_cpo::_fn start{};
 
 namespace _connect {
-namespace _cpo {
-struct _fn {
-  template(typename Sender, typename Receiver)  //
-      (requires sender<Sender> AND receiver<Receiver> AND
-           tag_invocable<_fn, Sender, Receiver>)  //
-      auto
-      operator()(Sender&& s, Receiver&& r) const
-      noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Receiver>)
-          -> tag_invoke_result_t<_fn, Sender, Receiver> {
-    return unifex::tag_invoke(
-        _fn{}, std::forward<Sender>(s), std::forward<Receiver>(r));
-  }
 
-  template(typename Sender, typename Receiver)  //
-      (requires sender<Sender> AND
-           receiver<Receiver> AND(!tag_invocable<_fn, Sender, Receiver>))  //
-      auto
-      operator()(Sender&& s, Receiver&& r) const
-      noexcept(noexcept(std::forward<Sender>(s).connect(std::forward<Receiver>(
-          r)))) -> decltype(std::forward<Sender>(s)
-                                .connect(std::forward<Receiver>(r))) {
-    return std::forward<Sender>(s).connect(std::forward<Receiver>(r));
+template <typename Sender, typename Receiver>
+using _member_connect_result_t =
+    decltype((UNIFEX_DECLVAL(Sender&&)).connect(UNIFEX_DECLVAL(Receiver&&)));
+
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT_FRAGMENT(   //
+    _has_member_connect_,  //
+    requires()(            //
+        typename(_member_connect_result_t<Sender, Receiver>)));
+
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT                //
+    _is_member_connectible =  //
+    sender<Sender> &&
+    UNIFEX_FRAGMENT(_connect::_has_member_connect_, Sender, Receiver);
+
+template <typename Sender, typename Receiver>
+UNIFEX_CONCEPT                        //
+    _is_nothrow_member_connectible =  //
+    _is_member_connectible<Sender, Receiver> &&
+    noexcept(UNIFEX_DECLVAL(Sender&&).connect(UNIFEX_DECLVAL(Receiver&&)));
+
+namespace _cpo {
+
+struct _fn {
+private:
+  struct _impl {
+    template(typename S, typename R)         //
+        (requires tag_invocable<_fn, S, R>)  //
+        auto
+        operator()(S&& s, R&& r) const
+        noexcept(is_nothrow_tag_invocable_v<_fn, S, R>)
+            -> tag_invoke_result_t<_fn, S, R> {
+      return unifex::tag_invoke(_fn{}, std::forward<S>(s), std::forward<R>(r));
+    }
+
+    template(typename S, typename R)  //
+        (requires(!tag_invocable<_fn, S, R>)
+             AND _is_member_connectible<S, R>)  //
+        auto
+        operator()(S&& s, R&& r) const
+        noexcept(_is_nothrow_member_connectible<S, R>)
+            -> _member_connect_result_t<S, R> {
+      return std::forward<S>(s).connect(std::forward<R>(r));
+    }
+  };
+
+  template <typename S, typename R>
+  using op_t = _inject::
+      op_wrapper<std::invoke_result_t<_impl, S, _inject::receiver_t<R>>, R>;
+
+public:
+  template(typename S, typename R)  //
+      (requires sender<S> AND receiver<R>) auto
+      operator()(S&& s, R&& r) const noexcept(noexcept(_inject::make_op_wrapper(
+          std::forward<S>(s), std::forward<R>(r), _impl{}))) -> op_t<S, R> {
+    return _inject::make_op_wrapper(
+        std::forward<S>(s), std::forward<R>(r), _impl{});
   }
 };
+
 }  // namespace _cpo
 }  // namespace _connect
 inline const _connect::_cpo::_fn connect{};

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace unifex {
+
+inline void checkAsyncStackFrameIsActive(
+    [[maybe_unused]] const unifex::AsyncStackFrame& frame) noexcept {
+  (void)frame;
+  assert(frame.stackRoot != nullptr);
+  assert(tryGetCurrentAsyncStackRoot() == frame.stackRoot);
+  assert(frame.stackRoot->topFrame.load(std::memory_order_relaxed) == &frame);
+}
+
+inline void activateAsyncStackFrame(
+    unifex::AsyncStackRoot& root, unifex::AsyncStackFrame& frame) noexcept {
+  assert(tryGetCurrentAsyncStackRoot() == &root);
+  root.setTopFrame(frame);
+}
+
+inline void deactivateAsyncStackFrame(unifex::AsyncStackFrame& frame) noexcept {
+  checkAsyncStackFrameIsActive(frame);
+  frame.stackRoot->topFrame.store(nullptr, std::memory_order_relaxed);
+  frame.stackRoot = nullptr;
+}
+
+inline void pushAsyncStackFrameCallerCallee(
+    unifex::AsyncStackFrame& callerFrame,
+    unifex::AsyncStackFrame& calleeFrame) noexcept {
+  checkAsyncStackFrameIsActive(callerFrame);
+  calleeFrame.stackRoot = callerFrame.stackRoot;
+  calleeFrame.parentFrame = &callerFrame;
+  calleeFrame.stackRoot->topFrame.store(
+      &calleeFrame, std::memory_order_release);
+
+  // Clearing out non-top-frame's stackRoot is not strictly necessary
+  // but it may help with debugging.
+  callerFrame.stackRoot = nullptr;
+}
+
+inline void
+popAsyncStackFrameCallee(unifex::AsyncStackFrame& calleeFrame) noexcept {
+  checkAsyncStackFrameIsActive(calleeFrame);
+  auto* callerFrame = calleeFrame.parentFrame;
+  auto* stackRoot = calleeFrame.stackRoot;
+  if (callerFrame != nullptr) {
+    callerFrame->stackRoot = stackRoot;
+  }
+  stackRoot->topFrame.store(callerFrame, std::memory_order_release);
+
+  // Clearing out non-top-frame's stackRoot is not strictly necessary
+  // but it may help with debugging.
+  calleeFrame.stackRoot = nullptr;
+}
+
+inline std::size_t getAsyncStackTraceFromInitialFrame(
+    unifex::AsyncStackFrame* initialFrame,
+    std::uintptr_t* addresses,
+    std::size_t maxAddresses) {
+  std::size_t numFrames = 0;
+  for (auto* frame = initialFrame; frame != nullptr && numFrames < maxAddresses;
+       frame = frame->getParentFrame()) {
+    addresses[numFrames++] =
+        reinterpret_cast<std::uintptr_t>(frame->getReturnAddress());
+  }
+  return numFrames;
+}
+
+#if !UNIFEX_NO_COROUTINES
+
+template <typename Promise>
+void resumeCoroutineWithNewAsyncStackRoot(
+    coro::coroutine_handle<Promise> h) noexcept {
+  resumeCoroutineWithNewAsyncStackRoot(h, h.promise().getAsyncFrame());
+}
+
+#endif
+
+inline AsyncStackFrame* AsyncStackFrame::getParentFrame() noexcept {
+  return parentFrame;
+}
+
+inline const AsyncStackFrame* AsyncStackFrame::getParentFrame() const noexcept {
+  return parentFrame;
+}
+
+inline void AsyncStackFrame::setParentFrame(AsyncStackFrame& frame) noexcept {
+  parentFrame = &frame;
+}
+
+inline AsyncStackRoot* AsyncStackFrame::getStackRoot() noexcept {
+  return stackRoot;
+}
+
+inline void AsyncStackFrame::setReturnAddress(void* p) noexcept {
+  instructionPointer = p;
+}
+
+inline void* AsyncStackFrame::getReturnAddress() const noexcept {
+  return instructionPointer;
+}
+
+inline void AsyncStackRoot::setTopFrame(AsyncStackFrame& frame) noexcept {
+  assert(this->topFrame.load(std::memory_order_relaxed) == nullptr);
+  assert(frame.stackRoot == nullptr);
+  frame.stackRoot = this;
+  this->topFrame.store(&frame, std::memory_order_release);
+}
+
+inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
+  return topFrame.load(std::memory_order_relaxed);
+}
+
+inline void
+AsyncStackRoot::setStackFrameContext(void* framePtr, void* ip) noexcept {
+  stackFramePtr = framePtr;
+  returnAddress = ip;
+}
+
+inline void* AsyncStackRoot::getStackFramePointer() const noexcept {
+  return stackFramePtr;
+}
+
+inline void* AsyncStackRoot::getReturnAddress() const noexcept {
+  return returnAddress;
+}
+
+inline const AsyncStackRoot* AsyncStackRoot::getNextRoot() const noexcept {
+  return nextRoot;
+}
+
+inline void AsyncStackRoot::setNextRoot(AsyncStackRoot* next) noexcept {
+  nextRoot = next;
+}
+
+}  // namespace unifex

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -75,7 +75,7 @@ inline std::size_t getAsyncStackTraceFromInitialFrame(
   for (auto* frame = initialFrame; frame != nullptr && numFrames < maxAddresses;
        frame = frame->getParentFrame()) {
     addresses[numFrames++] =
-        reinterpret_cast<std::uintptr_t>(frame->getReturnAddress());
+        static_cast<std::uintptr_t>(frame->getReturnAddress());
   }
   return numFrames;
 }
@@ -106,11 +106,11 @@ inline AsyncStackRoot* AsyncStackFrame::getStackRoot() noexcept {
   return stackRoot;
 }
 
-inline void AsyncStackFrame::setReturnAddress(void* p) noexcept {
+inline void AsyncStackFrame::setReturnAddress(instruction_ptr p) noexcept {
   instructionPointer = p;
 }
 
-inline void* AsyncStackFrame::getReturnAddress() const noexcept {
+inline instruction_ptr AsyncStackFrame::getReturnAddress() const noexcept {
   return instructionPointer;
 }
 
@@ -125,17 +125,17 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
   return topFrame.load(std::memory_order_relaxed);
 }
 
-inline void
-AsyncStackRoot::setStackFrameContext(void* framePtr, void* ip) noexcept {
+inline void AsyncStackRoot::setStackFrameContext(
+    frame_ptr framePtr, instruction_ptr ip) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
 }
 
-inline void* AsyncStackRoot::getStackFramePointer() const noexcept {
+inline frame_ptr AsyncStackRoot::getStackFramePointer() const noexcept {
   return stackFramePtr;
 }
 
-inline void* AsyncStackRoot::getReturnAddress() const noexcept {
+inline instruction_ptr AsyncStackRoot::getReturnAddress() const noexcept {
   return returnAddress;
 }
 

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -507,6 +507,16 @@ public:
     unifex::activateAsyncStackFrame(root_, frame);
   }
 
+  void ensureFrameDeactivated(
+      [[maybe_unused]] AsyncStackFrame* possiblyDeadFrame) noexcept {
+    // this is like deactivateAsyncStackFrame(*possibleDeadFrame) but it
+    // doesn't make assertions about the state of the possibly-dead frame
+    assert(tryGetCurrentAsyncStackRoot() == &root_);
+    [[maybe_unused]] auto topFrame =
+        root_.topFrame.exchange(nullptr, std::memory_order_relaxed);
+    assert(topFrame == possiblyDeadFrame);
+  }
+
 private:
   AsyncStackRoot root_;
 };

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -258,6 +258,8 @@ void resumeCoroutineWithNewAsyncStackRoot(
 
 #endif  // FOLLY_HAS_COROUTINES
 
+// The following lldb command will make instruction_ptrs more legible
+//  type summary add unifex::instruction_ptr --summary-string "${var.p_%A}"
 struct instruction_ptr final {
   constexpr instruction_ptr(std::nullptr_t = nullptr) noexcept : p_(nullptr) {}
 

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unifex/coroutine.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+// Gets the instruction pointer of the return-address of the current function.
+//
+// Generally a function that uses this macro should be declared FOLLY_NOINLINE
+// to prevent this returning surprising results in cases where the function
+// is inlined.
+#if UNIFEX_HAS_BUILTIN(__builtin_return_address)
+#  define FOLLY_ASYNC_STACK_RETURN_ADDRESS() __builtin_return_address(0)
+#else
+#  define FOLLY_ASYNC_STACK_RETURN_ADDRESS() static_cast<void*>(nullptr)
+#endif
+
+// Gets pointer to the current function invocation's stack-frame.
+//
+// Generally a function that uses this macro should be declared FOLLY_NOINLINE
+// to prevent this returning surprising results in cases where the function
+// is inlined.
+#if UNIFEX_HAS_BUILTIN(__builtin_frame_address)
+#  define FOLLY_ASYNC_STACK_FRAME_POINTER() __builtin_frame_address(0)
+#else
+#  define FOLLY_ASYNC_STACK_FRAME_POINTER() static_cast<void*>(nullptr)
+#endif
+
+// This header defines data-structures used to represent an async stack-trace.
+//
+// These data-structures are intended for use by coroutines (and possibly other
+// representations of async operations) to allow the current program to record
+// an async-stack as a linked-list of async-stack-frames in a similar way to
+// how a normal thread represents the stack as a linked-list of stack frames.
+//
+// From a high-level, just looking at the AsyncStackRoot/AsyncStackFrame
+// data-structures, each thread maintains a linked-list of active AsyncStack
+// chains that looks a bit like this.
+//
+//  Stack Register
+//      |
+//      V
+//  Stack Frame   currentStackRoot (TLS)
+//      |               |
+//      V               V
+//  Stack Frame <- AsyncStackRoot  -> AsyncStackFrame -> AsyncStackFrame -> ...
+//      |               |
+//      V               |
+//  Stack Frame         |
+//      :               |
+//      V               V
+//  Stack Frame <- AsyncStackRoot  -> AsyncStackFrame -> AsyncStackFrame -> ...
+//      |               |
+//      V               X
+//  Stack Frame
+//      :
+//      V
+//
+// Whenever a thread enters an event loop or is about to execute some
+// asynchronus callback/continuation the current thread registers an
+// AsyncStackRoot and records the stack-frame of the normal thread
+// stack that corresponds to that call so that each AsyncStackRoot
+// can be later interleaved with a normal thread stack-trace at
+// the appropriate location.
+//
+// Each AsyncStackRoot contains a pointer to the currently active
+// AsyncStackFrame (if any). This AsyncStackFrame forms the head
+// of a linked-list of AsyncStackFrame objects that represent the
+// async stack-trace. Each non-head AsyncStackFrame is a suspended
+// asynchronous operation, which is typically suspended waiting for
+// the previous operation to complete.
+//
+//
+// The following diagram shows in more detail how each of the fields
+// in these data-structures relate to each other and how the
+// async-stack interleaves with the normal thread-stack.
+//
+//      Current Thread Stack
+//      ====================
+// +------------------------------------+ <--- current top of stack
+// | Normal Stack Frame                 |
+// | - stack-base-pointer  ---.         |
+// | - return-address         |         |          Thread Local Storage
+// |                          |         |          ====================
+// +--------------------------V---------+
+// |         ...                        |     +-------------------------+
+// |                          :         |     | - currentStackRoot  -.  |
+// |                          :         |     |                      |  |
+// +--------------------------V---------+     +----------------------|--+
+// | Normal Stack Frame                 |                            |
+// | - stack-base-pointer  ---.         |                            |
+// | - return-address         |      .-------------------------------`
+// |                          |      |  |
+// +--------------------------V------|--+
+// | Active Async Operation          |  |
+// | (Callback or Coroutine)         |  |            Heap Allocated
+// | - stack-base-pointer  ---.      |  |            ==============
+// | - return-address         |      |  |
+// | - pointer to async state | --------------> +-------------------------+
+// |   (e.g. coro frame or    |      |  |       | Coroutine Frame         |
+// |    future core)          |      |  |       | +---------------------+ |
+// |                          |      |  |       | | Promise             | |
+// +--------------------------V------|--+       | | +-----------------+ | |
+// |   Event  / Callback             |  |   .------>| AsyncStackFrame | | |
+// |   Loop     Callsite             |  |   |   | | | - parentFrame  --------.
+// | - stack-base-pointer  ---.      |  |   |   | | | - instructionPtr| | |  |
+// | - return-address         |      |  |   |   | | | - stackRoot -.  | | |  |
+// |                          |      |  |   |   | | +--------------|--+ | |  |
+// |  +--------------------+  |      |  |   |   | | ...            |    | |  |
+// |  | AsyncStackRoot     |<--------`  |   |   | +----------------|----+ |  |
+// |  | - topFrame   -----------------------`   | ...              |      |  |
+// |  | - stackFramePtr -. |<---------------,   +------------------|------+  |
+// |  | - nextRoot --.   | |  |         |   |                      |         |
+// |  +--------------|---|-+  |         |   '----------------------`         |
+// +-----------------|---V----V---------+       +-------------------------+  |
+// |         ...     |                  |       | Coroutine Frame         |  |
+// |                 |        :         |       |                         |  |
+// |                 |        :         |       |  +-------------------+  |  |
+// +-----------------|--------V---------+       |  | AsyncStackFrame   |<----`
+// | Async Operation |                  |       |  | - parentFrame   --------.
+// | (Callback/Coro) |                  |       |  | - instructionPtr  |  |  |
+// |                 |        :         |       |  | - stackRoot       |  |  |
+// |                 |        :         |       |  +-------------------+  |  |
+// +-----------------|--------V---------+       +-------------------------+  |
+// |  Event Loop /   |                  |                                    :
+// |  Callback Call  |                  |                                    :
+// | - frame-pointer | -------.         |                                    V
+// | - return-address|        |         |
+// |                 |        |         |      Another chain of potentially
+// |  +--------------V-----+  |         |      unrelated AsyncStackFrame
+// |  | AsyncStackRoot     |  |         |       +---------------------+
+// |  | - topFrame  ---------------- - - - - >  | AsyncStackFrame     |
+// |  | - stackFramePtr -. |  |         |       | - parentFrame -.    |
+// |  | - nextRoot -.    | |  |         |       +----------------|----+
+// |  +-------------|----|-+  |         |                        :
+// |                |    |    |         |                        V
+// +----------------|----V----V---------+
+// |         ...    :                   |
+// |                V                   |
+// |                                    |
+// +------------------------------------+
+//
+//
+// This data-structure can be inspected from within the current process
+// if desired, but is also intended to allow tools such as debuggers or
+// profilers that are inspecting the memory of this process remotely.
+
+struct AsyncStackRoot;
+struct AsyncStackFrame;
+namespace detail {
+class ScopedAsyncStackRoot;
+}
+
+// Get access to the current thread's top-most AsyncStackRoot.
+//
+// Returns nullptr if there is no active AsyncStackRoot.
+[[nodiscard]] AsyncStackRoot* tryGetCurrentAsyncStackRoot() noexcept;
+
+// Get access to the current thread's top-most AsyncStackRoot.
+//
+// Assumes that there is a current AsyncStackRoot.
+[[nodiscard]] AsyncStackRoot& getCurrentAsyncStackRoot() noexcept;
+
+// Exchange the current thread's active AsyncStackRoot with the
+// specified AsyncStackRoot pointer, returning the old AsyncStackRoot
+// pointer.
+//
+// This is intended to be used to update the thread-local pointer
+// when context-switching fiber stacks.
+[[nodiscard]] AsyncStackRoot*
+exchangeCurrentAsyncStackRoot(AsyncStackRoot* newRoot) noexcept;
+
+// Perform some consistency checks on the specified AsyncStackFrame,
+// assuming that it is the currently active AsyncStackFrame.
+void checkAsyncStackFrameIsActive(
+    const unifex::AsyncStackFrame& frame) noexcept;
+
+// Activate the specified AsyncStackFrame on the specified AsyncStackRoot,
+// setting it as the current 'topFrame'.
+//
+// The AsyncStackRoot must be the current thread's top-most AsyncStackRoot
+// and it must not currently have an active 'topFrame'.
+//
+// This is typically called immediately prior to executing a callback that
+// resumes the async operation represented by 'frame'.
+void activateAsyncStackFrame(
+    unifex::AsyncStackRoot& root, unifex::AsyncStackFrame& frame) noexcept;
+
+// Deactivate the specified AsyncStackFrame, clearing the current 'topFrame'.
+//
+// Typically called when the current async operation completes or is suspended
+// and execution is about to return from the callback to the executor's event
+// loop.
+void deactivateAsyncStackFrame(unifex::AsyncStackFrame& frame) noexcept;
+
+// Push the 'callee' frame onto the current thread's async stack, deactivating
+// the 'caller' frame and setting up the 'caller' to be the parent-frame of
+// the 'callee'.
+//
+// The 'caller' frame must be the current thread's active frame.
+//
+// After this call, the 'callee' frame will be the current thread's active
+// frame.
+//
+// This is typically used when one async operation is about to transfer
+// execution to a child async operation. e.g. via a coroutine symmetric
+// transfer.
+void pushAsyncStackFrameCallerCallee(
+    unifex::AsyncStackFrame& callerFrame,
+    unifex::AsyncStackFrame& calleeFrame) noexcept;
+
+// Pop the 'callee' frame off the stack, restoring the parent frame as the
+// current frame.
+//
+// This is typically used when the current async operation completes and
+// you are about to call/resume the caller. e.g. performing a symmetric
+// transfer to the calling coroutine in final_suspend().
+//
+// If calleeFrame.getParentFrame() is null then this method is equivalent
+// to deactivateAsyncStackFrame(), leaving no active AsyncStackFrame on
+// the current AsyncStackRoot.
+void popAsyncStackFrameCallee(unifex::AsyncStackFrame& calleeFrame) noexcept;
+
+// Get a pointer to a special frame that can be used as the root-frame
+// for a chain of AsyncStackFrame that does not chain onto a normal
+// call-stack.
+//
+// The caller should never modify this frame as it will be shared across
+// many frames and threads. The implication of this restriction is that
+// you should also never activate this frame.
+AsyncStackFrame& getDetachedRootAsyncStackFrame() noexcept;
+
+// Given an initial AsyncStackFrame, this will write `addresses` with
+// the return addresses of the frames in this async stack trace, up to
+// `maxAddresses` written.
+// This assumes `addresses` has `maxAddresses` allocated space available.
+// Returns the number of frames written.
+std::size_t getAsyncStackTraceFromInitialFrame(
+    unifex::AsyncStackFrame* initialFrame,
+    std::uintptr_t* addresses,
+    std::size_t maxAddresses);
+
+#if !UNIFEX_NO_COROUTINES
+
+// Resume the specified coroutine after installing a new AsyncStackRoot
+// on the current thread and setting the specified AsyncStackFrame as
+// the current async frame.
+UNIFEX_NO_INLINE void resumeCoroutineWithNewAsyncStackRoot(
+    coro::coroutine_handle<> h, AsyncStackFrame& frame) noexcept;
+
+// Resume the specified coroutine after installing a new AsyncStackRoot
+// on the current thread and setting the coroutine's associated
+// AsyncStackFrame, obtained by calling promise.getAsyncFrame(), as the
+// current async frame.
+template <typename Promise>
+void resumeCoroutineWithNewAsyncStackRoot(
+    coro::coroutine_handle<Promise> h) noexcept;
+
+#endif  // FOLLY_HAS_COROUTINES
+
+// An async stack frame contains information about a particular
+// invocation of an asynchronous operation.
+//
+// For example, asynchronous operations implemented using coroutines
+// would have each coroutine-frame contain an instance of AsyncStackFrame
+// to record async-stack trace information for that coroutine invocation.
+struct AsyncStackFrame {
+public:
+  AsyncStackFrame() = default;
+
+  // The parent frame is the frame of the async operation that is logically
+  // the caller of this frame.
+  AsyncStackFrame* getParentFrame() noexcept;
+  const AsyncStackFrame* getParentFrame() const noexcept;
+  void setParentFrame(AsyncStackFrame& frame) noexcept;
+
+  // Get access to the current stack-root.
+  //
+  // This is only valid for either the root or leaf AsyncStackFrame
+  // in a chain of frames.
+  //
+  // In the case of an active leaf-frame it is used as a cache to
+  // avoid accessing the thread-local when pushing/popping frames.
+  // In the case of the root frame (which has a null parent frame)
+  // it points to an AsyncStackRoot that contains information about
+  // the normal-stack caller.
+  AsyncStackRoot* getStackRoot() noexcept;
+
+  // The return address is generallty the address of the code in the
+  // caller that will be executed when the operation owning the current
+  // frame completes.
+  void setReturnAddress(void* p = FOLLY_ASYNC_STACK_RETURN_ADDRESS()) noexcept;
+  void* getReturnAddress() const noexcept;
+
+private:
+  friend AsyncStackRoot;
+
+  friend AsyncStackFrame& getDetachedRootAsyncStackFrame() noexcept;
+  friend void activateAsyncStackFrame(
+      unifex::AsyncStackRoot&, unifex::AsyncStackFrame&) noexcept;
+  friend void deactivateAsyncStackFrame(unifex::AsyncStackFrame&) noexcept;
+  friend void pushAsyncStackFrameCallerCallee(
+      unifex::AsyncStackFrame&, unifex::AsyncStackFrame&) noexcept;
+  friend void
+  checkAsyncStackFrameIsActive(const unifex::AsyncStackFrame&) noexcept;
+  friend void popAsyncStackFrameCallee(unifex::AsyncStackFrame&) noexcept;
+
+  // Pointer to the async caller's stack-frame info.
+  //
+  // This forms a linked-list of frames that make up a stack.
+  // The list is terminated by a null pointer which indicates
+  // the top of the async stack - either because the operation
+  // is detached or because the next frame is a thread that is
+  // blocked waiting for the async stack to complete.
+  AsyncStackFrame* parentFrame = nullptr;
+
+  // Instruction pointer of the caller of this frame.
+  // This will typically be either the address of the continuation
+  // of this asynchronous operation, or the address of the code
+  // that launched this asynchronous operation. May be null
+  // if the address is not known.
+  //
+  // Typically initialised with the result of a call to
+  // FOLLY_ASYNC_STACK_RETURN_ADDRESS().
+  void* instructionPointer = nullptr;
+
+  // Pointer to the stack-root for the current thread.
+  // Cache this in each async-stack frame so we don't have to
+  // read from a thread-local to get the pointer.
+  //
+  // This pointer is only valid for the top-most stack frame.
+  // When a frame is pushed or popped it should be copied to
+  // the next frame, etc.
+  //
+  // The exception is for the bottom-most frame (ie. where
+  // parentFrame == null). In this case, if stackRoot is non-null
+  // then it points to a root that is currently blocked on some
+  // thread waiting for the async work to complete. In this case
+  // you can find the information about the stack-frame for that
+  // thread in the AsyncStackRoot and can use it to continue
+  // walking the stack-frames.
+  AsyncStackRoot* stackRoot = nullptr;
+};
+
+// A stack-root represents the context of an event loop
+// that is running some asynchronous work. The current async
+// operation that is being executed by the event loop (if any)
+// is pointed to by the 'topFrame'.
+//
+// If the current event loop is running nested inside some other
+// event loop context then the 'nextRoot' points to the AsyncStackRoot
+// context for the next event loop up the stack on the current thread.
+//
+// The 'stackFramePtr' holds a pointer to the normal stack-frame
+// that is currently executing this event loop. This allows
+// reconciliation of the parts between a normal stack-trace and
+// the start of the async-stack trace.
+//
+// The current thread's top-most context (the head of the linked
+// list of contexts) is obtained by calling getCurrentAsyncStackRoot().
+struct AsyncStackRoot {
+public:
+  // Sets the top-frame to be 'frame' and also updates the cached
+  // 'frame.stackRoot' to be 'this'.
+  //
+  // The current stack root must not currently have any active
+  // frame.
+  void setTopFrame(AsyncStackFrame& frame) noexcept;
+  AsyncStackFrame* getTopFrame() const noexcept;
+
+  // Initialises this stack root with information about the context
+  // in which the stack-root was declared. This records information
+  // about where the async-stack-trace should be spliced into the
+  // normal stack-trace.
+  void setStackFrameContext(
+      void* framePtr = FOLLY_ASYNC_STACK_FRAME_POINTER(),
+      void* ip = FOLLY_ASYNC_STACK_RETURN_ADDRESS()) noexcept;
+  void* getStackFramePointer() const noexcept;
+  void* getReturnAddress() const noexcept;
+
+  const AsyncStackRoot* getNextRoot() const noexcept;
+  void setNextRoot(AsyncStackRoot* next) noexcept;
+
+private:
+  friend class detail::ScopedAsyncStackRoot;
+  friend void activateAsyncStackFrame(
+      unifex::AsyncStackRoot&, unifex::AsyncStackFrame&) noexcept;
+  friend void deactivateAsyncStackFrame(unifex::AsyncStackFrame&) noexcept;
+  friend void pushAsyncStackFrameCallerCallee(
+      unifex::AsyncStackFrame&, unifex::AsyncStackFrame&) noexcept;
+  friend void
+  checkAsyncStackFrameIsActive(const unifex::AsyncStackFrame&) noexcept;
+  friend void popAsyncStackFrameCallee(unifex::AsyncStackFrame&) noexcept;
+
+  // Pointer to the currently-active AsyncStackFrame for this event
+  // loop or callback invocation. May be null if this event loop is
+  // not currently executing any async operations.
+  //
+  // This is atomic primarily to enforce visibility of writes to the
+  // AsyncStackFrame that occur before the topFrame in other processes,
+  // such as profilers/debuggers that may be running concurrently
+  // with the current thread.
+  std::atomic<AsyncStackFrame*> topFrame{nullptr};
+
+  // Pointer to the next event loop context lower on the current
+  // thread's stack.
+  // This is nullptr if this is not a nested call to an event loop.
+  AsyncStackRoot* nextRoot = nullptr;
+
+  // Pointer to the stack-frame and return-address of the function
+  // call that registered this AsyncStackRoot on the current thread.
+  // This is generally the stack-frame responsible for executing async
+  // callbacks (typically an event-loop).
+  // Anything prior to this frame on the stack in the current thread
+  // is potentially unrelated to the call-chain of the current async-stack.
+  //
+  // Typically initialised with FOLLY_ASYNC_STACK_FRAME_POINTER() or
+  // setStackFrameContext().
+  void* stackFramePtr = nullptr;
+
+  // Typically initialise with FOLLY_ASYNC_STACK_RETURN_ADDRESS() or
+  // setStackFrameContext().
+  void* returnAddress = nullptr;
+};
+
+namespace detail {
+
+class ScopedAsyncStackRoot {
+public:
+  explicit ScopedAsyncStackRoot(
+      void* framePointer = FOLLY_ASYNC_STACK_FRAME_POINTER(),
+      void* returnAddress = FOLLY_ASYNC_STACK_RETURN_ADDRESS()) noexcept;
+  ~ScopedAsyncStackRoot();
+
+  void activateFrame(AsyncStackFrame& frame) noexcept {
+    unifex::activateAsyncStackFrame(root_, frame);
+  }
+
+private:
+  AsyncStackRoot root_;
+};
+
+}  // namespace detail
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>
+
+#include <unifex/tracing/async_stack-inl.hpp>

--- a/include/unifex/tracing/get_async_stack_frame.hpp
+++ b/include/unifex/tracing/get_async_stack_frame.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/tracing/async_stack.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _get_async_stack_frame {
+struct _fn {
+  template(typename T)                           //
+      (requires(!tag_invocable<_fn, const T&>))  //
+      constexpr AsyncStackFrame*
+      operator()(const T&) const noexcept {
+    return nullptr;
+  }
+
+  template(typename T)                         //
+      (requires tag_invocable<_fn, const T&>)  //
+      constexpr AsyncStackFrame*
+      operator()(const T& sender) const noexcept {
+    static_assert(
+        is_nothrow_tag_invocable_v<_fn, const T&>,
+        "get_async_stack_frame() customisations must be declared noexcept");
+    static_assert(
+        same_as<AsyncStackFrame*, tag_invoke_result_t<_fn, const T&>>);
+    return tag_invoke(_fn{}, sender);
+  }
+};
+}  // namespace _get_async_stack_frame
+
+inline constexpr _get_async_stack_frame::_fn get_async_stack_frame{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/tracing/get_return_address.hpp
+++ b/include/unifex/tracing/get_return_address.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/sender_concepts.hpp>
+#include <unifex/tracing/async_stack.hpp>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _get_return_address {
+
+template <typename T>
+instruction_ptr default_return_address() noexcept;
+
+struct _fn {
+  template(typename T)                           //
+      (requires(!tag_invocable<_fn, const T&>))  //
+      instruction_ptr
+      operator()(const T&) const noexcept {
+    // this address is mostly bonkers *but* it points at a function with
+    // the sender's type in it, which is (hopefully) better than nothing
+    return default_return_address<T>();
+  }
+
+  template(typename T)                         //
+      (requires tag_invocable<_fn, const T&>)  //
+      constexpr instruction_ptr
+      operator()(const T& sender) const noexcept {
+    static_assert(
+        is_nothrow_tag_invocable_v<_fn, const T&>,
+        "get_return_address() customisations must be declared noexcept");
+    static_assert(same_as<instruction_ptr, tag_invoke_result_t<_fn, const T&>>);
+    return tag_invoke(_fn{}, sender);
+  }
+
+  UNIFEX_NO_INLINE static instruction_ptr get_return_address() noexcept {
+    return instruction_ptr::read_return_address();
+  }
+};
+
+template <typename T>
+UNIFEX_NO_INLINE instruction_ptr default_return_address() noexcept {
+  return _fn::get_return_address();
+}
+
+}  // namespace _get_return_address
+
+inline constexpr _get_return_address::_fn get_return_address{};
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/tracing/inject_async_stack.hpp
+++ b/include/unifex/tracing/inject_async_stack.hpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+#include <unifex/receiver_concepts.hpp>
+#include <unifex/tracing/async_stack.hpp>
+#include <unifex/tracing/get_async_stack_frame.hpp>
+#include <unifex/tracing/get_return_address.hpp>
+#include <unifex/detail/unifex_fwd.hpp>
+
+#include <exception>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _inject {
+
+struct _op_base {
+  explicit _op_base(instruction_ptr returnAddress) noexcept {
+    frame_.setReturnAddress(returnAddress);
+  }
+
+  _op_base(_op_base&&) = delete;
+
+  AsyncStackFrame frame_;
+
+protected:
+  ~_op_base() = default;
+};
+
+template <typename Receiver>
+struct _op_with_receiver final {
+  struct type;
+};
+
+template <typename Receiver>
+struct _op_with_receiver<Receiver>::type : _op_base {
+  template <typename Receiver2>
+  explicit type(instruction_ptr returnAddress, Receiver2&& receiver) noexcept(
+      std::is_nothrow_constructible_v<Receiver, Receiver2>)
+    : _op_base{returnAddress}
+    , receiver_{std::forward<Receiver2>(receiver)} {}
+
+  type(type&&) = delete;
+
+  Receiver receiver_;
+
+protected:
+  ~type() = default;
+};
+
+template <typename Receiver>
+using op_with_receiver_t = typename _op_with_receiver<Receiver>::type;
+
+struct _root_and_frame {
+  UNIFEX_NO_INLINE explicit _root_and_frame(AsyncStackFrame* frame) noexcept {
+    if (frame) {
+      if (auto* parent = frame->getParentFrame()) {
+        frame_.setParentFrame(*parent);
+      }
+
+      frame_.setReturnAddress(frame->getReturnAddress());
+    }
+    root_.activateFrame(frame_);
+  }
+
+  _root_and_frame(_root_and_frame&&) = delete;
+
+  ~_root_and_frame() { deactivateAsyncStackFrame(frame_); }
+
+private:
+  AsyncStackFrame frame_;
+  unifex::detail::ScopedAsyncStackRoot root_;
+};
+
+struct _root_and_frame_ref {
+  UNIFEX_NO_INLINE explicit _root_and_frame_ref(
+      AsyncStackFrame& frame, AsyncStackFrame* parentFrame) noexcept
+    : frame_(&frame) {
+    if (parentFrame) {
+      frame_->setParentFrame(*parentFrame);
+    }
+
+    root_.activateFrame(*frame_);
+  }
+
+  _root_and_frame_ref(_root_and_frame_ref&&) = delete;
+
+  ~_root_and_frame_ref() { root_.ensureFrameDeactivated(frame_); }
+
+private:
+  AsyncStackFrame* frame_;
+  unifex::detail::ScopedAsyncStackRoot root_;
+};
+
+struct _rcvr_base {
+  _op_base* op_;
+
+  friend constexpr AsyncStackFrame*
+  tag_invoke(tag_t<get_async_stack_frame>, const _rcvr_base& r) noexcept {
+    return &r.op_->frame_;
+  }
+};
+
+template <typename Receiver>
+struct _rcvr_wrapper final {
+  struct type;
+};
+
+template <typename Receiver>
+struct _rcvr_wrapper<Receiver>::type final : _rcvr_base {
+  template <typename... T>
+  void set_value(T&&... ts) noexcept {
+    _root_and_frame rf(get_async_stack_frame(receiver()));
+
+    UNIFEX_TRY {
+      unifex::set_value(std::move(receiver()), std::forward<T>(ts)...);
+    }
+    UNIFEX_CATCH(...) {
+      unifex::set_error(std::move(receiver()), std::current_exception());
+    }
+  }
+
+  template <typename... T>
+  void
+  set_next(T&&... ts) noexcept(is_nothrow_next_receiver_v<Receiver, T...>) {
+    _root_and_frame rf(get_async_stack_frame(receiver()));
+
+    unifex::set_next(receiver(), std::forward<T>(ts)...);
+  }
+
+  template <typename E>
+  void set_error(E&& e) noexcept {
+    _root_and_frame rf(get_async_stack_frame(receiver()));
+
+    unifex::set_error(std::move(receiver()), std::forward<E>(e));
+  }
+
+  void set_done() noexcept {
+    _root_and_frame rf(get_async_stack_frame(receiver()));
+
+    unifex::set_done(std::move(receiver()));
+  }
+
+  template(typename CPO, typename R)  //
+      (requires(!same_as<CPO, tag_t<get_async_stack_frame>>)
+           AND is_receiver_query_cpo_v<CPO> AND same_as<R, type>)  //
+      friend auto tag_invoke(CPO cpo, const R& r) noexcept(
+          std::is_nothrow_invocable_v<CPO, const Receiver&>)
+          -> std::invoke_result_t<CPO, const Receiver&> {
+    return std::move(cpo)(std::as_const(r.receiver()));
+  }
+
+#if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+  template <typename Visit>
+  friend void
+  tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
+    std::invoke(visit, r.receiver());
+  }
+#endif
+
+  Receiver& receiver() const noexcept {
+    return static_cast<op_with_receiver_t<Receiver>*>(this->op_)->receiver_;
+  }
+};
+
+template <typename R>
+using receiver_t = typename _rcvr_wrapper<remove_cvref_t<R>>::type;
+
+template <typename Op, typename R>
+struct _op_wrapper final {
+  struct type;
+};
+
+template <typename Op, typename R>
+struct _op_wrapper<Op, R>::type final
+  : _op_with_receiver<remove_cvref_t<R>>::type {
+  template(typename S, typename Fn)                         //
+      (requires std::is_invocable_v<Fn, S, receiver_t<R>>)  //
+      explicit type(S&& s, R&& r, Fn&& fn) noexcept(
+          std::is_nothrow_invocable_v<Fn, S, receiver_t<R>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<R>, R>)
+    : _op_with_receiver<
+          remove_cvref_t<R>>::type{get_return_address(s), std::forward<R>(r)}
+    , op_{std::forward<Fn>(fn)(std::forward<S>(s), receiver_t<R>{{this}})} {}
+
+  type(type&&) = delete;
+
+  ~type() = default;
+
+  UNIFEX_NO_INLINE void start() & noexcept {
+    _root_and_frame_ref rf{
+        this->frame_, get_async_stack_frame(this->receiver_)};
+
+    unifex::start(op_);
+  }
+
+private:
+  Op op_;
+};
+
+template <typename Op, typename R>
+using op_wrapper = typename _op_wrapper<Op, R>::type;
+
+template <typename S, typename R, typename Fn>
+auto make_op_wrapper(S&& s, R&& r, Fn&& fn) noexcept(
+    std::is_nothrow_constructible_v<
+        op_wrapper<std::invoke_result_t<Fn, S, receiver_t<R>>, R>,
+        S,
+        R,
+        Fn>) -> op_wrapper<std::invoke_result_t<Fn, S, receiver_t<R>>, R> {
+  return op_wrapper<std::invoke_result_t<Fn, S, receiver_t<R>>, R>{
+      std::forward<S>(s), std::forward<R>(r), std::forward<Fn>(fn)};
+}
+
+}  // namespace _inject
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/tracing/inject_async_stack.hpp
+++ b/include/unifex/tracing/inject_async_stack.hpp
@@ -16,18 +16,21 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/receiver_concepts.hpp>
-#include <unifex/tracing/async_stack.hpp>
-#include <unifex/tracing/get_async_stack_frame.hpp>
-#include <unifex/tracing/get_return_address.hpp>
-#include <unifex/detail/unifex_fwd.hpp>
 
-#include <exception>
-#include <functional>
-#include <type_traits>
-#include <utility>
+#if !UNIFEX_NO_ASYNC_STACKS
 
-#include <unifex/detail/prologue.hpp>
+#  include <unifex/receiver_concepts.hpp>
+#  include <unifex/tracing/async_stack.hpp>
+#  include <unifex/tracing/get_async_stack_frame.hpp>
+#  include <unifex/tracing/get_return_address.hpp>
+#  include <unifex/detail/unifex_fwd.hpp>
+
+#  include <exception>
+#  include <functional>
+#  include <type_traits>
+#  include <utility>
+
+#  include <unifex/detail/prologue.hpp>
 
 namespace unifex {
 namespace _inject {
@@ -168,13 +171,13 @@ struct _rcvr_wrapper<Receiver>::type final : _rcvr_base {
     return std::move(cpo)(std::as_const(r.receiver()));
   }
 
-#if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
+#  if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
   template <typename Visit>
   friend void
   tag_invoke(tag_t<visit_continuations>, const type& r, Visit&& visit) {
     std::invoke(visit, r.receiver());
   }
-#endif
+#  endif
 
   Receiver& receiver() const noexcept {
     return static_cast<op_with_receiver_t<Receiver>*>(this->op_)->receiver_;
@@ -234,4 +237,6 @@ auto make_op_wrapper(S&& s, R&& r, Fn&& fn) noexcept(
 
 }  // namespace unifex
 
-#include <unifex/detail/epilogue.hpp>
+#  include <unifex/detail/epilogue.hpp>
+
+#endif  // !UNIFEX_NO_ASYNC_STACKS

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(unifex
     async_auto_reset_event.cpp
     async_manual_reset_event.cpp
     async_mutex.cpp
+    async_stack.cpp
     exception.cpp
     inplace_stop_token.cpp
     manual_event_loop.cpp

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/tracing/async_stack.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <mutex>
+
+#if defined(__linux__)
+#  define FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD 1
+#else
+#  define FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD 0
+#endif
+
+#if FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD
+
+#  include <pthread.h>
+
+// Use a global TLS key variable to make it easier for profilers/debuggers
+// to lookup the current thread's AsyncStackRoot by walking the pthread
+// TLS structures.
+extern "C" {
+// Current pthread implementation has valid keys in range 0 .. 1023.
+// Initialise to some value that will be interpreted as an invalid key.
+inline pthread_key_t folly_async_stack_root_tls_key = 0xFFFF'FFFFu;
+}
+
+#endif  // FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD
+
+namespace unifex {
+
+namespace {
+
+// Folly's async stack library uses Folly's benchmarking tools to force a
+// non-inlining of this function; we can come back to this and make it better
+// later if necessary
+UNIFEX_NO_INLINE void compiler_must_not_elide(void*) {
+
+}
+
+#if FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD
+static pthread_once_t initialiseTlsKeyFlag = PTHREAD_ONCE_INIT;
+
+static void ensureAsyncRootTlsKeyIsInitialised() noexcept {
+  (void)pthread_once(&initialiseTlsKeyFlag, []() noexcept {
+    [[maybe_unused]] int result =
+        pthread_key_create(&folly_async_stack_root_tls_key, nullptr);
+    UNIFEX_ASSERT(result == 0);
+  });
+}
+
+#endif
+
+struct AsyncStackRootHolder {
+#if FOLLY_ASYNC_STACK_ROOT_USE_PTHREAD
+  AsyncStackRootHolder() noexcept {
+    ensureAsyncRootTlsKeyIsInitialised();
+    [[maybe_unused]] const int result =
+        pthread_setspecific(folly_async_stack_root_tls_key, this);
+    UNIFEX_ASSERT(result == 0);
+  }
+#endif
+
+  AsyncStackRoot* get() const noexcept {
+    return value.load(std::memory_order_relaxed);
+  }
+
+  void set(AsyncStackRoot* root) noexcept {
+    value.store(root, std::memory_order_release);
+  }
+
+  void set_relaxed(AsyncStackRoot* root) noexcept {
+    value.store(root, std::memory_order_relaxed);
+  }
+
+  std::atomic<AsyncStackRoot*> value{nullptr};
+};
+
+static thread_local AsyncStackRootHolder currentThreadAsyncStackRoot;
+
+}  // namespace
+
+AsyncStackRoot* tryGetCurrentAsyncStackRoot() noexcept {
+  return currentThreadAsyncStackRoot.get();
+}
+
+AsyncStackRoot*
+exchangeCurrentAsyncStackRoot(AsyncStackRoot* newRoot) noexcept {
+  auto* oldStackRoot = currentThreadAsyncStackRoot.get();
+  currentThreadAsyncStackRoot.set(newRoot);
+  return oldStackRoot;
+}
+
+namespace detail {
+
+ScopedAsyncStackRoot::ScopedAsyncStackRoot(
+    void* framePointer, void* returnAddress) noexcept {
+  root_.setStackFrameContext(framePointer, returnAddress);
+  root_.nextRoot = currentThreadAsyncStackRoot.get();
+  currentThreadAsyncStackRoot.set(&root_);
+}
+
+ScopedAsyncStackRoot::~ScopedAsyncStackRoot() {
+  assert(currentThreadAsyncStackRoot.get() == &root_);
+  assert(root_.topFrame.load(std::memory_order_relaxed) == nullptr);
+  currentThreadAsyncStackRoot.set_relaxed(root_.nextRoot);
+}
+
+}  // namespace detail
+}  // namespace unifex
+
+namespace unifex {
+
+UNIFEX_NO_INLINE static void* get_return_address() noexcept {
+  return FOLLY_ASYNC_STACK_RETURN_ADDRESS();
+}
+
+// This function is a special function that returns an address
+// that can be used as a return-address and that will resolve
+// debug-info to itself.
+UNIFEX_NO_INLINE static void* detached_task() noexcept {
+  void* p = get_return_address();
+
+  // Add this after the call to prevent the compiler from
+  // turning the call to get_return_address() into a tailcall.
+  compiler_must_not_elide(p);
+
+  return p;
+}
+
+AsyncStackRoot& getCurrentAsyncStackRoot() noexcept {
+  auto* root = tryGetCurrentAsyncStackRoot();
+  assert(root != nullptr);
+  return *root;
+}
+
+static AsyncStackFrame makeDetachedRootFrame() noexcept {
+  AsyncStackFrame frame;
+  frame.setReturnAddress(detached_task());
+  return frame;
+}
+
+static AsyncStackFrame detachedRootFrame = makeDetachedRootFrame();
+
+AsyncStackFrame& getDetachedRootAsyncStackFrame() noexcept {
+  return detachedRootFrame;
+}
+
+#if !UNIFEX_NO_COROUTINES
+
+UNIFEX_NO_INLINE void resumeCoroutineWithNewAsyncStackRoot(
+    coro::coroutine_handle<> h, unifex::AsyncStackFrame& frame) noexcept {
+  detail::ScopedAsyncStackRoot root;
+  root.activateFrame(frame);
+  h.resume();
+}
+
+#endif  // FOLLY_HAS_COROUTINES
+
+}  // namespace unifex

--- a/test/AsyncStackTest.cpp
+++ b/test/AsyncStackTest.cpp
@@ -26,8 +26,10 @@
 #include <gtest/gtest.h>
 
 TEST(AsyncStack, ScopedAsyncStackRoot) {
-  void* const stackFramePtr = FOLLY_ASYNC_STACK_FRAME_POINTER();
-  void* const returnAddress = FOLLY_ASYNC_STACK_RETURN_ADDRESS();
+  unifex::frame_ptr const stackFramePtr =
+      unifex::frame_ptr::read_frame_pointer();
+  unifex::instruction_ptr const returnAddress =
+      unifex::instruction_ptr::read_return_address();
 
   ASSERT_TRUE(unifex::tryGetCurrentAsyncStackRoot() == nullptr);
 

--- a/test/AsyncStackTest.cpp
+++ b/test/AsyncStackTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/tracing/async_stack.hpp>
+
+#if __has_include(<pthread.h>)
+#  include <pthread.h>
+#  define UNIFEX_NO_PTHREAD 0
+#else
+#  define UNIFEX_NO_PTHREAD 1
+#endif
+
+#include <gtest/gtest.h>
+
+TEST(AsyncStack, ScopedAsyncStackRoot) {
+  void* const stackFramePtr = FOLLY_ASYNC_STACK_FRAME_POINTER();
+  void* const returnAddress = FOLLY_ASYNC_STACK_RETURN_ADDRESS();
+
+  ASSERT_TRUE(unifex::tryGetCurrentAsyncStackRoot() == nullptr);
+
+  {
+    unifex::detail::ScopedAsyncStackRoot scopedRoot{
+        stackFramePtr, returnAddress};
+    auto* root = unifex::tryGetCurrentAsyncStackRoot();
+    ASSERT_FALSE(root == nullptr);
+
+    unifex::AsyncStackFrame frame;
+    scopedRoot.activateFrame(frame);
+
+    ASSERT_EQ(root, frame.getStackRoot());
+    ASSERT_EQ(stackFramePtr, root->getStackFramePointer());
+    ASSERT_EQ(returnAddress, root->getReturnAddress());
+    ASSERT_EQ(&frame, root->getTopFrame());
+
+    unifex::deactivateAsyncStackFrame(frame);
+
+    ASSERT_TRUE(frame.getStackRoot() == nullptr);
+    ASSERT_TRUE(root->getTopFrame() == nullptr);
+  }
+
+  ASSERT_TRUE(unifex::tryGetCurrentAsyncStackRoot() == nullptr);
+}
+
+TEST(AsyncStack, PushPop) {
+  unifex::detail::ScopedAsyncStackRoot scopedRoot{nullptr};
+
+  auto& root = unifex::getCurrentAsyncStackRoot();
+
+  unifex::AsyncStackFrame frame1;
+  unifex::AsyncStackFrame frame2;
+  unifex::AsyncStackFrame frame3;
+
+  scopedRoot.activateFrame(frame1);
+
+  ASSERT_EQ(&frame1, root.getTopFrame());
+  ASSERT_EQ(&root, frame1.getStackRoot());
+
+  unifex::pushAsyncStackFrameCallerCallee(frame1, frame2);
+
+  ASSERT_EQ(&frame2, root.getTopFrame());
+  ASSERT_EQ(&frame1, frame2.getParentFrame());
+  ASSERT_EQ(&root, frame2.getStackRoot());
+  ASSERT_TRUE(frame1.getStackRoot() == nullptr);
+
+  unifex::pushAsyncStackFrameCallerCallee(frame2, frame3);
+
+  ASSERT_EQ(&frame3, root.getTopFrame());
+  ASSERT_EQ(&frame2, frame3.getParentFrame());
+  ASSERT_EQ(&frame1, frame2.getParentFrame());
+  ASSERT_TRUE(frame1.getParentFrame() == nullptr);
+  ASSERT_TRUE(frame2.getStackRoot() == nullptr);
+
+  unifex::deactivateAsyncStackFrame(frame3);
+
+  ASSERT_TRUE(root.getTopFrame() == nullptr);
+  ASSERT_TRUE(frame3.getStackRoot() == nullptr);
+
+  unifex::activateAsyncStackFrame(root, frame3);
+
+  ASSERT_EQ(&frame3, root.getTopFrame());
+  ASSERT_EQ(&root, frame3.getStackRoot());
+
+  unifex::popAsyncStackFrameCallee(frame3);
+
+  ASSERT_EQ(&frame2, root.getTopFrame());
+  ASSERT_EQ(&root, frame2.getStackRoot());
+  ASSERT_TRUE(frame3.getStackRoot() == nullptr);
+
+  unifex::popAsyncStackFrameCallee(frame2);
+
+  ASSERT_EQ(&frame1, root.getTopFrame());
+  ASSERT_EQ(&root, frame1.getStackRoot());
+  ASSERT_TRUE(frame2.getStackRoot() == nullptr);
+
+  unifex::deactivateAsyncStackFrame(frame1);
+
+  ASSERT_TRUE(root.getTopFrame() == nullptr);
+  ASSERT_TRUE(frame1.getStackRoot() == nullptr);
+}

--- a/test/variant_sender_test.cpp
+++ b/test/variant_sender_test.cpp
@@ -64,7 +64,9 @@ struct TestSender {
 
   static constexpr bool sends_done = true;
 
-  struct op {};
+  struct op {
+    void start() & noexcept {}
+  };
 
   template <typename Receiver>
   op connect([[maybe_unused]] Receiver&& r) & noexcept(lvalueConnectNoexcept) {


### PR DESCRIPTION
This PR copies the core of Folly's [async stack trace support](https://github.com/facebook/folly/tree/main/folly/tracing) into `include/unifex/tracing` and builds on it to add support for generalized *Senders*.

When `UNIFEX_NO_ASYNC_STACKS` is falsey, `unifex::connect` returns a wrapped operation state that injects async stack tracing into the operation tree.
 - The wrapper operation:
    - stores an `AsyncStackFrame` for the wrapped operation; and
    - wraps the receiver.
 - In the wrapper operation's customization of `unifex::start` we:
    - create an `AsyncStackRoot` on the stack;
    - push the wrapper operation's `AsyncStackFrame` onto the current async stack;
    - activate the wrapper operation's `AsyncStackFrame` on the current `AsyncStackRoot`; and
    - start the wrapped operation.
 - In the wrapper receiver's completion methods we:
    - create an `AsyncStackRoot` on the stack;
    - copy the *parent* operation's `AsyncStackFrame` to the stack;
    - activate the parent `AsyncStackFrame` on the current `AsyncStackRoot`; and
    - invoke the parent operation's receiver.

The effect is that we build up a linked list (technically a DAG) of `AsyncStackFrame`s pointing "up" toward the start of the operation as `unifex::start` recurses into the nested operation state and then unwind it on the way back out as the receiver completion methods are invoked. At any given time, the current thread's `AsyncStackRoot` is sitting on the most recently-activated "normal" stack frame that is participating in async stack management, allowing Folly's `co_bt.py` debugger extension to figure out when it should stop walking normal stack frames and start walking async stack frames.

As alluded to above, the behaviour of the async stack tracing machinery is controlled by the `UNIFEX_NO_ASYNC_STACKS` preprocessor macro. If it's truthy, async stacks are not traced; if it's falsey, they are traced. The default in `unifex/config.hpp` is to enable async stack tracing in non-Windows debug builds.
 - Why not Windows builds?
    - Because there's something weird about how `any_sender_of<>` builds on Windows (both Clang and MSVC); the resolution is to land PR #619, but that PR breaks an internal Meta build so I'll have to come back to it.
 - Why only debug builds?
    - The additional work done to track async stacks adds non-trivial binary size to the output so I figure it should default to off for release builds. You can turn it on by defining `UNIFEX_NO_ASYNC_STACKS=0` in your release build script if the extra debuggability is worth the extra binary size in production.

This iteration is an MVP:
 - only general senders are supported, not coroutines
 - the "return addresses" captured for each sender point to `unifex::_get_return_address::default_return_address<T>()`, where `T` is the type of the sender
    - this is better than nothing because the resulting symbol includes the sender's fully-qualified name, but it's not great

Futures PRs will:
 - add support for tracing the async stacks of coroutines
 - improve the rendering of async stack traces by making senders capture a pointer to the call site of their factory
 - maybe shrink the binary size overhead of enabling this feature if I can figure out how to eliminate some of the recursion

Co-authored-by: Ján Ondrušek <ondrusek@fb.com>
Co-authored-by: Jessica Wong <jesswong@fb.com>
Co-authored-by: Deniz Evrenci <denizevrenci@gmail.com>