### PR TITLE
Add threadid to AsyncStackRootHolder

### DIFF
--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -136,9 +136,10 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
 }
 
 inline void AsyncStackRoot::setStackFrameContext(
-    frame_ptr framePtr, instruction_ptr ip) noexcept {
+    frame_ptr framePtr, instruction_ptr ip, uint64_t tId) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
+  threadId = tId;
 }
 
 inline frame_ptr AsyncStackRoot::getStackFramePointer() const noexcept {

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -136,7 +136,7 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
 }
 
 inline void AsyncStackRoot::setStackFrameContext(
-    frame_ptr framePtr, instruction_ptr ip, uint64_t tId) noexcept {
+    frame_ptr framePtr, instruction_ptr ip, std::uint64_t tId) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
   threadId = tId;

--- a/include/unifex/tracing/async_stack-inl.hpp
+++ b/include/unifex/tracing/async_stack-inl.hpp
@@ -136,10 +136,9 @@ inline AsyncStackFrame* AsyncStackRoot::getTopFrame() const noexcept {
 }
 
 inline void AsyncStackRoot::setStackFrameContext(
-    frame_ptr framePtr, instruction_ptr ip, std::uint64_t tId) noexcept {
+    frame_ptr framePtr, instruction_ptr ip) noexcept {
   stackFramePtr = framePtr;
   returnAddress = ip;
-  threadId = tId;
 }
 
 inline frame_ptr AsyncStackRoot::getStackFramePointer() const noexcept {

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -153,7 +153,7 @@ class ScopedAsyncStackRoot;
 } // namespace detail
 
 namespace utils {
-  uint64_t get_os_thread_id();
+  std::uint64_t get_os_thread_id();
 } // namespace utils
 
 // Get access to the current thread's top-most AsyncStackRoot.

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -24,7 +24,6 @@
 #include <thread>
 
 #include <unifex/detail/prologue.hpp>
-#include <sys/syscall.h>
 
 #if defined(__APPLE__)
 #define UNIFEX_SYS_gettid SYS_thread_selfid

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -25,6 +25,7 @@
 
 #include <unifex/detail/prologue.hpp>
 #if defined(__linux__)
+#include <unistd.h>
 #include <sys/syscall.h>
 #endif
 

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -24,18 +24,6 @@
 #include <thread>
 
 #include <unifex/detail/prologue.hpp>
-#if defined(__linux__)
-#include <unistd.h>
-#include <sys/syscall.h>
-#endif
-
-#if defined(__APPLE__)
-#define UNIFEX_SYS_gettid SYS_thread_selfid
-#elif defined(SYS_gettid)
-#define UNIFEX_SYS_gettid SYS_gettid
-#else
-#define UNIFEX_SYS_gettid __NR_gettid
-#endif
 
 namespace unifex {
 
@@ -165,7 +153,7 @@ class ScopedAsyncStackRoot;
 } // namespace detail
 
 namespace utils {
-  uint64_t getOSThreadID();
+  uint64_t get_os_thread_id();
 } // namespace utils
 
 // Get access to the current thread's top-most AsyncStackRoot.
@@ -471,7 +459,7 @@ public:
   void setStackFrameContext(
       frame_ptr fp = frame_ptr::read_frame_pointer(),
       instruction_ptr ip = instruction_ptr::read_return_address(),
-      uint64_t tId = utils::getOSThreadID()) noexcept;
+      std::uint64_t tId = utils::get_os_thread_id()) noexcept;
   frame_ptr getStackFramePointer() const noexcept;
   instruction_ptr getReturnAddress() const noexcept;
 
@@ -518,7 +506,7 @@ private:
   // Typically initialise with instruction_ptr::read_return_address() or
   // setStackFrameContext().
   instruction_ptr returnAddress;
