### PR TITLE
Include continuations.hpp instead of async_trace.hpp

### DIFF
--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -21,7 +21,6 @@
 #  error "Coroutine support is required to use <unifex/await_transform.hpp>"
 #endif
 
-#include <unifex/async_trace.hpp>
 #include <unifex/continuations.hpp>
 #include <unifex/coroutine_concepts.hpp>
 #include <unifex/manual_lifetime.hpp>

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/async_trace.hpp>
 #include <unifex/await_transform.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/coroutine.hpp>
 #include <unifex/coroutine_concepts.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -180,10 +180,14 @@ public:
   static constexpr bool is_always_scheduler_affine =
       sender_traits<Source>::is_always_scheduler_affine;
 
-  template (typename Source2)
-      (requires (!same_as<remove_cvref_t<Source2>, type>))
-  explicit type(Source2&& source) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>)
+  template(typename Source2)(requires(
+      !same_as<
+          remove_cvref_t<Source2>,
+          type>)) explicit type(Source2&&
+                                    source) noexcept(std::
+                                                         is_nothrow_constructible_v<
+                                                             Source,
+                                                             Source2>)
     : source_(static_cast<Source2&&>(source)) {}
 
   template(typename Self, typename Receiver)  //
@@ -192,8 +196,8 @@ public:
       friend auto tag_invoke(tag_t<unifex::connect>, Self&& self, Receiver&& r) noexcept(
           is_nothrow_connectable_v<
               member_t<Self, Source>,
-              receiver_t<Receiver>>&& std::
-              is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+              receiver_t<Receiver>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
           -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
     return unifex::connect(
         static_cast<Self&&>(self).source_,
@@ -225,7 +229,7 @@ public:
       auto
       operator()(Sender&& predecessor) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender>) -> _result_t<Sender> {
-    return unifex::tag_invoke(_fn{}, (Sender &&) predecessor);
+    return unifex::tag_invoke(_fn{}, (Sender&&)predecessor);
   }
   template(typename Sender)                    //
       (requires(!tag_invocable<_fn, Sender>))  //
@@ -233,7 +237,7 @@ public:
       operator()(Sender&& predecessor) const
       noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>)
           -> _result_t<Sender> {
-    return _demat::sender<Sender>{(Sender &&) predecessor};
+    return _demat::sender<Sender>{(Sender&&)predecessor};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -180,14 +180,12 @@ public:
   static constexpr bool is_always_scheduler_affine =
       sender_traits<Source>::is_always_scheduler_affine;
 
-  template(typename Source2)(requires(
-      !same_as<
-          remove_cvref_t<Source2>,
-          type>)) explicit type(Source2&&
-                                    source) noexcept(std::
-                                                         is_nothrow_constructible_v<
-                                                             Source,
-                                                             Source2>)
+  template(typename Source2)  //
+      (requires(!same_as<
+                remove_cvref_t<Source2>,
+                type>))  //
+      explicit type(Source2&& source) noexcept(
+          std::is_nothrow_constructible_v<Source, Source2>)
     : source_(static_cast<Source2&&>(source)) {}
 
   template(typename Self, typename Receiver)  //

--- a/include/unifex/dematerialize.hpp
+++ b/include/unifex/dematerialize.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/finally.hpp
+++ b/include/unifex/finally.hpp
@@ -648,16 +648,9 @@ public:
       sender_traits<CompletionSender>::is_always_scheduler_affine;
 
   template <typename SourceSender2, typename CompletionSender2>
-  explicit type(
-      SourceSender2&& source,
-      CompletionSender2&&
-          completion) noexcept(std::
-                                   is_nothrow_constructible_v<
-                                       SourceSender,
-                                       SourceSender2>&&
-                                       std::is_nothrow_constructible_v<
-                                           CompletionSender,
-                                           CompletionSender2>)
+  explicit type(SourceSender2&& source, CompletionSender2&& completion) noexcept(
+      std::is_nothrow_constructible_v<SourceSender, SourceSender2> &&
+      std::is_nothrow_constructible_v<CompletionSender, CompletionSender2>)
     : source_(static_cast<SourceSender2&&>(source))
     , completion_(static_cast<CompletionSender2&&>(completion)) {}
 
@@ -715,10 +708,10 @@ struct _fn {
         static_cast<CompletionSender&&>(completion)};
   }
   template <typename CompletionSender>
-  constexpr auto operator()(CompletionSender&& completion) const
-      noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, CompletionSender>)
-          -> bind_back_result_t<_fn, CompletionSender> {
-    return bind_back(*this, (CompletionSender &&) completion);
+  constexpr auto operator()(CompletionSender&& completion) const noexcept(
+      std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, CompletionSender>)
+      -> bind_back_result_t<_fn, CompletionSender> {
+    return bind_back(*this, (CompletionSender&&)completion);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -94,7 +94,7 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
         Tuple&& t,
         std::index_sequence<Idx...>) {
       unifex::set_value(
-          (OutputReceiver &&) output_receiver, std::move(std::get<Idx>(t))...);
+          (OutputReceiver&&)output_receiver, std::move(std::get<Idx>(t))...);
     }
 
     template <typename Iterator, typename... Values>
@@ -102,26 +102,26 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
       operation_state_.cleanup();
       UNIFEX_TRY {
         unpack_helper(
-            (OutputReceiver &&) output_receiver_,
+            (OutputReceiver&&)output_receiver_,
             std::move(packedResult),
             std::make_index_sequence<
                 std::tuple_size_v<std::tuple<Iterator, Values...>>>{});
       }
       UNIFEX_CATCH(...) {
         unifex::set_error(
-            (OutputReceiver &&) output_receiver_, std::current_exception());
+            (OutputReceiver&&)output_receiver_, std::current_exception());
       }
     }
 
     template <typename Error>
     void set_error(Error&& error) && noexcept {
       operation_state_.cleanup();
-      unifex::set_error((OutputReceiver &&) output_receiver_, (Error &&) error);
+      unifex::set_error((OutputReceiver&&)output_receiver_, (Error&&)error);
     }
 
     void set_done() && noexcept {
       operation_state_.cleanup();
-      unifex::set_done((OutputReceiver &&) output_receiver_);
+      unifex::set_done((OutputReceiver&&)output_receiver_);
     }
 
     template(typename CPO, typename R)  //
