### PR TITLE
Bump the version of cmake_minimum_required in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the license found in the
 # LICENSE.txt file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(libunifex LANGUAGES CXX
                   VERSION 0.1.0)

--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -3,7 +3,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Bumping the version because the googletest build was failing when I tried to build unifex locally

This was the error - 
```

-- Could NOT find LibUring (missing: LIBURING_INCLUDE_DIR) 
CMake Error at cmake/gtest.cmake:14 (message):
  CMake step for googletest failed: no such file or directory
Call Stack (most recent call first):
  CMakeLists.txt:41 (include)


-- Configuring incomplete, errors occurred!
```

Bumping the version to 3.10 from 2.8