### PR TITLE
New atomic data structure used to reimplement v2/async_mutex

### DIFF
--- a/include/unifex/detail/atomic_intrusive_list.hpp
+++ b/include/unifex/detail/atomic_intrusive_list.hpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+
+#include <unifex/detail/prologue.hpp>
+
+namespace unifex {
+
+// A tagged atomic word used as a list link: bit 0 is a per-link
+// spinlock; the remaining bits encode a node* (or 0 for null).
+// Node alignment must be >= 2 so valid pointers have bit 0 clear.
+using atomic_intrusive_list_link = std::atomic<uintptr_t>;
+
+// Intrusive node.  Items stored in the list inherit from this.
+//
+//   self  — back-pointer to the link word referencing this node.
+//           nullptr when the node is not in any list.
+//   rest  — forward link (tagged, lockable).
+struct atomic_intrusive_list_node {
+  using link = atomic_intrusive_list_link;
+
+  std::atomic<link*> self{nullptr};
+  link rest{0};
+};
+
+// ---- Lock helpers (shared across all list instantiations) ----
+
+class atomic_intrusive_list_link_ops {
+public:
+  using node = atomic_intrusive_list_node;
+  using link = atomic_intrusive_list_link;
+
+protected:
+  static constexpr uintptr_t lock_bit = 1;
+
+  // TTAS spinlock on a link word.  Returns the value (without
+  // lock bit).
+  static uintptr_t lock(link& lk) noexcept;
+
+  // Release a link's spinlock, storing a new unlocked value.
+  static void unlock(link& lk, uintptr_t value) noexcept {
+    UNIFEX_ASSERT((value & lock_bit) == 0);
+    lk.store(value, std::memory_order_release);
+  }
+
+  // Try to lock a link while monitoring an atomic<link*> for
+  // changes.  Returns true (with head_val set) if locked,
+  // false if the monitored pointer changed (caller retries).
+  static bool try_lock_checking(
+      link& lk,
+      std::atomic<link*>& monitored,
+      link* expected,
+      uintptr_t& head_val) noexcept;
+};
+
+// ---- List implementation (parameterised on Latch) ------------
+//
+// A concurrent intrusive singly-linked list with per-link
+// spinlocks and a permanent sentinel node.
+//
+// Operations:
+//   push_front  O(1)  locks head
+//   push_back   O(1)  locks tail
+//   pop_front   O(1)  locks head + first item's rest
+//   try_remove  O(1)  locks predecessor + item's rest
+//   drain_into  O(1)  locks head + tail; moves all items
+//
+// Lock ordering: predecessor before successor.
+//
+// Latch mode (Latch=true):
+//   Adds a second sentinel node.  The list is "latched" when
+//   head_ points to the latch sentinel instead of the normal
+//   one.  push_front_unless_latched, latch_and_drain, unlatch,
+//   and is_latched all serialise through head_'s spinlock, so
+//   there is no window between latching and draining.
+//
+//   Intended for async_manual_reset_event where "latched"
+//   means "signalled".
+
+template <bool Latch>
+class atomic_intrusive_list_impl : protected atomic_intrusive_list_link_ops {
+protected:
+  using node = atomic_intrusive_list_node;
+  using link = atomic_intrusive_list_link;
+
+  atomic_intrusive_list_impl() noexcept;
+  ~atomic_intrusive_list_impl();
+
+  atomic_intrusive_list_impl(const atomic_intrusive_list_impl&) = delete;
+  atomic_intrusive_list_impl(atomic_intrusive_list_impl&&) = delete;
+  atomic_intrusive_list_impl&
+  operator=(const atomic_intrusive_list_impl&) = delete;
+  atomic_intrusive_list_impl& operator=(atomic_intrusive_list_impl&&) = delete;
+
+  bool is_sentinel(const node* n) const noexcept;
+
+  void push_front_impl(node* item) noexcept;
+  void push_back_impl(node* item) noexcept;
+  node* pop_front_impl() noexcept;
+  bool try_remove_impl(node* item) noexcept;
+  void drain_into_impl(atomic_intrusive_list_impl& target) noexcept;
+
+  [[nodiscard]] bool empty_impl() const noexcept {
+    auto val = head_.load(std::memory_order_relaxed);
+    return is_sentinel(reinterpret_cast<node*>(val & ~lock_bit));
+  }
+
+  // ---- Latch operations (Latch=true only) ----
+
+  // Push to front unless latched.  Returns true if pushed.
+  bool push_front_unless_latched_impl(node* item) noexcept;
+
+  // Atomically latch + move all items into target.
+  void latch_and_drain_impl(atomic_intrusive_list_impl& target) noexcept;
+
+  // Clear the latch (only if latched and empty).
+  void unlatch_impl() noexcept;
+
+  [[nodiscard]] bool is_latched_impl() const noexcept;
+
+  // ---- Data ----
+
+  node sentinel_;
+
+  struct empty_t {};
+  // sentinel_latch_ only occupies space when Latch=true.
+  // With Latch=false, EBO eliminates it.
+  UNIFEX_NO_UNIQUE_ADDRESS std::conditional_t<Latch, node, empty_t>
+      sentinel_latch_{};
+
+  link head_;
+};
+
+// ---- Typed wrapper -------------------------------------------
+
+template <typename Item, bool Latch = false>
+class atomic_intrusive_list : atomic_intrusive_list_impl<Latch> {
+  using base = atomic_intrusive_list_impl<Latch>;
+
+  static_assert(
+      std::is_base_of_v<atomic_intrusive_list_node, Item>,
+      "Item must inherit from atomic_intrusive_list_node");
+  static_assert(
+      alignof(Item) >= 2,
+      "Item alignment must be >= 2 for the tag-bit protocol");
+
+public:
+  void push_front(Item* item) noexcept { base::push_front_impl(item); }
+
+  void push_back(Item* item) noexcept { base::push_back_impl(item); }
+
+  [[nodiscard]] Item* pop_front() noexcept {
+    return static_cast<Item*>(base::pop_front_impl());
+  }
+
+  [[nodiscard]] bool try_remove(Item* item) noexcept {
+    return base::try_remove_impl(item);
+  }
+
+  void drain_into(atomic_intrusive_list& target) noexcept {
+    base::drain_into_impl(target);
+  }
+
+  [[nodiscard]] bool empty() const noexcept { return base::empty_impl(); }
+
+  // ---- Latch operations (available only when Latch=true) ----
+
+  template <bool L = Latch, std::enable_if_t<L, int> = 0>
+  bool push_front_unless_latched(Item* item) noexcept {
+    return base::push_front_unless_latched_impl(item);
+  }
+
+  template <bool L = Latch, std::enable_if_t<L, int> = 0>
+  void latch_and_drain(atomic_intrusive_list& target) noexcept {
+    base::latch_and_drain_impl(target);
+  }
+
+  template <bool L = Latch, std::enable_if_t<L, int> = 0>
+  void unlatch() noexcept {
+    base::unlatch_impl();
+  }
+
+  template <bool L = Latch, std::enable_if_t<L, int> = 0>
+  [[nodiscard]] bool is_latched() const noexcept {
+    return base::is_latched_impl();
+  }
+};
+
+// Explicit-instantiation declarations (definitions in .cpp).
+extern template class atomic_intrusive_list_impl<false>;
+extern template class atomic_intrusive_list_impl<true>;
+
+}  // namespace unifex
+
+#include <unifex/detail/epilogue.hpp>