@@ -150,7 +150,7 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
           unifex::just(std::forward<Values>(values)...),
           [this, begin_it, end_it](auto... values) {
             for (auto it = begin_it; it != end_it; ++it) {
-              if (std::invoke((Func &&) func_, *it, values...)) {
+              if (std::invoke((Func&&)func_, *it, values...)) {
                 return std::tuple<Iterator, Values...>(
                     it, std::move(values)...);
               }
@@ -297,10 +297,10 @@ struct _receiver<Predecessor, Receiver, Func, FuncPolicy>::type {
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-    unifex::set_error((Receiver &&) receiver_, (Error &&) error);
+    unifex::set_error((Receiver&&)receiver_, (Error&&)error);
   }
 
-  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
+  void set_done() && noexcept { unifex::set_done((Receiver&&)receiver_); }
 
   template(typename CPO, typename R)                                //
       (requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>)  //
@@ -376,10 +376,10 @@ template <typename Iterator, typename... Values>
 void _receiver<Predecessor, Receiver, Func, FuncPolicy>::type::set_value(
     Iterator begin_it, Iterator end_it, Values&&... values) && noexcept {
   auto sched = unifex::get_scheduler(receiver_);
-  unpack_receiver<Receiver> unpack{(Receiver &&) receiver_, operation_state_};
+  unpack_receiver<Receiver> unpack{(Receiver&&)receiver_, operation_state_};
   UNIFEX_TRY {
     auto find_if_implementation_sender = find_if_helper{std::move(func_)}(
-        std::move(sched), funcPolicy_, begin_it, end_it, (Values &&) values...);
+        std::move(sched), funcPolicy_, begin_it, end_it, (Values&&)values...);
     // Store nested operation state inside find_if's operation state
     operation_state_.innerOp_.construct_with([&]() mutable {
       return unifex::connect(
@@ -437,20 +437,12 @@ struct _sender<Predecessor, Func, FuncPolicy>::type {
   template(typename Sender, typename Receiver)  //
       (requires same_as<remove_cvref_t<Sender>, type> AND
            receiver<Receiver>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&& r) noexcept(std::
-                                     is_nothrow_constructible_v<
-                                         remove_cvref_t<Receiver>,
-                                         Receiver>&&
-                                         std::is_nothrow_constructible_v<
-                                             Func,
-                                             member_t<Sender, Func>>&&
-                                             is_nothrow_connectable_v<
-                                                 member_t<Sender, Predecessor>,
-                                                 receiver_type<
-                                                     remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_type<remove_cvref_t<Receiver>>>)
           -> _operation_state<Predecessor, Receiver, Func, FuncPolicy> {
     return _operation_state<Predecessor, Receiver, Func, FuncPolicy>{
         static_cast<Sender&&>(s), static_cast<Receiver&&>(r)};
@@ -468,27 +460,33 @@ public:
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func, FuncPolicy>)
           -> tag_invoke_result_t<_fn, Sender, Func, FuncPolicy> {
     return unifex::tag_invoke(
-        _fn{}, (Sender &&) predecessor, (Func &&) func, (FuncPolicy &&) policy);
+        _fn{}, (Sender&&)predecessor, (Func&&)func, (FuncPolicy&&)policy);
   }
   template(typename Sender, typename Func, typename FuncPolicy)  //
       (requires(!tag_invocable<_fn, Sender, Func, FuncPolicy>))  //
       auto
       operator()(Sender&& predecessor, Func&& func, FuncPolicy policy) const
-      noexcept(std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender>&&
-                   std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func>&&
-                       std::is_nothrow_constructible_v<
-                           remove_cvref_t<FuncPolicy>,
-                           FuncPolicy>) -> _find_if::
-          sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy> {
+      noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Sender>, Sender> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Func>, Func> &&
+          std::is_nothrow_constructible_v<
+              remove_cvref_t<FuncPolicy>,
+              FuncPolicy>)
+          -> _find_if::
+              sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy> {
     return _find_if::
         sender_t<remove_cvref_t<Sender>, std::decay_t<Func>, FuncPolicy>{
-            (Sender &&) predecessor, (Func &&) func, (FuncPolicy &&) policy};
+            (Sender&&)predecessor, (Func&&)func, (FuncPolicy&&)policy};
   }
   template <typename Func, typename FuncPolicy>
-  constexpr auto operator()(Func&& f, const FuncPolicy& policy) const noexcept(
-      std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func, const FuncPolicy&>)
-      -> bind_back_result_t<_fn, Func, const FuncPolicy&> {
-    return bind_back(*this, (Func &&) f, policy);
+  constexpr auto operator()(Func&& f, const FuncPolicy& policy) const
+      noexcept(std::is_nothrow_invocable_v<
+               tag_t<bind_back>,
+               _fn,
+               Func,
+               const FuncPolicy&>)
+          -> bind_back_result_t<_fn, Func, const FuncPolicy&> {
+    return bind_back(*this, (Func&&)f, policy);
   }
 } find_if{};
 }  // namespace _find_if_cpo

--- a/include/unifex/find_if.hpp
+++ b/include/unifex/find_if.hpp
@@ -16,12 +16,12 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/bulk_join.hpp>
 #include <unifex/bulk_schedule.hpp>
 #include <unifex/bulk_transform.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/execution_policy.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/just.hpp>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>

--- a/include/unifex/indexed_for.hpp
+++ b/include/unifex/indexed_for.hpp
@@ -98,26 +98,26 @@ struct _receiver<Policy, Range, Func, Receiver>::type {
                           typename Range::iterator>::reference,
                       Values...>) {
       apply_func_with_policy(
-          policy_, (Range &&) range_, (Func &&) func_, values...);
-      unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
+          policy_, (Range&&)range_, (Func&&)func_, values...);
+      unifex::set_value((Receiver&&)receiver_, (Values&&)values...);
     } else {
       UNIFEX_TRY {
         apply_func_with_policy(
-            policy_, (Range &&) range_, (Func &&) func_, values...);
-        unifex::set_value((Receiver &&) receiver_, (Values &&) values...);
+            policy_, (Range&&)range_, (Func&&)func_, values...);
+        unifex::set_value((Receiver&&)receiver_, (Values&&)values...);
       }
       UNIFEX_CATCH(...) {
-        unifex::set_error((Receiver &&) receiver_, std::current_exception());
+        unifex::set_error((Receiver&&)receiver_, std::current_exception());
       }
     }
   }
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-    unifex::set_error((Receiver &&) receiver_, (Error &&) error);
+    unifex::set_error((Receiver&&)receiver_, (Error&&)error);
   }
 
-  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
+  void set_done() && noexcept { unifex::set_done((Receiver&&)receiver_); }
 
   template(typename CPO)                       //
       (requires is_receiver_query_cpo_v<CPO>)  //
@@ -185,10 +185,10 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
     return unifex::connect(
         std::move(pred_),
         _ifor::receiver_t<Policy, Range, Func, Receiver>{
-            (Func &&) func_,
-            (Policy &&) policy_,
-            (Range &&) range_,
-            (Receiver &&) receiver});
+            (Func&&)func_,
+            (Policy&&)policy_,
+            (Range&&)range_,
+            (Receiver&&)receiver});
   }
 };
 }  // namespace _ifor
@@ -196,21 +196,18 @@ struct _sender<Predecessor, Policy, Range, Func>::type {
 namespace _ifor_cpo {
 struct _fn {
   template <typename Sender, typename Policy, typename Range, typename Func>
-  auto operator()(
-      Sender&& predecessor, Policy&& policy, Range&& range, Func&& func) const
-      -> _ifor::sender<Sender, Policy, Range, Func> {
+  auto
+  operator()(Sender&& predecessor, Policy&& policy, Range&& range, Func&& func)
+      const -> _ifor::sender<Sender, Policy, Range, Func> {
     return _ifor::sender<Sender, Policy, Range, Func>{
-        (Sender &&) predecessor,
-        (Policy &&) policy,
-        (Range &&) range,
-        (Func &&) func};
+        (Sender&&)predecessor, (Policy&&)policy, (Range&&)range, (Func&&)func};
   }
   template <typename Policy, typename Range, typename Func>
-  constexpr auto operator()(Policy&& policy, Range&& range, Func&& f) const
-      noexcept(
-          std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Policy, Range, Func>)
-          -> bind_back_result_t<_fn, Policy, Range, Func> {
-    return bind_back(*this, (Policy &&) policy, (Range &&) range, (Func &&) f);
+  constexpr auto
+  operator()(Policy&& policy, Range&& range, Func&& f) const noexcept(
+      std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Policy, Range, Func>)
+      -> bind_back_result_t<_fn, Policy, Range, Func> {
+    return bind_back(*this, (Policy&&)policy, (Range&&)range, (Func&&)f);
   }
 } indexed_for{};
 }  // namespace _ifor_cpo

--- a/include/unifex/into_variant.hpp
+++ b/include/unifex/into_variant.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/type_list.hpp>

--- a/include/unifex/into_variant.hpp
+++ b/include/unifex/into_variant.hpp
@@ -47,17 +47,17 @@ struct _receiver<Receiver, VariantType>::type {
           Values...>)  //
       void set_value(Values&&... values) && {
     unifex::set_value(
-        (Receiver &&) receiver_,
-        VariantType(std::make_tuple((Values &&)(values)...)));
+        (Receiver&&)receiver_,
+        VariantType(std::make_tuple((Values&&)(values)...)));
   }
 
   template(typename Error)                  //
       (requires receiver<Receiver, Error>)  //
       void set_error(Error&& error) && noexcept {
-    unifex::set_error((Receiver &&)(receiver_), (Error &&)(error));
+    unifex::set_error((Receiver&&)(receiver_), (Error&&)(error));
   }
 
-  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
+  void set_done() && noexcept { unifex::set_done((Receiver&&)receiver_); }
 
   template(typename CPO)  //
       (requires is_receiver_query_cpo_v<CPO> AND
@@ -122,17 +122,11 @@ struct _sender<Predecessor>::type {
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  is_nothrow_connectable_v<
-                                      member_t<Sender, Predecessor>,
-                                      receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {
@@ -157,7 +151,7 @@ public:
       auto
       operator()(Sender&& predecessor) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender>) -> _result_t<Sender> {
-    return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor));
+    return unifex::tag_invoke(_fn{}, (Sender&&)(predecessor));
   }
 
   template(typename Sender)                    //
@@ -167,7 +161,7 @@ public:
       noexcept(std::is_nothrow_constructible_v<
                _into_variant::sender<Sender>,
                Sender>) -> _result_t<Sender> {
-    return _into_variant::sender<Sender>{(Sender &&) predecessor};
+    return _into_variant::sender<Sender>{(Sender&&)predecessor};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)

--- a/include/unifex/let_done.hpp
+++ b/include/unifex/let_done.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/let_done.hpp
+++ b/include/unifex/let_done.hpp
@@ -81,7 +81,7 @@ public:
       void set_value(Values&&... values) noexcept(
           is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
+    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
   }
 
   void set_done() noexcept {
@@ -117,7 +117,7 @@ public:
       (requires receiver<Receiver, Error>)  //
       void set_error(Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
+    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
   }
 
 private:
@@ -137,8 +137,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&&
-          func) noexcept(std::is_nothrow_invocable_v<VisitFunc&, const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     func(r.get_receiver());
   }
 #endif
@@ -165,7 +167,7 @@ public:
       void set_value(Values&&... values) noexcept(
           is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
+    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
   }
 
   void set_done() noexcept {
@@ -177,7 +179,7 @@ public:
       (requires receiver<Receiver, Error>)  //
       void set_error(Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
+    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
   }
 
 private:
@@ -195,8 +197,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&&
-          func) noexcept(std::is_nothrow_invocable_v<VisitFunc&, const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     func(r.get_receiver());
   }
 #endif
@@ -217,13 +221,13 @@ class _op<Source, Done, Receiver>::type {
 public:
   template <typename Done2, typename Receiver2>
   explicit type(Source&& source, Done2&& done, Receiver2&& dest) noexcept(
-      std::is_nothrow_move_constructible_v<Receiver>&&
-          std::is_nothrow_move_constructible_v<Done>&&
-              is_nothrow_connectable_v<Source, source_receiver>)
-    : done_((Done2 &&) done)
-    , receiver_((Receiver2 &&) dest) {
+      std::is_nothrow_move_constructible_v<Receiver> &&
+      std::is_nothrow_move_constructible_v<Done> &&
+      is_nothrow_connectable_v<Source, source_receiver>)
+    : done_((Done2&&)done)
+    , receiver_((Receiver2&&)dest) {
     unifex::activate_union_member_with(sourceOp_, [&] {
-      return unifex::connect((Source &&) source, source_receiver{this});
+      return unifex::connect((Source&&)source, source_receiver{this});
     });
     startedOp_ = 0 + 1;
   }
@@ -292,10 +296,10 @@ public:
 
   template <typename Source2, typename Done2>
   explicit type(Source2&& source, Done2&& done) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>&&
-          std::is_nothrow_constructible_v<Done, Done2>)
-    : source_((Source2 &&) source)
-    , done_((Done2 &&) done) {}
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      std::is_nothrow_constructible_v<Done, Done2>)
+    : source_((Source2&&)source)
+    , done_((Done2&&)done) {}
 
   template(
       typename Sender,
@@ -312,11 +316,9 @@ public:
                            final_sender_t,
                            FinalReceiver>)  //
       friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