-  uint64_t threadId = 0;
+  std::uint64_t threadId = 0;
 };
 
 namespace detail {

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -150,7 +150,7 @@ struct AsyncStackRoot;
 struct AsyncStackFrame;
 namespace detail {
 class ScopedAsyncStackRoot;
-} // namespace detail
+}  // namespace detail
 
 // Get access to the current thread's top-most AsyncStackRoot.
 //
@@ -321,9 +321,7 @@ struct frame_ptr {
     return frame_ptr{p};
   }
 
-  explicit operator void*() const noexcept {
-    return p_;
-  }
+  explicit operator void*() const noexcept { return p_; }
 
 private:
   void* p_;

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -152,10 +152,6 @@ namespace detail {
 class ScopedAsyncStackRoot;
 } // namespace detail
 
-namespace utils {
-  std::uint64_t get_os_thread_id();
-} // namespace utils
-
 // Get access to the current thread's top-most AsyncStackRoot.
 //
 // Returns nullptr if there is no active AsyncStackRoot.
@@ -458,8 +454,7 @@ public:
   // normal stack-trace.
   void setStackFrameContext(
       frame_ptr fp = frame_ptr::read_frame_pointer(),
-      instruction_ptr ip = instruction_ptr::read_return_address(),
-      std::uint64_t tId = utils::get_os_thread_id()) noexcept;
+      instruction_ptr ip = instruction_ptr::read_return_address()) noexcept;
   frame_ptr getStackFramePointer() const noexcept;
   instruction_ptr getReturnAddress() const noexcept;
 
@@ -506,7 +501,6 @@ private:
   // Typically initialise with instruction_ptr::read_return_address() or
   // setStackFrameContext().
   instruction_ptr returnAddress;
