### PR TITLE
Add threadid macros for emscripten

### DIFF
--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -99,13 +99,12 @@ static std::uint64_t get_os_thread_id() {
   return tid;
 #  elif defined(_WIN32)
   return std::uint64_t(GetCurrentThreadId());
-#  elif defined(__FreeBSD__)
-  long tid;
-  thr_self(&tid);
 #  elif defined(__EMSCRIPTEN__)
   return 0;
-#  else
+#  elif defined(__linux__)
   return std::uint64_t(gettid());
+#  else
+#    error "Unsupported platform in get_os_thread_id"
 #  endif
 }
 #endif  // UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD == 0

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -99,6 +99,11 @@ static std::uint64_t get_os_thread_id() {
   return tid;
 #  elif defined(_WIN32)
   return std::uint64_t(GetCurrentThreadId());
+#  elif defined(__FreeBSD__)
+  long tid;
+  thr_self(&tid);
+#  elif defined(__EMSCRIPTEN__)
+  return 0;
 #  else
   return std::uint64_t(gettid());
 #  endif


### PR DESCRIPTION
It turns out there's some usage of unifex in emscripten. We don't plan on adding support for this work on emscripten so just return 0 is fine