### PR TITLE
Enlazy unhandled done

### DIFF
--- a/include/unifex/at_coroutine_exit.hpp
+++ b/include/unifex/at_coroutine_exit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -50,7 +50,7 @@ inline constexpr struct _fn {
           ParentPromise& parent,
           continuation_handle<ChildPromise> action) const noexcept {
     return tag_invoke(
-        *this, parent, (continuation_handle<ChildPromise> &&) action);
+        *this, parent, (continuation_handle<ChildPromise>&&)action);
   }
 } exchange_continuation{};
 }  // namespace _xchg_cont
@@ -119,7 +119,7 @@ struct _cleanup_promise_base {
   friend void tag_invoke(
       tag_t<visit_continuations>, const _cleanup_promise_base& p, Func&& func) {
     // Skip cleanup actions when visiting continuations:
-    visit_continuations(p.continuation_, (Func &&) func);
+    visit_continuations(p.continuation_, (Func&&)func);
   }
 #endif
 
@@ -151,12 +151,12 @@ struct _die_on_done_rec {
         (requires receiver_of<Receiver, Ts...>)  //
         void set_value(Ts&&... ts) && noexcept(
             is_nothrow_receiver_of_v<Receiver, Ts...>) {
-      unifex::set_value((Receiver &&) rec_, (Ts &&) ts...);
+      unifex::set_value((Receiver&&)rec_, (Ts&&)ts...);
     }
     template(typename E)                  //
         (requires receiver<Receiver, E>)  //
         void set_error(E&& e) && noexcept {
-      unifex::set_error((Receiver &&) rec_, (E &&) e);
+      unifex::set_error((Receiver&&)rec_, (E&&)e);
     }
     [[noreturn]] void set_done() && noexcept {
       UNIFEX_ASSERT(!"A cleanup action tried to cancel. Calling terminate...");
@@ -206,7 +206,7 @@ struct _die_on_done {
             is_nothrow_connectable_v<Sender, _die_on_done_rec_t<Receiver>>)
             -> connect_result_t<Sender, _die_on_done_rec_t<Receiver>> {
       return unifex::connect(
-          (Sender &&) sender_, _die_on_done_rec_t<Receiver>{(Receiver &&) rec});
+          (Sender&&)sender_, _die_on_done_rec_t<Receiver>{(Receiver&&)rec});
     }
 
     UNIFEX_NO_UNIQUE_ADDRESS Sender sender_;
@@ -222,12 +222,12 @@ struct _die_on_done_fn {
       _die_on_done_t<Value>
       operator()(Value&& value) /*mutable*/
       noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Value>, Value>) {
-    return _die_on_done_t<Value>{(Value &&) value};
+    return _die_on_done_t<Value>{(Value&&)value};
   }
 
   template <typename Value>
   Value&& operator()(Value&& value) const noexcept {
-    return (Value &&) value;
+    return (Value&&)value;
   }
 };
 
@@ -255,8 +255,8 @@ struct _cleanup_promise : _cleanup_promise_base {
 
   template <typename Value>
   decltype(auto) await_transform(Value&& value) noexcept(noexcept(
-      unifex::await_transform(*this, _die_on_done_fn{}((Value &&) value)))) {
-    return unifex::await_transform(*this, _die_on_done_fn{}((Value &&) value));
+      unifex::await_transform(*this, _die_on_done_fn{}((Value&&)value)))) {
+    return unifex::await_transform(*this, _die_on_done_fn{}((Value&&)value));
   }
 
   UNIFEX_NO_UNIQUE_ADDRESS std::tuple<Ts&...> args_;
@@ -312,11 +312,12 @@ private:
   }
 
 public:
