### PR TITLE
Give spawn_detached's receiver an async stack frame

### DIFF
--- a/include/unifex/spawn_detached.hpp
+++ b/include/unifex/spawn_detached.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/v1/async_scope.hpp
+++ b/include/unifex/v1/async_scope.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/unifex/v1/async_scope.hpp
+++ b/include/unifex/v1/async_scope.hpp
@@ -189,17 +189,9 @@ struct _attach_op<Sender, Receiver>::type final
   using op_t = connect_result_t<Sender, receiver_t>;
 
   template <typename Sender2, typename Receiver2>
-  explicit type(
-      inplace_stop_token stoken,
-      Sender2&& sender,
-      Receiver2&& receiver) noexcept(std::
-                                         is_nothrow_constructible_v<
-                                             base_t,
-                                             inplace_stop_token&,
-                                             Receiver2>&&
-                                             is_nothrow_connectable_v<
-                                                 Sender2,
-                                                 receiver_t>)
+  explicit type(inplace_stop_token stoken, Sender2&& sender, Receiver2&& receiver) noexcept(
+      std::is_nothrow_constructible_v<base_t, inplace_stop_token&, Receiver2> &&
+      is_nothrow_connectable_v<Sender2, receiver_t>)
     : base_t{stoken, static_cast<Receiver2&&>(receiver)}
     , op_(connect(static_cast<Sender2&&>(sender), receiver_t{this})) {}
 
