### PR TITLE
Cancellable and create_raw_sender can now be lvalue-connectable

### DIFF
--- a/include/unifex/cancellable.hpp
+++ b/include/unifex/cancellable.hpp
@@ -231,35 +231,56 @@ public:
       std::is_nothrow_constructible_v<Sender, Args...>)
     : sender_(std::forward<Args>(args)...) {}
 
-  template(typename Receiver)                                           //
-      (requires is_stop_never_possible_v<stop_token_type_t<Receiver>>)  //
-      friend auto tag_invoke(
-          unifex::tag_t<connect>,
-          cancellable&& self,
-          Receiver&&
-              receiver) noexcept(is_nothrow_connectable_v<Sender, Receiver>) {
+  // Rvalue and lvalue connect overloads. if-constexpr selects the
+  // non-stop vs stoppable path within each.
+  template <typename Receiver>
+  friend auto tag_invoke(
+      unifex::tag_t<connect>,
+      cancellable&& self,
+      Receiver&&
+          receiver) noexcept(is_nothrow_connectable_v<Sender, Receiver>) {
     using nested_op_t = raw_connect_result_t<Sender, Receiver>;
-    return typename _op<nested_op_t>::non_stop_type{
-        std::move(self.sender_), std::forward<Receiver>(receiver)};
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      return typename _op<nested_op_t>::non_stop_type{
+          std::move(self.sender_), std::forward<Receiver>(receiver)};
+    } else {
+      static_assert(
+          std::is_nothrow_invocable_v<
+              decltype(&nested_op_t::stop),
+              nested_op_t*>,
+          "operation must provide a nothrow stop() method");
+      using op_type = typename _op<
+          nested_op_t>::template type<stop_token_type_t<Receiver>, StopsEarly>;
+      return op_type{
+          std::move(self.sender_),
+          std::forward<Receiver>(receiver),
+          get_stop_token(receiver)};
+    }
   }
 