-  template(typename Action, typename... Ts)                           //
-      (requires std::is_invocable_v<std::decay_t<Action>, std::decay_t<Ts>...>)  //
+  template(typename Action, typename... Ts)  //
+      (requires std::
+           is_invocable_v<std::decay_t<Action>, std::decay_t<Ts>...>)  //
       _cleanup_task<std::decay_t<Ts>...>
       operator()(Action&& action, Ts&&... ts) const {
-    return _fn::at_coroutine_exit((Action &&) action, (Ts &&) ts...);
+    return _fn::at_coroutine_exit((Action&&)action, (Ts&&)ts...);
   }
 } at_coroutine_exit{};
 }  // namespace _at_coroutine_exit

--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -99,7 +99,7 @@ struct _awaitable_base<Promise, Value>::type {
         void set_value(Us&&... us) && noexcept(
             std::is_nothrow_constructible_v<Value, Us...> ||
             std::is_void_v<Value>) {
-      unifex::activate_union_member(result_->value_, (Us &&) us...);
+      unifex::activate_union_member(result_->value_, (Us&&)us...);
       result_->state_ = _state::value;
       continuation_.resume();
     }
@@ -134,7 +134,7 @@ struct _awaitable_base<Promise, Value>::type {
     template <typename Func>
     friend void
     tag_invoke(tag_t<visit_continuations>, const _rec& r, Func&& func) {
-      visit_continuations(r.continuation_.promise(), (Func &&) func);
+      visit_continuations(r.continuation_.promise(), (Func&&)func);
     }
 #endif
 
@@ -175,7 +175,7 @@ private:
 public:
   explicit type(Sender&& sender, coro::coroutine_handle<Promise> h) noexcept(
       is_nothrow_connectable_v<Sender, _rec>)
-    : op_(unifex::connect((Sender &&) sender, _rec{&this->result_, h})) {}
+    : op_(unifex::connect((Sender&&)sender, _rec{&this->result_, h})) {}
 
   void await_suspend(coro::coroutine_handle<Promise>) noexcept {
     unifex::start(op_);
@@ -197,7 +197,7 @@ struct _fn {
         detail::_awaitable<tag_invoke_result_t<_fn, Promise&, Value>>,
         "The return type of a customization of unifex::await_transform() "
         "must satisfy the awaitable concept.");
-    return unifex::tag_invoke(_fn{}, promise, (Value &&) value);
+    return unifex::tag_invoke(_fn{}, promise, (Value&&)value);
   }
 
   // Default implementation.
@@ -209,19 +209,19 @@ struct _fn {
     // to avoid instantiating 'unifex::sender<Value>' concept check in
     // the case that _awaitable<Value> evaluates to true.
     if constexpr (detail::_awaitable<Value>) {
-      return (Value &&) value;
+      return (Value&&)value;
     } else if constexpr (unifex::sender<Value>) {
       if constexpr (unifex::sender_to<Value, _receiver_t<Promise, Value>>) {
         auto h = coro::coroutine_handle<Promise>::from_promise(promise);
-        return _as_awaitable<Promise, Value>{(Value &&) value, h};
+        return _as_awaitable<Promise, Value>{(Value&&)value, h};
       } else {
         static_assert(
             unifex::sender_to<Value, _receiver_t<Promise, Value>>,
             "This sender is not awaitable in this coroutine type.");
-        return (Value &&) value;
+        return (Value&&)value;
       }
     } else {
-      return (Value &&) value;
+      return (Value&&)value;
     }
   }
 };

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -70,7 +70,7 @@ public:
       bool await_ready() noexcept { return false; }
       void await_suspend(coro::coroutine_handle<promise_type>) noexcept(
           std::is_nothrow_invocable_v<Func>) {
-        ((Func &&) func_)();
+        ((Func&&)func_)();
       }
       [[noreturn]] void await_resume() noexcept { std::terminate(); }
     };
@@ -82,14 +82,14 @@ public:
 
     template <typename Value>
     auto await_transform(Value&& value) -> decltype(auto) {
-      return unifex::await_transform(*this, (Value &&) value);
+      return unifex::await_transform(*this, (Value&&)value);
     }
 
 #if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
     template <typename Func>
     friend void
     tag_invoke(tag_t<visit_continuations>, const promise_type& p, Func&& func) {
-      visit_continuations(p.receiver_, (Func &&) func);
+      visit_continuations(p.receiver_, (Func&&)func);
     }
 #endif
 
