### PR TITLE
DONOTSTRIP for kUnifexAsyncStackRootHolderList

### DIFF
--- a/source/async_stack.cpp
+++ b/source/async_stack.cpp
@@ -62,6 +62,15 @@ namespace unifex {
 
 #if UNIFEX_ASYNC_STACK_ROOT_USE_VECTOR
 
+// Ensure anything tagged with UNIFEX_DONOTSTRIP is not stripped by the linker.
+// This will not protect against the `strip` tool, but it will allow us to 
+// make a symbol visible to debuggers and profilers even in the face of LTO.
+//
+// Users of the `strip` tool will need to use the 
+// `--keep-symbol=kUnifexAsyncStackRootHolderList` flag if they want to keep 
+// the async stack roots for introspection.
+#define UNIFEX_DONOTSTRIP __attribute__((used))
+
 struct AsyncStackRootHolderList {
   std::vector<void*> asyncStackRootHolders_;
   std::mutex mutex_;
@@ -97,7 +106,7 @@ struct AsyncStackRootHolderList {
 };
 
 extern "C" {
-auto* kUnifexAsyncStackRootHolderList = new AsyncStackRootHolderList();
+auto* kUnifexAsyncStackRootHolderList UNIFEX_DONOTSTRIP = new AsyncStackRootHolderList();
 }
 
 static std::uint64_t get_os_thread_id() {


### PR DESCRIPTION
This ensures the `kUnifexAsyncStackRootHolderList` symbol is not stripped during the link phase so it can always be found in the symbol table.

This does *not* protect against the `strip` tool which completely removes the .symtab.  If you need to retain the pointer to the AsyncStackRootHolderList you will have to use the `--keep-symbol` flag if you are using the `strip` tool for smaller binaries.

Note that `strip` tool will keep this symbol if you are sticking to "needed" symbols as it is marked as "used" but it won't survive under strip "all".