-  std::uint64_t threadId = 0;
 };
 
 namespace detail {

--- a/include/unifex/tracing/async_stack.hpp
+++ b/include/unifex/tracing/async_stack.hpp
@@ -24,6 +24,9 @@
 #include <thread>
 
 #include <unifex/detail/prologue.hpp>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
 
 #if defined(__APPLE__)
 #define UNIFEX_SYS_gettid SYS_thread_selfid

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -91,9 +91,7 @@ struct AsyncStackRootHolderList {
 extern "C" {
 auto* kUnifexAsyncStackRootHolderList = new AsyncStackRootHolderList();
 }
-#endif  // UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
 
-#if !UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD
 namespace utils {
 static std::uint64_t get_os_thread_id() {
 #  if defined(__APPLE__)
@@ -107,7 +105,7 @@ static std::uint64_t get_os_thread_id() {
 #  endif
 }
 }  // namespace utils
-#endif  // !UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD
+#endif  // UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
 
 namespace {
 
@@ -146,6 +144,9 @@ struct AsyncStackRootHolder {
   ~AsyncStackRootHolder() noexcept {
     kUnifexAsyncStackRootHolderList->remove(this);
   }
+
+  std::uint64_t get_thread_id() const noexcept { return threadId; }
+
 #endif
 
   AsyncStackRoot* get() const noexcept {
@@ -159,10 +160,6 @@ struct AsyncStackRootHolder {
   void set_relaxed(AsyncStackRoot* root) noexcept {
     value.store(root, std::memory_order_relaxed);
   }
-
-#if !UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD
-  std::uint64_t get_thread_id() const noexcept { return threadId; }
-#endif
 
   std::atomic<AsyncStackRoot*> value{nullptr};
 #if !UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -19,7 +19,6 @@
 #include <atomic>
 #include <cassert>
 #include <mutex>
-#include <sys/syscall.h>
 
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)
 #if defined(__linux__)
@@ -148,15 +147,15 @@ static thread_local AsyncStackRootHolder currentThreadAsyncStackRoot;
 
 namespace utils {
   uint64_t getOSThreadID() {
-  #if defined(__APPLE__)
-    uint64_t tid;
-    pthread_threadid_np(nullptr, &tid);
-    return tid;
-  #elif defined(_WIN32)
-    return uint64_t(GetCurrentThreadId());
-  #else
+   #if defined(__APPLE__)
+     uint64_t tid;
+     pthread_threadid_np(nullptr, &tid);
+     return tid;
+   #elif defined(_WIN32)
+     return uint64_t(GetCurrentThreadId());
+   #else
     return uint64_t(syscall(UNIFEX_SYS_gettid));
-  #endif
+   #endif
   }
 }
 

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -160,7 +160,7 @@ namespace utils {
    #elif defined(_WIN32)
      return std::uint64_t(GetCurrentThreadId());
    #else
-     return std::uint64_t(gettid())
+     return std::uint64_t(gettid());
    #endif
   }
 }

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -145,6 +145,20 @@ static thread_local AsyncStackRootHolder currentThreadAsyncStackRoot;
 
 }  // namespace
 
+namespace utils {
+  uint64_t getOSThreadID() {
+  #if defined(__APPLE__)
+    uint64_t tid;
+    pthread_threadid_np(nullptr, &tid);
+    return tid;
+  #elif defined(_WIN32)
+    return uint64_t(GetCurrentThreadId());
+  #else
+    return uint64_t(syscall(UNIFEX_SYS_gettid));
+  #endif
+  }
+}
+
 AsyncStackRoot* tryGetCurrentAsyncStackRoot() noexcept {
   return currentThreadAsyncStackRoot.get();
 }

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -22,6 +22,8 @@
 
 #if defined(_WIN32)
 #include <windows.h>
+#elif defined(__linux__)
+#include <unistd.h>
 #endif
 
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)
@@ -150,15 +152,15 @@ static thread_local AsyncStackRootHolder currentThreadAsyncStackRoot;
 }  // namespace
 
 namespace utils {
-  uint64_t getOSThreadID() {
+  std::uint64_t get_os_thread_id() {
    #if defined(__APPLE__)
-     uint64_t tid;
+     std::uint64_t tid;
      pthread_threadid_np(nullptr, &tid);
      return tid;
    #elif defined(_WIN32)
-     return uint64_t(GetCurrentThreadId());
+     return std::uint64_t(GetCurrentThreadId());
    #else
-    return uint64_t(syscall(UNIFEX_SYS_gettid));
+     return std::uint64_t(gettid())
    #endif
   }
 }

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cassert>
 #include <mutex>
+#include <sys/syscall.h>
 
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)
 #if defined(__linux__)

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <windows.h>
 #endif
 
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -20,6 +20,10 @@
 #include <cassert>
 #include <mutex>
 
+#if defined(_WIN32)
+#include <processthreadsapi.h>
+#endif
+
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)
 #if defined(__linux__)
 #  define UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD 1

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -92,7 +92,6 @@ extern "C" {
 auto* kUnifexAsyncStackRootHolderList = new AsyncStackRootHolderList();
 }
 
-namespace utils {
 static std::uint64_t get_os_thread_id() {
 #  if defined(__APPLE__)
   std::uint64_t tid;
@@ -104,7 +103,6 @@ static std::uint64_t get_os_thread_id() {
   return std::uint64_t(gettid());
 #  endif
 }
-}  // namespace utils
 #endif  // UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0
 
 namespace {
@@ -136,7 +134,7 @@ struct AsyncStackRootHolder {
     UNIFEX_ASSERT(result == 0);
 #else
     kUnifexAsyncStackRootHolderList->add(this);
-    threadId = unifex::utils::get_os_thread_id();
+    threadId = unifex::get_os_thread_id();
 #endif
   }
 


### PR DESCRIPTION
This diff adds the threadid to the ASR in order to unambiguously correlate the ASR's symbol to the thread.

This is loosely based off folly's implementation of getOSThreadID: https://github.com/facebook/folly/blob/main/folly/system/ThreadId.cpp#L41

The main difference is that folly supports EMSCRIPTEN and BSD, which I do not include.

We expect to only need this for ios, android, and linux applications.