-          is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver>&&
-              std::is_nothrow_constructible_v<Done, member_t<Sender, Done>>&&
-                  std::is_nothrow_constructible_v<
-                      remove_cvref_t<Receiver>,
-                      Receiver>)
+          is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver> &&
+          std::is_nothrow_constructible_v<Done, member_t<Sender, Done>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
           -> operation_type<member_t<Sender, Source>, Done, Receiver> {
     return operation_type<member_t<Sender, Source>, Done, Receiver>{
         static_cast<Sender&&>(s).source_,
@@ -348,7 +350,7 @@ struct _fn {
       operator()(Source&& source, Done&& done) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source, Done>)
           -> tag_invoke_result_t<_fn, Source, Done> {
-    return tag_invoke(*this, (Source &&) source, (Done &&) done);
+    return tag_invoke(*this, (Source&&)source, (Done&&)done);
   }
 
   template(typename Source, typename Done)  //
@@ -364,7 +366,7 @@ struct _fn {
                Source,
                Done>) -> _sender<remove_cvref_t<Source>, remove_cvref_t<Done>> {
     return _sender<remove_cvref_t<Source>, remove_cvref_t<Done>>{
-        (Source &&) source, (Done &&) done};
+        (Source&&)source, (Done&&)done};
   }
   template(typename Done)  //
       (requires std::is_invocable_v<Done> AND
@@ -373,7 +375,7 @@ struct _fn {
       operator()(Done&& done) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Done>)
           -> bind_back_result_t<_fn, Done> {
-    return bind_back(*this, (Done &&) done);
+    return bind_back(*this, (Done&&)done);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/let_done.hpp
+++ b/include/unifex/let_done.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>

--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/let_error.hpp
+++ b/include/unifex/let_error.hpp
@@ -108,7 +108,8 @@ public:
     auto op = op_;
     UNIFEX_ASSERT(op != nullptr);
 
-    using final_sender_t = std::invoke_result_t<Func, remove_cvref_t<ErrorValue>&>;
+    using final_sender_t =
+        std::invoke_result_t<Func, remove_cvref_t<ErrorValue>&>;
     using final_op_t = connect_result_t<
         final_sender_t,
         final_receiver<remove_cvref_t<ErrorValue>>>;
@@ -118,7 +119,7 @@ public:
         unifex::deactivate_union_member(op->sourceOp_);
       };
       auto& err = op->error_.template construct<remove_cvref_t<ErrorValue>>(
-          (ErrorValue &&) e);
+          (ErrorValue&&)e);
       destroyPredOp.reset();
       scope_guard destroyErr = [&]() noexcept {
         op->error_.template destruct<remove_cvref_t<ErrorValue>>();
@@ -154,8 +155,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&&
-          func) noexcept(std::is_nothrow_invocable_v<VisitFunc&, const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     func(r.get_receiver());
   }
 #endif
@@ -239,8 +242,10 @@ private:
   friend void tag_invoke(
       tag_t<visit_continuations>,
       const type& r,
-      VisitFunc&&
-          func) noexcept(std::is_nothrow_invocable_v<VisitFunc&, const Receiver&>) {
+      VisitFunc&& func) noexcept(std::
+                                     is_nothrow_invocable_v<
+                                         VisitFunc&,
+                                         const Receiver&>) {
     func(r.get_receiver());
   }
 #endif
@@ -262,13 +267,13 @@ class _op<Source, Func, Receiver>::type final {
 public:
   template <typename Func2, typename Receiver2>
   explicit type(Source&& source, Func2&& func, Receiver2&& dest) noexcept(
-      std::is_nothrow_constructible_v<Receiver, Receiver2&&>&&
-          std::is_nothrow_constructible_v<Func, Func2&&>&&
-              is_nothrow_connectable_v<Source, source_receiver>)
-    : func_((Func2 &&) func)
-    , receiver_((Receiver2 &&) dest) {
+      std::is_nothrow_constructible_v<Receiver, Receiver2&&> &&
+      std::is_nothrow_constructible_v<Func, Func2&&> &&
+      is_nothrow_connectable_v<Source, source_receiver>)
+    : func_((Func2&&)func)
+    , receiver_((Receiver2&&)dest) {
     unifex::activate_union_member_with(sourceOp_, [&] {
-      return unifex::connect((Source &&) source, source_receiver{this});
+      return unifex::connect((Source&&)source, source_receiver{this});
     });
   }
 
@@ -400,10 +405,10 @@ public:
 
   template <typename Source2, typename Func2>
   explicit type(Source2&& source, Func2&& func) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>&&
-          std::is_nothrow_constructible_v<Func, Func2>)
-    : source_((Source2 &&) source)
-    , func_((Func2 &&) func) {}
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      std::is_nothrow_constructible_v<Func, Func2>)
+    : source_((Source2&&)source)
+    , func_((Func2&&)func) {}
 
   template(
       typename Sender,
@@ -418,11 +423,10 @@ public:
                        Source,
                        SourceReceiver>)  //
       friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
