### PR TITLE
Simplify the definition of unifex::connect

### DIFF
--- a/include/unifex/with_query_value.hpp
+++ b/include/unifex/with_query_value.hpp
@@ -148,7 +148,8 @@ public:
 
   template(typename Self, typename Receiver)  //
       (requires same_as<remove_cvref_t<Self>, type> AND
-           constructible_from<Value, member_t<Self, Value>> AND sender_to<
+           constructible_from<Value, member_t<Self, Value>> AND receiver<Receiver> AND
+           sender_to<
                member_t<Self, Sender>,
                receiver_wrapper<
                    CPO,


### PR DESCRIPTION
This change simplifies how the constraints on `unifex::connect` are
expressed. To get the tests building with the simplified `connect`,
I had to delete some over-general `tag_invoke` overloads in the
`sequence` and `with_query_value` receivers, and better constrain
`with_query_value`'s `connect`.