@@ -306,17 +298,17 @@ struct async_scope {
   template(typename Sender, typename Scheduler)  //
       (requires scheduler<Scheduler>)            //
       auto spawn_on(Scheduler&& scheduler, Sender&& sender)
-          -> decltype(spawn(on((Scheduler &&) scheduler, (Sender &&) sender))) {
-    return spawn(on((Scheduler &&) scheduler, (Sender &&) sender));
+          -> decltype(spawn(on((Scheduler&&)scheduler, (Sender&&)sender))) {
+    return spawn(on((Scheduler&&)scheduler, (Sender&&)sender));
   }
 
   /**
    * Equivalent to spawn_on((Scheduler&&)scheduler, just_from((Fun&&)fun)).
    */
-  template(typename Scheduler, typename Fun)             //
+  template(typename Scheduler, typename Fun)                        //
       (requires scheduler<Scheduler> AND std::is_invocable_v<Fun>)  //
       auto spawn_call_on(Scheduler&& scheduler, Fun&& fun) {
-    return spawn_on((Scheduler &&) scheduler, just_from((Fun &&) fun));
+    return spawn_on((Scheduler&&)scheduler, just_from((Fun&&)fun));
   }
 
   /**
@@ -326,7 +318,7 @@ struct async_scope {
    * error.
    */
   template <typename Sender>
-  auto detached_spawn(Sender&& sender)
+  UNIFEX_ALWAYS_INLINE auto detached_spawn(Sender&& sender)
       -> decltype(spawn_detached(static_cast<Sender&&>(sender), *this)) {
     spawn_detached(static_cast<Sender&&>(sender), *this);
   }
@@ -337,24 +329,26 @@ struct async_scope {
    */
   template(typename Sender, typename Scheduler)  //
       (requires scheduler<Scheduler>)            //
+      UNIFEX_ALWAYS_INLINE
       auto detached_spawn_on(Scheduler&& scheduler, Sender&& sender)
           -> decltype(detached_spawn(
-              on((Scheduler &&) scheduler, (Sender &&) sender))) {
-    detached_spawn(on((Scheduler &&) scheduler, (Sender &&) sender));
+              on((Scheduler&&)scheduler, (Sender&&)sender))) {
+    detached_spawn(on((Scheduler&&)scheduler, (Sender&&)sender));
   }
 
   /**
    * Equivalent to detached_spawn_on((Scheduler&&)scheduler,
    * just_from((Fun&&)fun)).
    */
-  template(typename Scheduler, typename Fun)             //
+  template(typename Scheduler, typename Fun)                        //
       (requires scheduler<Scheduler> AND std::is_invocable_v<Fun>)  //
+      UNIFEX_ALWAYS_INLINE
       void detached_spawn_call_on(Scheduler&& scheduler, Fun&& fun) {
     static_assert(
         std::is_nothrow_invocable_v<Fun>,
         "Please annotate your invocable with noexcept.");
 
-    detached_spawn_on((Scheduler &&) scheduler, just_from((Fun &&) fun));
+    detached_spawn_on((Scheduler&&)scheduler, just_from((Fun&&)fun));
   }
 
   /**
@@ -377,11 +371,11 @@ struct async_scope {
   /**
    * Equivalent to attach(just_from((Fun&&)fun)).
    */
-  template(typename Fun)        //
+  template(typename Fun)                   //
       (requires std::is_invocable_v<Fun>)  //
       [[nodiscard]] auto attach_call(Fun&& fun) noexcept(
-          noexcept(attach(just_from((Fun &&) fun)))) {
-    return attach(just_from((Fun &&) fun));
+          noexcept(attach(just_from((Fun&&)fun)))) {
+    return attach(just_from((Fun&&)fun));
   }
 
   /**
@@ -390,19 +384,18 @@ struct async_scope {
   template(typename Sender, typename Scheduler)           //
       (requires scheduler<Scheduler> AND sender<Sender>)  //
       [[nodiscard]] auto attach_on(Scheduler&& scheduler, Sender&& sender) noexcept(
-          noexcept(attach(on((Scheduler &&) scheduler, (Sender &&) sender)))) {
-    return attach(on((Scheduler &&) scheduler, (Sender &&) sender));
+          noexcept(attach(on((Scheduler&&)scheduler, (Sender&&)sender)))) {
+    return attach(on((Scheduler&&)scheduler, (Sender&&)sender));
   }
 
   /**
    * Equivalent to attach_on((Scheduler&&)scheduler, just_from((Fun&&)fun)).
    */
-  template(typename Scheduler, typename Fun)             //
+  template(typename Scheduler, typename Fun)                        //
       (requires scheduler<Scheduler> AND std::is_invocable_v<Fun>)  //
       [[nodiscard]] auto attach_call_on(Scheduler&& scheduler, Fun&& fun) noexcept(
-          noexcept(
-              attach_on((Scheduler &&) scheduler, just_from((Fun &&) fun)))) {
-    return attach_on((Scheduler &&) scheduler, just_from((Fun &&) fun));
+          noexcept(attach_on((Scheduler&&)scheduler, just_from((Fun&&)fun)))) {
+    return attach_on((Scheduler&&)scheduler, just_from((Fun&&)fun));
   }
 
   /**

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -221,9 +221,11 @@ struct read_async_stack_frame {
     return {std::forward<Receiver>(receiver)};
   }
 
-  friend unifex::instruction_ptr tag_invoke(
-      unifex::tag_t<unifex::get_return_address>,
-      const read_async_stack_frame& self) noexcept {
+  UNIFEX_TEMPLATE(typename Self)                            //
+  (requires unifex::same_as<Self, read_async_stack_frame>)  //
+      friend unifex::instruction_ptr tag_invoke(
+          unifex::tag_t<unifex::get_return_address>,
+          const Self& self) noexcept {
     return self.returnAddress;
   }
 

--- a/test/spawn_detached_test.cpp
+++ b/test/spawn_detached_test.cpp
@@ -187,4 +187,93 @@ TEST(
 }
 #endif
 
+struct read_async_stack_frame {
+  template <
+      template <typename...>
+      typename Variant,
+      template <typename...>
+      typename Tuple>
+  using value_types = Variant<Tuple<unifex::AsyncStackFrame*>>;
+
+  template <template <typename...> typename Variant>
+  using error_types = Variant<>;
+
+  static constexpr bool sends_done = false;
+
+  static constexpr unifex::blocking_kind blocking =
+      unifex::blocking_kind::always_inline;
+
+  template <typename Receiver>
+  struct op {
+    Receiver receiver;
+
+    void start() & noexcept {
+      auto frame = unifex::get_async_stack_frame(receiver);
+      unifex::set_value(std::move(receiver), frame);
+    }
+  };
+
+  template <typename Receiver>
+  using op_t = op<unifex::remove_cvref_t<Receiver>>;
+
+  template <typename Receiver>
+  op_t<Receiver> connect(Receiver&& receiver) const noexcept {
+    return {std::forward<Receiver>(receiver)};
+  }
+
+  friend unifex::instruction_ptr tag_invoke(
+      unifex::tag_t<unifex::get_return_address>,
+      const read_async_stack_frame& self) noexcept {
+    return self.returnAddress;
+  }
+
+  unifex::instruction_ptr returnAddress;
+};
+
+TEST(spawn_detached_test, capstone_receiver_has_expected_async_stack_depth) {
+  identity_scope scope;
+
+  // this is a meaningless but unique address that we can check for in our test
+  auto returnAddress = unifex::instruction_ptr::read_return_address();
+
+  unifex::spawn_detached(
+      unifex::then(
+          read_async_stack_frame{returnAddress},
+          [&](auto* frame) noexcept {
+            if constexpr (!UNIFEX_NO_ASYNC_STACKS) {
+              // the expected structure of this operation is:
+              // op = connect(then-sender, capstone-receiver)
+              //   child = connect(read-sender, then-receiver)
+              //
+              // There's no nest-sender because we're using an identity_scope,
+              // which implements nest() by returning its argument.
+              //
+              // Each connect() wraps the resulting operation in a stack
+              // frame-injecting operation state/receiver pair so we expect the
+              // read-sender to get a non-null frame from its wrapper-receiver;
+              // the parent of that frame should come from the then-sender's
+              // wrapper-receiver; the parent of that frame should come from the
+              // spawn_detached capstone receiver.
+
+              // the read-sender's frame
+              ASSERT_NE(frame, nullptr);
+              EXPECT_EQ(frame->getReturnAddress(), returnAddress);
+
+              // the then-sender's frame
+              ASSERT_NE(frame->getParentFrame(), nullptr);
+
+              // the capstone receiver's frame
+              ASSERT_NE(frame->getParentFrame()->getParentFrame(), nullptr);
+
+              // there should be no further frames
+              EXPECT_EQ(
+                  frame->getParentFrame()->getParentFrame()->getParentFrame(),
+                  nullptr);
+            } else {
+              EXPECT_EQ(frame, nullptr);
+            }
+          }),
+      scope);
+}
+
 }  // namespace


### PR DESCRIPTION
This change adds an `AsyncStackFrame` (when support is enabled) to the capstone receiver connected to any sender passed to `unifex::spawn_detached()`. Forcing `unifex::v1::async_scope`'s `detached_spawn*` methods to be always-inline means that capturing the return address of `unifex:spawn_detached()` captures the call site of the v1 scope's methods.