-          is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver>&&
-              std::is_nothrow_constructible_v<Func, member_t<Sender, Func>>&&
-                  std::is_nothrow_constructible_v<
-                      remove_cvref_t<Receiver>,
-                      Receiver>) -> operation_type<Source, Func, Receiver> {
+          is_nothrow_connectable_v<member_t<Sender, Source>, SourceReceiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+          -> operation_type<Source, Func, Receiver> {
     return operation_type<Source, Func, Receiver>{
         static_cast<Sender&&>(s).source_,
         static_cast<Sender&&>(s).func_,
@@ -454,7 +458,7 @@ struct _fn final {
       operator()(Source&& source, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func>)
           -> tag_invoke_result_t<_fn, Source, Func> {
-    return tag_invoke(*this, (Source &&) source, (Func &&) func);
+    return tag_invoke(*this, (Source&&)source, (Func&&)func);
   }
 
   template(typename Source, typename Func)  //
@@ -468,13 +472,13 @@ struct _fn final {
                Source,
                Func>) -> _sender<remove_cvref_t<Source>, remove_cvref_t<Func>> {
     return _sender<remove_cvref_t<Source>, remove_cvref_t<Func>>{
-        (Source &&) source, (Func &&) func};
+        (Source&&)source, (Func&&)func};
   }
   template <typename Func>
   constexpr auto operator()(Func&& func) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func>)
           -> bind_back_result_t<_fn, Func> {
-    return bind_back(*this, (Func &&) func);
+    return bind_back(*this, (Func&&)func);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -100,8 +100,11 @@ private:
   template(typename CPO)                       //
       (requires is_receiver_query_cpo_v<CPO>)  //
       friend auto tag_invoke(CPO cpo, const successor_receiver& r) noexcept(
-          std::is_nothrow_invocable_v<CPO, const typename Operation::receiver_type&>)
-          -> std::invoke_result_t<CPO, const typename Operation::receiver_type&> {
+          std::is_nothrow_invocable_v<
+              CPO,
+              const typename Operation::receiver_type&>)
+          -> std::
+              invoke_result_t<CPO, const typename Operation::receiver_type&> {
     return std::move(cpo)(std::as_const(r.get_receiver()));
   }
 
@@ -250,11 +253,11 @@ struct _op<Predecessor, SuccessorFactory, Receiver>::type {
   template <typename SuccessorFactory2, typename Receiver2>
   explicit type(
       Predecessor&& pred, SuccessorFactory2&& func, Receiver2&& receiver)
-    : func_((SuccessorFactory2 &&) func)
-    , receiver_((Receiver2 &&) receiver) {
+    : func_((SuccessorFactory2&&)func)
+    , receiver_((Receiver2&&)receiver) {
     unifex::activate_union_member_with(predOp_, [&] {
       return unifex::connect(
-          (Predecessor &&) pred, predecessor_receiver<operation>{*this});
+          (Predecessor&&)pred, predecessor_receiver<operation>{*this});
     });
   }
 
@@ -401,10 +404,10 @@ public:
 public:
   template <typename Predecessor2, typename SuccessorFactory2>
   explicit type(Predecessor2&& pred, SuccessorFactory2&& func) noexcept(
-      std::is_nothrow_constructible_v<Predecessor, Predecessor2>&&
-          std::is_nothrow_constructible_v<SuccessorFactory, SuccessorFactory2>)
-    : pred_((Predecessor2 &&) pred)
-    , func_((SuccessorFactory2 &&) func) {}
+      std::is_nothrow_constructible_v<Predecessor, Predecessor2> &&
+      std::is_nothrow_constructible_v<SuccessorFactory, SuccessorFactory2>)
+    : pred_((Predecessor2&&)pred)
+    , func_((SuccessorFactory2&&)func) {}
 
   template(typename CPO, typename Sender, typename Receiver)  //
       (requires same_as<CPO, tag_t<unifex::connect>> AND same_as<
@@ -447,13 +450,13 @@ struct _fn {
                SuccessorFactory>)
           -> _let_v::sender<Predecessor, SuccessorFactory> {
     return _let_v::sender<Predecessor, SuccessorFactory>{
-        (Predecessor &&) pred, (SuccessorFactory &&) func};
+        (Predecessor&&)pred, (SuccessorFactory&&)func};
   }
   template <typename SuccessorFactory>
-  constexpr auto operator()(SuccessorFactory&& func) const
-      noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, SuccessorFactory>)
-          -> bind_back_result_t<_fn, SuccessorFactory> {
-    return bind_back(*this, (SuccessorFactory &&) func);
+  constexpr auto operator()(SuccessorFactory&& func) const noexcept(
+      std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, SuccessorFactory>)
+      -> bind_back_result_t<_fn, SuccessorFactory> {
+    return bind_back(*this, (SuccessorFactory&&)func);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/let_value.hpp
+++ b/include/unifex/let_value.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -196,9 +196,8 @@ public:
       sender_traits<Source>::is_always_scheduler_affine;
 
   template(typename Source2)  //
-      (requires constructible_from<
-          Source,
-          Source2> AND (!same_as<remove_cvref_t<Source2>, type>))  //
+      (requires constructible_from<Source, Source2> AND(
+          !same_as<remove_cvref_t<Source2>, type>))  //
       explicit type(Source2&& source) noexcept(
           std::is_nothrow_constructible_v<Source, Source2>)
     : source_(static_cast<Source2&&>(source)) {}
@@ -211,8 +210,8 @@ public:
       friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(
           is_nothrow_connectable_v<
               member_t<Self, Source>,
-              receiver_t<Receiver>>&& std::
-              is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
+              receiver_t<Receiver>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver>)
           -> connect_result_t<member_t<Self, Source>, receiver_t<Receiver>> {
     return unifex::connect(
         static_cast<Self&&>(self).source_,
@@ -244,7 +243,7 @@ public:
       auto
       operator()(Source&& source) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source>) -> _result_t<Source> {
-    return unifex::tag_invoke(_fn{}, (Source &&) source);
+    return unifex::tag_invoke(_fn{}, (Source&&)source);
   }
   template(typename Source)                    //
       (requires(!tag_invocable<_fn, Source>))  //
@@ -252,7 +251,7 @@ public:
       operator()(Source&& source) const
       noexcept(std::is_nothrow_constructible_v<_mat::sender<Source>, Source>)
           -> _result_t<Source> {
-    return _mat::sender<Source>{(Source &&) source};
+    return _mat::sender<Source>{(Source&&)source};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/materialize.hpp
+++ b/include/unifex/materialize.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/exception.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>

--- a/include/unifex/reduce_stream.hpp
+++ b/include/unifex/reduce_stream.hpp
@@ -92,7 +92,7 @@ struct _error_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::
   void set_error(Error error) noexcept {
     auto& op = op_;
     unifex::deactivate_union_member(op.errorCleanup_);
-    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error&&)error);
   }
 
   void set_done() noexcept {
@@ -156,7 +156,7 @@ struct _done_cleanup_receiver<StreamSender, State, ReducerFunc, Receiver>::
   void set_error(Error error) && noexcept {
     auto& op = op_;
     unifex::deactivate_union_member(op.doneCleanup_);
-    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error &&) error);
+    unifex::set_error(static_cast<Receiver&&>(op.receiver_), (Error&&)error);
   }
 
   void set_done() && noexcept {
@@ -242,7 +242,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
     unifex::deactivate_union_member(op.next_);
     UNIFEX_TRY {
       op.state_ =
-          std::invoke(op.reducer_, std::move(op.state_), (Values &&) values...);
+          std::invoke(op.reducer_, std::move(op.state_), (Values&&)values...);
       unifex::activate_union_member_with(op.next_, [&] {
         return unifex::connect(next(op.stream_), next_receiver_t{op});
       });
@@ -279,7 +279,7 @@ struct _next_receiver<StreamSender, State, ReducerFunc, Receiver>::type {
 
   template <typename Error>
   void set_error(Error&& e) && noexcept {
-    std::move(*this).set_error(make_exception_ptr((Error &&) e));
+    std::move(*this).set_error(make_exception_ptr((Error&&)e));
   }
 };
 
@@ -404,7 +404,7 @@ struct _sender<StreamSender, State, ReducerFunc>::type {
         static_cast<Self&&>(self).stream_,
         static_cast<Self&&>(self).initialState_,
         static_cast<Self&&>(self).reducer_,
-        (Receiver &&) receiver};
+        (Receiver&&)receiver};
   }
 };
 }  // namespace _reduce
@@ -421,15 +421,14 @@ inline const struct _fn {
                ReducerFunc>)
           -> _reduce::sender<StreamSender, State, ReducerFunc> {
     return _reduce::sender<StreamSender, State, ReducerFunc>{
-        (StreamSender &&) stream,
-        (State &&) initialState,
-        (ReducerFunc &&) reducer};
+        (StreamSender&&)stream, (State&&)initialState, (ReducerFunc&&)reducer};
   }
   template <typename State, typename ReducerFunc>
-  constexpr auto operator()(State&& initialState, ReducerFunc&& reducer) const
-      noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, State, ReducerFunc>)
-          -> bind_back_result_t<_fn, State, ReducerFunc> {
-    return bind_back(*this, (State &&) initialState, (ReducerFunc &&) reducer);
+  constexpr auto
+  operator()(State&& initialState, ReducerFunc&& reducer) const noexcept(
+      std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, State, ReducerFunc>)
+      -> bind_back_result_t<_fn, State, ReducerFunc> {
+    return bind_back(*this, (State&&)initialState, (ReducerFunc&&)reducer);
   }
 } reduce_stream{};
 }  // namespace _reduce_cpo

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -110,7 +110,7 @@ public:
       (requires receiver<Receiver, Error>)  //
       void set_error(Error&& error) noexcept {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_error(std::move(op_->receiver_), (Error &&) error);
+    unifex::set_error(std::move(op_->receiver_), (Error&&)error);
   }
 
 private:
@@ -151,21 +151,14 @@ class _op<Source, Predicate, Receiver>::type {
 
 public:
   template <typename Source2, typename Predicate2, typename Receiver2>
-  explicit type(
-      Source2&& source,
-      Predicate2&& predicate,
-      Receiver2&&
-          dest) noexcept(std::is_nothrow_constructible_v<Receiver, Receiver2>&&
-                             std::is_nothrow_constructible_v<
-                                 Predicate,
-                                 Predicate2>&& std::
-                                 is_nothrow_constructible_v<Source, Source2>&&
-                                     is_nothrow_connectable_v<
-                                         Source&,
-                                         _receiver_t>)
-    : source_((Source2 &&) source)
-    , predicate_((Predicate2 &&) predicate)
-    , receiver_((Receiver2 &&) dest) {
+  explicit type(Source2&& source, Predicate2&& predicate, Receiver2&& dest) noexcept(
+      std::is_nothrow_constructible_v<Receiver, Receiver2> &&
+      std::is_nothrow_constructible_v<Predicate, Predicate2> &&
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      is_nothrow_connectable_v<Source&, _receiver_t>)
+    : source_((Source2&&)source)
+    , predicate_((Predicate2&&)predicate)
+    , receiver_((Receiver2&&)dest) {
     sourceOp_.construct_with(
         [&] { return unifex::connect(source_, _receiver_t{this}); });
   }
@@ -215,43 +208,32 @@ public:
 
   template <typename Source2, typename Predicate2>
   explicit type(Source2&& source, Predicate2&& predicate) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>&&
-          std::is_nothrow_constructible_v<Predicate, Predicate2>)
-    : source_((Source2 &&) source)
-    , predicate_((Predicate2 &&) predicate) {}
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      std::is_nothrow_constructible_v<Predicate, Predicate2>)
+    : source_((Source2&&)source)
+    , predicate_((Predicate2&&)predicate) {}
 
   template(typename Sender, typename Receiver)  //
       (requires same_as<remove_cvref_t<Sender>, type> AND
            constructible_from<remove_cvref_t<Receiver>, Receiver> AND sender_to<
                Source&,
                receiver_t<Source, Predicate, remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  Source,
-                                  decltype((
-                                      static_cast<Sender&&>(s).source_))>&&
-                                  std::is_nothrow_constructible_v<
-                                      Predicate,
-                                      decltype((static_cast<Sender&&>(s)
-                                                    .predicate_))>&&
-                                      std::is_nothrow_constructible_v<
-                                          remove_cvref_t<Receiver>,
-                                          Receiver>&&
-                                          is_nothrow_connectable_v<
-                                              Source&,
-                                              receiver_t<
-                                                  Source,
-                                                  Predicate,
-                                                  remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<
+              Source,
+              decltype((static_cast<Sender&&>(s).source_))> &&
+          std::is_nothrow_constructible_v<
+              Predicate,
+              decltype((static_cast<Sender&&>(s).predicate_))> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          is_nothrow_connectable_v<
+              Source&,
+              receiver_t<Source, Predicate, remove_cvref_t<Receiver>>>)
           -> operation_type<Source, Predicate, remove_cvref_t<Receiver>> {
     return operation_type<Source, Predicate, remove_cvref_t<Receiver>>{
         static_cast<Sender&&>(s).source_,
         static_cast<Sender&&>(s).predicate_,
-        (Receiver &&) r};
+        (Receiver&&)r};
   }
 
   friend constexpr blocking_kind
