### PR TITLE
Add missing licensing headers

### DIFF
--- a/examples/asynchronous_sleep.cpp
+++ b/examples/asynchronous_sleep.cpp
@@ -1,4 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 #include <chrono>
 #include <iostream>
 

--- a/examples/asynchronous_sleep.cpp
+++ b/examples/asynchronous_sleep.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <chrono>
 #include <iostream>
 

--- a/examples/synchronous_sleep.cpp
+++ b/examples/synchronous_sleep.cpp
@@ -1,4 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 #include <chrono>
 #include <iostream>
 

--- a/examples/synchronous_sleep.cpp
+++ b/examples/synchronous_sleep.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <chrono>
 #include <iostream>
 

--- a/include/unifex/async_auto_reset_event.hpp
+++ b/include/unifex/async_auto_reset_event.hpp
@@ -1,19 +1,19 @@
 /*
- 
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #pragma once
 
 #include <unifex/async_manual_reset_event.hpp>
@@ -154,7 +154,8 @@ struct async_auto_reset_event::stream_view final {
                 typename stop_token_t::template callback_type<
                     decltype(stopCallback)>;
 
-            return std::optional<stop_callback_t>{std::in_place, stopToken, stopCallback};
+            return std::optional<stop_callback_t>{
+                std::in_place, stopToken, stopCallback};
           },
           [evt](auto& stopCallback) noexcept {
             return unifex::let_value(

--- a/include/unifex/async_auto_reset_event.hpp
+++ b/include/unifex/async_auto_reset_event.hpp
@@ -1,5 +1,19 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ 
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 #pragma once
 
 #include <unifex/async_manual_reset_event.hpp>

--- a/include/unifex/cleanup_adapt_stream.hpp
+++ b/include/unifex/cleanup_adapt_stream.hpp
@@ -1,5 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #pragma once
 
 #include <unifex/stream_concepts.hpp>

--- a/include/unifex/cleanup_adapt_stream.hpp
+++ b/include/unifex/cleanup_adapt_stream.hpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #pragma once
 
 #include <unifex/stream_concepts.hpp>
@@ -58,7 +59,7 @@ inline constexpr struct _fn final {
       std::is_nothrow_constructible_v<remove_cvref_t<Stream>, Stream>&&
           std::is_nothrow_constructible_v<std::decay_t<AdaptFunc>, AdaptFunc>) {
     return _cleanup_adapt::stream<Stream, AdaptFunc>{
-        (Stream &&) stream, (AdaptFunc &&) adapt};
+        (Stream&&)stream, (AdaptFunc&&)adapt};
   }
 } cleanup_adapt_stream{};
 }  // namespace _cleanup_adapt_cpo

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -199,20 +199,12 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Sender, Func>>&&
-                                      is_nothrow_connectable_v<
-                                          member_t<Sender, Predecessor>,
-                                          receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+	  std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #pragma once
 
 #include <unifex/config.hpp>

--- a/include/unifex/upon_done.hpp
+++ b/include/unifex/upon_done.hpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #pragma once
 
 #include <unifex/config.hpp>
@@ -198,12 +199,20 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
-          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
-          is_nothrow_connectable_v<
-              member_t<Sender, Predecessor>,
-              receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(
+          tag_t<unifex::connect>,
+          Sender&& s,
+          Receiver&&
+              r) noexcept(std::
+                              is_nothrow_constructible_v<
+                                  remove_cvref_t<Receiver>,
+                                  Receiver>&&
+                                  std::is_nothrow_constructible_v<
+                                      Func,
+                                      member_t<Sender, Func>>&&
+                                      is_nothrow_connectable_v<
+                                          member_t<Sender, Predecessor>,
+                                          receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #pragma once
 
 #include <unifex/config.hpp>

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -179,20 +179,12 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(
-          tag_t<unifex::connect>,
-          Sender&& s,
-          Receiver&&
-              r) noexcept(std::
-                              is_nothrow_constructible_v<
-                                  remove_cvref_t<Receiver>,
-                                  Receiver>&&
-                                  std::is_nothrow_constructible_v<
-                                      Func,
-                                      member_t<Sender, Func>>&&
-                                      is_nothrow_connectable_v<
-                                          member_t<Sender, Predecessor>,
-                                          receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
+	  std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
+          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
+          is_nothrow_connectable_v<
+              member_t<Sender, Predecessor>,
+              receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {

--- a/include/unifex/upon_error.hpp
+++ b/include/unifex/upon_error.hpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #pragma once
 
 #include <unifex/config.hpp>
@@ -178,12 +179,20 @@ public:
            sender_to<
                member_t<Sender, Predecessor>,
                receiver_t<remove_cvref_t<Receiver>>>)  //
-      friend auto tag_invoke(tag_t<unifex::connect>, Sender&& s, Receiver&& r) noexcept(
-          std::is_nothrow_constructible_v<remove_cvref_t<Receiver>, Receiver> &&
-          std::is_nothrow_constructible_v<Func, member_t<Sender, Func>> &&
-          is_nothrow_connectable_v<
-              member_t<Sender, Predecessor>,
-              receiver_t<remove_cvref_t<Receiver>>>)
+      friend auto tag_invoke(
+          tag_t<unifex::connect>,
+          Sender&& s,
+          Receiver&&
+              r) noexcept(std::
+                              is_nothrow_constructible_v<
+                                  remove_cvref_t<Receiver>,
+                                  Receiver>&&
+                                  std::is_nothrow_constructible_v<
+                                      Func,
+                                      member_t<Sender, Func>>&&
+                                      is_nothrow_connectable_v<
+                                          member_t<Sender, Predecessor>,
+                                          receiver_t<remove_cvref_t<Receiver>>>)
           -> connect_result_t<
               member_t<Sender, Predecessor>,
               receiver_t<remove_cvref_t<Receiver>>> {

--- a/source/async_auto_reset_event.cpp
+++ b/source/async_auto_reset_event.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/async_auto_reset_event.hpp>
 
 namespace unifex::_aare {

--- a/source/async_auto_reset_event.cpp
+++ b/source/async_auto_reset_event.cpp
@@ -1,5 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/async_auto_reset_event.hpp>
 
 namespace unifex::_aare {

--- a/test/async_auto_reset_event_test.cpp
+++ b/test/async_auto_reset_event_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <gtest/gtest.h>
 
 #include <unifex/async_auto_reset_event.hpp>

--- a/test/async_auto_reset_event_test.cpp
+++ b/test/async_auto_reset_event_test.cpp
@@ -1,5 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <gtest/gtest.h>
 
 #include <unifex/async_auto_reset_event.hpp>

--- a/test/detach_on_cancel_test.cpp
+++ b/test/detach_on_cancel_test.cpp
@@ -1,3 +1,18 @@
+/* 
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/async_manual_reset_event.hpp>
 #include <unifex/async_scope.hpp>
 #include <unifex/detach_on_cancel.hpp>

--- a/test/detach_on_cancel_test.cpp
+++ b/test/detach_on_cancel_test.cpp
@@ -1,18 +1,19 @@
-/* 
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/async_manual_reset_event.hpp>
 #include <unifex/async_scope.hpp>
 #include <unifex/detach_on_cancel.hpp>

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/filter_stream.hpp>
 
 #include <unifex/for_each.hpp>

--- a/test/filter_stream_test.cpp
+++ b/test/filter_stream_test.cpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/filter_stream.hpp>
 
 #include <unifex/for_each.hpp>

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/type_list.hpp>
 
 using namespace unifex;

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/type_list.hpp>
 
 using namespace unifex;

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/upon_done.hpp>
 
 #include <unifex/just.hpp>

--- a/test/upon_done_test.cpp
+++ b/test/upon_done_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/upon_done.hpp>
 
 #include <unifex/just.hpp>

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <unifex/upon_error.hpp>
 
 #include <unifex/just.hpp>

--- a/test/upon_error_test.cpp
+++ b/test/upon_error_test.cpp
@@ -1,3 +1,18 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <unifex/upon_error.hpp>
 
 #include <unifex/just.hpp>

--- a/test/when_all_range_test.cpp
+++ b/test/when_all_range_test.cpp
@@ -1,5 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+ */
 #include <gtest/gtest.h>
 
 #include <unifex/allocate.hpp>

--- a/test/when_all_range_test.cpp
+++ b/test/when_all_range_test.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include <gtest/gtest.h>
 
 #include <unifex/allocate.hpp>


### PR DESCRIPTION
Unifex is not currently adhering to Meta's open source standards. This diff makes unifex compliant by adding the missing license headers