-  template(typename Receiver)                                             //
-      (requires(!is_stop_never_possible_v<stop_token_type_t<Receiver>>))  //
-      friend auto tag_invoke(
-          unifex::tag_t<connect>,
-          cancellable&& self,
-          Receiver&&
-              receiver) noexcept(is_nothrow_connectable_v<Sender, Receiver>) {
-    using nested_op_t = raw_connect_result_t<Sender, Receiver>;
-    static_assert(
-        std::is_nothrow_invocable_v<decltype(&nested_op_t::stop), nested_op_t*>,
-        "operation must provide a nothrow stop() method");
-    using op_type = typename _op<
-        nested_op_t>::template type<stop_token_type_t<Receiver>, StopsEarly>;
-    return op_type{
-        std::move(self.sender_),
-        std::forward<Receiver>(receiver),
-        get_stop_token(receiver)};
+  template <typename Receiver>
+  friend auto tag_invoke(
+      unifex::tag_t<connect>,
+      cancellable& self,
+      Receiver&&
+          receiver) noexcept(is_nothrow_connectable_v<Sender&, Receiver>) {
+    using nested_op_t = raw_connect_result_t<Sender&, Receiver>;
+    if constexpr (is_stop_never_possible_v<stop_token_type_t<Receiver>>) {
+      return typename _op<nested_op_t>::non_stop_type{
+          self.sender_, std::forward<Receiver>(receiver)};
+    } else {
+      static_assert(
+          std::is_nothrow_invocable_v<
+              decltype(&nested_op_t::stop),
+              nested_op_t*>,
+          "operation must provide a nothrow stop() method");
+      using op_type = typename _op<
+          nested_op_t>::template type<stop_token_type_t<Receiver>, StopsEarly>;
+      return op_type{
+          self.sender_,
+          std::forward<Receiver>(receiver),
+          get_stop_token(receiver)};
+    }
   }
 
 private:

--- a/include/unifex/create_raw_sender.hpp
+++ b/include/unifex/create_raw_sender.hpp
@@ -87,32 +87,37 @@ struct _sender : public Tr {
   explicit _sender(Fn&& fn) noexcept(std::is_nothrow_move_constructible_v<Fn>)
     : fn_(std::forward<Fn>(fn)) {}
 
-  // Overload 1: factory returns a type with start(). Returned directly.
-  template <typename Receiver>
-    requires receiver_of<Receiver, ValueTypes...> &&
-      std::is_invocable_v<
-                 _start_cpo::_fn,
-                 decltype(UNIFEX_DECLVAL(Fn)(UNIFEX_DECLVAL(Receiver)))&>
-  friend auto
-  tag_invoke(tag_t<connect>, _sender&& self, Receiver&& rec) noexcept(
-      std::is_nothrow_invocable_v<Fn, Receiver&&>) {
-    return std::move(self.fn_)(std::forward<Receiver>(rec));
+  // Shared logic for rvalue and lvalue connect. If the factory result
+  // has start(), returns it directly. Otherwise wraps in _lambda_op::_op
+  // which auto-selects: plain callable -> start() only;
+  // event-dispatch -> start() + stop().
+  template <typename FnRef, typename Receiver>
+  static auto connect_impl_(FnRef&& fn, Receiver&& rec) noexcept(
+      noexcept(std::forward<FnRef>(fn)(std::forward<Receiver>(rec)))) {
+    using state_t =
+        decltype(std::forward<FnRef>(fn)(std::forward<Receiver>(rec)));
+    if constexpr (std::is_invocable_v<_start_cpo::_fn, state_t&>) {
+      return std::forward<FnRef>(fn)(std::forward<Receiver>(rec));
+    } else {
+      return _lambda_op::_op<state_t>{
+          std::forward<FnRef>(fn)(std::forward<Receiver>(rec))};
+    }
   }
 
-  // Overload 2: factory returns a callable (no start()). Wrapped in
-  // _sender_op::_op which auto-selects the right specialization:
-  // plain callable → start() only; event-dispatch → start() + stop().
   template <typename Receiver>
-    requires receiver_of<Receiver, ValueTypes...> &&
-      (!std::is_invocable_v<
-          _start_cpo::_fn,
-          decltype(UNIFEX_DECLVAL(Fn)(UNIFEX_DECLVAL(Receiver)))&>)
+    requires receiver_of<Receiver, ValueTypes...>
   friend auto
-  tag_invoke(tag_t<connect>, _sender&& self, Receiver&& rec) noexcept(
-      std::is_nothrow_invocable_v<Fn, Receiver&&>) {
-    using state_t = decltype(std::move(self.fn_)(std::forward<Receiver>(rec)));
-    return _lambda_op::_op<state_t>{
-        std::move(self.fn_)(std::forward<Receiver>(rec))};
+  tag_invoke(tag_t<connect>, _sender&& self, Receiver&& rec) noexcept(noexcept(
+      connect_impl_(std::move(self.fn_), std::forward<Receiver>(rec)))) {
+    return connect_impl_(std::move(self.fn_), std::forward<Receiver>(rec));
+  }
+
+  template <typename Receiver>
+    requires receiver_of<Receiver, ValueTypes...>
+  friend auto
+  tag_invoke(tag_t<connect>, _sender& self, Receiver&& rec) noexcept(
+      noexcept(connect_impl_(self.fn_, std::forward<Receiver>(rec)))) {
+    return connect_impl_(self.fn_, std::forward<Receiver>(rec));
   }
 
   UNIFEX_NO_UNIQUE_ADDRESS Fn fn_;

--- a/test/cancellable_test.cpp
+++ b/test/cancellable_test.cpp
@@ -17,6 +17,8 @@
 #include <unifex/async_scope.hpp>
 #include <unifex/cancellable.hpp>
 #include <unifex/let_value_with_stop_source.hpp>
+#include <unifex/repeat_effect_until.hpp>
+#include <unifex/single_thread_context.hpp>
 #include <unifex/stop_when.hpp>
 #include <unifex/sync_wait.hpp>
 #include <unifex/then.hpp>
@@ -377,7 +379,65 @@ TEST(cancellable_lambda_test, event_probe_fields) {
   static_assert(_stop_probe::is_stop);
 }
 
-#endif
+#  if defined(_MSC_VER)
+
+TEST(cancellable_test, recursive_pipeline) {
+  // Uses the struct-based test_sender_opstate to keep type nesting
+  // shallow — the equivalent lambda version triggers an MSVC internal
+  // compiler error.
+  using namespace std::chrono_literals;
+  async_scope scope;
+  single_thread_context ctx;
+
+  auto sender{cancellable{create_raw_sender<int>(
+      [&scope](auto&& receiver)
+          -> test_sender_opstate<std::remove_cvref_t<decltype(receiver)>> {
+        return test_sender_opstate{
+            std::forward<decltype(receiver)>(receiver), scope};
+      })}};
+
+  scope.detached_spawn_on(
+      ctx.get_scheduler(),
+      std::move(sender) | then([](int) noexcept {}) | repeat_effect());
+  sync_wait(schedule_after(timer.get_scheduler(), 250ms));
+  sync_wait(scope.cleanup());
+}
+
+#  else
+
+TEST(cancellable_lambda_test, recursive_pipeline) {
+  using namespace std::chrono_literals;
+  async_scope scope;
+  single_thread_context ctx;
+
+  auto sender{cancellable{create_raw_sender<int>([&scope](auto&& receiver) {
+    return [&scope, receiver = std::forward<decltype(receiver)>(receiver)](
+               auto event, auto* self) mutable {
+      if constexpr (event.is_start) {
+        scope.detached_spawn(
+            schedule_after(timer.get_scheduler(), 100ms) |
+            then([self, &receiver]() noexcept {
+              if (try_complete(self)) {
+                set_value(std::move(receiver), 42);
+              }
+            }));
+      } else if constexpr (event.is_stop) {
+        if (try_complete(self)) {
+          set_done(std::move(receiver));
+        }
+      }
+    };
+  })}};
+
+  scope.detached_spawn_on(
+      ctx.get_scheduler(),
+      std::move(sender) | then([](int) noexcept {}) | repeat_effect());
+  sync_wait(schedule_after(timer.get_scheduler(), 250ms));
+  sync_wait(scope.cleanup());
+}
+
+#  endif  // _MSC_VER
+#endif    // __cplusplus >= 201911L
 
 TEST(cancellable_test, constructs_sender_in_place) {
   bool started = false;


### PR DESCRIPTION
_[AI-generated code: Claude 4.6 Opus]_

Added overloads to `connect()` accepting sender by lvalue reference in `cancellable` and `create_raw_sender` for compatibility with multi-use contexts (`repeat_effect_until()` et. al).