### PR TITLE
Modify async stacks to keep track of a vector of ASRs

### DIFF
--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -136,10 +136,9 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
 }
 
 inline void AsyncStackRoot::setStackFrameContext(
-    frame_ptr framePtr, instruction_ptr ip, std::thread::id tId) noexcept {
+    frame_ptr framePtr, instruction_ptr ip) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
-  threadId = tId;
 }
 
 inline frame_ptr AsyncStackRoot::getStackFramePointer() const noexcept {

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -136,9 +136,10 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
 }
 
 inline void AsyncStackRoot::setStackFrameContext(
-    frame_ptr framePtr, instruction_ptr ip) noexcept {
+    frame_ptr framePtr, instruction_ptr ip, std::thread::id tId) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
+  threadId = tId;
 }
 
 inline frame_ptr AsyncStackRoot::getStackFramePointer() const noexcept {

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <thread>
 
 #include <unifex/detail/prologue.hpp>
 
@@ -453,7 +454,8 @@ public:
   // normal stack-trace.
   void setStackFrameContext(
       frame_ptr fp = frame_ptr::read_frame_pointer(),
-      instruction_ptr ip = instruction_ptr::read_return_address()) noexcept;
+      instruction_ptr ip = instruction_ptr::read_return_address(),
+      std::thread::id tId = std::this_thread::get_id()) noexcept;
   frame_ptr getStackFramePointer() const noexcept;
   instruction_ptr getReturnAddress() const noexcept;
 
@@ -500,6 +502,7 @@ private:
   // Typically initialise with instruction_ptr::read_return_address() or
   // setStackFrameContext().
   instruction_ptr returnAddress;
+  std::thread::id threadId;
 };
 
 namespace detail {

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -454,8 +454,7 @@ public:
   // normal stack-trace.
   void setStackFrameContext(
       frame_ptr fp = frame_ptr::read_frame_pointer(),
-      instruction_ptr ip = instruction_ptr::read_return_address(),
-      std::thread::id tId = std::this_thread::get_id()) noexcept;
+      instruction_ptr ip = instruction_ptr::read_return_address()) noexcept;
   frame_ptr getStackFramePointer() const noexcept;
   instruction_ptr getReturnAddress() const noexcept;
 
@@ -502,7 +501,6 @@ private:
   // Typically initialise with instruction_ptr::read_return_address() or
   // setStackFrameContext().
   instruction_ptr returnAddress;
-  std::thread::id threadId;
 };
 
 namespace detail {

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -58,9 +58,6 @@ void add(void* holder) noexcept {
 }
 
 void remove(void* holder) noexcept {
-  if (mutex_ == nullptr) {
-    return;
-  }
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = std::find(asyncStackRootHolders_.begin(), asyncStackRootHolders_.end(), holder);
   if (it != asyncStackRootHolders_.end()) {
@@ -70,17 +67,18 @@ void remove(void* holder) noexcept {
 }
 
 std::vector<void*> getAsyncStackRoots() noexcept {
-  if (!asyncStackRootsMutex.try_lock()) {
+  if (!mutex_.try_lock()) {
     // assume we crashed holding the lock and give up
     return {};
   }
   std::lock_guard<std::mutex> lock(mutex_, std::adopt_lock);
   return asyncStackRootHolders_;
 }
-
-extern "C" auto* kUnifexAsyncStackRootHolderList = new AsyncStackRootHolderList();
 };
 
+extern "C" {
+  auto* kUnifexAsyncStackRootHolderList = new AsyncStackRootHolderList();
+}
 #endif // UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
 
 namespace {

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -72,7 +72,7 @@ void remove(void* holder) {
   }
 }
 
-std::vector<void*> getAsyncStackRoots() noexcept {
+std::vector<void*> getAsyncStackRoots() {
   if (!mutex_.try_lock()) {
     // assume we crashed holding the lock and give up
     return {};

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -54,8 +54,8 @@ struct AsyncStackRootHolderList {
   std::mutex mutex_;
 
   AsyncStackRootHolderList() {
-    // reserve some space to avoid reallocations
-    asyncStackRootHolders_.reserve(300);
+    // reserve space to avoid frequent reallocations
+    asyncStackRootHolders_.reserve(50);
   }
 
 void add(void* holder) {

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -50,8 +50,13 @@ namespace unifex {
 #if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
 
 struct AsyncStackRootHolderList {
-  std::vector<void*> asyncStackRootHolders_{150};
+  std::vector<void*> asyncStackRootHolders_;
   std::mutex mutex_;
+
+  AsyncStackRootHolderList() {
+    // reserve some space to avoid reallocations
+    asyncStackRootHolders_.reserve(300);
+  }
 
 void add(void* holder) {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -41,23 +41,24 @@ extern "C" {
 // Initialise to some value that will be interpreted as an invalid key.
 inline pthread_key_t folly_async_stack_root_tls_key = 0xFFFF'FFFFu;
 }
+#else 
+#   include <vector>
 #endif  //UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD
 
 namespace unifex {
 
 #if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
-#include <vector>
 
 struct AsyncStackRootHolderList {
-  std::vector<void*> asyncStackRootHolders_;
+  std::vector<void*> asyncStackRootHolders_{150};
   std::mutex mutex_;
 
-void add(void* holder) noexcept {
+void add(void* holder) {
   std::lock_guard<std::mutex> lock(mutex_);
   asyncStackRootHolders_.push_back(holder);
 }
 
-void remove(void* holder) noexcept {
+void remove(void* holder) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = std::find(asyncStackRootHolders_.begin(), asyncStackRootHolders_.end(), holder);
   if (it != asyncStackRootHolders_.end()) {


### PR DESCRIPTION
This diff updates async stack to keep track of the ASRs via a std::vector instead of a TLS key. This will allow us to keep track of the different ASRs for all threads, instead of just the crashing thread.

We also store the thread id to reduce ambiguity.