### PR TITLE
Add async stack support to coroutines

### DIFF
--- a/include/unifex/await_transform.hpp
+++ b/include/unifex/await_transform.hpp
@@ -68,18 +68,18 @@ private:
 namespace _await_tfx {
 using namespace _util;
 
-template <typename Promise, typename Value>
+template <typename Promise, typename Value, bool WithAsyncStackSupport>
 struct _awaitable_base {
   struct type;
 };
 
-template <typename Promise, typename Sender>
+template <typename Promise, typename Sender, bool WithAsyncStackSupport>
 struct _awaitable {
   struct type;
 };
 
-template <typename Promise, typename Value>
-struct _awaitable_base<Promise, Value>::type {
+template <typename Promise, typename Value, bool WithAsyncStackSupport>
+struct _awaitable_base<Promise, Value, WithAsyncStackSupport>::type {
   struct _rec {
   public:
     explicit _rec(
@@ -92,6 +92,19 @@ struct _awaitable_base<Promise, Value>::type {
       : result_(std::exchange(r.result_, nullptr))
       , continuation_(std::move(r.continuation_)) {}
 
+    void complete() noexcept {
+      if constexpr (WithAsyncStackSupport) {
+        if (auto* frame = get_async_stack_frame(continuation_.promise())) {
+          detail::ScopedAsyncStackRoot root;
+          root.activateFrame(*frame);
+          return continuation_.resume();
+        }
+      }
+
+      // run this when stacks are disabled and when the parent hasn't got one
+      continuation_.resume();
+    }
+
     template(class... Us)  //
         (requires(
             constructible_from<Value, Us...> ||
@@ -101,13 +114,13 @@ struct _awaitable_base<Promise, Value>::type {
             std::is_void_v<Value>) {
       unifex::activate_union_member(result_->value_, (Us&&)us...);
       result_->state_ = _state::value;
-      continuation_.resume();
+      complete();
     }
 
     void set_error(std::exception_ptr eptr) && noexcept {
       unifex::activate_union_member(result_->exception_, std::move(eptr));
       result_->state_ = _state::exception;
-      continuation_.resume();
+      complete();
     }
 
     void set_error(std::error_code code) && noexcept {
@@ -117,6 +130,23 @@ struct _awaitable_base<Promise, Value>::type {
 
     void set_done() && noexcept {
       result_->state_ = _state::done;
+
+      if constexpr (WithAsyncStackSupport) {
+        if (auto* parentFrame =
+                get_async_stack_frame(continuation_.promise())) {
+          // we need a dummy frame for the waiting coroutine's unhandled_done()
+          // to pop for us
+          AsyncStackFrame frame;
+          frame.setParentFrame(*parentFrame);
+
+          detail::ScopedAsyncStackRoot root;
+          root.activateFrame(frame);
+
+          return continuation_.resume_done();
+        }
+      }
+
+      // run this when stacks are disabled and when the parent hasn't got one
       continuation_.resume_done();
     }
 
@@ -158,18 +188,21 @@ protected:
   _expected<Value> result_;
 };
 
-template <typename Promise, typename Sender>
+template <typename Promise, typename Sender, bool WithAsyncStackSupport>
 using _awaitable_base_t = typename _awaitable_base<
     Promise,
-    sender_single_value_return_type_t<remove_cvref_t<Sender>>>::type;
+    sender_single_value_return_type_t<remove_cvref_t<Sender>>,
+    WithAsyncStackSupport>::type;
 
-template <typename Promise, typename Sender>
-using _receiver_t = typename _awaitable_base_t<Promise, Sender>::_rec;
+template <typename Promise, typename Sender, bool WithAsyncStackSupport>
+using _receiver_t =
+    typename _awaitable_base_t<Promise, Sender, WithAsyncStackSupport>::_rec;
 
-template <typename Promise, typename Sender>
-struct _awaitable<Promise, Sender>::type : _awaitable_base_t<Promise, Sender> {
+template <typename Promise, typename Sender, bool WithAsyncStackSupport>
+struct _awaitable<Promise, Sender, WithAsyncStackSupport>::type
+  : _awaitable_base_t<Promise, Sender, WithAsyncStackSupport> {
 private:
-  using _rec = _receiver_t<Promise, Sender>;
+  using _rec = _receiver_t<Promise, Sender, WithAsyncStackSupport>;
   connect_result_t<Sender, _rec> op_;
 
 public:
@@ -177,13 +210,288 @@ public:
       is_nothrow_connectable_v<Sender, _rec>)
     : op_(unifex::connect((Sender&&)sender, _rec{&this->result_, h})) {}
 
-  void await_suspend(coro::coroutine_handle<Promise>) noexcept {
+  void await_suspend(coro::coroutine_handle<Promise> handle) noexcept {
+    if constexpr (WithAsyncStackSupport) {
+      auto* frame = get_async_stack_frame(handle.promise());
+      if (frame) {
+        deactivateAsyncStackFrame((*frame));
+      }
+    }
     unifex::start(op_);
   }
 };
 
-template <typename Promise, typename Sender>
-using _as_awaitable = typename _awaitable<Promise, Sender>::type;
+template <typename Promise, typename Sender, bool WithAsyncStackSupport>
+using _as_awaitable =
+    typename _awaitable<Promise, Sender, WithAsyncStackSupport>::type;
+
+template <typename T, typename = void>
+struct is_resumer_promise : std::false_type {};
+
+template <typename T>
+struct is_resumer_promise<T, typename T::resumer_promise_t> : std::true_type {};
+
+template <typename T>
+constexpr bool is_resumer_promise_v = is_resumer_promise<T>::value;
+
+template <typename Promise>
+struct _coro_resumer final {
+  struct type;
+};
+
+template <typename Promise>
+struct _coro_resumer<Promise>::type final {
+  struct promise_type {
+    using resumer_promise_t = void;
+
+    static_assert(!is_resumer_promise_v<Promise>);
+
+    promise_type(coro::coroutine_handle<Promise>& h) noexcept : handle_(h) {}
+
+    type get_return_object() noexcept {
+      return type{coro::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+
+    coro::suspend_always initial_suspend() noexcept { return {}; }
+
+    [[noreturn]] coro::suspend_always final_suspend() noexcept {
+      std::terminate();
+    }
+
+    // TODO: unhandled_done()?
+
+    [[noreturn]] void return_void() noexcept { std::terminate(); }
+
+    [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
+
+    struct awaiter {
+      coro::coroutine_handle<Promise> h;
+
+      bool await_ready() noexcept { return false; }
+
+      void await_suspend(coro::coroutine_handle<>) noexcept {
+        auto* frame = get_async_stack_frame(h.promise());
+        if (frame) {
+          detail::ScopedAsyncStackRoot root;
+          root.activateFrame(*frame);
+
+          h.resume();
+
+          root.ensureFrameDeactivated(frame);
+        } else {
+          h.resume();
+        }
+      }
+
+      [[noreturn]] void await_resume() noexcept { std::terminate(); }
+    };
+
+    awaiter await_transform(coro::coroutine_handle<Promise> h) noexcept {
+      return awaiter{h};
+    }
+
+    template(typename CPO)                       //
+        (requires is_receiver_query_cpo_v<CPO>)  //
+        friend auto tag_invoke(CPO cpo, const promise_type& self) noexcept(
+            is_nothrow_tag_invocable_v<CPO, const Promise&>)
+            -> tag_invoke_result_t<CPO, const Promise&> {
+      return tag_invoke(std::move(cpo), std::as_const(self.handle_.promise()));
+    }
+
+    continuation_handle<Promise> handle_;
+  };
+
+  type() noexcept = default;
+
+  type(type&& other) noexcept : h_(std::exchange(other.h_, {})) {}
+
+  ~type() {
+    if (h_) {
+      h_.destroy();
+    }
+  }
+
+  type& operator=(type rhs) noexcept {
+    std::swap(h_, rhs.h_);
+    return *this;
+  }
+
+  coro::coroutine_handle<promise_type> handle() && noexcept {
+    return std::exchange(h_, {});
+  }
+
+private:
+  explicit type(coro::coroutine_handle<promise_type> h) noexcept : h_(h) {}
+
+  coro::coroutine_handle<promise_type> h_;
+};
+
+template <typename Promise>
+using coro_resumer = typename _coro_resumer<Promise>::type;
+
+template <typename Promise>
+coro_resumer<Promise>
+resume_with_stack_root(coro::coroutine_handle<Promise> h) {
+  co_await h;
+}
+
+template <typename Awaitable>
+struct _awaitable_wrapper final {
+  class type;
+};
+
+template <typename Awaitable>
+class _awaitable_wrapper<Awaitable>::type final {
+  using awaiter_t = awaiter_type_t<Awaitable>;
+
+  Awaitable&& awaitable_;
+  awaiter_t awaiter_;
+  coro::coroutine_handle<> coro_;
+
+public:
+  using awaitable_wrapper_t = void;
+
+  explicit type(Awaitable&& awaitable)
+    : awaitable_(std::forward<Awaitable>(awaitable))
+    , awaiter_(get_awaiter(std::forward<Awaitable>(awaitable))) {}
+
+  type(type&& other) noexcept(std::is_nothrow_move_constructible_v<awaiter_t>)
+    : awaitable_(std::move(other.awaitable_))
+    , awaiter_(std::move(other.awaiter_))
+    , coro_(std::exchange(other.coro_, {})) {
+    // we should only be move-constructed before being awaited
+    UNIFEX_ASSERT(!coro_);
+  }
+
+  ~type() {
+    if (coro_) {
+      coro_.destroy();
+    }
+  }
+
+  bool await_ready() noexcept(noexcept(awaiter_.await_ready())) {
+    return awaiter_.await_ready();
+  }
+
+  template <typename Promise>
+  using resume_coro_handle_t =
+      coro::coroutine_handle<typename coro_resumer<Promise>::promise_type>;
+
+  template <typename Promise>
+  using _suspend_result_t = decltype(awaiter_.await_suspend(
+      resume_coro_handle_t<Promise>::from_address(nullptr)));
+
+  template <typename Promise>
+  using suspend_result_t = std::conditional_t<
+      convertible_to<_suspend_result_t<Promise>, coro::coroutine_handle<>>,
+      coro::coroutine_handle<>,
+      _suspend_result_t<Promise>>;
+
+  template(typename Promise)                               //
+      (requires same_as<bool, suspend_result_t<Promise>>)  //
+      bool await_suspend_impl(
+          coro::coroutine_handle<Promise> h, AsyncStackFrame* frame) {
+    auto* root = frame->getStackRoot();
+
+    auto resumer = resume_with_stack_root(h).handle();
+
+    // save for later destruction
+    coro_ = resumer;
+
+    // ensure that it's safe for the resumer coroutine to activate h's stack
+    // frame on resumption
+    deactivateAsyncStackFrame(*frame);
+
+    if (awaiter_.await_suspend(resumer)) {
+      // suspend
+      return true;
+    } else {
+      // we're not actually suspending so undo the stack manipulation we just
+      // did
+      activateAsyncStackFrame(*root, *frame);
+
+      // proactively destroy the unneeded coro_resumer
+      std::exchange(coro_, {}).destroy();
+
+      // resume the caller
+      return false;
+    }
+  }
+
+  template(typename Promise)                                 //
+      (requires(!same_as<bool, suspend_result_t<Promise>>))  //
+      suspend_result_t<Promise> await_suspend_impl(
+          coro::coroutine_handle<Promise> h, AsyncStackFrame* frame) {
+    auto resumer = resume_with_stack_root(h).handle();
+
+    // save for later destruction
+    coro_ = resumer;
+
+    // ensure that it's safe for the resumer coroutine to activate h's stack
+    // frame on resumption
+    deactivateAsyncStackFrame(*frame);
+
+    return awaiter_.await_suspend(resumer);
+  }
+
+  template <typename Promise>
+  suspend_result_t<Promise> await_suspend(coro::coroutine_handle<Promise> h) {
+    if (auto* frame = get_async_stack_frame(h.promise())) {
+      return await_suspend_impl(h, frame);
+    }
+
+    using awaiter_suspend_result_t = decltype(awaiter_.await_suspend(h));
+
+    // Note: it's technically possible for an awaitable's implementation of
+    //       await_suspend() to return different types depending on its argument
+    //       type. This is easily handled if the "different types" are different
+    //       coroutine_handle<> types: just convert them all to
+    //       coro::coroutine_handle<>; but it's a pain if the different return
+    //       types mix-and-match between void, bool, and coroutine handles. If
+    //       any reports ever come in that these static asserts are breaking
+    //       builds, we can handle it by forcing *our* return type to always be
+    //       coro::coroutine_handle<> and just map the void and bool cases to
+    //       the appropriate handle, but let's avoid that complexity until it's
+    //       proven necessary.
+    if constexpr (same_as<void, suspend_result_t<Promise>>) {
+      static_assert(same_as<void, awaiter_suspend_result_t>);
+    } else if constexpr (same_as<bool, suspend_result_t<Promise>>) {
+      static_assert(same_as<bool, awaiter_suspend_result_t>);
+    } else {
+      static_assert(
+          convertible_to<awaiter_suspend_result_t, coro::coroutine_handle<>>);
+    }
+
+    return awaiter_.await_suspend(h);
+  }
+
+  auto await_resume() noexcept(noexcept(awaiter_.await_resume()))
+      -> decltype(awaiter_.await_resume()) {
+    return awaiter_.await_resume();
+  }
+
+  template(typename CPO)  //
+      (requires same_as<tag_t<blocking>, CPO> AND
+           std::is_invocable_v<CPO, const Awaitable&>)  //
+      friend auto tag_invoke(CPO cpo, const type& self) noexcept(
+          std::is_nothrow_invocable_v<CPO, const Awaitable&>)
+          -> std::invoke_result_t<CPO, const Awaitable&> {
+    return std::move(cpo)(std::as_const(self.awaitable));
+  }
+};
+
+template <typename Awaitable>
+using awaitable_wrapper = typename _awaitable_wrapper<Awaitable>::type;
+
+template <typename T, typename = void>
+struct is_awaitable_wrapper : std::false_type {};
+
+template <typename T>
+struct is_awaitable_wrapper<T, typename T::awaitable_wrapper_t>
+  : std::true_type {};
+
+template <typename T>
+constexpr bool is_awaitable_wrapper_v = is_awaitable_wrapper<T>::value;
 
 struct _fn {
   // Call custom implementation if present.
@@ -201,26 +509,41 @@ struct _fn {
   }
 
   // Default implementation for naturally awaitable types
-  template(typename Promise, typename Value)  //
+  template(
+      typename Promise,
+      typename Value,
+      bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS)  //
       (requires(!tag_invocable<_fn, Promise&, Value>)
            AND detail::_awaitable<Value>)  //
-      Value&&
+      decltype(auto)
       operator()(Promise&, Value&& value) const noexcept {
-    return std::forward<Value>(value);
+    if constexpr (
+        WithAsyncStackSupport &&
+        !is_awaitable_wrapper_v<remove_cvref_t<Value>>) {
+      return awaitable_wrapper<Value>{std::forward<Value>(value)};
+    } else {
+      return std::forward<Value>(value);
+    }
   }
 
   // Default implementation for non-awaitable senders
-  template(typename Promise, typename Value)  //
+  template(
+      typename Promise,
+      typename Value,
+      bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS)  //
       (requires(!tag_invocable<_fn, Promise&, Value>)
            AND(!detail::_awaitable<Value>) AND unifex::sender<Value>)  //
       decltype(auto)
       operator()(Promise& promise, Value&& value) const {
     static_assert(
-        unifex::sender_to<Value, _receiver_t<Promise, Value>>,
+        unifex::sender_to<
+            Value,
+            _receiver_t<Promise, Value, WithAsyncStackSupport>>,
         "This sender is not awaitable in this coroutine type.");
 
     auto h = coro::coroutine_handle<Promise>::from_promise(promise);
-    return _as_awaitable<Promise, Value>{(Value&&)value, h};
+    return _as_awaitable<Promise, Value, WithAsyncStackSupport>{
+        (Value&&)value, h};
   }
 
   // Fall back to returning the argument if none of the above conditions are met

--- a/include/unifex/connect_awaitable.hpp
+++ b/include/unifex/connect_awaitable.hpp
@@ -21,6 +21,8 @@
 #include <unifex/coroutine_concepts.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
+#include <unifex/tracing/async_stack.hpp>
+#include <unifex/tracing/get_async_stack_frame.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/unhandled_done.hpp>
 
@@ -36,19 +38,28 @@
 namespace unifex {
 namespace _await {
 
-template <typename Receiver>
+template <typename Receiver, bool WithAsyncStackSupport>
 struct _sender_task {
   class type;
 };
-template <typename Receiver>
-using sender_task = typename _sender_task<Receiver>::type;
+template <typename Receiver, bool WithAsyncStackSupport>
+using sender_task =
+    typename _sender_task<Receiver, WithAsyncStackSupport>::type;
 
-template <typename Receiver>
-class _sender_task<Receiver>::type {
+template <typename Receiver, bool WithAsyncStackSupport>
+class _sender_task<Receiver, WithAsyncStackSupport>::type {
 public:
   struct promise_type {
     template <typename Awaitable>
-    explicit promise_type(Awaitable&, Receiver& r) noexcept : receiver_(r) {}
+    explicit promise_type(
+        Awaitable&,
+        Receiver& r,
+        [[maybe_unused]] instruction_ptr returnAddress) noexcept
+      : receiver_(r) {
+      if constexpr (WithAsyncStackSupport) {
+        frame_.setReturnAddress(returnAddress);
+      }
+    }
 
     type get_return_object() noexcept {
       return type{coro::coroutine_handle<promise_type>::from_promise(*this)};
@@ -68,8 +79,12 @@ public:
     struct awaiter {
       Func&& func_;
       bool await_ready() noexcept { return false; }
-      void await_suspend(coro::coroutine_handle<promise_type>) noexcept(
+      void await_suspend(coro::coroutine_handle<promise_type> h) noexcept(
           std::is_nothrow_invocable_v<Func>) {
+        if constexpr (WithAsyncStackSupport) {
+          deactivateAsyncStackFrame(h.promise().frame_);
+        }
+
         std::forward<Func>(func_)();
       }
       [[noreturn]] void await_resume() noexcept { std::terminate(); }
@@ -99,12 +114,27 @@ public:
         friend auto tag_invoke(CPO cpo, const promise_type& p) noexcept(
             std::is_nothrow_invocable_v<CPO, const Receiver&>)
             -> std::invoke_result_t<CPO, const Receiver&> {
-      return cpo(std::as_const(p.receiver_));
+      if constexpr (
+          WithAsyncStackSupport && same_as<CPO, tag_t<get_async_stack_frame>>) {
+        return &p.frame_;
+      } else {
+        return std::move(cpo)(std::as_const(p.receiver_));
+      }
     }
 
     Receiver& receiver_;
-    done_coro doneCoro_ = unifex::unhandled_done(
-        [this]() noexcept { unifex::set_done(std::move(receiver_)); });
+    done_coro doneCoro_ = unifex::unhandled_done([this]() noexcept {
+      if constexpr (WithAsyncStackSupport) {
+        popAsyncStackFrameFromCaller(frame_);
+        deactivateAsyncStackFrame(frame_);
+      }
+
+      unifex::set_done(std::move(receiver_));
+    });
+
+    UNIFEX_NO_UNIQUE_ADDRESS mutable std::
+        conditional_t<WithAsyncStackSupport, AsyncStackFrame, detail::_empty<0>>
+            frame_;
   };
 
   coro::coroutine_handle<promise_type> coro_;
@@ -119,7 +149,24 @@ public:
       coro_.destroy();
   }
 
-  void start() & noexcept { coro_.resume(); }
+  void start() & noexcept {
+    if constexpr (WithAsyncStackSupport) {
+      detail::ScopedAsyncStackRoot root;
+
+      auto* frame = &coro_.promise().frame_;
+      if (auto parentFrame = get_async_stack_frame(coro_.promise().receiver_)) {
+        frame->setParentFrame(*parentFrame);
+      }
+
+      root.activateFrame(*frame);
+
+      coro_.resume();
+
+      root.ensureFrameDeactivated(frame);
+    } else {
+      coro_.resume();
+    }
+  }
 };
 
 }  // namespace _await
@@ -138,9 +185,10 @@ private:
     operator unit() const noexcept { return {}; }
   };
 
-  template <typename Awaitable, typename Receiver>
-  static auto connect_impl(Awaitable awaitable, Receiver receiver)
-      -> _await::sender_task<Receiver> {
+  template <bool WithAsyncStackSupport, typename Awaitable, typename Receiver>
+  static auto
+  connect_impl(Awaitable awaitable, Receiver receiver, instruction_ptr)
+      -> _await::sender_task<Receiver, WithAsyncStackSupport> {
 #if !UNIFEX_NO_EXCEPTIONS
     std::exception_ptr ex;
     try {
@@ -149,7 +197,8 @@ private:
       // The _sender_task's promise type has an await_transform that passes the
       // awaitable through unifex::await_transform. So take that into
       // consideration when computing the result type:
-      using promise_type = typename _await::sender_task<Receiver>::promise_type;
+      using promise_type = typename _await::
+          sender_task<Receiver, WithAsyncStackSupport>::promise_type;
       using awaitable_type = std::invoke_result_t<
           tag_t<unifex::await_transform>,
           promise_type&,
@@ -165,12 +214,17 @@ private:
       // after the coroutine is suspended so that it is safe
       // for the receiver to destroy the coroutine.
       co_yield [&](result_type&& result) {
-        return [&] {
-          if constexpr (std::is_void_v<await_result_t<awaitable_type>>) {
-            unifex::set_value(std::move(receiver));
-          } else {
-            unifex::set_value(
-                std::move(receiver), std::forward<result_type>(result));
+        return [&]() noexcept {
+          UNIFEX_TRY {
+            if constexpr (std::is_void_v<await_result_t<awaitable_type>>) {
+              unifex::set_value(std::move(receiver));
+            } else {
+              unifex::set_value(
+                  std::move(receiver), std::forward<result_type>(result));
+            }
+          }
+          UNIFEX_CATCH(...) {
+            unifex::set_error(std::move(receiver), std::current_exception());
           }
         };
         // The _comma_hack here makes this well-formed when the co_await
@@ -189,11 +243,16 @@ private:
   }
 
 public:
-  template <typename Awaitable, typename Receiver>
+  template <
+      typename Awaitable,
+      typename Receiver,
+      bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS>
   auto operator()(Awaitable&& awaitable, Receiver&& receiver) const
-      -> _await::sender_task<remove_cvref_t<Receiver>> {
-    return connect_impl(
-        std::forward<Awaitable>(awaitable), std::forward<Receiver>(receiver));
+      -> _await::sender_task<remove_cvref_t<Receiver>, WithAsyncStackSupport> {
+    return connect_impl<WithAsyncStackSupport>(
+        std::forward<Awaitable>(awaitable),
+        std::forward<Receiver>(receiver),
+        instruction_ptr::read_return_address());
   }
 } connect_awaitable{};
 }  // namespace _await_cpo
@@ -297,6 +356,7 @@ struct _fn {
       (requires detail::_awaitable<Awaitable>)  //
       _sender<remove_cvref_t<Awaitable>>
       operator()(Awaitable&& awaitable) const {
+    // TODO: this is going to generate an unfortunate return address
     return _sender<remove_cvref_t<Awaitable>>{
         std::forward<Awaitable>(awaitable),
         instruction_ptr::read_return_address()};

--- a/include/unifex/task.hpp
+++ b/include/unifex/task.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <unifex/any_scheduler.hpp>
+#include <unifex/at_coroutine_exit.hpp>
 #include <unifex/await_transform.hpp>
 #include <unifex/blocking.hpp>
 #include <unifex/connect_awaitable.hpp>
@@ -33,6 +34,8 @@
 #include <unifex/sender_concepts.hpp>
 #include <unifex/std_concepts.hpp>
 #include <unifex/then.hpp>
+#include <unifex/tracing/async_stack.hpp>
+#include <unifex/tracing/get_async_stack_frame.hpp>
 #include <unifex/type_list.hpp>
 #include <unifex/type_traits.hpp>
 #include <unifex/unhandled_done.hpp>
@@ -181,6 +184,11 @@ struct _promise_base {
     return std::exchange(p.continuation_, std::move(action));
   }
 
+  friend constexpr AsyncStackFrame*
+  tag_invoke(tag_t<get_async_stack_frame>, const _promise_base& p) noexcept {
+    return p.frame_;
+  }
+
 #ifdef UNIFEX_ENABLE_CONTINUATION_VISITATIONS
   template <typename Func>
   friend void
@@ -201,6 +209,10 @@ struct _promise_base {
   done_coro doneCoro_;
   // gets set to the return address of the ramp function
   instruction_ptr returnAddress_;
+  // the async stack frame corresponding to this coroutine
+  // null until this coroutine is awaited; stays null when async stack support
+  // is disabled
+  AsyncStackFrame* frame_{};
 };
 
 /**
@@ -208,8 +220,13 @@ struct _promise_base {
  */
 struct _task_promise_base : _promise_base {
   _task_promise_base()
-    : _promise_base([this]() noexcept { return continuation_.done_handle(); }) {
-  }
+    : _promise_base([this]() noexcept {
+      if (frame_) {
+        popAsyncStackFrameFromCaller(*frame_);
+      }
+
+      return continuation_.done_handle();
+    }) {}
 
   // the implementation of the magic of co_await schedule(s); this is to be
   // ripped out and replaced with something more explicit
@@ -347,7 +364,9 @@ struct _promise final {
       return awaiter{};
     }
 
-    template <typename Value>
+    template <
+        typename Value,
+        bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS>
     // todo: consider if this should be nothrow or not
     // NOTE: Magic rescheduling is not currently supported by nothrow tasks
     decltype(auto) await_transform(Value&& value) {
@@ -366,9 +385,9 @@ struct _promise final {
       } else if constexpr (
           tag_invocable<tag_t<unifex::await_transform>, type&, Value> ||
           detail::_awaitable<Value>) {
-        // Either await_transform has been customized or Value is an awaitable.
-        // Either way, we can dispatch to the await_transform CPO, then insert a
-        // transition back to the correct execution context if necessary.
+        // await_transform has been customized so we can dispatch to the
+        // await_transform CPO, then insert a transition back to the correct
+        // execution context if necessary.
         return with_scheduler_affinity(
             *this,
             unifex::await_transform(*this, static_cast<Value&&>(value)),
@@ -401,18 +420,28 @@ struct _promise final {
   };
 };
 
+struct _frame_state {
+  _frame_state() noexcept = default;
+
+  explicit _frame_state(AsyncStackFrame& frame, AsyncStackRoot& root) noexcept
+    : frame_(&frame)
+    , root_(&root) {}
+
+  void restore_frame_state() const noexcept {
+    if (frame_) {
+      activateAsyncStackFrame(*root_, *frame_);
+    }
+  }
+
+private:
+  AsyncStackFrame* frame_{};
+  AsyncStackRoot* root_;  // only conditionally initialized
+};
+
 struct _sr_thunk_promise_base : _promise_base {
   _sr_thunk_promise_base()
     : _promise_base([this]() noexcept -> coro::coroutine_handle<> {
-      callback_.destruct();
-
-      whoToContinue_ = continuation::DONE;
-
-      if (refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        return continuation_.done_handle();
-      } else {
-        return coro::noop_coroutine();
-      }
+      return complete_and_choose_continuation(continuation_.done_handle());
     }) {}
 
   friend inplace_stop_token
@@ -444,11 +473,15 @@ struct _sr_thunk_promise_base : _promise_base {
 
     void set_value(bool) noexcept {
       if (self->refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        if (self->whoToContinue_ == continuation::PRIMARY) {
-          self->continuation_.resume();
+        UNIFEX_ASSERT(self->whoToContinue_);
+
+        if (self->frame_) {
+          unifex::detail::ScopedAsyncStackRoot root;
+          root.activateFrame(*self->frame_);
+
+          self->whoToContinue_.resume();
         } else {
-          UNIFEX_ASSERT(self->whoToContinue_ == continuation::DONE);
-          self->continuation_.resume_done();
+          self->whoToContinue_.resume();
         }
       }
     }
@@ -480,16 +513,70 @@ struct _sr_thunk_promise_base : _promise_base {
 
   std::atomic<uint8_t> refCount_{1};
 
-  enum class continuation : uint8_t {
-    UNSET,
-    PRIMARY,
-    DONE,
-  };
-
-  continuation whoToContinue_{continuation::UNSET};
+  coro::coroutine_handle<> whoToContinue_{};
 
   void register_stop_callback() noexcept {
     callback_.construct(stoken_, stop_callback{this});
+  }
+
+  _frame_state ensure_frame_deactivated() noexcept {
+    if (frame_ != nullptr) {
+      if (whoToContinue_ == continuation_.done_handle()) {
+        popAsyncStackFrameFromCaller(*frame_);
+      }
+
+      auto* root = frame_->getStackRoot();
+      // this asserts that root is not null
+      deactivateAsyncStackFrame(*frame_);
+
+      return _frame_state(*frame_, *root);
+    }
+
+    return {};
+  }
+
+  // performs the final steps of completing this coroutine:
+  //  - destroy (and thus synchronize with) the stop callback if it exists
+  //  - record the continuation (normal or done) that should be resumed
+  //  - ensure the async stack state is correct
+  //  - decrement the refcount
+  //
+  // returns the coroutine handle to resume, which will either be the argument,
+  // or the no-op coroutine, depending on whether there's an outstanding
+  // deferred stop request to wait for
+  coro::coroutine_handle<> complete_and_choose_continuation(
+      coro::coroutine_handle<> whoToContinue) noexcept {
+    UNIFEX_ASSERT(
+        whoToContinue == continuation_.handle() ||
+        whoToContinue == continuation_.done_handle());
+
+    callback_.destruct();
+
+    // whoToContinue_ needs to be written before we decrement the refcount
+    // to ensure that we synchronize this write with the corresponding
+    // read in the deferred stop callback's completion
+    whoToContinue_ = whoToContinue;
+
+    // deactivate our async stack frame before decrementing the refcount
+    //
+    // Once the refcount has been decremented, it's possible for the
+    // deferred stop callback to resume our continuation and it must
+    // activate our frame on a new stack root before doing; for that to be
+    // safe, it can't be active on any other stack root. If it turns out
+    // *we* are going to resume our continuation then we have to
+    // reactivate our frame to undo this proactivate deactivation.
+    const auto frameState = ensure_frame_deactivated();
+
+    // if we're last to complete, continue our continuation; otherwise do
+    // nothing and wait for the async stop request to do it
+    if (refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      frameState.restore_frame_state();
+
+      return whoToContinue;
+    } else {
+      // the deferred stop callback will reactivate this frame
+      return coro::noop_coroutine();
+    }
   }
 };
 
@@ -526,48 +613,24 @@ struct _sr_thunk_promise final {
 
     auto final_suspend() noexcept {
       struct awaiter final : _final_suspend_awaiter_base {
+        coro::coroutine_handle<>
+        await_suspend_impl(coro::coroutine_handle<type> h) noexcept {
+          auto& p = h.promise();
+
+          return p.complete_and_choose_continuation(p.continuation_.handle());
+        }
+
 #if (defined(_MSC_VER) && !defined(__clang__)) || defined(__EMSCRIPTEN__)
         // MSVC doesn't seem to like symmetric transfer in this final awaiter
         // and the Emscripten (WebAssembly) compiler doesn't support tail-calls
         void await_suspend(coro::coroutine_handle<type> h) noexcept {
-          auto& p = h.promise();
-
-          p.callback_.destruct();
-
-          // this needs to be written before we decrement the refcount to ensure
-          // that we synchronize this write with the corresponding read in the
-          // deferred stop callback's completion
-          p.whoToContinue_ = continuation::PRIMARY;
-
-          // if we're last to complete, continue our continuation; otherwise do
-          // nothing and wait for the async stop request to do it
-          if (p.refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-            return h.promise().continuation_.handle().resume();
-          }
-
-          // don't resume anything here; wait for the deferred stop request to
-          // resume our continuation
+          await_suspend_impl(h).resume();
         }
 #else
         coro::coroutine_handle<>
         await_suspend(coro::coroutine_handle<type> h) noexcept {
-          auto& p = h.promise();
-
-          p.callback_.destruct();
-
-          // this needs to be written before we decrement the refcount to ensure
-          // that we synchronize this write with the corresponding read in the
-          // deferred stop callback's completion
-          p.whoToContinue_ = continuation::PRIMARY;
-
-          // if we're last to complete, continue our continuation; otherwise do
-          // nothing and wait for the async stop request to do it
-          if (p.refCount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-            return h.promise().continuation_.handle();
-          } else {
-            return coro::noop_coroutine();
-          }
-        }
+          return await_suspend_impl(h);
+        };
 #endif
       };
 
@@ -581,7 +644,10 @@ struct _sr_thunk_promise final {
   };
 };
 
-template <typename ThisPromise, typename OtherPromise>
+template <
+    typename ThisPromise,
+    typename OtherPromise,
+    bool WithAsyncStackSupport>
 struct _awaiter final {
   /**
    * An awaitable type that knows how to await a task<>, sa_task<>, or
@@ -636,6 +702,9 @@ struct _awaiter final {
 
       promise.register_stop_callback();
 
+      maybePushAsyncStackFrame(
+          promise, h.promise(), instruction_ptr::read_return_address());
+
       return thisCoro;
     }
 
@@ -648,6 +717,9 @@ struct _awaiter final {
       auto thisCoro = coro::coroutine_handle<ThisPromise>::from_address(
           (void*)std::exchange(--coro_, 0));
       coro_holder destroyOnExit{thisCoro};
+
+      maybePopAsyncStackFrame();
+
       return thisCoro.promise().result();
     }
 
@@ -658,6 +730,28 @@ struct _awaiter final {
         std::bool_constant<!same_as<scheduler_t, any_scheduler>>;
     using needs_stop_token_t =
         std::bool_constant<!same_as<stop_token_t, inplace_stop_token>>;
+    using needs_async_stack_frame_t = std::bool_constant<WithAsyncStackSupport>;
+
+    void maybePushAsyncStackFrame(
+        [[maybe_unused]] ThisPromise& callee,
+        [[maybe_unused]] OtherPromise& caller,
+        [[maybe_unused]] instruction_ptr returnAddress) noexcept {
+      if constexpr (WithAsyncStackSupport) {
+        if (auto* callerFrame = get_async_stack_frame(caller)) {
+          frame_.setReturnAddress(returnAddress);
+          callee.frame_ = &frame_;
+          pushAsyncStackFrameCallerCallee(*callerFrame, frame_);
+        }
+      }
+    }
+
+    void maybePopAsyncStackFrame() noexcept {
+      if constexpr (WithAsyncStackSupport) {
+        if (frame_.getParentFrame() != nullptr) {
+          popAsyncStackFrameCallee(frame_);
+        }
+      }
+    }
 
     // Only store the scheduler and the stop_token in the awaiter if we need to
     // type erase them. Otherwise, these members are "empty" and should take up
@@ -676,6 +770,12 @@ struct _awaiter final {
         inplace_stop_token_adapter<stop_token_t>,
         detail::_empty<1>>
         stopTokenAdapter_;
+    UNIFEX_NO_UNIQUE_ADDRESS
+    conditional_t<
+        needs_async_stack_frame_t::value,
+        AsyncStackFrame,
+        detail::_empty<2>>
+        frame_;
   };
 };
 
@@ -689,16 +789,20 @@ struct _sr_thunk_task<T>::type final : coro_holder {
   friend promise_type;
 
 private:
-  template <typename OtherPromise>
-  using awaiter = typename _awaiter<promise_type, OtherPromise>::type;
+  template <typename OtherPromise, bool WithAsyncStackSupport>
+  using awaiter =
+      typename _awaiter<promise_type, OtherPromise, WithAsyncStackSupport>::
+          type;
 
   explicit type(coro::coroutine_handle<promise_type> h) noexcept
     : coro_holder(h) {}
 
-  template <typename Promise>
-  friend awaiter<Promise>
+  template <
+      typename Promise,
+      bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS>
+  friend awaiter<Promise, WithAsyncStackSupport>
   tag_invoke(tag_t<unifex::await_transform>, Promise&, type&& t) noexcept {
-    return awaiter<Promise>{std::exchange(t.coro_, {})};
+    return awaiter<Promise, WithAsyncStackSupport>{std::exchange(t.coro_, {})};
   }
 
   friend instruction_ptr
@@ -827,18 +931,22 @@ struct _sa_task<T, nothrow>::type final : public _task<T, nothrow>::type {
 
   type(base&& t) noexcept : base(std::move(t)) {}
 
-  template <typename OtherPromise>
-  using awaiter =
-      typename _awaiter<typename base::promise_type, OtherPromise>::type;
+  template <typename OtherPromise, bool WithAsyncStackSupport>
+  using awaiter = typename _awaiter<
+      typename base::promise_type,
+      OtherPromise,
+      WithAsyncStackSupport>::type;
 
   // given that we're awaited in a scheduler-affine context, we are ourselves
   // scheduler-affine
   static constexpr bool is_always_scheduler_affine = true;
 
-  template <typename Promise>
-  friend awaiter<Promise>
+  template <
+      typename Promise,
+      bool WithAsyncStackSupport = !UNIFEX_NO_ASYNC_STACKS>
+  friend awaiter<Promise, WithAsyncStackSupport>
   tag_invoke(tag_t<unifex::await_transform>, Promise&, type&& t) noexcept {
-    return awaiter<Promise>{std::exchange(t.coro_, {})};
+    return awaiter<Promise, WithAsyncStackSupport>{std::exchange(t.coro_, {})};
   }
 
   template <typename Receiver>

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -67,6 +67,16 @@ popAsyncStackFrameCallee(unifex::AsyncStackFrame& calleeFrame) noexcept {
   calleeFrame.stackRoot = nullptr;
 }
 
+inline void popAsyncStackFrameFromCaller(
+    [[maybe_unused]] unifex::AsyncStackFrame& callerFrame) noexcept {
+  auto root = tryGetCurrentAsyncStackRoot();
+  assert(root != nullptr);
+  auto topFrame = root->getTopFrame();
+  assert(topFrame != nullptr);
+  assert(topFrame->getParentFrame() == &callerFrame);
+  popAsyncStackFrameCallee(*topFrame);
+}
+
 inline std::size_t getAsyncStackTraceFromInitialFrame(
     unifex::AsyncStackFrame* initialFrame,
     std::uintptr_t* addresses,

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -221,6 +221,9 @@ void pushAsyncStackFrameCallerCallee(
 // the current AsyncStackRoot.
 void popAsyncStackFrameCallee(unifex::AsyncStackFrame& calleeFrame) noexcept;
 
+void popAsyncStackFrameFromCaller(
+    unifex::AsyncStackFrame& callerFrame) noexcept;
+
 // Get a pointer to a special frame that can be used as the root-frame
 // for a chain of AsyncStackFrame that does not chain onto a normal
 // call-stack.
@@ -516,7 +519,7 @@ public:
     assert(tryGetCurrentAsyncStackRoot() == &root_);
     [[maybe_unused]] auto topFrame =
         root_.topFrame.exchange(nullptr, std::memory_order_relaxed);
-    assert(topFrame == possiblyDeadFrame);
+    assert(topFrame == nullptr || topFrame == possiblyDeadFrame);
   }
 
 private:

--- a/source/task.cpp
+++ b/source/task.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ void _task_promise_base::transform_schedule_sender_impl_(
   // correct scheduler, do so now:
   if (!std::exchange(this->rescheduled_, true)) {
     // Create a cleanup action that transitions back onto the current scheduler:
-    auto cleanupTask = at_coroutine_exit(schedule, this->sched_);
+    auto cleanupTask =
+        await_transform(*this, at_coroutine_exit(schedule, this->sched_));
     // Insert the cleanup action into the head of the continuation chain by
     // making direct calls to the cleanup task's awaiter member functions. See
     // type _cleanup_task in at_coroutine_exit.hpp:


### PR DESCRIPTION
This change extends the work in #616 to support async stack frames in
`task<>` coroutines, including those that invoke `at_coroutine_exit()`.

In `task<>`, when `UNIFEX_NO_ASYNC_STACKS` is falsey, the awaiter returned from
`task<>`'s customization of `unifex::await_transform` stores an
`AsyncStackFrame`. The awaiter pushes its frame onto the current async stack in
`await_suspend()` and pops it again in `await_resume()`; since
`await_resume()` is only invoked for value and error completions, this
arrangement leaves it up to the waiting task to pop the awaiter's frame
when the awaited task completes with done. This can be expressed as a
new rule:

- when a coroutine completes with a value or an error, it is responsible
  for popping its own `AsyncStackFrame`; but
- when a coroutine completes with done, the *caller* is responsible for
  popping the callee's `AsyncStackFrame` as a part of the caller's
  `unhandled_done()` coroutine.

To support this new requirement of `unhandled_done()` (that it is
responsible for popping the callee's stack frame), this change
introduces `popAsyncStackFrameFromCaller`, which takes the caller's
stack frame by reference so that it can assert that, after popping the
current async frame (whatever it is), the new top frame is the caller's
frame.

A `task<>` promise has an `AsyncStackFrame*` that, when it's not
`nullptr`, points to the `AsyncStackFrame` in the awaiter waiting for
the task. This pointer exists even when `UNIFEX_NO_ASYNC_STACKS` is
truthy to help mitigate against ODR violations; linking together two TUs
with `UNIFEX_NO_ASYNC_STACKS` set differently is not explicitly
supported but, by ensuring this pointer always exists, some ODR problems
are avoided. When a `task<>` is awaited from a TU with async stack
support enabled, the awaited task's awaiter sets the promise's
`AsyncStackFrame*` to point to the awaiter's frame; when a `task<>` is
awaited from a TU with async stack support disabled, this assignment
never happens and the promise's pointer remains null.

The above description of `task<>`'s async stack maintenance only covers
the recursive case of on coroutine awaiting another. The base case is
handled in `connect_awaitable()`, where an `AsyncStackRoot` is set up
before starting the connected awaitable.

`stop_if_requested` used to model both `sender` and `awaitable` so that
`co_await stop_if_requested();` could take advantage of symmetric
transfer. The `stop_if_requested` sender now customizes
`await_transform` to express its participation in async stack
management. This means of expressing async stack awareness is
unsatisfying but I don't have any better ideas right now.

Lastly, `unifex::await_transform()` now wraps naturally-awaitable
arguments in an `awaiter_wrapper` that ensures the `coroutine_handle<>`
passed to the wrapped awaitable is one that establishes an active
`AsyncStackRoot` before resuming the real waiting coroutine.