### PR TITLE
Fix Wformat compiler warnings

### DIFF
--- a/examples/linux/http_server_io_uring_test.cpp
+++ b/examples/linux/http_server_io_uring_test.cpp
@@ -96,7 +96,7 @@ parse_request(io_uring_context::async_read_write_file& readWriteFile) {
     }
     // protect from infite request
     if (req.size() > 8 * buffer.size()) {
-      std::printf("req too big=%ld\n", req.size());
+      std::printf("req too big=%zu\n", req.size());
       request.method = Method::OTHER;
       break;
     }
@@ -157,7 +157,7 @@ stopTrigger(std::chrono::milliseconds ms, io_uring_context::scheduler sched) {
   if (ms.count() > 0) {
     co_await stop_when(
         schedule_at(sched, now(sched) + ms) |
-            then([ms] { std::printf("Timeout after %ldms\n", ms.count()); }),
+            then([ms] { std::printf("Timeout after %lldms\n", ms.count()); }),
         quit(sched));
   } else {
     co_await quit(sched);


### PR DESCRIPTION
```
examples/linux/http_server_io_uring_test.cpp: In function 'unifex::task<{anonymous}::Request> {anonymous}::parse_request(unifex::linuxos::io_uring_context::async_read_write_file&)':
examples/linux/http_server_io_uring_test.cpp:99:34: error: format '%ld' expects argument of type 'long int', but argument 2 has type 'std::basic_string<char>::size_type' {aka 'unsigned int'} [-Werror=format=]
   99 |       std::printf("req too big=%ld\n", req.size());
      |                                ~~^     ~~~~~~~~~~
      |                                  |             |
      |                                  long int      std::basic_string<char>::size_type {aka unsigned int}
      |                                %d
examples/linux/http_server_io_uring_test.cpp: In lambda function:
examples/linux/http_server_io_uring_test.cpp:160:54: error: format '%ld' expects argument of type 'long int', but argument 2 has type 'std::chrono::duration<long long int, std::ratio<1, 1000> >::rep' {aka 'long long int'} [-Werror=format=]
  160 |             then([ms] { std::printf("Timeout after %ldms\n", ms.count()); }),
      |                                                    ~~^       ~~~~~~~~~~
      |                                                      |               |
      |                                                      long int        std::chrono::duration<long long int, std::ratio<1, 1000> >::rep {aka long long int}
      |                                                    %lld
```