### PR TITLE
More Fixes for Error Types

### DIFF
--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -378,7 +378,6 @@ public:
 
   template <template <typename...> class Variant>
   using error_types = typename concat_type_lists_unique_t<
-      sender_error_type_list_t<Source>,
       apply_to_type_list_t<
           concat_type_lists_unique_t,
           map_type_list_t<final_senders_list, sender_error_type_list_t>>,

--- a/include/unifex/variant_sender.hpp
+++ b/include/unifex/variant_sender.hpp
@@ -106,8 +106,9 @@ public:
       template apply<Variant>;
 
   template <template <typename...> class Variant>
-  using error_types =
-      concat_type_lists_unique_t<sender_error_types_t<Senders, Variant>...>;
+  using error_types = typename concat_type_lists_unique_t<
+      sender_error_types_t<Senders, type_list>...>::
+      template apply<Variant>;
 
   static constexpr bool sends_done = std::disjunction_v<
       std::bool_constant<sender_traits<Senders>::sends_done>...>;

--- a/test/let_error_test.cpp
+++ b/test/let_error_test.cpp
@@ -19,6 +19,7 @@
 #include <unifex/just_from.hpp>
 #include <unifex/let_done.hpp>
 #include <unifex/let_error.hpp>
+#include <unifex/never.hpp>
 #include <unifex/on.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sequence.hpp>
@@ -174,6 +175,16 @@ TEST(TransformError, SequenceFwd) {
 }
 
 #if !UNIFEX_NO_COROUTINES
