### PR TITLE
Clean up some type computations

### DIFF
--- a/include/unifex/never.hpp
+++ b/include/unifex/never.hpp
@@ -91,7 +91,7 @@ struct sender {
   static constexpr bool is_always_scheduler_affine = true;
 
   template <typename Receiver>
-  operation<Receiver> connect(Receiver&& receiver) {
+  operation<Receiver> connect(Receiver&& receiver) const {
     return operation<Receiver>{(Receiver &&) receiver};
   }
 };

--- a/include/unifex/v2/async_scope.hpp
+++ b/include/unifex/v2/async_scope.hpp
@@ -433,16 +433,16 @@ struct _nest_sender<Sender>::type final {
           tag_t<connect>,
           const type& s,
           Receiver&& r) noexcept(nothrow_connect<const type&, Receiver>)
-          -> nest_op<Sender, remove_cvref_t<Receiver>> {
+          -> nest_op<const Sender&, remove_cvref_t<Receiver>> {
     // make a copy of the scope_reference, which will try to record the start of
     // a new nested operation
     auto scope = s.scope_;
 
     if (scope) {
-      return nest_op<Sender, remove_cvref_t<Receiver>>{
+      return nest_op<const Sender&, remove_cvref_t<Receiver>>{
           s.sender_.get(), static_cast<Receiver&&>(r), std::move(scope)};
     } else {
-      return nest_op<Sender, remove_cvref_t<Receiver>>{
+      return nest_op<const Sender&, remove_cvref_t<Receiver>>{
           static_cast<Receiver&&>(r)};
     }
   }

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -146,7 +146,7 @@ public:
                                   Receiver>...>) {
     // MSVC needs this type alias declared outside the lambda below to reliably
     // compile the visit() expression as C++20
-    using op_t = operation<connect_result_t<Senders, Receiver>...>;
+    using op_t = operation<connect_result_t<member_t<This, Senders>, Receiver>...>;
     return std::visit(
         [&r](auto&& sender) noexcept(
             unifex::is_nothrow_connectable_v<decltype(sender), Receiver>) {

--- a/test/async_scope_v2_test.cpp
+++ b/test/async_scope_v2_test.cpp
@@ -94,7 +94,7 @@ struct throwing_sender final {
   (requires unifex::sender_to<decltype(unifex::just()), Receiver>)  //
       friend auto tag_invoke(
           unifex::tag_t<unifex::connect>,
-          throwing_sender&&,
+          throwing_sender,
           Receiver&& receiver) noexcept(false) {
     return unifex::connect(unifex::just(), std::forward<Receiver>(receiver));
   }


### PR DESCRIPTION
The result of `connect` is allowed to vary with the value categories of its arguments. This diff fixes some places where we forgot that.