@@ -131,7 +131,7 @@ private:
   struct _comma_hack {
     template <typename T>
     friend T&& operator,(T&& t, _comma_hack) noexcept {
-      return (T &&) t;
+      return (T&&)t;
     }
     operator unit() const noexcept { return {}; }
   };
@@ -175,7 +175,7 @@ private:
         // expression has type void. This could potentially run into trouble
         // if the type of the co_await expression itself overloads operator
         // comma, but that's pretty unlikely.
-      }((co_await(Awaitable &&) awaitable, _comma_hack{}));
+      }((co_await (Awaitable&&) awaitable, _comma_hack{}));
 #if !UNIFEX_NO_EXCEPTIONS
     } catch (...) {
       ex = std::current_exception();
@@ -190,7 +190,7 @@ public:
   template <typename Awaitable, typename Receiver>
   auto operator()(Awaitable&& awaitable, Receiver&& receiver) const
       -> _await::sender_task<remove_cvref_t<Receiver>> {
-    return connect_impl((Awaitable &&) awaitable, (Receiver &&) receiver);
+    return connect_impl((Awaitable&&)awaitable, (Receiver&&)receiver);
   }
 } connect_awaitable{};
 }  // namespace _await_cpo
@@ -214,13 +214,12 @@ struct _sndr {
 
     static constexpr bool sends_done = true;
 
-    type(Awaitable awaitable) : awaitable_((Awaitable &&) awaitable) {}
+    type(Awaitable awaitable) : awaitable_((Awaitable&&)awaitable) {}
 
     template(typename Receiver)                   //
         (requires receiver_of<Receiver, Result>)  //
         friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-      return unifex::connect_awaitable(
-          ((type &&) t).awaitable_, (Receiver &&) r);
+      return unifex::connect_awaitable(((type&&)t).awaitable_, (Receiver&&)r);
     }
 
     // TODO: how do we make this property statically discoverable?
@@ -251,13 +250,12 @@ struct _sndr<Awaitable, void> {
 
     explicit type(Awaitable awaitable) noexcept(
         std::is_nothrow_move_constructible_v<Awaitable>)
-      : awaitable_((Awaitable &&) awaitable) {}
+      : awaitable_((Awaitable&&)awaitable) {}
 
     template(typename Receiver)           //
         (requires receiver_of<Receiver>)  //
         friend auto tag_invoke(tag_t<unifex::connect>, type&& t, Receiver&& r) {
-      return unifex::connect_awaitable(
-          ((type &&) t).awaitable_, (Receiver &&) r);
+      return unifex::connect_awaitable(((type&&)t).awaitable_, (Receiver&&)r);
     }
 
     // TODO: how do we make this property statically discoverable?
@@ -279,7 +277,7 @@ struct _fn {
       (requires detail::_awaitable<Awaitable>)  //
       _sender<remove_cvref_t<Awaitable>>
       operator()(Awaitable&& awaitable) const {
-    return _sender<remove_cvref_t<Awaitable>>{(Awaitable &&) awaitable};
+    return _sender<remove_cvref_t<Awaitable>>{(Awaitable&&)awaitable};
   }
 };
 }  // namespace _as_sender

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -22,6 +22,7 @@
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_traits.hpp>
+#include <unifex/unhandled_done.hpp>
 
 #if UNIFEX_NO_COROUTINES
 #  error "Coroutine support is required to use <unifex/connect_awaitable.hpp>"
@@ -60,8 +61,7 @@ public:
     [[noreturn]] void return_void() noexcept { std::terminate(); }
 
     coro::coroutine_handle<> unhandled_done() noexcept {
-      unifex::set_done(std::move(receiver_));
-      return coro::noop_coroutine();
+      return doneCoro_.handle();
     }
 
     template <typename Func>