+TEST(TransformError, TaskAwaitable) {
+  auto value = []() -> task<int> {
+    co_return co_await (
+        just_error(42) | let_error(just_int{}) | stop_when(never_sender()));
+  }() |
+      sync_wait();
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, 42);
+}
+
 TEST(TransformError, WithTask) {
   auto value = let_error(
                    then(

--- a/test/variant_sender_test.cpp
+++ b/test/variant_sender_test.cpp
@@ -81,8 +81,12 @@ struct TestSender {
 }  // namespace
 
 TEST(Variant, CombineJustAndError) {
-  auto func =
-      [](bool v) -> variant_sender<decltype(just(5)), decltype(just_error(5))> {
+  using combined_sender_t =
+      variant_sender<decltype(just(5)), decltype(just_error(5))>;
+  static_assert(std::is_same_v<
+                sender_traits<combined_sender_t>::template error_types<type_list>,
+                type_list<std::exception_ptr, int>>);
+  auto func = [](bool v) -> combined_sender_t {
     if (v) {
       return just(5);
     } else {


### PR DESCRIPTION
This is a two for one. The first seems like a slam-dunk bug with error types on variant sender. This code doesn't compile:
```cpp
#include <unifex/variant_sender.hpp>
#include <unifex/just_error.hpp>
#include <unifex/just.hpp>

using namespace unifex;

using Sender = variant_sender<
    decltype(just_error(2)),
    decltype(just())
>;
using Errors = typename sender_traits<Sender>::
    template error_types<std::variant>;

```
Here on [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:13,endLineNumber:15,positionColumn:13,positionLineNumber:15,selectionStartColumn:13,selectionStartLineNumber:15,startColumn:13,startLineNumber:15),source:'%23define+UNIFEX_HAS_BUILTIN(...)+0+//+%3C-+godbolt+needs+this+for+some+reason+%0A%23include+%3Cunifex/variant_sender.hpp%3E%0A%23include+%3Cunifex/just_error.hpp%3E%0A%23include+%3Cunifex/just.hpp%3E%0A%0Ausing+namespace+unifex%3B%0A%0Ausing+Sender+%3D+variant_sender%3C%0A++++decltype(just_error(2)),%0A++++decltype(just())%0A%3E%3B%0Ausing+Errors+%3D+typename+sender_traits%3CSender%3E::%0A++++template+error_types%3Cstd::variant%3E%3B%0A%0Aint+main()%7B%7D'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:49.763872491145214,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:clang_trunk,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!((name:unifex,ver:trunk)),options:'',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+clang+(trunk)+(Editor+%231)',t:'0')),k:100,l:'4',m:43.64994663820704,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'x86-64+gcc+(trunk)',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+(trunk)+(Compiler+%231)',t:'0')),header:(),l:'4',m:56.35005336179295,n:'0',o:'',s:0,t:'0')),k:50.23612750885478,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

The second one is a little more tricky, `let_error` propagates the error type of the `Source` sender to its own sender. This might be intentional but it causes issues when `co_await`ing certain chains of senders. For reasons I haven't had time to fully grok, it seems like non-scheduler affine senders being `co_await`ed have their `error_types` checked, whereas scheduler affine senders' `error_types` are not checked. `let_error` I don't think has any path that lets the original error through so the duck-typing works out at the end of the day.

This example doesn't compile
```cpp
#include <unifex/task.hpp>
#include <unifex/let_error.hpp>
#include <unifex/stop_when.hpp>
#include <unifex/never.hpp>
#include <unifex/just.hpp>
#include <unifex/just_error.hpp>
#include <unifex/sync_wait.hpp>
using namespace unifex;

struct just_int {
  template <typename Unused>
  auto operator()(Unused&&) {
    return just(0);
  }
  auto operator()(int val) { return just(val); }
};

int main() {
    auto value = []() -> task<int> {
        co_return co_await (
            just_error(42) | let_error(just_int{}) | stop_when(never_sender())
        );
    }() | sync_wait();
}
```
here on [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:2,endLineNumber:25,positionColumn:1,positionLineNumber:2,selectionStartColumn:2,selectionStartLineNumber:25,startColumn:1,startLineNumber:2),source:'%23define+UNIFEX_HAS_BUILTIN(...)+0+//+%3C-+godbolt+needs+this+for+some+reason+%0A%23include+%3Cunifex/task.hpp%3E%0A%23include+%3Cunifex/let_error.hpp%3E%0A%23include+%3Cunifex/stop_when.hpp%3E%0A%23include+%3Cunifex/never.hpp%3E%0A%23include+%3Cunifex/just.hpp%3E%0A%23include+%3Cunifex/just_error.hpp%3E%0A%23include+%3Cunifex/sync_wait.hpp%3E%0Ausing+namespace+unifex%3B%0A%0Astruct+just_int+%7B%0A++template+%3Ctypename+Unused%3E%0A++auto+operator()(Unused%26%26)+%7B%0A++++return+just(0)%3B%0A++%7D%0A++auto+operator()(int+val)+%7B+return+just(val)%3B+%7D%0A%7D%3B%0A%0Aint+main()+%7B%0A++++auto+value+%3D+%5B%5D()+-%3E+task%3Cint%3E+%7B%0A++++++++co_return+co_await+(%0A++++++++++++just_error(42)+%7C+let_error(just_int%7B%7D)+%7C+stop_when(never_sender())%0A++++++++)%3B%0A++++%7D()+%7C+sync_wait()%3B%0A%7D'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:49.763872491145214,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:clang_trunk,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!((name:unifex,ver:trunk)),options:'-std%3Dc%2B%2B20',overrides:!(),selection:(endColumn:45,endLineNumber:3,positionColumn:45,positionLineNumber:3,selectionStartColumn:45,selectionStartLineNumber:3,startColumn:45,startLineNumber:3),source:1),l:'5',n:'0',o:'+x86-64+clang+(trunk)+(Editor+%231)',t:'0')),k:100,l:'4',m:43.64994663820704,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'x86-64+gcc+(trunk)',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+(trunk)+(Compiler+%231)',t:'0')),header:(),l:'4',m:56.35005336179295,n:'0',o:'',s:0,t:'0')),k:50.23612750885478,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)
And weirdly it DOES compile if you remove the `stop_when` operation (because it's not scheduler affine).

I could be missing some intended behavior on this so feedback is much appreciated!


