### PR TITLE
expose underlying address of frame_ptr in async_stack

### DIFF
--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -320,6 +320,10 @@ struct frame_ptr {
     return frame_ptr{p};
   }
 
+  explicit operator void*() const noexcept {
+    return p_;
+  }
+
 private:
   void* p_;
 


### PR DESCRIPTION
This creates an explicit operator to expose the underlying address of `struct frame_ptr` in the async stack tracking.