### PR TITLE
io_uring_context with non-TU local c++23 htons implementation

### DIFF
--- a/.github/workflows/libunifex-ci.yml
+++ b/.github/workflows/libunifex-ci.yml
@@ -3,15 +3,13 @@ name: libunifex CI
 # Trigger on pushes to all branches and for all pull-requests
 on: [push, pull_request]
 
-env:
-  CMAKE_VERSION: 3.16.2
-  NINJA_VERSION: 1.9.0
-
-
 jobs:
   build:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    env:
+      CMAKE_VERSION: ${{ matrix.config.cmake_version || '3.16.2' }}
+      NINJA_VERSION: ${{ matrix.config.ninja_version || '1.9.0' }}
     strategy:
       fail-fast: false
       matrix:
@@ -151,6 +149,33 @@ jobs:
             build_type: RelWithDebInfo,
             cc: "gcc-14", cxx: "g++-14",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=20 -D CMAKE_CXX_FLAGS=-fno-exceptions"
+          }
+        - {
+            name: "Linux GCC 14 Debug (C++23)", artifact: "Linux.tar.xz",
+            os: ubuntu-24.04,
+            io_sys: io_uring,
+            build_type: Debug,
+            cc: "gcc-14", cxx: "g++-14",
+            cmake_version: "3.20.0",
+            cmake_args: "-D CMAKE_CXX_STANDARD:STRING=23"
+          }
+        - {
+            name: "Linux GCC 14 Optimised (C++23)", artifact: "Linux.tar.xz",
+            os: ubuntu-24.04,
+            io_sys: io_uring,
+            build_type: RelWithDebInfo,
+            cc: "gcc-14", cxx: "g++-14",
+            cmake_version: "3.20.0",
+            cmake_args: "-D CMAKE_CXX_STANDARD:STRING=23"
+          }
+        - {
+            name: "Linux GCC 14 Optimised noexcept (C++23)", artifact: "Linux.tar.xz",
+            os: ubuntu-24.04,
+            io_sys: io_uring,
+            build_type: RelWithDebInfo,
+            cc: "gcc-14", cxx: "g++-14",
+            cmake_version: "3.20.0",
+            cmake_args: "-D CMAKE_CXX_STANDARD:STRING=23 -D CMAKE_CXX_FLAGS=-fno-exceptions"
           }
         - {
             name: "Linux Clang 15 Debug (C++17)", artifact: "Linux.tar.xz",
@@ -414,7 +439,11 @@ jobs:
         elseif ("${{ runner.os }}" STREQUAL "Linux")
           set(ninja_suffix "linux.zip")
           set(cmake_suffix "Linux-x86_64.tar.gz")
-          set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
+          if(cmake_version VERSION_GREATER_EQUAL 3.20.0)
+            set(cmake_dir "cmake-${cmake_version}-linux-x86_64/bin")
+          else()
+            set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
+          endif()
         elseif ("${{ runner.os }}" STREQUAL "macOS")
           set(ninja_suffix "mac.zip")
           set(cmake_suffix "Darwin-x86_64.tar.gz")

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -52,6 +52,9 @@
 #  include <sys/socket.h>
 #  include <sys/uio.h>
 #  include <unistd.h>
+#  if __has_include(<bit>)
+#  include <bit>
+#  endif // __has_include(<bit>)
 
 #  include <unifex/detail/prologue.hpp>
 
@@ -1352,11 +1355,15 @@ private:
   safe_file_descriptor fd_;
 
   static constexpr std::uint16_t host_to_network(std::uint16_t value) {
-      if constexpr (std::endian::native == std::endian::little) {
-          return std::byteswap(value);
-      } else {
-          return value;
-      }
+#   if __has_include(<bit>)
+      return (
+        std::endian::native == std::endian::little
+          ? std::byteswap(value)
+          : value
+      );
+#   else
+      return htons(value);
+#   endif
   }
 
   // TODO should this run on the io_context? If so, why?
@@ -1387,4 +1394,4 @@ private:
 
 #  include <unifex/detail/epilogue.hpp>
 
-#endif  // __has_include(<liburing.h>)
+#endif // UNIFEX_NO_LIBURING

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -1354,17 +1354,19 @@ private:
   port_t port_;
   safe_file_descriptor fd_;
 
+# if __cpp_lib_byteswap >= 202110L
   static constexpr std::uint16_t host_to_network(std::uint16_t value) {
-#   if __has_include(<bit>)
       return (
         std::endian::native == std::endian::little
           ? std::byteswap(value)
           : value
       );
-#   else
-      return htons(value);
-#   endif
   }
+# else
+  static std::uint16_t host_to_network(std::uint16_t value) {
+    return htons(value);
+  }
+# endif // __cpp_lib_byteswap
 
   // TODO should this run on the io_context? If so, why?
   void open_socket() noexcept {

--- a/include/unifex/linux/io_uring_context.hpp
+++ b/include/unifex/linux/io_uring_context.hpp
@@ -1351,6 +1351,14 @@ private:
   port_t port_;
   safe_file_descriptor fd_;
 
+  static constexpr std::uint16_t host_to_network(std::uint16_t value) {
+      if constexpr (std::endian::native == std::endian::little) {
+          return std::byteswap(value);
+      } else {
+          return value;
+      }
+  }
+
   // TODO should this run on the io_context? If so, why?
   void open_socket() noexcept {
     // both IPv4 and IPv6
@@ -1365,7 +1373,7 @@ private:
     UNIFEX_ASSERT(ret != -1);
 
     addr.sin6_family = AF_INET6;
-    addr.sin6_port = htons(port_);
+    addr.sin6_port = host_to_network(port_);
     addr.sin6_addr = in6addr_any;
     ret = bind(fd_.get(), (const struct sockaddr*)&addr, sizeof(addr));
     UNIFEX_ASSERT(ret != -1);


### PR DESCRIPTION
The single low lying issue with exporting `io_uring_context` to module is the use of the C API function `htons` which results in module compilation error:

```
error: ‘void unifex::linuxos::io_uring_context::accept_stream::open_socket()’ exposes TU-local entity ‘__uint16_t __bswap_16(__uint16_t)’
 1371 |   void open_socket() noexcept {
      |        ^~~~~~~~~~~
In file included from /usr/include/endian.h:35,
                 from /usr/include/sys/types.h:176,
                 from /usr/include/stdlib.h:518,
                 from /usr/include/c++/15.2.1/cstdlib:83,
                 from /usr/include/c++/15.2.1/ext/string_conversions.h:45,
                 from /usr/include/c++/15.2.1/bits/basic_string.h:4444,
                 from /usr/include/c++/15.2.1/string:56,
                 from /usr/include/c++/15.2.1/bits/locale_classes.h:42,
                 from /usr/include/c++/15.2.1/bits/ios_base.h:43,
                 from /usr/include/c++/15.2.1/ios:46,
                 from /usr/include/c++/15.2.1/bits/ostream.h:43,
                 from /usr/include/c++/15.2.1/ostream:42,
                 from /usr/include/c++/15.2.1/iostream:43,
                 from /code/modules/unifex/src/unifex.cppm:3:
/usr/include/bits/byteswap.h:34:1: note: ‘__uint16_t __bswap_16(__uint16_t)’ declared with internal linkage
   34 | __bswap_16 (__uint16_t __bsx)
      | ^~~~~~~~~~
ninja: build stopped: subcommand failed.
```

On linux this is a static function as follows:

```c
// /usr/include/bits/byteswap.h
static __inline __uint16_t
__bswap_16 (__uint16_t __bsx)
{
#if __GNUC_PREREQ (4, 8)
  return __builtin_bswap16 (__bsx);
#else
  return __bswap_constant_16 (__bsx);
#endif
}
```

static functions (excluding static methods) are not exportable through modules, however c++23 introduces new module-friendly byteswapping via `std::byteswap`. 

tested with gcc 15 using:

```cpp
export namspace unifex {
    using ::unifex::linuxos::io_uring_context;
}
```