### PR TITLE
Disable ASR by default

### DIFF
--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD)
-#  if defined(__linux__)
+#  if defined(__linux__) || defined(_WIN32)
 #    define UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD 1
 #  else
 // defaults to using vector to store AsyncStackRoots instead of a pthread key

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -20,7 +20,8 @@
 #include <cassert>
 #include <mutex>
 
-#if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD) || !defined(UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR)
+#if !defined(UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD) || \
+    !defined(UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR)
 // defaults to using pthread if linux, otherwise no async stack root
 #  if defined(__linux__)
 #    define UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD 1
@@ -31,8 +32,9 @@
 #  endif
 #endif
 
-# if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD && UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR
-#  error "Only one of UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD and UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR can be set to true"
+#if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD && UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR
+#  error \
+      "Only one of UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD and UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR can be set to true"
 #endif
 
 #if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD

--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -31,6 +31,10 @@
 #  endif
 #endif
 
+# if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD && UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR
+#  error "Only one of UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD and UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR can be set to true"
+#endif
+
 #if UNIFEX_ASYNC_STACK_ROOT_USE_PTHREAD
 
 #  include <pthread.h>


### PR DESCRIPTION
In the old implementation, ASR tracking was disabled by default for all builds except linux. This was changed when ASR tracking via a vector was added. This caused windows to crash, probably due to static order initialization fiasco.

We don't support windows for async stacks anyways, so this PR just disables that option for all builds except linux unless you explicitly opt in.