@@ -275,7 +257,7 @@ inline const struct repeat_effect_until_cpo {
   auto operator()(Source&& source, Predicate&& predicate) const noexcept(
       is_nothrow_tag_invocable_v<repeat_effect_until_cpo, Source, Predicate>)
       -> tag_invoke_result_t<repeat_effect_until_cpo, Source, Predicate> {
-    return tag_invoke(*this, (Source &&) source, (Predicate &&) predicate);
+    return tag_invoke(*this, (Source&&)source, (Predicate&&)predicate);
   }
 
   template(typename Source, typename Predicate)  //
@@ -295,7 +277,7 @@ inline const struct repeat_effect_until_cpo {
               std::decay_t<Predicate>> {
     return repeat_effect_until_sender<
         remove_cvref_t<Source>,
-        std::decay_t<Predicate>>{(Source &&) source, (Predicate &&) predicate};
+        std::decay_t<Predicate>>{(Source&&)source, (Predicate&&)predicate};
   }
   template <typename Predicate>
   constexpr auto operator()(Predicate&& predicate) const
@@ -304,7 +286,7 @@ inline const struct repeat_effect_until_cpo {
                repeat_effect_until_cpo,
                Predicate>)
           -> bind_back_result_t<repeat_effect_until_cpo, Predicate> {
-    return bind_back(*this, (Predicate &&) predicate);
+    return bind_back(*this, (Predicate&&)predicate);
   }
 } repeat_effect_until{};
 
@@ -316,7 +298,7 @@ inline const struct repeat_effect_cpo {
   auto operator()(Source&& source) const
       noexcept(is_nothrow_tag_invocable_v<repeat_effect_cpo, Source>)
           -> tag_invoke_result_t<repeat_effect_cpo, Source> {
-    return tag_invoke(*this, (Source &&) source);
+    return tag_invoke(*this, (Source&&)source);
   }
 
   template(typename Source)  //
@@ -329,7 +311,7 @@ inline const struct repeat_effect_cpo {
                Source>)
           -> repeat_effect_until_sender<remove_cvref_t<Source>, forever> {
     return repeat_effect_until_sender<remove_cvref_t<Source>, forever>{
-        (Source &&) source, forever{}};
+        (Source&&)source, forever{}};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, repeat_effect_cpo>)

--- a/include/unifex/repeat_effect_until.hpp
+++ b/include/unifex/repeat_effect_until.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/manual_lifetime_union.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/retry_when.hpp
+++ b/include/unifex/retry_when.hpp
@@ -91,8 +91,7 @@ public:
         unifex::start(sourceOp);
       }
       UNIFEX_CATCH(...) {
-        unifex::set_error(
-            (Receiver &&) op->receiver_, std::current_exception());
+        unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
     }
   }
@@ -104,7 +103,7 @@ public:
 
     auto* const op = op_;
     destroy_trigger_op();
-    unifex::set_done((Receiver &&) op->receiver_);
+    unifex::set_done((Receiver&&)op->receiver_);
   }
 
   template(typename Error)                  //
@@ -118,7 +117,7 @@ public:
     // to be valid after we destroy the operation-state that sent it.
     destroy_trigger_op();
 
-    unifex::set_error((Receiver &&) op->receiver_, (Error &&) error);
+    unifex::set_error((Receiver&&)op->receiver_, (Error&&)error);
   }
 
 private:
@@ -171,7 +170,7 @@ public:
       void set_value(Values&&... values) noexcept(
           is_nothrow_receiver_of_v<Receiver, Values...>) {
     UNIFEX_ASSERT(op_ != nullptr);
-    unifex::set_value(std::move(op_->receiver_), (Values &&) values...);
+    unifex::set_value(std::move(op_->receiver_), (Values&&)values...);
   }
 
   void set_done() noexcept {
@@ -202,8 +201,7 @@ public:
       auto& triggerOp = unifex::activate_union_member_with<trigger_op_t>(
           op->triggerOps_, [&]() noexcept {
             return unifex::connect(
-                std::invoke(op->func_, (Error &&) error),
-                trigger_receiver_t{op});
+                std::invoke(op->func_, (Error&&)error), trigger_receiver_t{op});
           });
       unifex::start(triggerOp);
     } else {
@@ -211,14 +209,13 @@ public:
         auto& triggerOp = unifex::activate_union_member_with<trigger_op_t>(
             op->triggerOps_, [&]() {
               return unifex::connect(
-                  std::invoke(op->func_, (Error &&) error),
+                  std::invoke(op->func_, (Error&&)error),
                   trigger_receiver_t{op});
             });
         unifex::start(triggerOp);
       }
       UNIFEX_CATCH(...) {
-        unifex::set_error(
-            (Receiver &&) op->receiver_, std::current_exception());
+        unifex::set_error((Receiver&&)op->receiver_, std::current_exception());
       }
     }
   }
@@ -263,13 +260,13 @@ class _op<Source, Func, Receiver>::type {
 public:
   template <typename Source2, typename Func2, typename Receiver2>
   explicit type(Source2&& source, Func2&& func, Receiver2&& receiver) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>&&
-          std::is_nothrow_constructible_v<Func, Func2>&&
-              std::is_nothrow_constructible_v<Receiver, Receiver2>&&
-                  is_nothrow_connectable_v<Source&, source_receiver_t>)
-    : source_((Source2 &&) source)
-    , func_((Func2 &&) func)
-    , receiver_((Receiver &&) receiver) {
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      std::is_nothrow_constructible_v<Func, Func2> &&
+      std::is_nothrow_constructible_v<Receiver, Receiver2> &&
+      is_nothrow_connectable_v<Source&, source_receiver_t>)
+    : source_((Source2&&)source)
+    , func_((Func2&&)func)
+    , receiver_((Receiver&&)receiver) {
     unifex::activate_union_member_with(sourceOp_, [&] {
       return unifex::connect(source_, source_receiver_t{this});
     });
@@ -370,10 +367,10 @@ public:
 
   template <typename Source2, typename Func2>
   explicit type(Source2&& source, Func2&& func) noexcept(
-      std::is_nothrow_constructible_v<Source, Source2>&&
-          std::is_nothrow_constructible_v<Func, Func2>)
-    : source_((Source2 &&) source)
-    , func_((Func2 &&) func) {}
+      std::is_nothrow_constructible_v<Source, Source2> &&
+      std::is_nothrow_constructible_v<Func, Func2>)
+    : source_((Source2&&)source)
+    , func_((Func2&&)func) {}
 
   // TODO: The connect() methods are currently under-constrained.
   // Ideally they should also check that func() invoked with each of the errors
@@ -390,31 +387,18 @@ public:
                                Source,
                                Func,
                                remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<connect>,
-          Self&& self,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  Source,
-                                  member_t<Self, Source>>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Self, Func>>&&
-                                      std::is_nothrow_constructible_v<
-                                          remove_cvref_t<Receiver>,
-                                          Receiver>&&
-                                          is_nothrow_connectable_v<
-                                              Source&,
-                                              source_receiver<
-                                                  Source,
-                                                  Func,
-                                                  remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<connect>, Self&& self, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<Source, member_t<Self, Source>> &&
+          std::is_nothrow_constructible_v<Func, member_t<Self, Func>> &&
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          is_nothrow_connectable_v<
+              Source&,
+              source_receiver<Source, Func, remove_cvref_t<Receiver>>>)
           -> operation<Source, Func, Receiver> {
     return operation<Source, Func, Receiver>{
         static_cast<Self&&>(self).source_,
         static_cast<Self&&>(self).func_,
-        (Receiver &&) r};
+        (Receiver&&)r};
   }
 
 private:
@@ -439,7 +423,7 @@ public:
       operator()(Source&& source, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Source, Func>)
           -> _result_t<Source, Func> {
-    return unifex::tag_invoke(_fn{}, (Source &&) source, (Func &&) func);
+    return unifex::tag_invoke(_fn{}, (Source&&)source, (Func&&)func);
   }
   template(typename Source, typename Func)  //
       (requires(!tag_invocable<_fn, Source, Func>)
@@ -451,14 +435,13 @@ public:
                _retry_when::sender<Source, Func>,
                Source,
                Func>) -> _result_t<Source, Func> {
-    return _retry_when::sender<Source, Func>{
-        (Source &&) source, (Func &&) func};
+    return _retry_when::sender<Source, Func>{(Source&&)source, (Func&&)func};
   }
   template <typename Func>
   constexpr auto operator()(Func&& func) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func>)
           -> bind_back_result_t<_fn, Func> {
-    return bind_back(*this, (Func &&) func);
+    return bind_back(*this, (Func&&)func);
   }
 } retry_when{};
 }  // namespace _retry_when_cpo

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>
 #include <unifex/receiver_concepts.hpp>

--- a/include/unifex/sequence.hpp
+++ b/include/unifex/sequence.hpp
@@ -79,9 +79,7 @@ public:
     unifex::set_error(std::move(op_->receiver_), std::forward<E>(e));
   }
 
-  void set_done() noexcept {
-    unifex::set_done(std::move(op_->receiver_));
-  }
+  void set_done() noexcept { unifex::set_done(std::move(op_->receiver_)); }
 
 private:
   template(typename CPO, typename R)  //
@@ -299,16 +297,9 @@ struct _sndr<Predecessor, Successor>::type {
            constructible_from<
                Successor,
                Successor2>)  //