--- a/include/unifex/v2/async_mutex.hpp
+++ b/include/unifex/v2/async_mutex.hpp
@@ -15,54 +15,57 @@
  */
 #pragma once
 
+#include <unifex/cancellable.hpp>
 #include <unifex/get_stop_token.hpp>
 #include <unifex/receiver_concepts.hpp>
 #include <unifex/scheduler_concepts.hpp>
 #include <unifex/sender_concepts.hpp>
 #include <unifex/tag_invoke.hpp>
+#include <unifex/detail/atomic_intrusive_list.hpp>
 #include <unifex/detail/completion_forwarder.hpp>
-#include <unifex/detail/intrusive_list.hpp>
 
 #include <unifex/detail/prologue.hpp>
 
 #include <atomic>
-#include <mutex>
-#include <optional>
 
 namespace unifex::v2 {
 
+// Lock-free async mutex.  Cancellation via try_remove.
+//
+// Uses a Dekker pattern between locked_ and queue_ to
+// prevent lost wakeups: seq_cst fences in start() (after
+// push, before locked_ exchange) and process_queue() (after
+// locked_ release, before empty check) guarantee at least
+// one side sees the other.
+//
+// Unlike async_manual_reset_event, the mutex has no
+// concurrent-reset problem: only the lock holder (a single
+// thread) transitions locked_ from true to false.
 class async_mutex {
-  class lock_sender;
+  class lock_raw_sender;
 
 public:
   [[nodiscard]] bool try_lock() noexcept;
 
-  [[nodiscard]] lock_sender async_lock() noexcept;
+  [[nodiscard]] auto async_lock() noexcept;
 
   void unlock() noexcept;
 
 private:
-  struct waiter_base {
-    bool enqueued() const noexcept {
-      return next_ != this;
-    }
-
-    void set_dequeued() noexcept {
-      next_ = this;
-    }
-
+  struct waiter_base : atomic_intrusive_list_node {
     void (*resume_)(waiter_base*) noexcept;
-    waiter_base* next_{this};
-    waiter_base* prev_;
   };
 
-  class lock_sender {
+  void process_queue() noexcept;
+
+  atomic_intrusive_list<waiter_base> queue_;
+  std::atomic<bool> locked_{false};
+
+  class lock_raw_sender {
   public:
     template <
-        template <typename...>
-        class Variant,
-        template <typename...>
-        class Tuple>
+        template <typename...> class Variant,
+        template <typename...> class Tuple>
     using value_types = Variant<Tuple<>>;
 
     template <template <typename...> class Variant>
@@ -72,233 +75,123 @@ private:
     static constexpr blocking_kind blocking = blocking_kind::maybe;
     static constexpr bool is_always_scheduler_affine = true;
 
-    lock_sender(const lock_sender&) = delete;
-    lock_sender(lock_sender&&) = default;
+    lock_raw_sender(const lock_raw_sender&) = delete;
+    lock_raw_sender(lock_raw_sender&&) = default;
 
   private:
     friend async_mutex;
 
-    explicit lock_sender(async_mutex& mutex) noexcept : mutex_(mutex) {}
+    explicit lock_raw_sender(async_mutex& mutex) noexcept : mutex_(mutex) {}
 
     template <typename Receiver>
     struct _op {
       class type : waiter_base {
-        friend lock_sender;
+        friend lock_raw_sender;
 
       public:
-        explicit type(async_mutex& mutex, Receiver&& r) noexcept 
-        : mutex_(mutex)
-        , receiver_(std::forward<Receiver>(r)) {
+        explicit type(async_mutex& mutex, Receiver&& r) noexcept
+          : mutex_(mutex)
+          , receiver_(std::forward<Receiver>(r)) {
           this->resume_ = [](waiter_base* self) noexcept {
-            static_cast<type*>(self)->set_value();
+            auto* op = static_cast<type*>(self);
+            if (try_complete(op)) {
+              op->forwardingOp_.start(*op);
+            } else {
+              // Pop gave us the lock but stop already completed
+              // us.  Release the lock to avoid deadlock.
+              op->mutex_.unlock();
+            }
           };
         }
 
         type(type&&) = delete;
 
-        Receiver& get_receiver() noexcept {
-          return receiver_;
-        }
+        Receiver& get_receiver() noexcept { return receiver_; }
 
         void forward_set_value() noexcept {
-          if (enqueued_state_.load(std::memory_order_acquire) ==
-                enqueued_state::kCancelled) {
+          if (cancelled_) {
             unifex::set_done(std::move(receiver_));
           } else {
             unifex::set_value(std::move(receiver_));
           }
         }
 
-        void start() noexcept;        
+        void start() noexcept;
+        void stop() noexcept;
 
       private:
-        enum class enqueued_state : uint8_t {
-          kNotEnqueued,
-          kLocking,
-          kLockedButNotEnqueued,
-          kEnqueued,
-          kUnlocked,
-          kCancelled
-        };
-
-        void set_done() noexcept;
-        void set_value() noexcept;
-
-        struct stop_callback final {
-          type* self;
-
-          void operator()() noexcept;
-        };
-
-        using stop_callback_type = typename stop_token_type_t<Receiver>
-          ::template callback_type<stop_callback>;
-
         async_mutex& mutex_;
         Receiver receiver_;
         completion_forwarder<type, Receiver> forwardingOp_;
-        std::optional<stop_callback_type> stop_callback_;
-        std::atomic<enqueued_state> enqueued_state_{
-            enqueued_state::kNotEnqueued};
+        bool cancelled_{false};
+        bool started_{false};
       };
     };
 
     template <typename Receiver>
     using operation = typename _op<Receiver>::type;
 
-    template(typename Receiver)                                        //
-    (requires receiver_of<Receiver> AND scheduler_provider<Receiver>)  //
-    friend operation<Receiver> tag_invoke(
-        tag_t<connect>, lock_sender&& s, Receiver&& r) noexcept {      
+    template(typename Receiver)                                            //
+        (requires receiver_of<Receiver> AND scheduler_provider<Receiver>)  //
+        friend operation<Receiver> tag_invoke(
+            tag_t<connect>, lock_raw_sender&& s, Receiver&& r) noexcept {
       return operation<Receiver>{s.mutex_, std::forward<Receiver>(r)};
     }
 
     async_mutex& mutex_;
   };
-
-  // Attempt to enqueue the waiter object to the queue.
-  // Returns true if successfully enqueued, false if it was not enqueued because
-  // the lock was acquired synchronously.
-  bool try_enqueue(waiter_base* waiter) noexcept;
-  // Returns false if waiter was not in the queue.
-  bool try_dequeue(waiter_base* waiter) noexcept;
-
-  intrusive_list<waiter_base, &waiter_base::next_, &waiter_base::prev_> queue_;
-  std::atomic<bool> locked_{false};
-  std::mutex mutex_;
 };
 
-inline async_mutex::lock_sender async_mutex::async_lock() noexcept {
-  return lock_sender{*this};
+inline auto async_mutex::async_lock() noexcept {
+  return cancellable<lock_raw_sender, true>{lock_raw_sender{*this}};
 }
 
 inline bool async_mutex::try_lock() noexcept {
-  return !locked_.exchange(true);
+  return !locked_.exchange(true, std::memory_order_acquire);
 }
 
 template <typename Receiver>
-void async_mutex::lock_sender::_op<Receiver>::type::start() noexcept {
-  stop_callback_.emplace(get_stop_token(receiver_), stop_callback{this});
-  if (enqueued_state_.exchange(enqueued_state::kLocking, std::memory_order_acq_rel)
-      == enqueued_state::kCancelled) {
-    // stop callback ran synchronously
-    stop_callback_.reset();
-    enqueued_state_.store(enqueued_state::kCancelled, std::memory_order_release);
-    forwardingOp_.start(*this);
-    return;
-  }
-  
-  // if this returns true then we've opened ourselves up to an unlocker
-  // resuming us!
-  bool enqueued{mutex_.try_enqueue(this)};
-  
-  auto oldState = enqueued_state::kLocking;
-  auto newState = enqueued ? enqueued_state::kEnqueued
-                           : enqueued_state::kLockedButNotEnqueued;
-  
-  if (enqueued_state_.compare_exchange_strong(
-      oldState, newState, std::memory_order_acq_rel)) {
-    // successfully transitioned locking -> enqueued|locked
-    if (enqueued) {
-      // we need to return here; the next state transition will happen when an unlocker
-      // dequeues us or the stop request fires, both of which could be happening
-      // concurrently to this code so it's unsafe to touch any members at this point
-      return;
-    } else {
-      // we took the lock synchronously, so no unlocker will wake us up, but the stop
-      // request could run
-      stop_callback_.reset();
-      assert([this]() noexcept {
-        auto state = enqueued_state_.load(std::memory_order_acquire);
-        return state == enqueued_state::kCancelled ||
-            state == enqueued_state::kLockedButNotEnqueued;
-      }());
-    }
-  } else {
-    // we've been completed concurrently while trying to set up
-    stop_callback_.reset();    
-    if (oldState == enqueued_state::kCancelled) {
-      // the stop request ran; we have to handle the possibility that we were enqueued onto
-      // the list of waiters and then popped by an unlocker
-      if (!enqueued || !mutex_.try_dequeue(this)) {
-        // we got the lock but don't intend to keep it so give it back
-        mutex_.unlock();
-      }
-    } else {
-      // we were enqueued but an unlocker dequeued us, giving us the lock but not completing
-      assert(oldState == enqueued_state::kUnlocked);
-      assert(enqueued);
-    }
-  }
-  // Complete with value or done, depending on enqueued_state_ == kCancelled
-  forwardingOp_.start(*this);
-}
+void async_mutex::lock_raw_sender::_op<Receiver>::type::start() noexcept {
+  started_ = true;
 
-template <typename Receiver>
-void async_mutex::lock_sender::_op<Receiver>::type::stop_callback::operator()() noexcept {
-  self->set_done();
-}
-
-template <typename Receiver>
-void async_mutex::lock_sender::_op<Receiver>::type::set_done() noexcept {
-  auto oldState = enqueued_state_.load(std::memory_order_relaxed);
-
-  do {
-    if (oldState == enqueued_state::kUnlocked) {
-      // the stop request ran after we acquired the lock
-      return;
-    }
-  } while (!enqueued_state_.compare_exchange_weak(
-      oldState, enqueued_state::kCancelled, std::memory_order_acq_rel));
-
-  // we transitioned to cancelled; whether there's more to do depends on what from
-  switch (oldState) {
-    case enqueued_state::kUnlocked:
-    default:
-      // invalid state
-      std::terminate();
-
-    case enqueued_state::kNotEnqueued:
-    case enqueued_state::kLocking:
-    case enqueued_state::kLockedButNotEnqueued:
-      // start() is still running
-      return;
-
-    case enqueued_state::kEnqueued:
-      // start() put us in the queue
-      if (!mutex_.try_dequeue(this)) {
-        // an unlocker gave us the lock by popping us from the queue
-        mutex_.unlock();
-      }
-      stop_callback_.reset();
+  if (mutex_.try_lock()) {
+    if (try_complete(this)) {
       forwardingOp_.start(*this);
     }
+    return;
+  }
+
+  // Save ref: after push_back, another thread may pop and
+  // complete us, potentially destroying *this.
+  async_mutex& mutex = mutex_;
+
+  mutex.queue_.push_back(this);
+
+  // Dekker fence: orders the push before the locked_ exchange.
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+
+  if (!mutex.locked_.exchange(true, std::memory_order_acq_rel)) {
+    mutex.process_queue();
+  }
 }
 
 template <typename Receiver>
-void async_mutex::lock_sender::_op<Receiver>::type::set_value() noexcept {
-  // an unlocker has popped us from the mutex's queue
-  auto oldState = enqueued_state_.load(std::memory_order_relaxed);
-
-  do {
-    if (oldState == enqueued_state::kCancelled) {
-      // set_done is running; let it run
-      return;
+void async_mutex::lock_raw_sender::_op<Receiver>::type::stop() noexcept {
+  if (!started_) {
+    // StopsEarly: never enqueued, don't hold the lock.
+    cancelled_ = true;
+    if (try_complete(this)) {
+      forwardingOp_.start(*this);
     }
-  } while (!enqueued_state_.compare_exchange_weak(
-      oldState, enqueued_state::kUnlocked, std::memory_order_acq_rel));
-
-  // we transitioned to unlocked; whether there's more to do depends on what from
-  if (oldState == enqueued_state::kLocking) {
-    // start() is still running
     return;
-  } else if (oldState == enqueued_state::kEnqueued) {
-    // start() has returned or will soon and we beat the stop request to updating state
-    stop_callback_.reset();
-    forwardingOp_.start(*this);
-  } else {
-    // invalid state
-    std::terminate();
   }
+  if (mutex_.queue_.try_remove(this)) {
+    cancelled_ = true;
+    if (try_complete(this)) {
+      forwardingOp_.start(*this);
+    }
+  }
+  // else: already popped by process_queue; resume_ handles it.
 }
 
 }  // namespace unifex::v2

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -10,6 +10,7 @@ set_target_properties(unifex PROPERTIES
 
 target_sources(unifex
   PRIVATE
+    atomic_intrusive_list.cpp
     async_auto_reset_event.cpp
     async_manual_reset_event.cpp
     async_mutex_v1.cpp

--- a/source/async_mutex_v2.cpp
+++ b/source/async_mutex_v2.cpp
@@ -18,35 +18,34 @@
 
 namespace unifex::v2 {
 
-bool async_mutex::try_enqueue(waiter_base* waiter) noexcept {
-  if (try_lock()) {
-    return false;
-  }
+void async_mutex::process_queue() noexcept {
+  while (true) {
+    waiter_base* w = queue_.pop_front();
+    if (w) {
+      w->resume_(w);
+      return;
+    }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  queue_.push_back(waiter);
-  return true;
-}
+    // Queue empty — release the lock.
+    locked_.store(false, std::memory_order_release);
 
-bool async_mutex::try_dequeue(waiter_base* waiter) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (waiter->enqueued()) {
-    queue_.remove(waiter);
-    waiter->set_dequeued();
-    return true;
+    // Dekker fence: orders the release before the re-check.
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+
+    if (queue_.empty()) {
+      return;
+    }
+
+    // Item appeared after release.  Re-acquire; if another
+    // thread beat us, they will drain.
+    if (locked_.exchange(true, std::memory_order_acq_rel)) {
+      return;
+    }
   }
-  return false;
 }
 
 void async_mutex::unlock() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (queue_.empty()) {
-    locked_.store(false);
-  } else {
-    waiter_base* next{queue_.pop_front()};
-    next->set_dequeued();
-    next->resume_(next);
-  }
+  process_queue();
 }
 
 }  // namespace unifex::v2

--- a/source/atomic_intrusive_list.cpp
+++ b/source/atomic_intrusive_list.cpp
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unifex/detail/atomic_intrusive_list.hpp>
+
+namespace unifex {
+
+using node = atomic_intrusive_list_node;
+using link = atomic_intrusive_list_link;
+
+namespace {
+
+node* to_node(uintptr_t v) noexcept {
+  return reinterpret_cast<node*>(v);
+}
+
+uintptr_t to_value(node* p) noexcept {
+  return reinterpret_cast<uintptr_t>(p);
+}
+
+}  // namespace
+
+// ---- Lock helpers (non-template) ----
+
+uintptr_t atomic_intrusive_list_link_ops::lock(link& lk) noexcept {
+  uintptr_t val = lk.load(std::memory_order_relaxed);
+  while (true) {
+    while (val & lock_bit) {
+      val = lk.load(std::memory_order_relaxed);
+    }
+    if (lk.compare_exchange_weak(
+            val,
+            val | lock_bit,
+            std::memory_order_acquire,
+            std::memory_order_relaxed)) {
+      return val;
+    }
+  }
+}
+
+bool atomic_intrusive_list_link_ops::try_lock_checking(
+    link& lk,
+    std::atomic<link*>& monitored,
+    link* expected,
+    uintptr_t& head_val) noexcept {
+  {
+    link* cur = monitored.load(std::memory_order_acquire);
+    if (cur != expected) {
+      return false;
+    }
+  }
+
+  uintptr_t val = lk.load(std::memory_order_relaxed);
+  while (true) {
+    if (val & lock_bit) {
+      link* cur = monitored.load(std::memory_order_acquire);
+      if (cur != expected) {
+        return false;
+      }
+      val = lk.load(std::memory_order_relaxed);
+      continue;
+    }
+
+    // Acquire fence synchronises with the release that wrote
+    // this unlocked value, making any monitored-pointer update
+    // sequenced before that release visible.
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+    link* cur = monitored.load(std::memory_order_acquire);
+    if (cur != expected) {
+      return false;
+    }
+
+    if (lk.compare_exchange_weak(
+            val,
+            val | lock_bit,
+            std::memory_order_relaxed,
+            std::memory_order_relaxed)) {
+      head_val = val;
+      return true;
+    }
+  }
+}
+
+// ---- List implementation (template) ----
+
+template <bool Latch>
+atomic_intrusive_list_impl<Latch>::atomic_intrusive_list_impl() noexcept {
+  head_.store(to_value(&sentinel_), std::memory_order_relaxed);
+  sentinel_.self.store(&head_, std::memory_order_relaxed);
+}
+
+template <bool Latch>
+atomic_intrusive_list_impl<Latch>::~atomic_intrusive_list_impl() {
+  UNIFEX_ASSERT(is_sentinel(to_node(head_.load(std::memory_order_relaxed))));
+}
+
+template <bool Latch>
+bool atomic_intrusive_list_impl<Latch>::is_sentinel(
+    const node* n) const noexcept {
+  if constexpr (Latch) {
+    return n == &sentinel_ || n == &sentinel_latch_;
+  } else {
+    return n == &sentinel_;
+  }
+}
+
+template <bool Latch>
+void atomic_intrusive_list_impl<Latch>::push_front_impl(node* item) noexcept {
+  UNIFEX_ASSERT(item != nullptr);
+  UNIFEX_ASSERT(item->self.load(std::memory_order_relaxed) == nullptr);
+
+  uintptr_t old_head = lock(head_);
+  node* old_first = to_node(old_head);
+  UNIFEX_ASSERT(old_first != nullptr);
+
+  item->rest.store(old_head, std::memory_order_relaxed);
+  old_first->self.store(&item->rest, std::memory_order_release);
+  item->self.store(&head_, std::memory_order_release);
+
+  unlock(head_, to_value(item));
+}
+
+template <bool Latch>
+void atomic_intrusive_list_impl<Latch>::push_back_impl(node* item) noexcept {
+  UNIFEX_ASSERT(item != nullptr);
+  UNIFEX_ASSERT(item->self.load(std::memory_order_relaxed) == nullptr);
+
+  item->rest.store(to_value(&sentinel_), std::memory_order_relaxed);
+
+  while (true) {
+    link* pred_link = sentinel_.self.load(std::memory_order_acquire);
+
+    uintptr_t pred_val;
+    if (!try_lock_checking(*pred_link, sentinel_.self, pred_link, pred_val)) {
+      continue;
+    }
+    UNIFEX_ASSERT(pred_val == to_value(&sentinel_));
+
+    item->self.store(pred_link, std::memory_order_release);
+    sentinel_.self.store(&item->rest, std::memory_order_release);
+
+    unlock(*pred_link, to_value(item));
+    return;
+  }
+}
+
+template <bool Latch>
+node* atomic_intrusive_list_impl<Latch>::pop_front_impl() noexcept {
+  uintptr_t old_head = lock(head_);
+  node* first = to_node(old_head);
+
+  if (is_sentinel(first)) {
+    unlock(head_, old_head);
+    return nullptr;
+  }
+
+  uintptr_t rest_val = lock(first->rest);
+  node* second = to_node(rest_val);
+  UNIFEX_ASSERT(second != nullptr);
+
+  second->self.store(&head_, std::memory_order_release);
+  first->self.store(nullptr, std::memory_order_relaxed);
+
+  unlock(head_, rest_val);
+  unlock(first->rest, 0);
+  return first;
+}
+
+template <bool Latch>
+bool atomic_intrusive_list_impl<Latch>::try_remove_impl(node* item) noexcept {
+  UNIFEX_ASSERT(item != nullptr);
+
+  while (true) {
+    link* head_ptr = item->self.load(std::memory_order_acquire);
+    if (!head_ptr) {
+      return false;
+    }
+
+    uintptr_t head_val;
+    if (!try_lock_checking(*head_ptr, item->self, head_ptr, head_val)) {
+      continue;
+    }
+
+    link* cur_self = item->self.load(std::memory_order_acquire);
+    if (cur_self != head_ptr) {
+      unlock(*head_ptr, head_val);
+      if (!cur_self) {
+        return false;
+      }
+      continue;
+    }
+    UNIFEX_ASSERT(to_node(head_val) == item);
+
+    uintptr_t rest_val = lock(item->rest);
+    node* successor = to_node(rest_val);
+    UNIFEX_ASSERT(successor != nullptr);
+
+    successor->self.store(head_ptr, std::memory_order_release);
+    item->self.store(nullptr, std::memory_order_relaxed);
+
+    unlock(*head_ptr, rest_val);
+    unlock(item->rest, 0);
+    return true;
+  }
+}
+
+template <bool Latch>
+void atomic_intrusive_list_impl<Latch>::drain_into_impl(
+    atomic_intrusive_list_impl& target) noexcept {
+  UNIFEX_ASSERT(&target != this);
+  UNIFEX_ASSERT(target.empty_impl());
+
+  uintptr_t old_head = lock(head_);
+  node* first = to_node(old_head);
+
+  if (is_sentinel(first)) {
+    unlock(head_, old_head);
+    return;
+  }
+
+  // Lock the sentinel predecessor (last real node).
+  link* pred_link;
+  uintptr_t pred_val;
+  while (true) {
+    pred_link = sentinel_.self.load(std::memory_order_acquire);
+    if (try_lock_checking(*pred_link, sentinel_.self, pred_link, pred_val)) {
+      break;
+    }
+  }
+  UNIFEX_ASSERT(pred_val == to_value(&sentinel_));
+
+  // Retarget source sentinel to head before unlocking, so a
+  // concurrent push_back targets head_ (which we still hold).
+  sentinel_.self.store(&head_, std::memory_order_release);
+
+  // Splice the chain into the target.
+  target.sentinel_.self.store(pred_link, std::memory_order_release);
+  target.head_.store(old_head, std::memory_order_relaxed);
+  first->self.store(&target.head_, std::memory_order_release);
+
+  unlock(*pred_link, to_value(&target.sentinel_));
+  unlock(head_, to_value(&sentinel_));
+}
+
+// ---- Latch operations ----
+//
+// Only meaningful when Latch=true.  The if-constexpr guards
+// allow the class-level explicit instantiation below to
+// compile for Latch=false without emitting any latch code.
+
+template <bool Latch>
+bool atomic_intrusive_list_impl<Latch>::push_front_unless_latched_impl(
+    node* item) noexcept {
+  if constexpr (Latch) {
+    UNIFEX_ASSERT(item != nullptr);
+    UNIFEX_ASSERT(item->self.load(std::memory_order_relaxed) == nullptr);
+
+    uintptr_t old_head = lock(head_);
+    node* old_first = to_node(old_head);
+
+    if (old_first == &sentinel_latch_) {
+      unlock(head_, old_head);
+      return false;
+    }
+
+    UNIFEX_ASSERT(old_first != nullptr);
+    item->rest.store(old_head, std::memory_order_relaxed);
+    old_first->self.store(&item->rest, std::memory_order_release);
+    item->self.store(&head_, std::memory_order_release);
+
+    unlock(head_, to_value(item));
+    return true;
+  } else {
+    (void)item;
+    UNIFEX_ASSERT(false);
+    return false;
+  }
+}
+
+template <bool Latch>
+void atomic_intrusive_list_impl<Latch>::latch_and_drain_impl(
+    atomic_intrusive_list_impl& target) noexcept {
+  if constexpr (Latch) {
+    UNIFEX_ASSERT(&target != this);
+    UNIFEX_ASSERT(target.empty_impl());
+
+    uintptr_t old_head = lock(head_);
+    node* first = to_node(old_head);
+
+    if (first == &sentinel_latch_) {
+      unlock(head_, old_head);
+      return;
+    }
+
+    if (first == &sentinel_) {
+      sentinel_.self.store(nullptr, std::memory_order_relaxed);
+      sentinel_latch_.self.store(&head_, std::memory_order_release);
+      unlock(head_, to_value(&sentinel_latch_));
+      return;
+    }
+
+    // Has items — drain them into target, then latch.
+    link* pred_link;
+    uintptr_t pred_val;
+    while (true) {
+      pred_link = sentinel_.self.load(std::memory_order_acquire);
+      if (try_lock_checking(*pred_link, sentinel_.self, pred_link, pred_val)) {
+        break;
+      }
+    }
+    UNIFEX_ASSERT(pred_val == to_value(&sentinel_));
+
+    sentinel_.self.store(nullptr, std::memory_order_relaxed);
+    sentinel_latch_.self.store(&head_, std::memory_order_release);
+
+    target.sentinel_.self.store(pred_link, std::memory_order_release);
+    target.head_.store(old_head, std::memory_order_relaxed);
+    first->self.store(&target.head_, std::memory_order_release);
+
+    unlock(*pred_link, to_value(&target.sentinel_));
+    unlock(head_, to_value(&sentinel_latch_));
+  } else {
+    (void)target;
+    UNIFEX_ASSERT(false);
+  }
+}
+
+template <bool Latch>
+void atomic_intrusive_list_impl<Latch>::unlatch_impl() noexcept {
+  if constexpr (Latch) {
+    uintptr_t old_head = lock(head_);
+    node* first = to_node(old_head);
+
+    if (first == &sentinel_latch_) {
+      sentinel_latch_.self.store(nullptr, std::memory_order_relaxed);
+      sentinel_.self.store(&head_, std::memory_order_release);
+      unlock(head_, to_value(&sentinel_));
+    } else {
+      unlock(head_, old_head);
+    }
+  } else {
+    UNIFEX_ASSERT(false);
+  }
+}
+
+template <bool Latch>
+bool atomic_intrusive_list_impl<Latch>::is_latched_impl() const noexcept {
+  if constexpr (Latch) {
+    auto val = head_.load(std::memory_order_acquire);
+    return (val & ~lock_bit) == reinterpret_cast<uintptr_t>(&sentinel_latch_);
+  } else {
+    return false;
+  }
+}
+
+// Explicit instantiations.
+template class atomic_intrusive_list_impl<false>;
+template class atomic_intrusive_list_impl<true>;
+
+}  // namespace unifex


### PR DESCRIPTION
[AI-generated code: Claude 4.6 Opus]

- Implemented new atomic (based on CAS loops) data structure, `atomic_intrusive_list`. The API is targeted to support synchronization primitives with multiple cancellable senders that may require completing waiting senders one by one (LIFO or FIFO order) or all at once, with optional "latched" operations required by `async_manual_reset_event`. Implementation analytically verified with separate agents and extensively tested under contention (tests included in subsequent PR);
- Reimplemented `v2/async_mutex` using the new data structure instead of `std::mutex` shared between all waiting senders. The new version is a full functional equivalent i.e. provides cancellable senders unlike `v1/async_mutex`.