@@ -103,6 +103,8 @@ public:
     }
 
     Receiver& receiver_;
+    done_coro doneCoro_ = unifex::unhandled_done(
+        [this]() noexcept { unifex::set_done(std::move(receiver_)); });
   };
 
   coro::coroutine_handle<promise_type> coro_;

--- a/include/unifex/continuations.hpp
+++ b/include/unifex/continuations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -30,13 +30,15 @@ namespace unifex {
 namespace _visit_continuations_cpo {
 inline const struct _fn {
 #if !UNIFEX_NO_COROUTINES
-  template(typename Promise, typename Func)                                  //
-      (requires(!same_as<Promise, void>) AND std::is_invocable_v<_fn, Promise&, Func>)  //
+  template(typename Promise, typename Func)  //
+      (requires(!same_as<Promise, void>)
+           AND std::is_invocable_v<_fn, Promise&, Func>)  //
       friend void tag_invoke(
           _fn cpo,
           coro::coroutine_handle<Promise> h,
-          Func&& func) noexcept(std::is_nothrow_invocable_v<_fn, Promise&, Func>) {
-    cpo(h.promise(), (Func &&) func);
+          Func&&
+              func) noexcept(std::is_nothrow_invocable_v<_fn, Promise&, Func>) {
+    cpo(h.promise(), (Func&&)func);
   }
 #endif  // UNIFEX_NO_COROUTINES
 
@@ -48,7 +50,7 @@ inline const struct _fn {
     static_assert(
         std::is_void_v<tag_invoke_result_t<_fn, const Continuation&, Func&&>>,
         "tag_invoke() overload for visit_continuations() must return void");
-    return tag_invoke(_fn{}, c, (Func &&) func);
+    return tag_invoke(_fn{}, c, (Func&&)func);
   }
 
   template(typename Continuation, typename Func)                  //
@@ -173,9 +175,9 @@ void _visit_for(
 #endif
 
 template <typename Continuation>
-inline constexpr _continuation_info_vtable _vtable_for {
+inline constexpr _continuation_info_vtable _vtable_for{
 #if UNIFEX_ENABLE_CONTINUATION_VISITATIONS
-  &_type_index_getter_for<Continuation>, &_visit_for<Continuation>
+    &_type_index_getter_for<Continuation>, &_visit_for<Continuation>
 #endif
 };
 
@@ -212,8 +214,7 @@ struct continuation_handle<void> {
       (requires(!same_as<Promise, void>))  //
       /*implicit*/ continuation_handle(
           coro::coroutine_handle<Promise> continuation) noexcept
-    : continuation_handle(
-          0, (coro::coroutine_handle<Promise> &&) continuation) {}
+    : continuation_handle(0, (coro::coroutine_handle<Promise>&&)continuation) {}
 
   explicit operator bool() const noexcept { return handle_ != nullptr; }
 
@@ -298,7 +299,7 @@ inline constexpr _continuation_handle_vtable _vtable_for{
 template <typename Promise>
 continuation_handle<void>::continuation_handle(
     int, coro::coroutine_handle<Promise> continuation) noexcept
-  : handle_((coro::coroutine_handle<Promise> &&) continuation)
+  : handle_((coro::coroutine_handle<Promise>&&)continuation)
   , vtable_(&_vtable_for<Promise>) {
 }
 
@@ -308,7 +309,7 @@ struct continuation_handle {
 
   /*implicit*/ continuation_handle(
       coro::coroutine_handle<Promise> continuation) noexcept
-    : self_((coro::coroutine_handle<Promise> &&) continuation) {}
+    : self_((coro::coroutine_handle<Promise>&&)continuation) {}
 
   explicit operator bool() const noexcept { return !!self_; }
 
@@ -333,7 +334,7 @@ struct continuation_handle {
       tag_t<visit_continuations>,
       const continuation_handle<Promise>& c,
       F&& f) {
-    visit_continuations(c.self_, (F &&) f);
+    visit_continuations(c.self_, (F&&)f);
   }
 #  endif
 

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -360,7 +360,7 @@ struct _promise final {
       } else {
         // Otherwise, we don't know how to await this type. Just return it and
         // let the compiler issue a diagnostic.
-        return (Value &&) value;
+        return (Value&&)value;
       }
     }
 
@@ -408,9 +408,11 @@ struct _sr_thunk_promise_base : _promise_base {
   struct deferred_stop_request final {
     _sr_thunk_promise_base* self;
 
-    auto operator()() noexcept -> decltype(unstoppable(on(
-        self->sched_,
-        just(&self->stopSource_) | then(&inplace_stop_source::request_stop)))) {
+    auto
+    operator()() noexcept -> decltype(unstoppable(on(
+                              self->sched_,
+                              just(&self->stopSource_) |
+                                  then(&inplace_stop_source::request_stop)))) {
       return unstoppable(on(
           self->sched_,
           just(&self->stopSource_) | then(&inplace_stop_source::request_stop)));
@@ -732,7 +734,7 @@ struct _task<T, nothrow>::type
       Args... args) noexcept(false) /* even if nothrow is true, ramp of a
                                        coroutine can still throw */
   {
-    co_return co_await std::invoke((Fn &&) fn, (Args &&) args...);
+    co_return co_await std::invoke((Fn&&)fn, (Args&&)args...);
   }
 
 private:

--- a/include/unifex/tracing/inject_async_stack.hpp
+++ b/include/unifex/tracing/inject_async_stack.hpp
@@ -19,6 +19,7 @@
 
 #if !UNIFEX_NO_ASYNC_STACKS
 
+#  include <unifex/continuations.hpp>
 #  include <unifex/receiver_concepts.hpp>
 #  include <unifex/tracing/async_stack.hpp>
 #  include <unifex/tracing/get_async_stack_frame.hpp>

--- a/include/unifex/unhandled_done.hpp
+++ b/include/unifex/unhandled_done.hpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unifex/config.hpp>
+
+#if !UNIFEX_NO_COROUTINES
+
+#  include <unifex/coroutine.hpp>
+#  include <unifex/std_concepts.hpp>
+
+#  include <exception>
+#  include <type_traits>
+#  include <utility>
+
+#  include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+namespace _unhandled_done {
+
+struct _func_awaiter_base {
+  constexpr bool await_ready() noexcept { return false; }
+
+  [[noreturn]] void await_resume() noexcept { std::terminate(); }
+};
+
+template <typename Func>
+struct _func_awaiter final : _func_awaiter_base {
+  static_assert(!std::is_reference_v<Func>);
+  static_assert(std::is_nothrow_invocable_v<Func>);
+  static_assert(
+      convertible_to<std::invoke_result_t<Func>, coro::coroutine_handle<>>);
+
+  Func&& func_;
+
+  coro::coroutine_handle<> await_suspend(coro::coroutine_handle<>) noexcept {
+    return std::move(func_)();
+  }
+};
+
+struct _done_coro {
+  struct promise_type {
+    _done_coro get_return_object() noexcept {
+      return _done_coro{
+          coro::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+
+    coro::suspend_always initial_suspend() noexcept { return {}; }
+
+    [[noreturn]] coro::suspend_always final_suspend() noexcept {
+      std::terminate();
+    }
+
+    [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
+
+    void return_void() noexcept {}
+
+    template <typename Func>
+    _func_awaiter<Func> await_transform(Func&& func) noexcept {
+      return {{}, std::move(func)};
+    }
+
+    template <typename Func>
+    void await_transform(Func&) = delete;
+  };
+
+  _done_coro() noexcept = default;
+
+  _done_coro(_done_coro&& other) noexcept
+    : handle_{std::exchange(other.handle_, {})} {}
+
+  ~_done_coro() {
+    if (handle_) {
+      handle_.destroy();
+    }
+  }
+
+  _done_coro& operator=(_done_coro other) noexcept {
+    std::swap(handle_, other.handle_);
+    return *this;
+  }
+
+  coro::coroutine_handle<> handle() const noexcept { return handle_; }
+
+private:
+  explicit _done_coro(coro::coroutine_handle<promise_type> h) noexcept
+    : handle_{h} {}
+
+  coro::coroutine_handle<promise_type> handle_{};
+};
+
+template(typename Func)  //
+    (requires std::is_nothrow_invocable_v<Func> AND convertible_to<
+        std::invoke_result_t<Func>,
+        coro::coroutine_handle<>>)  //
+    _done_coro unhandled_done(Func func) {
+  co_await std::move(func);
+}
+
+struct _fn final {
+  template(typename Func)  //
+      (requires std::is_nothrow_invocable_v<remove_cvref_t<Func>> AND
+           convertible_to<
+               std::invoke_result_t<remove_cvref_t<Func>>,
+               coro::coroutine_handle<>>)  //
+      _done_coro
+      operator()(Func&& func) const {
+    return unhandled_done(std::forward<Func>(func));
+  }
+
+  template(typename Func)  //
+      (requires std::is_nothrow_invocable_v<remove_cvref_t<Func>> AND
+           same_as<std::invoke_result_t<remove_cvref_t<Func>>, void>)  //
+      _done_coro
+      operator()(Func&& func) const {
+    return unhandled_done([func = std::forward<Func>(func)]() noexcept(
+                              std::is_nothrow_invocable_v<Func>) {
+      std::move(func)();
+      return coro::noop_coroutine();
+    });
+  }
+};
+
+}  // namespace _unhandled_done
+
+/**
+ * unhandled_done() takes a callable and returns a done_coro that owns a
+ * suspended coroutine that, when resumed, will invoke the callable with no
+ * arguments and then resume the coroutine_handle<> it returns. If the callable
+ * returns void, resuming the returned coroutine will invoke the callable and
+ * then suspend.
+ *
+ * The done_coro returned from unhandled_done() is intended to be used to
+ * implement a coroutine promise type's unhandled_done() function like so:
+ *
+ *   struct promise_type {
+ *     promise_type()
+ *      : doneCoro_(unifex::unhandled_done([] { ... })) {}
+ *
+ *     coroutine_handled<> unhandled_done() noexcept {
+ *       return doneCoro_.handle();
+ *     }
+ *
+ *     // the rest of a promise implementation...
+ *
+ *     unifex::done_coro doneCoro_;
+ *   };
+ *
+ * A coroutine's promise's unhandled_done() will be invoked by a *child*
+ * awaitable to signal that it completed with done (rather than resuming the
+ * parent coroutine directly, which triggers invocation of the child's
+ * await_resume(), to signal either value or error completion). The coroutine
+ * returned from a promise's unhandled_done() is responsible for cleaning up the
+ * child that completed with done before performing the parent coroutine's "on
+ * done" duties.
+ */
+constexpr _unhandled_done::_fn unhandled_done{};
+
+/**
+ * The return type of unhandled_done().
+ */
+using done_coro = _unhandled_done::_done_coro;
+
+}  // namespace unifex
+
+#  include <unifex/detail/epilogue.hpp>
+
+#endif  // !UNIFEX_NO_COROUTINES


### PR DESCRIPTION
This diff adds a new algorithm called `unifex::unhandled_done(Func)`,
which takes a callable (with signature `coroutine_handle<>()` or
`void()`) and returns a suspended coroutine. When the returned coroutine
is resumed, it invokes the callable and either a) resumes the coroutine
*it* returns, or b) suspends (if the callable returns `void`). The
intended use of `unhandled_done()` is to make it easier for a coroutine
promise type to implement its own `unhandled_done()`.