-      explicit type(
-          Predecessor2&& predecessor,
-          Successor2&&
-              successor) noexcept(std::
-                                      is_nothrow_constructible_v<
-                                          Predecessor,
-                                          Predecessor2>&&
-                                          std::is_nothrow_constructible_v<
-                                              Successor,
-                                              Successor2>)
+      explicit type(Predecessor2&& predecessor, Successor2&& successor) noexcept(
+          std::is_nothrow_constructible_v<Predecessor, Predecessor2> &&
+          std::is_nothrow_constructible_v<Successor, Successor2>)
     : predecessor_(static_cast<Predecessor&&>(predecessor))
     , successor_(static_cast<Successor&&>(successor)) {}
 
@@ -341,7 +332,7 @@ struct _sndr<Predecessor, Successor>::type {
     return operation<member_t<Sender, Predecessor>, Successor, Receiver>{
         static_cast<Sender&&>(sender).predecessor_,
         static_cast<Sender&&>(sender).successor_,
-        (Receiver &&) receiver};
+        (Receiver&&)receiver};
   }
 
 private:
@@ -409,7 +400,8 @@ struct _fn {
       auto
       operator()(First&& first, Second&& second, Third&& third, Rest&&... rest)
           const noexcept(
-              std::is_nothrow_invocable_v<_fn, First, Second>&& std::is_nothrow_invocable_v<
+              std::is_nothrow_invocable_v<_fn, First, Second> &&
+              std::is_nothrow_invocable_v<
                   _fn,
                   std::invoke_result_t<_fn, First, Second>,
                   Third,
@@ -420,8 +412,10 @@ struct _fn {
                   Third,
                   Rest...> {
     // Fall-back to pair-wise invocation of the sequence() CPO.
-    return (
-        *this)((*this)(static_cast<First&&>(first), static_cast<Second&&>(second)), static_cast<Third&&>(third), static_cast<Rest&&>(rest)...);
+    return (*this)(
+        (*this)(static_cast<First&&>(first), static_cast<Second&&>(second)),
+        static_cast<Third&&>(third),
+        static_cast<Rest&&>(rest)...);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/exception.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>

--- a/include/unifex/stop_immediately.hpp
+++ b/include/unifex/stop_immediately.hpp
@@ -118,7 +118,9 @@ private:
     // destroying before passing the values along to the next receiver.
     void set_value(Values... values) && noexcept {
       handle_signal([&](next_receiver_base* receiver) noexcept {
-        UNIFEX_TRY { std::move(*receiver).set_value((Values &&) values...); }
+        UNIFEX_TRY {
+          std::move(*receiver).set_value((Values&&)values...);
+        }
         UNIFEX_CATCH(...) {
           std::move(*receiver).set_error(std::current_exception());
         }
@@ -133,7 +135,7 @@ private:
 
     template <typename Error>
     void set_error(Error&& error) && noexcept {
-      std::move(*this).set_error(make_exception_ptr((Error &&) error));
+      std::move(*this).set_error(make_exception_ptr((Error&&)error));
     }
 
     void set_error(std::exception_ptr ex) && noexcept {
@@ -225,7 +227,7 @@ private:
 
           void set_value(Values&&... values) && noexcept final {
             op_.stopCallback_.destruct();
-            unifex::set_value(std::move(op_.receiver_), (Values &&) values...);
+            unifex::set_value(std::move(op_.receiver_), (Values&&)values...);
           }
 
           void set_done() && noexcept final {
@@ -252,7 +254,7 @@ private:
         explicit type(stream& strm, Receiver2&& receiver)
           : stream_(strm)
           , concreteReceiver_(*this)
-          , receiver_{(Receiver2 &&) receiver} {}
+          , receiver_{(Receiver2&&)receiver} {}
 
         void start() noexcept {
           auto stopToken = get_stop_token(receiver_);
@@ -297,7 +299,7 @@ private:
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
-      return operation<Receiver>{stream_, (Receiver &&) receiver};
+      return operation<Receiver>{stream_, (Receiver&&)receiver};
     }
     template <typename Receiver>
     void connect(Receiver&& receiver) const& = delete;
@@ -349,7 +351,7 @@ private:
               unifex::set_error(
                   std::move(op.receiver_), std::move(op.stream_.nextError_));
             } else {
-              unifex::set_error(std::move(op.receiver_), (Error &&) error);
+              unifex::set_error(std::move(op.receiver_), (Error&&)error);
             }
           }
         };
@@ -363,7 +365,7 @@ private:
         template <typename Receiver2>
         explicit type(stream& strm, Receiver2&& receiver)
           : stream_(strm)
-          , receiver_((Receiver2 &&) receiver) {}
+          , receiver_((Receiver2&&)receiver) {}
 
         void start() noexcept {
           auto oldState = stream_.state_.load(std::memory_order_acquire);
@@ -422,7 +424,7 @@ private:
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) && {
-      return operation<Receiver>{stream_, (Receiver &&) receiver};
+      return operation<Receiver>{stream_, (Receiver&&)receiver};
     }
     template <typename Receiver>
     void connect(Receiver&& receiver) const& = delete;
@@ -438,7 +440,7 @@ private:
 
 public:
   template <typename SourceStream2>
-  explicit type(SourceStream2&& source) : source_((SourceStream2 &&) source) {}
+  explicit type(SourceStream2&& source) : source_((SourceStream2&&)source) {}
 
   type(type&& other) : source_(std::move(other.source_)) {}
 
@@ -453,8 +455,8 @@ template <typename... Values>
 struct _fn {
   template <typename SourceStream>
   auto operator()(SourceStream&& source) const {
-    return _stop_immediately::stream<SourceStream, Values...>{(SourceStream &&)
-                                                                  source};
+    return _stop_immediately::stream<SourceStream, Values...>{
+        (SourceStream&&)source};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <unifex/any_scheduler.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/await_transform.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/connect_awaitable.hpp>

--- a/include/unifex/then.hpp
+++ b/include/unifex/then.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/then.hpp
+++ b/include/unifex/then.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>

--- a/include/unifex/then.hpp
+++ b/include/unifex/then.hpp
@@ -63,33 +63,31 @@ struct _receiver<Receiver, Func>::type {
   void set_value(Values&&... values) && noexcept {
     using result_type = std::invoke_result_t<Func, Values...>;
     if constexpr (std::is_void_v<result_type>) {
-      if constexpr (noexcept(
-                        std::invoke((Func &&) func_, (Values &&) values...))) {
-        std::invoke((Func &&) func_, (Values &&) values...);
-        unifex::set_value((Receiver &&) receiver_);
+      if constexpr (noexcept(std::invoke((Func&&)func_, (Values&&)values...))) {
+        std::invoke((Func&&)func_, (Values&&)values...);
+        unifex::set_value((Receiver&&)receiver_);
       } else {
         UNIFEX_TRY {
-          std::invoke((Func &&) func_, (Values &&) values...);
-          unifex::set_value((Receiver &&) receiver_);
+          std::invoke((Func&&)func_, (Values&&)values...);
+          unifex::set_value((Receiver&&)receiver_);
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     } else {
-      if constexpr (noexcept(
-                        std::invoke((Func &&) func_, (Values &&) values...))) {
+      if constexpr (noexcept(std::invoke((Func&&)func_, (Values&&)values...))) {
         unifex::set_value(
-            (Receiver &&) receiver_,
-            std::invoke((Func &&) func_, (Values &&) values...));
+            (Receiver&&)receiver_,
+            std::invoke((Func&&)func_, (Values&&)values...));
       } else {
         UNIFEX_TRY {
           unifex::set_value(
-              (Receiver &&) receiver_,
-              std::invoke((Func &&) func_, (Values &&) values...));
+              (Receiver&&)receiver_,
+              std::invoke((Func&&)func_, (Values&&)values...));
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     }
@@ -97,10 +95,10 @@ struct _receiver<Receiver, Func>::type {
 
   template <typename Error>
   void set_error(Error&& error) && noexcept {
-    unifex::set_error((Receiver &&) receiver_, (Error &&) error);
+    unifex::set_error((Receiver&&)receiver_, (Error&&)error);
   }
 
-  void set_done() && noexcept { unifex::set_done((Receiver &&) receiver_); }
+  void set_done() && noexcept { unifex::set_done((Receiver&&)receiver_); }
 
   template(typename CPO, typename R)                                //
       (requires is_receiver_query_cpo_v<CPO> AND same_as<R, type>)  //
@@ -171,20 +169,12 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Sender, Func>>&&
-                                      is_nothrow_connectable_v<
-                                          member_t<Sender, Predecessor>,
-                                          receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {
@@ -216,7 +206,7 @@ public:
       operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
           -> _result_t<Sender, Func> {
-    return unifex::tag_invoke(_fn{}, (Sender &&) predecessor, (Func &&) func);
+    return unifex::tag_invoke(_fn{}, (Sender&&)predecessor, (Func&&)func);
   }
   template(typename Sender, typename Func)           //
       (requires(!tag_invocable<_fn, Sender, Func>))  //
@@ -226,13 +216,13 @@ public:
                _then::sender<Sender, Func>,
                Sender,
                Func>) -> _result_t<Sender, Func> {
-    return _then::sender<Sender, Func>{(Sender &&) predecessor, (Func &&) func};
+    return _then::sender<Sender, Func>{(Sender&&)predecessor, (Func&&)func};
   }
   template <typename Func>
   constexpr auto operator()(Func&& func) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func>)
           -> bind_back_result_t<_fn, Func> {
-    return bind_back(*this, (Func &&) func);
+    return bind_back(*this, (Func&&)func);
   }
 };
 }  // namespace _cpo

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -58,7 +58,7 @@ struct _stream<Values...>::type final {
         tag_t<visit_continuations>,
         const next_receiver_base& receiver,
         Func&& func) {
-      visit_continuations(receiver.get_continuation_info(), (Func &&) func);
+      visit_continuations(receiver.get_continuation_info(), (Func&&)func);
     }
 #endif
 
@@ -83,7 +83,7 @@ struct _stream<Values...>::type final {
         tag_t<visit_continuations>,
         const cleanup_receiver_base& receiver,
         Func&& func) {
-      visit_continuations(receiver.get_continuation_info(), (Func &&) func);
+      visit_continuations(receiver.get_continuation_info(), (Func&&)func);
     }
 #endif
 
@@ -126,12 +126,12 @@ struct _stream<Values...>::type final {
       next_op_base* op_;
 
       explicit type(Receiver&& receiver, next_op_base* op)
-        : receiver_((Receiver &&) receiver)
+        : receiver_((Receiver&&)receiver)
         , op_(op) {}
 
       void set_value(Values&&... values) noexcept override {
         if (op_->complete()) {
-          unifex::set_value(std::move(receiver_), (Values &&) values...);
+          unifex::set_value(std::move(receiver_), (Values&&)values...);
         }
       }
 
@@ -165,7 +165,7 @@ struct _stream<Values...>::type final {
     struct type final : cleanup_receiver_base {
       UNIFEX_NO_UNIQUE_ADDRESS Receiver receiver_;
 
-      explicit type(Receiver&& receiver) : receiver_((Receiver &&) receiver) {}
+      explicit type(Receiver&& receiver) : receiver_((Receiver&&)receiver) {}
 
       void set_done() noexcept override {
         unifex::set_done(std::move(receiver_));
@@ -210,8 +210,8 @@ struct _stream<Values...>::type final {
             // the operation object.
             [&](Values... values) {
               unifex::deactivate_union_member(stream_.next_);
-              receiver_.set_value((Values &&) values...);
-            }((Values &&) values...);
+              receiver_.set_value((Values&&)values...);
+            }((Values&&)values...);
           }
           UNIFEX_CATCH(...) {
             unifex::deactivate_union_member(stream_.next_);
@@ -232,7 +232,7 @@ struct _stream<Values...>::type final {
         template <typename Error>
         void set_error(Error&& error) && noexcept {
           // Type-erase any errors that come through.
-          std::move(*this).set_error(make_exception_ptr((Error &&) error));
+          std::move(*this).set_error(make_exception_ptr((Error&&)error));
         }
 
         friend const inplace_stop_token& tag_invoke(
@@ -246,7 +246,7 @@ struct _stream<Values...>::type final {
             tag_t<visit_continuations>,
             const next_receiver_wrapper& receiver,
             Func&& func) {
-          visit_continuations(receiver.receiver_, (Func &&) func);
+          visit_continuations(receiver.receiver_, (Func&&)func);
         }
 #endif
 
@@ -283,7 +283,7 @@ struct _stream<Values...>::type final {
             tag_t<visit_continuations>,
             const cleanup_receiver_wrapper& receiver,
             Func&& func) {
-          visit_continuations(receiver.receiver_, (Func &&) func);
+          visit_continuations(receiver.receiver_, (Func&&)func);
         }
 #endif
 
@@ -295,7 +295,7 @@ struct _stream<Values...>::type final {
       };
 
       template <typename Stream2>
-      explicit type(Stream2&& strm) : stream_((Stream2 &&) strm) {}
+      explicit type(Stream2&& strm) : stream_((Stream2&&)strm) {}
 
       ~type() {}
 
@@ -316,7 +316,9 @@ struct _stream<Values...>::type final {
           });
           start(next_.get());
         }
-        UNIFEX_CATCH(...) { receiver.set_error(std::current_exception()); }
+        UNIFEX_CATCH(...) {
+          receiver.set_error(std::current_exception());
+        }
       }
 
       void start_cleanup(cleanup_receiver_base& receiver) noexcept override {
@@ -327,7 +329,9 @@ struct _stream<Values...>::type final {
           });
           start(cleanup_.get());
         }
-        UNIFEX_CATCH(...) { receiver.set_error(std::current_exception()); }
+        UNIFEX_CATCH(...) {
+          receiver.set_error(std::current_exception());
+        }
       }
     };
   };
@@ -369,7 +373,7 @@ struct _stream<Values...>::type final {
         explicit type(stream_base& strm, Receiver2&& receiver)
           : stream_(strm)
           , stopSource_()
-          , receiver_((Receiver2 &&) receiver, this)
+          , receiver_((Receiver2&&)receiver, this)
           , stopCallback_(
                 get_stop_token(receiver_.receiver_), cancel_callback{*this}) {}
 
@@ -399,7 +403,7 @@ struct _stream<Values...>::type final {
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) {
-      return operation<Receiver>{stream_, (Receiver &&) receiver};
+      return operation<Receiver>{stream_, (Receiver&&)receiver};
     }
   };
 
@@ -426,7 +430,7 @@ struct _stream<Values...>::type final {
 
         explicit type(stream_base& stream, Receiver&& receiver)
           : stream_(stream)
-          , receiver_((Receiver &&) receiver) {}
+          , receiver_((Receiver&&)receiver) {}
 
         void start() noexcept { stream_.start_cleanup(receiver_); }
       };
@@ -436,7 +440,7 @@ struct _stream<Values...>::type final {
 
     template <typename Receiver>
     operation<Receiver> connect(Receiver&& receiver) {
-      return operation<Receiver>{stream_, (Receiver &&) receiver};
+      return operation<Receiver>{stream_, (Receiver&&)receiver};
     }
   };
 
@@ -444,8 +448,8 @@ struct _stream<Values...>::type final {
 
   template <typename ConcreteStream>
   explicit type(ConcreteStream&& strm)
-    : stream_(std::make_unique<type::stream<ConcreteStream>>((ConcreteStream &&)
-                                                                 strm)) {}
+    : stream_(std::make_unique<type::stream<ConcreteStream>>(
+          (ConcreteStream&&)strm)) {}
 
   friend next_sender tag_invoke(tag_t<next>, type& s) noexcept {
     return next_sender{*s.stream_};
@@ -462,7 +466,7 @@ template <typename... Ts>
 struct _fn final {
   template <typename Stream>
   _type_erase::stream<Ts...> operator()(Stream&& strm) const {
-    return _type_erase::stream<Ts...>{(Stream &&) strm};
+    return _type_erase::stream<Ts...>{(Stream&&)strm};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)

--- a/include/unifex/type_erased_stream.hpp
+++ b/include/unifex/type_erased_stream.hpp
@@ -17,8 +17,8 @@
 
 #include <unifex/config.hpp>
 #include <unifex/any_scheduler.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/exception.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -48,41 +48,39 @@ struct _receiver<Receiver, Func>::type {
           Receiver,
           Values...>)  //
       void set_value(Values&&... values) && {
-    unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
+    unifex::set_value((Receiver&&)(receiver_), (Values&&)(values)...);
   }
 
   template(typename Error)                  //
       (requires receiver<Receiver, Error>)  //
       void set_error(Error&& error) && noexcept {
-    unifex::set_error((Receiver &&)(receiver_), (Error &&)(error));
+    unifex::set_error((Receiver&&)(receiver_), (Error&&)(error));
   }
 
   void set_done() && noexcept {
     using result_t = std::invoke_result_t<Func>;
     if constexpr (std::is_void_v<result_t>) {
-      if constexpr (noexcept(std::invoke((Func &&) func_))) {
-        std::invoke((Func &&) func_);
-        unifex::set_value((Receiver &&) receiver_);
+      if constexpr (noexcept(std::invoke((Func&&)func_))) {
+        std::invoke((Func&&)func_);
+        unifex::set_value((Receiver&&)receiver_);
       } else {
         UNIFEX_TRY {
-          std::invoke((Func &&) func_);
-          unifex::set_value((Receiver &&) receiver_);
+          std::invoke((Func&&)func_);
+          unifex::set_value((Receiver&&)receiver_);
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     } else {
-      if constexpr (noexcept(std::invoke((Func &&) func_))) {
-        unifex::set_value(
-            (Receiver &&) receiver_, std::invoke((Func &&) func_));
+      if constexpr (noexcept(std::invoke((Func&&)func_))) {
+        unifex::set_value((Receiver&&)receiver_, std::invoke((Func&&)func_));
       } else {
         UNIFEX_TRY {
-          unifex::set_value(
-              (Receiver &&) receiver_, std::invoke((Func &&) func_));
+          unifex::set_value((Receiver&&)receiver_, std::invoke((Func&&)func_));
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     }
@@ -185,20 +183,12 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Sender, Func>>&&
-                                      is_nothrow_connectable_v<
-                                          member_t<Sender, Predecessor>,
-                                          receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {
@@ -219,17 +209,19 @@ private:
       meta_quote2<_upon_done::sender>>::template apply<Sender, Func>;
 
 public:
-  template(typename Sender, typename Func)                             //
-      (requires std::is_invocable_v<Func> AND tag_invocable<_fn, Sender, Func>)  //
+  template(typename Sender, typename Func)  //
+      (requires std::is_invocable_v<Func> AND
+           tag_invocable<_fn, Sender, Func>)  //
       auto
       operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
           -> _result_t<Sender, Func> {
-    return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
+    return unifex::tag_invoke(_fn{}, (Sender&&)(predecessor), (Func&&)(func));
   }
 
-  template(typename Sender, typename Func)                               //
-      (requires(!tag_invocable<_fn, Sender, Func>) AND std::is_invocable_v<Func>)  //
+  template(typename Sender, typename Func)  //
+      (requires(!tag_invocable<_fn, Sender, Func>)
+           AND std::is_invocable_v<Func>)  //
       auto
       operator()(Sender&& predecessor, Func&& func) const
       noexcept(std::is_nothrow_constructible_v<
@@ -237,15 +229,15 @@ public:
                Sender,
                Func>) -> _result_t<Sender, Func> {
     return _upon_done::sender<Sender, Func>{
-        (Sender &&)(predecessor), (Func &&)(func)};
+        (Sender&&)(predecessor), (Func&&)(func)};
   }
-  template(typename Func)         //
+  template(typename Func)                   //
       (requires std::is_invocable_v<Func>)  //
       constexpr auto
       operator()(Func&& func) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func>)
           -> bind_back_result_t<_fn, Func> {
-    return bind_back(*this, (Func &&)(func));
+    return bind_back(*this, (Func&&)(func));
   }
 };
 }  // namespace _cpo

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <unifex/config.hpp>
-#include <unifex/async_trace.hpp>
 #include <unifex/bind_back.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -48,7 +48,7 @@ struct _receiver<Receiver, Func>::type {
           Receiver,
           Values...>)  //
       void set_value(Values&&... values) && {
-    unifex::set_value((Receiver &&)(receiver_), (Values &&)(values)...);
+    unifex::set_value((Receiver&&)(receiver_), (Values&&)(values)...);
   }
 
   template(typename Error)                  //
@@ -56,37 +56,36 @@ struct _receiver<Receiver, Func>::type {
       void set_error(Error&& error) && noexcept {
     using result_t = std::invoke_result_t<Func, Error>;
     if constexpr (std::is_void_v<result_t>) {
-      if constexpr (noexcept(std::invoke((Func &&) func_, (Error &&) error))) {
-        std::invoke((Func &&) func_, (Error &&) error);
-        unifex::set_value((Receiver &&) receiver_);
+      if constexpr (noexcept(std::invoke((Func&&)func_, (Error&&)error))) {
+        std::invoke((Func&&)func_, (Error&&)error);
+        unifex::set_value((Receiver&&)receiver_);
       } else {
         UNIFEX_TRY {
-          std::invoke((Func &&) func_, (Error &&) error);
-          unifex::set_value((Receiver &&) receiver_);
+          std::invoke((Func&&)func_, (Error&&)error);
+          unifex::set_value((Receiver&&)receiver_);
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     } else {
-      if constexpr (noexcept(std::invoke((Func &&) func_, (Error &&) error))) {
+      if constexpr (noexcept(std::invoke((Func&&)func_, (Error&&)error))) {
         unifex::set_value(
-            (Receiver &&) receiver_,
-            std::invoke((Func &&) func_, (Error &&) error));
+            (Receiver&&)receiver_, std::invoke((Func&&)func_, (Error&&)error));
       } else {
         UNIFEX_TRY {
           unifex::set_value(
-              (Receiver &&) receiver_,
-              std::invoke((Func &&) func_, (Error &&) error));
+              (Receiver&&)receiver_,
+              std::invoke((Func&&)func_, (Error&&)error));
         }
         UNIFEX_CATCH(...) {
-          unifex::set_error((Receiver &&) receiver_, std::current_exception());
+          unifex::set_error((Receiver&&)receiver_, std::current_exception());
         }
       }
     }
   }
 
-  void set_done() && noexcept { unifex::set_done((Receiver &&)(receiver_)); }
+  void set_done() && noexcept { unifex::set_done((Receiver&&)(receiver_)); }
 
   template(typename CPO)                       //
       (requires is_receiver_query_cpo_v<CPO>)  //
@@ -164,20 +163,12 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Sender, Func>>&&
-                                      is_nothrow_connectable_v<
-                                          member_t<Sender, Predecessor>,
-                                          receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {
@@ -204,7 +195,7 @@ public:
       operator()(Sender&& predecessor, Func&& func) const
       noexcept(is_nothrow_tag_invocable_v<_fn, Sender, Func>)
           -> _result_t<Sender, Func> {
-    return unifex::tag_invoke(_fn{}, (Sender &&)(predecessor), (Func &&)(func));
+    return unifex::tag_invoke(_fn{}, (Sender&&)(predecessor), (Func&&)(func));
   }
 
   template(typename Sender, typename Func)           //
@@ -216,14 +207,14 @@ public:
                Sender,
                Func>) -> _result_t<Sender, Func> {
     return _upon_error::sender<Sender, Func>{
-        (Sender &&)(predecessor), (Func &&)(func)};
+        (Sender&&)(predecessor), (Func&&)(func)};
   }
 
   template <typename Func>
   constexpr auto operator()(Func&& func) const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn, Func>)
           -> bind_back_result_t<_fn, Func> {
-    return bind_back(*this, (Func &&)(func));
+    return bind_back(*this, (Func&&)(func));
   }
 };
 }  // namespace _cpo

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -74,8 +74,8 @@ struct _operation_tuple<Index, Receiver, First, Rest...>::type
   : operation_tuple<Index + 1, Receiver, Rest...> {
   template <typename Parent>
   explicit type(Parent& parent, First&& first, Rest&&... rest)
-    : operation_tuple<Index + 1, Receiver, Rest...>{parent, (Rest &&) rest...}
-    , op_(connect((First &&) first, Receiver<Index>{parent})) {}
+    : operation_tuple<Index + 1, Receiver, Rest...>{parent, (Rest&&)rest...}
+    , op_(connect((First&&)first, Receiver<Index>{parent})) {}
 
   void start() noexcept {
     unifex::start(op_);
@@ -149,17 +149,19 @@ struct _element_receiver<Index, Receiver, Senders...>::type final {
       std::get<Index>(op_.values_)
           .emplace(
               std::in_place_type<std::tuple<std::decay_t<Values>...>>,
-              (Values &&) values...);
+              (Values&&)values...);
       op_.element_complete();
     }
-    UNIFEX_CATCH(...) { this->set_error(std::current_exception()); }
+    UNIFEX_CATCH(...) {
+      this->set_error(std::current_exception());
+    }
   }
 
   template <typename Error>
   void set_error(Error&& error) noexcept {
     if (!op_.doneOrError_.exchange(true, std::memory_order_relaxed)) {
       op_.error_.emplace(
-          std::in_place_type<std::decay_t<Error>>, (Error &&) error);
+          std::in_place_type<std::decay_t<Error>>, (Error&&)error);
       op_.stopSource_.request_stop();
     }
     op_.element_complete();
@@ -210,8 +212,8 @@ struct _op<Receiver, Senders...>::type {
 
   template <typename Receiver2, typename... Senders2>
   explicit type(Receiver2&& receiver, Senders2&&... senders)
-    : receiver_((Receiver2 &&) receiver)
-    , ops_(*this, (Senders2 &&) senders...) {}
+    : receiver_((Receiver2&&)receiver)
+    , ops_(*this, (Senders2&&)senders...) {}
 
   void start() noexcept {
     stopCallback_.construct(
@@ -344,7 +346,7 @@ public:
       (sender_traits<Senders>::is_always_scheduler_affine && ...);
 
   template <typename... Senders2>
-  explicit type(Senders2&&... senders) : senders_((Senders2 &&) senders...) {}
+  explicit type(Senders2&&... senders) : senders_((Senders2&&)senders...) {}
 
   template(typename CPO, typename Sender, typename Receiver)  //
       (requires same_as<CPO, tag_t<unifex::connect>> AND
@@ -359,8 +361,7 @@ public:
     return std::apply(
         [&](auto&&... senders) {
           return operation<Receiver, member_t<Sender, Senders>...>{
-              (Receiver &&) receiver,
-              static_cast<decltype(senders)>(senders)...};
+              (Receiver&&)receiver, static_cast<decltype(senders)>(senders)...};
         },
         static_cast<Sender&&>(sender).senders_);
   }
@@ -390,14 +391,14 @@ struct _fn {
       auto
       operator()(Senders&&... senders) const
       -> tag_invoke_result_t<_fn, Senders...> {
-    return tag_invoke(*this, (Senders &&) senders...);
+    return tag_invoke(*this, (Senders&&)senders...);
   }
   template(typename... Senders)  //
       (requires(unifex::sender<Senders>&&...)
            AND(!tag_invocable<_fn, Senders...>))  //
       auto
       operator()(Senders&&... senders) const -> _when_all::sender<Senders...> {
-    return _when_all::sender<Senders...>{(Senders &&) senders...};
+    return _when_all::sender<Senders...>{(Senders&&)senders...};
   }
 };
 }  // namespace _cpo

--- a/include/unifex/when_all.hpp
+++ b/include/unifex/when_all.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <unifex/async_trace.hpp>
 #include <unifex/blocking.hpp>
+#include <unifex/continuations.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/inplace_stop_token.hpp>
 #include <unifex/manual_lifetime.hpp>


### PR DESCRIPTION
As discovered in compiler-explorer/compiler-explorer#6711, GCC 15 doesn't like compiling `unifex/async_trace.hpp` as C++17 *however*, there's almost no need to include `unifex/async_trace.hpp` anywhere because it's only included to get `unifex/continuations.hpp` as a side effect. This change just includes the actual dependency directly.