### PR TITLE
Use intrusive_heap in timed_single_thread_context

### DIFF
--- a/include/unifex/detail/intrusive_heap.hpp
+++ b/include/unifex/detail/intrusive_heap.hpp
@@ -89,7 +89,12 @@ public:
     }
   }
 
-  void remove(T* item) noexcept {
+  // Returns true if the item was in the heap
+  bool remove(T* item) noexcept {
+    if (item->*Prev == nullptr && item != head_) {
+        return false;
+    }
+
     auto* prev = item->*Prev;
     auto* next = item->*Next;
     if (prev != nullptr) {
@@ -101,6 +106,7 @@ public:
     if (next != nullptr) {
       next->*Prev = prev;
     }
+    return true;
   }
 
 private:


### PR DESCRIPTION
Use a heap to avoid possibly linear enqueue operation time.

Fixes #648

Note: this doesn't quite accomplish what I wanted, since the `intrusive_heap` is not a real heap (yet).