### PR TITLE
Enable async stack support for MSVC

### DIFF
--- a/cmake/unifex_env.cmake
+++ b/cmake/unifex_env.cmake
@@ -21,7 +21,7 @@ endif()
 
 if (UNIFEX_CXX_COMPILER_MSVC)
     # warning level 3 and all warnings as errors
-    add_compile_options(/W3 /WX)
+    add_compile_options(/W3 /WX /bigobj)
 else()
     # lots of warnings and all warnings as errors
     add_compile_options(-Wall -Wextra -pedantic -Werror)

--- a/examples/fp_delegation.cpp
+++ b/examples/fp_delegation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if defined(_MSC_VER) && !defined(__clang__)
+// async stacks break this file when building with MSVC; we can probably fix it
+// by switching the implementation to use unifex::variant_sender, but that's a
+// post-CppCon problem
+#  define UNIFEX_NO_ASYNC_STACKS 1
+#endif
 
 #include <unifex/for_each.hpp>
 #include <unifex/manual_event_loop.hpp>
@@ -135,7 +141,7 @@ public:
       auto local_op = [&receiver, context = context_]() mutable {
         return LC{unifex::connect(
             unifex::schedule(context->single_thread_context_.get_scheduler()),
-            (Receiver &&) receiver)};
+            (Receiver&&)receiver)};
       };
       return op{std::move(local_op), context_};
     }
@@ -143,7 +149,7 @@ public:
     auto target_op = [&receiver]() mutable {
       return unifex::connect(
           unifex::schedule(unifex::get_scheduler(std::as_const(receiver))),
-          (Receiver &&) receiver);
+          (Receiver&&)receiver);
     };
 
     return op{std::move(target_op), context_};

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -301,11 +301,9 @@
 #if !defined(UNIFEX_NO_ASYNC_STACKS)
 // default:
 //  - release builds do not have async stacks
-//  - Windows builds do not have async stacks
 //
-// adding async stacks adds non-trivial binary size at the moment, and I can't
-// figure out how to make all the relevant Windows builds succeed
-#  if defined(NDEBUG) || defined(_MSC_VER)
+// adding async stacks adds non-trivial binary size at the moment
+#  if defined(NDEBUG)
 #    define UNIFEX_NO_ASYNC_STACKS 1
 #  else
 #    define UNIFEX_NO_ASYNC_STACKS 0

--- a/include/unifex/config.hpp
+++ b/include/unifex/config.hpp
@@ -308,4 +308,29 @@
 #  else
 #    define UNIFEX_NO_ASYNC_STACKS 0
 #  endif
+#elif UNIFEX_NO_ASYNC_STACKS
+// make sure the truthy value is 1
+#  undef UNIFEX_NO_ASYNC_STACKS
+#  define UNIFEX_NO_ASYNC_STACKS 1
+#else
+// make sure the falsey value is 0
+#  undef UNIFEX_NO_ASYNC_STACKS
+#  define UNIFEX_NO_ASYNC_STACKS 0
 #endif  // !defined(UNIFEX_NO_ASYNC_STACKS)
+
+#if UNIFEX_HAS_BUILTIN(__builtin_return_address)
+#  define UNIFEX_RETURN_ADDRESS __builtin_return_address(0)
+#elif defined(_MSC_VER)
+#  define UNIFEX_RETURN_ADDRESS _ReturnAddress()
+#else
+#  define UNIFEX_RETURN_ADDRESS nullptr
+#endif
+
+#if UNIFEX_HAS_BUILTIN(__builtin_frame_address)
+#  define UNIFEX_FRAME_ADDRESS __builtin_frame_address(0)
+#elif defined(_MSC_VER)
+// not sure, yet, that this is right, but it's where we're starting
+#  define UNIFEX_FRAME_ADDRESS _AddressOfReturnAddress()
+#else
+#  define UNIFEX_FRAME_ADDRESS nullptr
+#endif

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -22,6 +22,11 @@
 #include <cassert>
 #include <cstdint>
 
+#if defined(_MSC_VER)
+// needed for _ReturnAddress() and _AddressOfReturnAddress()
+#include <intrin.h>
+#endif
+
 #include <unifex/detail/prologue.hpp>
 
 namespace unifex {
@@ -273,13 +278,8 @@ struct instruction_ptr final {
   // Generally a function that uses this macro should be declared FOLLY_NOINLINE
   // to prevent this returning surprising results in cases where the function
   // is inlined.
-#if UNIFEX_HAS_BUILTIN(__builtin_return_address)
   static constexpr instruction_ptr
-  read_return_address(void* p = __builtin_return_address(0)) noexcept {
-#else
-  static constexpr instruction_ptr
-  read_return_address(void* p = nullptr) noexcept {
-#endif
+  read_return_address(void* p = UNIFEX_RETURN_ADDRESS) noexcept {
     return instruction_ptr{p};
   }
 
@@ -311,12 +311,8 @@ struct frame_ptr {
   // Generally a function that uses this macro should be declared FOLLY_NOINLINE
   // to prevent this returning surprising results in cases where the function
   // is inlined.
-#if UNIFEX_HAS_BUILTIN(__builtin_frame_address)
   static constexpr frame_ptr
-  read_frame_pointer(void* p = __builtin_frame_address(0)) noexcept {
-#else
-  static constexpr frame_ptr read_frame_pointer(void* p = nullptr) noexcept {
-#endif
+  read_frame_pointer(void* p = UNIFEX_FRAME_ADDRESS) noexcept {
     return frame_ptr{p};
   }
 


### PR DESCRIPTION
After #619, async stack support is almost possible with MSVC; this PR makes the final changes to support the feature.