### PR TITLE
Add more customizations of get_return_address

### DIFF
--- a/include/unifex/schedule_with_subscheduler.hpp
+++ b/include/unifex/schedule_with_subscheduler.hpp
@@ -70,7 +70,9 @@ public:
       operator()(Scheduler&& sched) const -> _result_t<Scheduler> {
     auto&& scheduleOp = schedule(sched);
     return _result_t<Scheduler>{
-        static_cast<decltype(scheduleOp)>(scheduleOp), {(Scheduler &&) sched}};
+        static_cast<decltype(scheduleOp)>(scheduleOp),
+        {(Scheduler &&) sched},
+        instruction_ptr::read_return_address()};
   }
   constexpr auto operator()() const
       noexcept(std::is_nothrow_invocable_v<tag_t<bind_back>, _fn>)


### PR DESCRIPTION
This PR adds customizations of `unifex::get_return_address` to the algorithms we plan to showcase in our CppCon talk; more algorithms to come later.